### PR TITLE
chore: clean up stale deliberation comments

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -23,31 +23,19 @@ var buildCmd = &cobra.Command{
 		source := args[0]
 		output := args[1]
 
-		// 1. Load/Infer Schema
-		// For simplicity in this new command, we'll try to infer or use default.
-		// Ideally we should respect --schema flag if set (it's global in root).
+		// Load or infer schema. Falls back to FCA inference when no schema file is provided.
 		var schema *api.Topology
 		if schemaPath != "" {
 			var err error
-			// Just verify it exists for now
 			if _, err = os.Stat(schemaPath); err != nil {
 				return fmt.Errorf("stat schema: %w", err)
 			}
 
-			// But for now let's just use inference if it's a Go project, similar to mount.
-			// Or just use empty schema if not provided.
-			// Actually, let's just infer from source if it's a directory.
 			inf := &lattice.Inferrer{Config: lattice.DefaultInferConfig()}
 			fmt.Println("Inferring schema...")
-			// Simple inference for Go
-			// In a real tool this would be more robust
-			// Let's assume user wants to just dump the file tree if no schema?
-			// But Engine REQUIRES a schema to generate nodes.
+			schema, _ = inf.InferFromRecords(nil)
 
-			// Let's replicate the mount.go inference logic simplified
-			schema, _ = inf.InferFromRecords(nil) // Start empty?
-
-			// Actually, let's just look at the first .go file
+			// Walk source to find the first .go file for bootstrap inference
 			if walkErr := filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 				if err != nil {
 					return err

--- a/internal/graph/arena_writer.go
+++ b/internal/graph/arena_writer.go
@@ -26,7 +26,7 @@ import (
 //	  1 MB  → ~5ms
 //	 10 MB  → ~10-25ms
 //
-// Future: page-level diff or CDC to avoid full-DB copy.
+// TODO: page-level diff or CDC to avoid full-DB copy.
 type ArenaFlusher struct {
 	arenaPath    string
 	masterDBPath string

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -398,10 +398,7 @@ func (g *SQLiteGraph) ListChildren(id string) ([]string, error) {
 
 	// Fast Path: Nodes Table
 	if g.useNodesTable {
-		// Root handling: if id is empty, parent_id should be NULL or empty depending on writer.
-		// My SQLiteWriter uses "" for root parent.
-		// Actually, top level nodes have parent_id = "".
-		// Let's assume parent_id is stored as is.
+		// Top-level nodes have parent_id = empty string.
 		var rows *sql.Rows
 		var err error
 		if id == "" {
@@ -505,9 +502,8 @@ func (g *SQLiteGraph) AddRef(token, nodeID string) error {
 }
 
 // FlushRefs writes all accumulated refs to the sidecar database in a single
-// transaction. Call once after ingestion is complete. This replaces the old
-// per-call AddRef write path, reducing N*M SQL round-trips to exactly
-// len(fileIDMap) + len(pendingRefs) inserts in one transaction.
+// transaction. Call once after ingestion is complete. Batches all inserts
+// (len(fileIDMap) + len(pendingRefs)) into one transaction.
 //
 // Guarded by sync.Once — safe to call multiple times; only the first call
 // performs the flush. This prevents the double-call bug where a second flush

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -336,9 +336,7 @@ func (e *Engine) ingestTreeSitter(path string, lang *sitter.Language, langName s
 		return err
 	}
 
-	// Use buffering target for atomic swap
-	// Note: We do NOT call DeleteFileNodes here anymore.
-	// ReplaceFileNodes will handle deletion + addition atomically.
+	// ReplaceFileNodes handles deletion + addition atomically.
 	bt := &bufferingTarget{IngestionTarget: e.Store}
 
 	parser := sitter.NewParser()

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -1,8 +1,7 @@
 package ingest
 
 func init() {
-	// Register Go context query.
-	// Note: context extraction is Go-only for now; other languages return nil.
+	// Context extraction is Go-only; other languages return nil.
 	RegisterContextQuery("go", `
 		(import_declaration) @ctx
 		(const_declaration) @ctx

--- a/internal/ingest/git.go
+++ b/internal/ingest/git.go
@@ -70,7 +70,6 @@ func LoadGitCommits(repoPath string) ([]any, error) {
 
 		lines := strings.SplitN(text, "\n", 6)
 		if len(lines) < 6 {
-			// Maybe empty body?
 			if len(lines) >= 5 {
 				// Pad with empty body
 				lines = append(lines, "")

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -153,11 +153,7 @@ func (w *SQLiteWriter) AddNode(n *graph.Node) {
 		}
 	}
 
-	// 2. Kind (0=File, 1=Dir for simple boolean, or use os.FileMode bits)
-	// We'll use 1 for Dir, 0 for File to match simple boolean logic,
-	// or we can store the full Mode. Let's store full Mode for fidelity?
-	// The requirement said "kind (file vs directory type)".
-	// Storing Mode is safer.
+	// Store full os.FileMode for fidelity (kind column: 1=dir, 0=file).
 	kind := 0
 	if n.Mode.IsDir() {
 		kind = 1

--- a/internal/lattice/project_ast.go
+++ b/internal/lattice/project_ast.go
@@ -76,11 +76,6 @@ var containmentRules = map[string]map[string][]string{
 func ProjectAST(concepts []Concept, ctx *FormalContext, config ProjectConfig) *api.Topology {
 	containerTypes := make(map[string]string) // type -> name_type (e.g. identifier, property_identifier)
 
-	// Scan attributes to find types that have "has_name" and "has_body"
-	// We look for concepts that have these attributes.
-	// Actually, easier: scan the attributes themselves to find the types.
-	// The context attributes look like: "type=function_definition", "has_name", "has_body"
-
 	// Find all unique types present in the data
 	types := make(map[string]bool)
 	for _, attr := range ctx.Attributes {
@@ -91,16 +86,7 @@ func ProjectAST(concepts []Concept, ctx *FormalContext, config ProjectConfig) *a
 		}
 	}
 
-	// For each type, check if the data supports "has_name" and "has_body"
-	// We check the ctx.Stats to see if "has_name" co-occurs with "type=X".
-	// But `ctx.Stats` is keyed by field path, e.g. "has_name".
-	// Wait, FlattenAST produces flat records.
-	// records = [{"type": "func", "has_name": true}, ...]
-	//
-	// We need to know: Does "type=func" implies "has_name"?
-	// We can use the lattice for this!
-	// Find the concept for "type=func". Check if its Intent contains "has_name".
-
+	// Use lattice closure to check if type=X implies has_name+has_body.
 	for t := range types {
 		// Find the attribute index for "type=t"
 		typeAttrIdx := -1
@@ -187,30 +173,8 @@ func ProjectAST(concepts []Concept, ctx *FormalContext, config ProjectConfig) *a
 		children = append(children, node)
 	}
 
-	// Assign the full list as children to each node (Recursive Structure)
-	// We need to copy the slice to avoid circular reference issues if we modify it later,
-	// but here we can just share the reference or copy.
-	// API Node is a struct, so assignment copies the struct but slices share backing array.
-	// We want the *structure* to be recursive.
-	//
-	// Node A -> Children [Node A, Node B]
-	// Node B -> Children [Node A, Node B]
-
-	// Since api.Node is a value type, we need to be careful.
-	// We can't make an infinite struct.
-	// But `children` is a slice of Nodes.
-	//
-	// Strategy: Create 1 level of recursion.
-	// Root -> [Func, Class]
-	// Func -> [Func, Class]
-	// Class -> [Func, Class]
-	// (Stop there to avoid infinite depth in schema JSON, although Mache engine handles it fine?
-	//  Actually Mache engine handles recursion if the schema graph has cycles.
-	//  But JSON marshalling of a cyclic Go struct will crash!)
-
-	// The Mache `ingest` engine walks the schema. If the schema is a tree, it terminates.
-	// If we want "Infinite recursion" (arbitrary depth), we need the schema to be a DAG or contain a self-reference.
-	// JSON doesn't support references.
+	// 1 level of nesting via containmentRules. Go structs can't be cyclic and
+	// JSON can't encode references, so we stop at depth 1.
 
 	// Language-aware containment: only assign children that the language permits.
 	// Unknown languages default to flat (safe — misses nesting but never generates garbage).

--- a/internal/nfsmount/file.go
+++ b/internal/nfsmount/file.go
@@ -213,9 +213,7 @@ func (f *writeFile) Truncate(size int64) error {
 		copy(grown, f.buf)
 		f.buf = grown
 	}
-	// Note: Truncate alone does NOT mark written. NFS SETATTR(size=0) causes
-	// a Truncate+Close cycle before WRITE — splicing on truncate-only would
-	// delete source content. Only Write() sets written=true.
+	// Truncate alone does NOT set written — see Close() comment.
 	return nil
 }
 

--- a/internal/refsvtab/refs_module.go
+++ b/internal/refsvtab/refs_module.go
@@ -67,17 +67,8 @@ func (m *RefsModule) Create(ctx vtab.Context, args []string) (vtab.Table, error)
 	if len(args) == 0 {
 		return nil, fmt.Errorf("mache_refs: missing DB ID argument")
 	}
-	// args[0] is module name, args[1] is table name, args[2]... are arguments.
-	// But modernc.org/sqlite passes arguments differently?
-	// According to docs/source, args includes module name etc?
-	// Actually, standard SQLite xCreate(db, pAux, argc, argv).
-	// modernc adapter passes args as []string.
-	// argv[0] = module name
-	// argv[1] = database name
-	// argv[2] = table name
-	// argv[3]... = arguments inside ()
-	//
-	// So if we do USING mache_refs(my_id), args[3] should be "my_id".
+	// argv: [0]=module, [1]=database, [2]=table, [3+]=CREATE VIRTUAL TABLE args.
+	// USING mache_refs(my_id) → args[3] = "my_id".
 	if len(args) < 4 {
 		return nil, fmt.Errorf("mache_refs: missing DB ID argument (expected USING mache_refs(id))")
 	}


### PR DESCRIPTION
## Summary
- Replaced ~12 instances of stream-of-consciousness comments with concise equivalents preserving design decisions
- Net removal of 71 lines of deliberation prose across 10 files
- No logic changes — comment-only cleanup

## Files touched
| File | Change |
|------|--------|
| `cmd/build.go` | Removed "Just verify", "But for now", "Actually" deliberation |
| `internal/lattice/project_ast.go` | Condensed 24-line recursion discussion → 2 lines |
| `internal/ingest/sqlite_writer.go` | "We'll use 1... or store full Mode... Let's store..." → one-liner |
| `internal/refsvtab/refs_module.go` | 11-line argv speculation → 2-line factual mapping |
| `internal/graph/sqlite_graph.go` | "My SQLiteWriter", "Actually", "Let's assume" → factual comment |
| `internal/graph/sqlite_graph.go` | Removed historical "replaces the old per-call..." from FlushRefs |
| `internal/ingest/engine.go` | "We do NOT call X anymore" → "Y handles it atomically" |
| `internal/ingest/engine_languages.go` | Tightened Go-only context note |
| `internal/nfsmount/file.go` | Deduped Truncate note (already in Close docstring) |
| `internal/ingest/git.go` | Removed "Maybe empty body?" (code already handles it) |
| `internal/graph/arena_writer.go` | "Future:" → `// TODO:` |

## Test plan
- [x] `task fmt && task vet && task lint` — clean
- [x] `task test` — all passing