### PR TITLE
feat: Friendly-name grouping for ProjectAST

### DIFF
--- a/internal/ingest/language.go
+++ b/internal/ingest/language.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smacker/go-tree-sitter/yaml"
 )
 
-
 // DetectLanguageFromExt returns the language name and tree-sitter Language
 // for a given file extension. Returns ok=false for unsupported extensions.
 func DetectLanguageFromExt(ext string) (langName string, lang *sitter.Language, ok bool) {

--- a/internal/lattice/project_ast.go
+++ b/internal/lattice/project_ast.go
@@ -9,6 +9,40 @@ import (
 	"github.com/agentic-research/mache/api"
 )
 
+// friendlyTypeNames maps tree-sitter node types to human-friendly group names.
+var friendlyTypeNames = map[string]string{
+	// Go
+	"function_declaration": "functions",
+	"method_declaration":   "methods",
+	"type_declaration":     "types",
+	// Python
+	"function_definition": "functions",
+	"class_definition":    "classes",
+	// JavaScript / TypeScript
+	"class_declaration": "classes",
+	"method_definition": "methods",
+	// Rust
+	"function_item": "functions",
+	"struct_item":   "structs",
+	"enum_item":     "enums",
+	"impl_item":     "implementations",
+	"trait_item":    "traits",
+	// HCL/Terraform
+	"hcl_container": "blocks",
+	// SQL
+	"create_table": "tables",
+	"create_view":  "views",
+	// HTML / DOM
+	"element":        "elements",
+	"script_element": "scripts",
+	"style_element":  "styles",
+	// CSS
+	"rule_set":            "rules",
+	"media_statement":     "media",
+	"keyframes_statement": "keyframes",
+	"import_statement":    "imports",
+}
+
 // containmentRules defines which AST container types can nest inside others,
 // per language. Keys are parent types; values are allowed child types.
 // Languages not listed (or with empty maps) default to flat — no nesting.
@@ -228,8 +262,32 @@ func ProjectAST(concepts []Concept, ctx *FormalContext, config ProjectConfig) *a
 		}
 	}
 
+	// Wrap each container type in a friendly-name grouping directory.
+	// e.g. function_definition → "functions/", class_definition → "classes/"
+	var grouped []api.Node
+	groupIndex := make(map[string]int) // friendly_name → index in grouped
+
+	for i, t := range sortedTypes {
+		friendly := friendlyTypeNames[t]
+		if friendly == "" {
+			friendly = t // fallback: use raw type name
+		}
+		if idx, ok := groupIndex[friendly]; ok {
+			grouped[idx].Children = append(grouped[idx].Children, result[i])
+		} else {
+			group := api.Node{
+				Name:     friendly,
+				Selector: "$",
+				Language: config.Language,
+				Children: []api.Node{result[i]},
+			}
+			groupIndex[friendly] = len(grouped)
+			grouped = append(grouped, group)
+		}
+	}
+
 	return &api.Topology{
 		Version: "v1",
-		Nodes:   result,
+		Nodes:   grouped,
 	}
 }

--- a/internal/lattice/project_ast_test.go
+++ b/internal/lattice/project_ast_test.go
@@ -53,13 +53,18 @@ func TestProjectAST_GoFlat(t *testing.T) {
 	topo := ProjectAST(concepts, ctx, ProjectConfig{Language: "go"})
 
 	require.NotNil(t, topo)
-	// Go has function_definition → exactly 1 root node
+	// Go has function_definition → 1 group node ("functions")
 	require.Len(t, topo.Nodes, 1)
 
-	funcNode := topo.Nodes[0]
+	group := topo.Nodes[0]
+	assert.Equal(t, "functions", group.Name)
+	assert.Equal(t, "$", group.Selector)
+	require.Len(t, group.Children, 1)
+
+	funcNode := group.Children[0]
 	assert.Equal(t, "{{.name}}", funcNode.Name)
 	assert.Contains(t, funcNode.Selector, "function_definition")
-	// Go is flat — no children
+	// Go is flat — no nested children
 	assert.Empty(t, funcNode.Children, "Go functions should have no children (flat)")
 }
 
@@ -69,16 +74,27 @@ func TestProjectAST_PythonNested(t *testing.T) {
 	topo := ProjectAST(concepts, ctx, ProjectConfig{Language: "python"})
 
 	require.NotNil(t, topo)
-	// Python has class_definition + function_definition → 2 root nodes
+	// Python has class_definition + function_definition → 2 groups ("classes", "functions")
 	require.Len(t, topo.Nodes, 2)
 
-	// Nodes are sorted alphabetically: class_definition, function_definition
-	classNode := topo.Nodes[0]
-	funcNode := topo.Nodes[1]
+	// Groups are ordered by first appearance of sorted types:
+	// sortedTypes = [class_definition, function_definition] → groups = [classes, functions]
+	classGroup := topo.Nodes[0]
+	funcGroup := topo.Nodes[1]
+	assert.Equal(t, "classes", classGroup.Name)
+	assert.Equal(t, "$", classGroup.Selector)
+	assert.Equal(t, "functions", funcGroup.Name)
+	assert.Equal(t, "$", funcGroup.Selector)
+
+	require.Len(t, classGroup.Children, 1)
+	require.Len(t, funcGroup.Children, 1)
+
+	classNode := classGroup.Children[0]
+	funcNode := funcGroup.Children[0]
 	assert.Contains(t, classNode.Selector, "class_definition")
 	assert.Contains(t, funcNode.Selector, "function_definition")
 
-	// class_definition should have function_definition as child
+	// class_definition should have function_definition as nested child
 	require.Len(t, classNode.Children, 1, "Python class should nest function_definition")
 	assert.Contains(t, classNode.Children[0].Selector, "function_definition")
 
@@ -93,10 +109,13 @@ func TestProjectAST_UnknownLanguageFlat(t *testing.T) {
 	topo := ProjectAST(concepts, ctx, ProjectConfig{Language: "cobol"})
 
 	require.NotNil(t, topo)
+	// Still grouped: "classes" and "functions"
 	require.Len(t, topo.Nodes, 2)
 
-	for _, node := range topo.Nodes {
-		assert.Empty(t, node.Children, "Unknown language should produce flat schema")
+	for _, group := range topo.Nodes {
+		assert.Equal(t, "$", group.Selector, "Group should use $ passthrough selector")
+		require.Len(t, group.Children, 1)
+		assert.Empty(t, group.Children[0].Children, "Unknown language should produce flat schema")
 	}
 }
 
@@ -107,7 +126,9 @@ func TestProjectAST_EmptyLanguageFlat(t *testing.T) {
 	topo := ProjectAST(concepts, ctx, ProjectConfig{Language: ""})
 
 	require.NotNil(t, topo)
-	for _, node := range topo.Nodes {
-		assert.Empty(t, node.Children, "Empty language should produce flat schema")
+	for _, group := range topo.Nodes {
+		assert.Equal(t, "$", group.Selector, "Group should use $ passthrough selector")
+		require.Len(t, group.Children, 1)
+		assert.Empty(t, group.Children[0].Children, "Empty language should produce flat schema")
 	}
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -169,15 +169,15 @@ func TestIntegration_InferAndIngest(t *testing.T) {
 	fix := setup(t)
 
 	// The inferred schema + ingestion should produce a HelloWorld node
-	node, err := fix.store.GetNode("HelloWorld/source")
-	require.NoError(t, err, "HelloWorld/source should exist in graph")
+	node, err := fix.store.GetNode("functions/HelloWorld/source")
+	require.NoError(t, err, "functions/HelloWorld/source should exist in graph")
 	assert.Contains(t, string(node.Data), "Original Content Long Long Long")
 }
 
 func TestIntegration_ContextAwareness(t *testing.T) {
 	fix := setup(t)
 
-	content := readNode(t, fix.gfs, "/HelloWorld/context")
+	content := readNode(t, fix.gfs, "/functions/HelloWorld/context")
 	assert.Contains(t, content, `import "fmt"`,
 		"context virtual file should contain imports from the source file")
 }
@@ -186,7 +186,7 @@ func TestIntegration_Truncation(t *testing.T) {
 	fix := setup(t)
 
 	// Write shorter content — old tail must not remain in source file
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte("func HelloWorld() {\n\tfmt.Println(\"Short\")\n}\n"))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte("func HelloWorld() {\n\tfmt.Println(\"Short\")\n}\n"))
 
 	src, err := os.ReadFile(fix.srcFile)
 	require.NoError(t, err)
@@ -200,7 +200,7 @@ func TestIntegration_Diagnostics(t *testing.T) {
 	fix := setup(t)
 
 	// Write broken syntax
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte("func HelloWorld() { BROKEN SYNTAX "))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte("func HelloWorld() { BROKEN SYNTAX "))
 
 	// Source file should NOT have the broken content (draft saved, not spliced)
 	src, err := os.ReadFile(fix.srcFile)
@@ -209,12 +209,12 @@ func TestIntegration_Diagnostics(t *testing.T) {
 		"broken syntax should not be spliced into source")
 
 	// Diagnostics virtual file should report the error
-	diag := readNode(t, fix.gfs, "/HelloWorld/_diagnostics/last-write-status")
+	diag := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/last-write-status")
 	assert.Contains(t, diag, "syntax error",
 		"diagnostics should report syntax error")
 
 	// ast-errors should also have content
-	astErrs := readNode(t, fix.gfs, "/HelloWorld/_diagnostics/ast-errors")
+	astErrs := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/ast-errors")
 	assert.NotEmpty(t, astErrs, "ast-errors should have content after bad write")
 }
 
@@ -222,10 +222,10 @@ func TestIntegration_Recovery(t *testing.T) {
 	fix := setup(t)
 
 	// First: write broken syntax to set diagnostic state
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte("func HelloWorld() { BROKEN "))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte("func HelloWorld() { BROKEN "))
 
 	// Then: write valid code — should recover
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte("func HelloWorld() {\n\tfmt.Println(\"Fixed\")\n}\n"))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte("func HelloWorld() {\n\tfmt.Println(\"Fixed\")\n}\n"))
 
 	src, err := os.ReadFile(fix.srcFile)
 	require.NoError(t, err)
@@ -233,7 +233,7 @@ func TestIntegration_Recovery(t *testing.T) {
 		"source file should contain recovered content")
 
 	// Diagnostics should clear to "ok"
-	diag := readNode(t, fix.gfs, "/HelloWorld/_diagnostics/last-write-status")
+	diag := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/last-write-status")
 	assert.Contains(t, diag, "ok",
 		"diagnostics should clear after valid write")
 }
@@ -245,14 +245,14 @@ func TestIntegration_SequentialWrites(t *testing.T) {
 	// The first write updates the origin via ShiftOrigins + UpdateNodeContent,
 	// so the second write should pick up the new byte range.
 	first := "func HelloWorld() {\n\tfmt.Println(\"First\")\n}\n"
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte(first))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte(first))
 
 	src1, err := os.ReadFile(fix.srcFile)
 	require.NoError(t, err)
 	assert.Contains(t, string(src1), "First")
 
 	second := "func HelloWorld() {\n\tfmt.Println(\"Second\")\n}\n"
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte(second))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte(second))
 
 	src2, err := os.ReadFile(fix.srcFile)
 	require.NoError(t, err)
@@ -268,7 +268,7 @@ func TestIntegration_GofumptFormat(t *testing.T) {
 	// Function-body snippets (what NFS write-back sends) pass through unmodified.
 	// Verify the pipeline still splices correctly even though formatting is a no-op.
 	snippet := "func HelloWorld() {\n\tfmt.Println(\"formatted\")\n}\n"
-	writeToNode(t, fix.gfs, "/HelloWorld/source", []byte(snippet))
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte(snippet))
 
 	src, err := os.ReadFile(fix.srcFile)
 	require.NoError(t, err)
@@ -278,7 +278,7 @@ func TestIntegration_GofumptFormat(t *testing.T) {
 		"content should be spliced into source")
 
 	// Write status should be "ok" (successful pipeline completion)
-	diag := readNode(t, fix.gfs, "/HelloWorld/_diagnostics/last-write-status")
+	diag := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/last-write-status")
 	assert.Contains(t, diag, "ok",
 		"write-back pipeline should complete successfully")
 }


### PR DESCRIPTION
## Summary
- ProjectAST now wraps tree-sitter container types in `$`-passthrough grouping directories (`functions/`, `classes/`, `types/`, etc.) so the mounted filesystem matches the blog's agent-mode file tree
- Added `friendlyTypeNames` map covering Go, Python, JS/TS, Rust, HCL, SQL, HTML/DOM, and CSS
- Updated all unit tests and integration tests for the new grouped structure

## Test plan
- [x] `task test -- -run TestProjectAST` — all 4 unit tests pass
- [x] `task test` — full suite green (0 failures)
- [x] `task check` — fmt + vet + lint + test + validate all pass
- [x] Pre-commit hooks pass (gofumpt, go vet, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)