### PR TITLE
fix(release): skip homebrew tap upload until configured

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -57,7 +57,8 @@ archives:
       - LICENSE
 
 brews:
-  - repository:
+  - skip_upload: true
+    repository:
       owner: agentic-research
       name: homebrew-tap
       token: "{{ .Env.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- Adds `skip_upload: true` to the brews section in `.goreleaser.yaml`
- The `agentic-research/homebrew-tap` repo is private and not yet ready
- GoReleaser will still generate the formula locally but won't try to push it
- Remove `skip_upload` when the tap repo is public and configured

## Context
Follow-up to #47 — the FUSE headers fix worked but the release then failed on the Homebrew upload step (404 on private repo).

## Test plan
- [ ] Merge, re-tag `v0.4.0`, verify release completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)