### PR TITLE
feat: --out flag for leyline integration

### DIFF
--- a/cmd/leyline.go
+++ b/cmd/leyline.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/agentic-research/mache/api"
@@ -156,33 +157,15 @@ func materializeCallers(tx *sql.Tx, now int64) error {
 }
 
 // extractFuncName pulls the function name from a node path like "functions/Foo/source".
-// Returns the second path component (the function directory name).
+// Returns the second-to-last path component (the function directory name).
 func extractFuncName(nodeID string) string {
-	// Split by "/" and take the second-to-last meaningful component
 	// "functions/ProcessOrder/source" -> "ProcessOrder"
 	// "types/MyStruct/source" -> "MyStruct"
-	parts := splitPath(nodeID)
+	parts := strings.Split(nodeID, "/")
 	if len(parts) < 2 {
 		return ""
 	}
 	return parts[len(parts)-2]
-}
-
-func splitPath(s string) []string {
-	var parts []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '/' {
-			if i > start {
-				parts = append(parts, s[start:i])
-			}
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		parts = append(parts, s[start:])
-	}
-	return parts
 }
 
 // copyFile copies src to dst, creating dst if it doesn't exist.
@@ -197,9 +180,9 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer func() { _ = out.Close() }()
 
 	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
 		return err
 	}
 	return out.Close()

--- a/cmd/leyline_test.go
+++ b/cmd/leyline_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"database/sql"
 	"encoding/json"
+	"path/filepath"
 	"testing"
 
 	"github.com/agentic-research/mache/api"
@@ -142,7 +143,7 @@ func TestMaterializeSchemaJSON(t *testing.T) {
 
 	// Use a temp file since materializeVirtuals opens by path
 	tmpDir := t.TempDir()
-	dbPath := tmpDir + "/test.db"
+	dbPath := filepath.Join(tmpDir, "test.db")
 
 	// Dump in-memory DB to file
 	_, err := db.Exec(`VACUUM INTO ?`, dbPath)
@@ -197,7 +198,7 @@ func TestMaterializePromptTxt(t *testing.T) {
 	schema := &api.Topology{Version: "v1"}
 
 	tmpDir := t.TempDir()
-	dbPath := tmpDir + "/test.db"
+	dbPath := filepath.Join(tmpDir, "test.db")
 
 	_, err := db.Exec(`VACUUM INTO ?`, dbPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Adds `--out` flag to export a `.db` file with materialized virtual files instead of mounting
- Enables Phase 1 leyline integration flow: `mache --infer -d ./src --out /tmp/index.db && leyline load --db /tmp/index.db --control /tmp/ll.ctrl`
- Materializes `_schema.json`, `PROMPT.txt` (agent mode), and `callers/` directories directly into the `.db`

## Backwards Compatibility
- `--out` is purely additive — all existing paths (mount, agent, build, control) are untouched
- Only triggers in the `!writable && SchemaUsesTreeSitter` fast path when `--out` is set

## Test plan
- [x] `TestMaterializeCallers` — refs → callers/ dir nodes
- [x] `TestMaterializeCallersNoRefs` — no-op when node_refs missing
- [x] `TestMaterializeSchemaJSON` — _schema.json at root
- [x] `TestMaterializePromptTxt` — PROMPT.txt in agent mode
- [x] `TestExtractFuncName` — path parsing edge cases
- [x] E2E validated: mache --out → leyline load → NFS mount serves data

🤖 Generated with [Claude Code](https://claude.com/claude-code)