### PR TITLE
feat(graph): Public ExportSQLite/ImportSQLite API

### DIFF
--- a/graph/sqlite.go
+++ b/graph/sqlite.go
@@ -1,0 +1,189 @@
+package graph
+
+import (
+	"database/sql"
+	"encoding/json"
+	"io/fs"
+	"path"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// ExportSQLite writes all nodes from a MemoryStore to a SQLite database.
+// Creates the nodes table if it doesn't exist. Existing entries are overwritten.
+// The resulting file uses the standard mache nodes table schema.
+func ExportSQLite(store *MemoryStore, dbPath string) error {
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS nodes (
+		id TEXT PRIMARY KEY,
+		parent_id TEXT,
+		name TEXT NOT NULL,
+		kind INTEGER NOT NULL,
+		size INTEGER DEFAULT 0,
+		mtime INTEGER NOT NULL,
+		record JSON
+	)`); err != nil {
+		return err
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	stmt, err := tx.Prepare(`INSERT OR REPLACE INTO nodes
+		(id, parent_id, name, kind, size, mtime, record)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return err
+	}
+	defer func() { _ = stmt.Close() }()
+
+	for _, rootID := range store.RootIDs() {
+		if err := exportNode(store, stmt, rootID, ""); err != nil {
+			_ = tx.Rollback()
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+// exportNode recursively writes a node and its children to the prepared statement.
+func exportNode(store *MemoryStore, stmt *sql.Stmt, nodeID, parentID string) error {
+	node, err := store.GetNode(nodeID)
+	if err != nil {
+		return err
+	}
+
+	kind := 0 // file
+	if node.Mode.IsDir() {
+		kind = 1
+	}
+
+	// Build record JSON: inline data + properties.
+	var record *string
+	if len(node.Data) > 0 || len(node.Properties) > 0 {
+		r := make(map[string]any)
+		if len(node.Data) > 0 {
+			r["data"] = string(node.Data)
+		}
+		if len(node.Properties) > 0 {
+			props := make(map[string]string, len(node.Properties))
+			for k, v := range node.Properties {
+				props[k] = string(v)
+			}
+			r["properties"] = props
+		}
+		b, _ := json.Marshal(r)
+		s := string(b)
+		record = &s
+	}
+
+	if _, err := stmt.Exec(
+		nodeID, parentID, path.Base(nodeID),
+		kind, node.ContentSize(), node.ModTime.UnixNano(), record,
+	); err != nil {
+		return err
+	}
+
+	for _, childID := range node.Children {
+		if err := exportNode(store, stmt, childID, nodeID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ImportSQLite reads nodes from a SQLite database into a new MemoryStore.
+// The database must have a nodes table in the standard mache format.
+func ImportSQLite(dbPath string) (*MemoryStore, error) {
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query(`SELECT id, parent_id, kind, mtime, record FROM nodes`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	type nodeRow struct {
+		id       string
+		parentID string
+		kind     int
+		mtime    int64
+		record   sql.NullString
+	}
+	var allRows []nodeRow
+
+	for rows.Next() {
+		var r nodeRow
+		if err := rows.Scan(&r.id, &r.parentID, &r.kind, &r.mtime, &r.record); err != nil {
+			return nil, err
+		}
+		allRows = append(allRows, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	store := NewMemoryStore()
+
+	// First pass: create all nodes.
+	for _, r := range allRows {
+		node := &Node{
+			ID:      r.id,
+			ModTime: time.Unix(0, r.mtime),
+		}
+		if r.kind == 1 {
+			node.Mode = fs.ModeDir
+			node.Children = []string{}
+		}
+
+		// Parse record JSON for inline data and properties.
+		if r.record.Valid && r.record.String != "" {
+			var rec map[string]any
+			if err := json.Unmarshal([]byte(r.record.String), &rec); err == nil {
+				if data, ok := rec["data"].(string); ok {
+					node.Data = []byte(data)
+				}
+				if props, ok := rec["properties"].(map[string]any); ok {
+					node.Properties = make(map[string][]byte, len(props))
+					for k, v := range props {
+						if vs, ok := v.(string); ok {
+							node.Properties[k] = []byte(vs)
+						}
+					}
+				}
+			}
+		}
+
+		if r.parentID == "" {
+			store.AddRoot(node)
+		} else {
+			store.AddNode(node)
+		}
+	}
+
+	// Second pass: wire parent-child relationships.
+	for _, r := range allRows {
+		if r.parentID != "" {
+			parent, err := store.GetNode(r.parentID)
+			if err == nil && parent.Mode.IsDir() {
+				parent.Children = append(parent.Children, r.id)
+			}
+		}
+	}
+
+	return store, nil
+}

--- a/graph/sqlite_test.go
+++ b/graph/sqlite_test.go
@@ -1,0 +1,115 @@
+package graph_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/graph"
+)
+
+func TestExportImportRoundTrip(t *testing.T) {
+	// Build a small in-memory graph simulating x-ray's mache engine.
+	store := graph.NewMemoryStore()
+
+	root := &graph.Node{
+		ID:       "main",
+		Mode:     fs.ModeDir,
+		Children: []string{"main/feed"},
+	}
+	store.AddRoot(root)
+
+	feed := &graph.Node{
+		ID:         "main/feed",
+		Mode:       fs.ModeDir,
+		Children:   []string{"main/feed/description", "main/feed/mache_id"},
+		Properties: map[string][]byte{"mache_id": []byte("mache-42")},
+	}
+	store.AddNode(feed)
+
+	store.AddNode(&graph.Node{
+		ID:   "main/feed/description",
+		Data: []byte("Main content feed with stories"),
+	})
+	store.AddNode(&graph.Node{
+		ID:   "main/feed/mache_id",
+		Data: []byte("mache-42"),
+	})
+
+	// Export to SQLite.
+	dbPath := filepath.Join(t.TempDir(), "test-graph.db")
+	if err := graph.ExportSQLite(store, dbPath); err != nil {
+		t.Fatalf("ExportSQLite: %v", err)
+	}
+
+	// Import from SQLite.
+	imported, err := graph.ImportSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("ImportSQLite: %v", err)
+	}
+
+	// Verify root.
+	roots := imported.RootIDs()
+	if len(roots) != 1 || roots[0] != "main" {
+		t.Fatalf("expected roots=[main], got %v", roots)
+	}
+
+	// Verify directory structure.
+	mainNode, err := imported.GetNode("main")
+	if err != nil {
+		t.Fatalf("GetNode(main): %v", err)
+	}
+	if !mainNode.Mode.IsDir() {
+		t.Error("main should be a directory")
+	}
+	if len(mainNode.Children) != 1 || mainNode.Children[0] != "main/feed" {
+		t.Errorf("main.Children = %v, want [main/feed]", mainNode.Children)
+	}
+
+	// Verify feed node with properties.
+	feedNode, err := imported.GetNode("main/feed")
+	if err != nil {
+		t.Fatalf("GetNode(main/feed): %v", err)
+	}
+	if string(feedNode.Properties["mache_id"]) != "mache-42" {
+		t.Errorf("feed.Properties[mache_id] = %q, want mache-42", feedNode.Properties["mache_id"])
+	}
+	if len(feedNode.Children) != 2 {
+		t.Errorf("feed.Children = %v, want 2 children", feedNode.Children)
+	}
+
+	// Verify file nodes.
+	desc, err := imported.GetNode("main/feed/description")
+	if err != nil {
+		t.Fatalf("GetNode(main/feed/description): %v", err)
+	}
+	if string(desc.Data) != "Main content feed with stories" {
+		t.Errorf("description data = %q", desc.Data)
+	}
+
+	mid, err := imported.GetNode("main/feed/mache_id")
+	if err != nil {
+		t.Fatalf("GetNode(main/feed/mache_id): %v", err)
+	}
+	if string(mid.Data) != "mache-42" {
+		t.Errorf("mache_id data = %q", mid.Data)
+	}
+}
+
+func TestExportImportEmptyStore(t *testing.T) {
+	store := graph.NewMemoryStore()
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+
+	if err := graph.ExportSQLite(store, dbPath); err != nil {
+		t.Fatalf("ExportSQLite: %v", err)
+	}
+
+	imported, err := graph.ImportSQLite(dbPath)
+	if err != nil {
+		t.Fatalf("ImportSQLite: %v", err)
+	}
+
+	if len(imported.RootIDs()) != 0 {
+		t.Errorf("expected 0 roots, got %d", len(imported.RootIDs()))
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -161,6 +161,15 @@ func (s *MemoryStore) SetResolver(fn ContentResolverFunc) {
 	s.cache = newContentCache(1024)
 }
 
+// RootIDs returns a copy of the top-level root node IDs.
+func (s *MemoryStore) RootIDs() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids := make([]string, len(s.roots))
+	copy(ids, s.roots)
+	return ids
+}
+
 // AddRoot registers a node as a top-level root and adds it to the store.
 // Callers must explicitly declare roots — there is no heuristic.
 func (s *MemoryStore) AddRoot(n *Node) {


### PR DESCRIPTION
## Summary
- Add `ExportSQLite(store, dbPath)` and `ImportSQLite(dbPath)` to public `graph/` package
- Add `RootIDs()` method to MemoryStore for root enumeration
- Round-trip tests verify graph serialization integrity

Enables x-ray to persist its schema cache as a real mache graph (not raw JSON), proving the semantic state is transferrable between agentic tools.

## Test plan
- [x] `go test ./graph/...` — round-trip and empty-store tests pass
- [x] `go build ./graph/...` — compiles cleanly
- [ ] x-ray integration: schema cache uses ExportSQLite, cache hit verified on restart