### PR TITLE
fix(release): provide Linux FUSE headers for cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           version: 0.13.0
 
+      - name: Fetch Linux FUSE headers (for cross-compilation)
+        run: |
+          mkdir -p /tmp/linux-fuse-headers
+          cd /tmp/linux-fuse-headers
+          curl -sL -o libfuse-dev.deb "http://archive.ubuntu.com/ubuntu/pool/main/f/fuse/libfuse-dev_2.9.9-5ubuntu3_amd64.deb"
+          ar x libfuse-dev.deb
+          tar xf data.tar.*
+
       - name: Import Signing Certificate
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
       - CGO_ENABLED=1
       - CC=zig cc -target x86_64-linux-gnu
       - CXX=zig c++ -target x86_64-linux-gnu
+      - CGO_CFLAGS=-I/tmp/linux-fuse-headers/usr/include
     flags:
       - -trimpath
     ldflags:


### PR DESCRIPTION
## Summary
- The v0.4.0 release failed because the Linux cross-build (Zig on macOS runner) couldn't find `fuse.h`
- Downloads `libfuse-dev` headers from Ubuntu repos into `/tmp/linux-fuse-headers/` during the release workflow
- Points the Linux goreleaser build at those headers via `CGO_CFLAGS`
- Only headers are needed — cgofuse uses `dlopen` for libfuse at runtime on Linux

## Test plan
- [ ] Merge PR, then delete + re-push `v0.4.0` tag to re-trigger the release workflow
- [ ] Verify both macOS and Linux builds succeed in goreleaser

🤖 Generated with [Claude Code](https://claude.com/claude-code)