### PR TITLE
docs: Update README, ARCHITECTURE, and add Prior Art landscape analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,9 @@ This isn't metaphorical. Mache literally treats both sides as graphs and uses SQ
   - [Example: Projecting JSON Data](#example-projecting-json-data)
   - [Example: Projecting Source Code](#example-projecting-source-code)
   - [Write-Back Mode](#write-back-mode)
-  - [Goto: Call-Chain Navigation](#goto-call-chain-navigation)
+  - [Cross-Reference Navigation](#cross-reference-navigation)
 - [How It Works](#how-it-works)
+- [Landscape](#landscape)
 - [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
@@ -101,7 +102,9 @@ Mache is in **early development**. The core pipeline (schema + ingestion + FUSE 
 | **Draft Mode** | **Stable** | Invalid writes save as drafts; node path stays stable. Diagnostics via `_diagnostics/`. |
 | **Context Awareness** | **Stable** | Virtual `context` files expose global scope (imports/types) to agents. |
 | **Tree-sitter Parsing** | **Stable** | Go, Python, JavaScript, TypeScript, SQL, Rust, HCL/Terraform, YAML. |
-| **Schema Inference** | **Beta** | Auto-infer schema from data via Formal Concept Analysis (FCA). |
+| **Cross-References** | **Stable** | `callers/` and `callees/` virtual dirs for bidirectional call-chain navigation. |
+| **`_project_files/`** | **Stable** | Non-AST files (READMEs, configs, docs) preserved in separate tree during source mounts. |
+| **Schema Inference** | **Beta** | Auto-infer schema from data via Formal Concept Analysis (FCA). Friendly-name grouping (`functions/`, `types/`, `classes/`). |
 
 ## Quick Start
 
@@ -194,12 +197,14 @@ claude
 **Key Points for Agents:**
 - **It's just files.** Use standard Read/Write/Edit tools — no special bash commands needed.
 - **Structure mirrors semantics.** Navigate by function name, not file path: `cd functions/HandleRequest/`
+- **Friendly-name grouping.** Schema inference creates intuitive containers — `functions/`, `types/`, `classes/` — instead of raw AST node types.
 - **Virtual files provide context:**
   - `source` — the function/type body (AST node content)
   - `context` — imports, types, globals visible to this scope
-  - `callers/` — directory of functions that call this one (cross-references)
-  - `callees/` — directory of functions this one calls
+  - `callers/` — directory of functions that call this one (incoming cross-references)
+  - `callees/` — directory of functions this one calls (outgoing cross-references)
   - `_diagnostics/` — write status, AST errors, lint output
+  - `_project_files/` — non-AST files (READMEs, configs, docs) preserved in a separate tree
 - **Write-back preserves identity.** Edit `source` files and changes splice back into the original source tree. Invalid writes save as drafts in `_diagnostics/ast-errors`.
 
 **Important: Writes only work on AST-backed `source` files.** Raw text files and virtual files are read-only. If a write fails validation (syntax error), the node path stays stable and the error is available in `_diagnostics/` so the agent can retry.
@@ -234,8 +239,29 @@ Given a `data.json` with users, you can project it into a `users/` directory whe
 
 Mache auto-detects source files (`.go`, `.py`, `.js`, `.ts`, `.rs`, `.tf`, `.hcl`, `.yaml`, `.sql`). Use tree-sitter queries in your schema to map AST nodes (functions, types) to directories.
 
+With `--infer`, schema inference creates **friendly-name container directories** — grouping constructs by type with intuitive names:
+
+```
+/tmp/mache-src/
+  functions/
+    HandleRequest/
+      source        # func HandleRequest(w http.ResponseWriter, r *http.Request) { ... }
+      context       # imports, types visible to this scope
+      callers/      # who calls this function
+      callees/      # what this function calls
+    ValidateToken/
+      source
+  types/
+    Config/
+      source        # type Config struct { ... }
+  _project_files/
+    README.md       # non-AST files preserved here
+    go.mod
+```
+
 - **Source:** The `source` file contains the function/type body.
 - **Context:** The `context` file (virtual) contains imports, types, and global variables visible to that scope. This is critical for LLM agents to understand dependencies without reading the whole file.
+- **`_project_files/`:** Non-AST files (READMEs, configs, build files) are automatically routed into a separate tree so they remain accessible without polluting the AST structure.
 
 ### Write-Back Mode
 
@@ -256,9 +282,11 @@ The write-back pipeline is **identity-preserving** — node paths stay stable ac
 
 If validation fails, the write is saved as a **draft** — the node path remains stable, and the error is available via `_diagnostics/ast-errors`. The agent can read its broken code and fix it without losing the file path.
 
-### Goto: Call-Chain Navigation
+### Cross-Reference Navigation
 
-Mache exposes cross-references as a virtual `callers/` directory. For any function or type, `callers/` lists every node in the graph that references it — turning "who calls this?" into a simple `ls`.
+Mache exposes bidirectional cross-references as virtual directories. For any function or type:
+- **`callers/`** lists every node that references it — "who calls this?"
+- **`callees/`** lists every function it calls — "what does this call?"
 
 ```bash
 # What calls HandleRequest?
@@ -268,11 +296,19 @@ ls /functions/HandleRequest/callers/
 # Read the calling code directly
 cat /functions/HandleRequest/callers/functions_Main_source
 # → func Main() { ... HandleRequest(ctx) ... }
+
+# What does HandleRequest call?
+ls /functions/HandleRequest/callees/
+# → functions_ValidateToken_source  functions_WriteResponse_source
+
+# Read callee source
+cat /functions/HandleRequest/callees/functions_ValidateToken_source
+# → func ValidateToken(tok string) error { ... }
 ```
 
-The `callers/` directory is **self-gating** — it only appears when a function actually has callers. No flag needed. This works on both NFS and FUSE backends, for both source code and SQLite mounts with cross-reference data.
+Both directories are **self-gating** — they only appear when a function actually has callers or callees. No flag needed. This works on both NFS and FUSE backends, for both source code and SQLite mounts with cross-reference data.
 
-Combined with `cat /functions/HandleRequest/source` for the definition, you get full call-chain tracing through filesystem paths alone — no grep, no LSP, no IDE required.
+Combined with `cat /functions/HandleRequest/source` for the definition, you get full bidirectional call-chain tracing through filesystem paths alone — no grep, no LSP, no IDE required.
 
 ## How It Works
 
@@ -284,9 +320,28 @@ Mache uses a **Topology Schema** to map data from SQLite, JSON, or source code i
 
 See [Architecture](docs/ARCHITECTURE.md) for details.
 
+## Landscape
+
+Mache occupies a unique position: it's a **projection engine** that maps structured data into a real, mounted filesystem using declarative schemas. Most tools in the AI-agent ecosystem solve adjacent problems — context retrieval (RAG), protocol plumbing (MCP), or agent orchestration — but none combine schema-driven projection, AST decomposition, write-back, and a real POSIX mount.
+
+| Tool | Schema-Driven | AST-Aware | Write-Back | Real FS Mount |
+|------|:---:|:---:|:---:|:---:|
+| **Mache** | Yes | Yes | Yes | Yes |
+| AgentFS (Turso) | No | No | Yes | No |
+| Dust | No | No | No | No (synthetic) |
+| MCP | No | No | Varies | No (protocol) |
+| LlamaIndex / LangChain | No | No | No | No |
+| FUSE-DB tools (FusqlFS, DBFS) | No | No | Some | Yes |
+| Plan 9 / 9P | Yes | No | Yes | Yes |
+
+Plan 9's "everything is a file server" philosophy is the closest historical precedent — Mache applies that idea to structured data with modern AST awareness. FUSE-DB tools mirror database schemas directly as directories; Mache adds a projection layer that reshapes data into task-appropriate topologies.
+
+See [Prior Art](docs/PRIOR_ART.md) for a full landscape analysis with detailed comparisons and academic references.
+
 ## Documentation
 
 - [Architecture & Design](docs/ARCHITECTURE.md) - Deep dive into internals, pipelines, and abstractions.
+- [Prior Art & Landscape](docs/PRIOR_ART.md) - Comparison with related tools and academic context.
 - [Roadmap](docs/ROADMAP.md) - Future plans and known limitations.
 - [Example Schemas](examples/README.md) - Details on the included examples.
 - [ADRs](docs/adr/) - Architectural Decision Records.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,8 @@ graph TD
     JW -->|Builds| MemoryStore
     SW -->|Builds| MemoryStore
     SL -->|Builds| MemoryStore
+    Engine -->|"Non-AST files"| ProjectFiles["_project_files/"]
+    ProjectFiles -->|Builds| MemoryStore
 
     SQLiteGraph -->|Graph Interface| NFS
     MemoryStore -->|Graph Interface| NFS
@@ -59,7 +61,7 @@ graph TD
 
 There are two data paths depending on the source:
 
-1. **SQLite direct (`.db` files)** — `SQLiteGraph` queries the source database directly. A one-pass scan builds the directory tree (~4s for 323K records), then content is resolved on demand via primary key lookup. No data is copied.
+1. **SQLite direct (`.db` files)** — `SQLiteGraph` queries the source database directly. A one-pass scan builds the directory tree (~12s for 323K records), then content is resolved on demand via primary key lookup. No data is copied.
 2. **Ingestion (`.json`, `.go`, `.py`, `.tf`, `.hcl`, `.yaml`, `.js`, `.ts`, `.sql`)** — The `Engine` dispatches to the appropriate `Walker`, renders templates, and bulk-loads nodes into `MemoryStore`.
 
 Both paths are fronted by the same `Graph` interface and served via either an **NFS server** (macOS default, `go-nfs` + `billy`) or a **FUSE bridge** (Linux default, `cgofuse` + `fuse-t`). A **Topology Schema** declares the directory structure using selectors and Go template strings for names/content.
@@ -75,6 +77,8 @@ With `--infer`, the schema itself can be derived automatically: the `lattice` pa
 - **`Engine`** — Drives ingestion: walks files, dispatches to walkers, renders templates, builds the graph. Tracks source file paths for origin-aware nodes. Deduplicates same-name constructs (e.g. multiple `init()`) by appending `.from_<filename>` suffixes.
 - **`GraphFS`** — NFS filesystem via `go-nfs`/`billy`. Adapts the `Graph` interface to `billy.Filesystem`. Default backend on macOS.
 - **`MacheFS`** — FUSE implementation via cgofuse. Handle-based readdir with auto-mode for fuse-t compatibility. Extended cache timeouts (300s) for NFS performance. Default backend on Linux.
+- **`_project_files/`** — Non-AST files (READMEs, configs, docs) encountered during tree-sitter ingestion are routed into a separate `_project_files/` tree via `ingestRawFileUnder()`. This preserves access to supporting files without polluting the AST-derived structure.
+- **Friendly-name grouping** — `ProjectAST` in the lattice package maps raw tree-sitter node types to intuitive container directory names: `function_declaration` → `functions/`, `class_definition` → `classes/`, `type_declaration` → `types/`, etc. Language-specific containment rules nest methods inside classes for Python/TypeScript.
 
 ## Write Pipeline
 
@@ -131,19 +135,40 @@ readlink /funcs/Bar/callers/funcs_Foo_source
 # → ../../../funcs/Foo/source
 ```
 
+### `callees/`
+Per-directory virtual subdirectory exposing outgoing cross-references — the inverse of `callers/`. For any construct directory, `callees/` lists functions and types that the construct calls or references. Self-gating: only appears when `GetCallees(id)` returns non-empty results.
+
+Resolution pipeline:
+1. Find the `source` child of the construct directory
+2. Extract qualified calls via tree-sitter (`CallExtractor` → `[]QualifiedCall`)
+3. Resolve each call against the `defs` index: qualified lookup (`auth.Validate`) → import-path fallback → bare token lookup
+
+- **NFS**: Entries are `graphFile`s — reading returns the callee's source content.
+- **FUSE**: Entries are symlinks pointing into the graph (mirrors `callers/` pattern).
+
+```bash
+# What does HandleRequest call?
+ls /functions/HandleRequest/callees/
+# → functions_ValidateToken_source  functions_WriteResponse_source
+
+# Read callee source directly (NFS)
+cat /functions/HandleRequest/callees/functions_ValidateToken_source
+# → func ValidateToken(tok string) error { ... }
+```
+
 ## Key File Reference
 
 | Concern | File | Key functions/types |
 |---------|------|-------------------|
 | CLI + mount wiring | `cmd/mount.go` | `rootCmd`, `--writable`, `--infer`, `--backend` flags |
 | Schema types | `api/schema.go` | `Topology`, `Node`, `Leaf` |
-| Ingestion orchestration | `internal/ingest/engine.go` | `Engine.Ingest`, `processNode`, `ingestTreeSitter`, `dedupSuffix` |
+| Ingestion orchestration | `internal/ingest/engine.go` | `Engine.Ingest`, `processNode`, `ingestTreeSitter`, `ingestRawFileUnder`, `dedupSuffix` |
 | JSON queries | `internal/ingest/json_walker.go` | `JsonWalker.Query` |
 | Tree-sitter queries | `internal/ingest/sitter_walker.go` | `SitterWalker.Query`, `sitterMatch.CaptureOrigin` |
 | Walker/Match contracts | `internal/ingest/interfaces.go` | `Walker`, `Match`, `OriginProvider` |
 | SQLite streaming | `internal/ingest/sqlite_loader.go` | `StreamSQLiteRaw` |
-| Graph (in-memory) | `internal/graph/graph.go` | `MemoryStore`, `Node`, `SourceOrigin`, `ContentRef` |
-| Graph (SQLite direct) | `internal/graph/sqlite_graph.go` | `SQLiteGraph`, `EagerScan`, `GetCallers` |
+| Graph (in-memory) | `internal/graph/graph.go` | `MemoryStore`, `Node`, `SourceOrigin`, `ContentRef`, `GetCallees`, `AddDef` |
+| Graph (SQLite direct) | `internal/graph/sqlite_graph.go` | `SQLiteGraph`, `EagerScan`, `GetCallers`, `GetCallees` |
 | NFS backend | `internal/nfsmount/graphfs.go` | `GraphFS`, `graphFile`, `writeFile`, `callers/` |
 | NFS server | `internal/nfsmount/server.go` | `NewServer`, NFS listener |
 | FUSE backend | `internal/fs/root.go` | `MacheFS`, `writeHandle`, `callers/`, `.query/` |
@@ -154,6 +179,7 @@ readlink /funcs/Bar/callers/funcs_Foo_source
 | Control block | `internal/control/` | HotSwapGraph, live schema reload |
 | Go schema | `examples/go-schema.json` | functions, methods, types, constants, variables, imports |
 | FCA inference | `internal/lattice/` | `FormalContext`, `NextClosure`, `Project`, `Inferrer` |
+| ProjectAST / friendly names | `internal/lattice/project_ast.go` | `ProjectAST`, `friendlyTypeNames`, containment rules |
 | Build/test | `Taskfile.yml` | `task build`, `task test`, `task check` |
 
 ## Architectural Decision Records (ADRs)

--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -1,0 +1,85 @@
+# Prior Art & Landscape
+
+## Introduction
+
+Mache is a **projection engine**: it takes structured data (JSON, SQLite, source code) and mounts it as a real POSIX filesystem. A declarative schema defines the topology — how source nodes map to directories and files — or, with `--infer`, the schema is derived automatically via Formal Concept Analysis (FCA). The engine handles ingestion, on-demand content resolution, cross-references, and write-back.
+
+This positions Mache at the intersection of several traditions — filesystem-as-interface (Plan 9), data virtualization (FUSE-DB tools), and AI-agent context engineering — but no existing tool combines all of its properties: schema-driven projection, AST decomposition, identity-preserving write-back, and a real OS-level mount.
+
+## Comparison Table
+
+| Tool | Schema-Driven Projection | AST-Aware Decomposition | Identity-Preserving Write-Back | On-Demand Content | Cross-References | Real FS Mount |
+|------|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Mache** | Yes | Yes | Yes | Yes | Yes (`callers/`, `callees/`) | Yes (NFS/FUSE) |
+| **AgentFS** (Turso) | No | No | Yes (KV store) | No | No | No |
+| **Dust** | No | No | No | No | No | No (synthetic FS via tool calls) |
+| **Vercel bash-tool** | No | No | No | No | No | No (manual file staging) |
+| **MCP** | No | No | Varies by server | N/A | N/A | No (protocol layer) |
+| **LlamaIndex / LangChain** | No | No | No | Yes (retrievers) | No | No |
+| **AIGNE / AFS** | No | No | No | No | No | No (namespace metaphor) |
+| **FUSE-DB tools** (FusqlFS, DBFS, wddbfs) | No | No | Some | Yes | No | Yes |
+| **Plan 9 / 9P** | Yes (per-server) | No | Yes | Yes | No | Yes |
+
+## Detailed Analysis
+
+### AgentFS (Turso)
+
+[AgentFS](https://github.com/tursodatabase/agentfs) provides a filesystem-like key-value store for AI agents backed by libSQL/Turso. It solves agent state persistence — saving and retrieving files that agents create during execution. It does not project external data into a filesystem; there is no schema, no topology reshaping, and no AST awareness. The "filesystem" is a storage abstraction, not an OS mount.
+
+### "FUSE is All You Need" (Emmerling, 2025)
+
+This [blog post](https://blog.philipmemmerling.com/fuse-is-all-you-need/) articulates the philosophical argument that FUSE filesystems are the ideal interface for AI agents — tools already speak files, so mount your data as files. Mache shares this philosophy entirely but goes further: it provides a general-purpose engine with declarative schemas, multi-format ingestion, and write-back, rather than a one-off FUSE implementation for a specific data source.
+
+### Dust
+
+[Dust](https://dust.tt/) provides AI assistants with access to company data through tool calls that return file-like results. The "filesystem" is synthetic — constructed per-query by the orchestration layer, not mounted as a real directory tree. There is no persistent topology, no schema-driven projection, and no write-back.
+
+### Vercel bash-tool
+
+Vercel's approach to agent file access uses a sandboxed bash environment where files are staged manually into the agent's working directory. This gives agents real file operations but requires explicit file preparation — there is no projection engine to reshape data, no schema, and no on-demand content resolution. The agent sees whatever files were placed in its sandbox.
+
+### MCP (Model Context Protocol)
+
+[MCP](https://modelcontextprotocol.io/) is a protocol standard for connecting AI models to data sources and tools. It defines the transport layer (JSON-RPC, stdio/SSE) but not the data plane. An MCP server *could* expose a filesystem, but MCP itself provides no schema language, no ingestion engine, and no topology projection. Mache could be wrapped as an MCP server, but it operates at a different layer — MCP is plumbing, Mache is the projection engine.
+
+### LangChain / LlamaIndex
+
+These frameworks provide RAG (Retrieval-Augmented Generation) pipelines: ingest documents, chunk them, embed them, and retrieve relevant fragments at query time. They solve the retrieval problem — finding relevant context — but not the structural problem. There is no filesystem interface, no schema-driven topology, and no write-back. An agent using LlamaIndex gets text chunks; an agent using Mache gets a navigable directory tree with cross-references.
+
+### AIGNE / AFS (Agent Filesystem)
+
+AIGNE's "Agent Filesystem" uses filesystem metaphors for agent tool registration — tools are "mounted" at namespace paths. This is a naming convention for tool dispatch, not a real filesystem. There are no inodes, no directory traversal, no read/write operations at the OS level.
+
+### FUSE-DB Tools (FusqlFS, DBFS, wddbfs)
+
+These tools mount databases as real FUSE filesystems — tables become directories, rows become files. They provide genuine OS-level mounts with read (and sometimes write) support. However, they **mirror** the database schema directly: the filesystem topology is 1:1 with the source schema. Mache adds a projection layer — the topology schema reshapes data into task-appropriate structures (e.g., temporal sharding by year/month, AST decomposition into function directories) that may differ entirely from the source layout.
+
+### Plan 9 / 9P
+
+Plan 9 from Bell Labs is the closest philosophical ancestor. Its core principle — "everything is a file server" — directly inspires Mache's approach. In Plan 9, every resource (network, process table, window system) is exposed as a synthetic filesystem via the 9P protocol. Each server defines its own namespace topology.
+
+Mache applies this idea to structured data with two modern additions: (1) declarative schemas that specify the projection without writing a custom file server, and (2) AST-aware decomposition that understands source code structure. Plan 9 required implementing a new file server for each data source; Mache requires only a JSON schema.
+
+## Academic Validation
+
+Two recent papers provide independent validation of the file-as-interface approach for AI agents:
+
+### "Files Are All You Need" (Piskala, January 2026)
+
+This paper argues that the filesystem is the natural interface between AI agents and structured data — agents already operate on files, so exposing data as files eliminates the impedance mismatch between data access patterns and agent tool interfaces. The paper surveys existing approaches and concludes that real OS-level mounts (not synthetic file metaphors) are essential for seamless agent integration. Mache's architecture aligns directly with this thesis.
+
+### "Structured Context Engineering" (McMillan, February 2026)
+
+Based on 9,649 experiments across multiple LLMs, this paper demonstrates that domain-partitioned file schemas significantly improve agent task performance compared to flat file dumps or RAG retrieval. The key finding: when data is organized into semantically meaningful directory hierarchies (by domain, by time period, by construct type), agents navigate more efficiently and produce more accurate results. This validates Mache's schema-driven topology approach — the projection is not just convenient, it materially affects agent performance.
+
+## Sources
+
+- AgentFS (Turso): https://github.com/tursodatabase/agentfs
+- "FUSE is All You Need": https://blog.philipmemmerling.com/fuse-is-all-you-need/
+- Dust: https://dust.tt/
+- Model Context Protocol: https://modelcontextprotocol.io/
+- LlamaIndex: https://www.llamaindex.ai/
+- LangChain: https://www.langchain.com/
+- FusqlFS: https://github.com/jking/fusqlfs
+- Plan 9 from Bell Labs: https://9p.io/plan9/
+- 9P Protocol: https://9p.io/sys/man/5/INDEX.html


### PR DESCRIPTION
## Summary

- **README.md**: Add `callees/`, `_project_files/`, friendly-name grouping to feature matrix and virtual files list. Add source code example with container dirs. Rename "Goto: Call-Chain Navigation" → "Cross-Reference Navigation" with bidirectional examples. Add "Landscape" section with condensed comparison table and link to Prior Art doc.
- **docs/ARCHITECTURE.md**: Add `callees/` virtual directory section with resolution pipeline. Add `_project_files/` routing to mermaid diagram and Core Abstractions. Add friendly-name grouping. Fix scan time (~4s → ~12s). Update Key File Reference with new functions/types.
- **docs/PRIOR_ART.md** (new): Full landscape analysis — 9-tool comparison table (6 dimensions), detailed per-project analysis (AgentFS, Dust, MCP, Plan 9, FUSE-DB tools, etc.), academic validation section (2 papers), sources.

## Test plan

- [x] `task check` passes (fmt + vet + lint + test + validate) — no code touched
- [x] Verify mermaid diagram renders on GitHub
- [x] Verify markdown table formatting renders correctly
- [x] Check all internal doc links resolve (`docs/PRIOR_ART.md`, `docs/ARCHITECTURE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)