### PR TITLE
refactor: extract shared vdir constants and diagnostics helpers

### DIFF
--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -132,31 +132,10 @@ func (fs *MacheFS) isQueryPath(path string) bool {
 	return fs.queryFn != nil && (path == "/.query" || strings.HasPrefix(path, "/.query/"))
 }
 
-// isDiagPath returns true if the path contains a _diagnostics/ segment.
+// isDiagPath returns true if writable and path contains /_diagnostics.
 func (fs *MacheFS) isDiagPath(path string) bool {
-	return fs.Writable && strings.Contains(path, "/_diagnostics")
+	return fs.Writable && graph.IsDiagPath(path)
 }
-
-// parseDiagPath splits a diagnostics path into (parentDir, fileName).
-func parseDiagPath(path string) (parentDir, fileName string) {
-	idx := strings.Index(path, "/_diagnostics")
-	if idx < 0 {
-		return "", ""
-	}
-	parentDir = path[:idx]
-	if parentDir == "" {
-		parentDir = "/"
-	}
-	rest := path[idx+len("/_diagnostics"):]
-	if rest == "" || rest == "/" {
-		return parentDir, ""
-	}
-	fileName = strings.TrimPrefix(rest, "/")
-	return parentDir, fileName
-}
-
-// callers/ and callees/ virtual directory path parsing uses shared helpers
-// from graph.IsCallersPath, graph.ParseCallersPath, graph.VDirSymlinkTarget, etc.
 
 // diagContent returns the content of a diagnostics virtual file.
 func (fs *MacheFS) diagContent(parentDir, fileName string) ([]byte, bool) {
@@ -165,13 +144,13 @@ func (fs *MacheFS) diagContent(parentDir, fileName string) ([]byte, bool) {
 		return nil, false
 	}
 	switch fileName {
-	case "last-write-status":
+	case graph.DiagLastWrite:
 		val, found := store.WriteStatus.Load(parentDir)
 		if !found {
 			return []byte("no writes yet\n"), true
 		}
 		return []byte(val.(string) + "\n"), true
-	case "ast-errors":
+	case graph.DiagASTErrors:
 		val, found := store.WriteStatus.Load(parentDir)
 		if !found {
 			return []byte("no errors\n"), true
@@ -347,7 +326,7 @@ func (fs *MacheFS) Getattr(path string, stat *fuse.Stat_t, fh uint64) int {
 	}
 
 	if fs.isDiagPath(path) {
-		parentDir, fileName := parseDiagPath(path)
+		parentDir, fileName := graph.ParseDiagPath(path)
 		if fileName == "" {
 			stat.Mode = fuse.S_IFDIR | 0o555
 			stat.Nlink = 2
@@ -482,11 +461,11 @@ func (fs *MacheFS) Opendir(path string) (int, uint64) {
 
 	// _diagnostics/ virtual directory
 	if fs.isDiagPath(path) {
-		_, fileName := parseDiagPath(path)
+		_, fileName := graph.ParseDiagPath(path)
 		if fileName != "" {
 			return -fuse.ENOTDIR, 0
 		}
-		entries := []string{".", "..", "last-write-status", "ast-errors"}
+		entries := []string{".", "..", graph.DiagLastWrite, graph.DiagASTErrors}
 		fs.handleMu.Lock()
 		fh := fs.nextHandle
 		fs.nextHandle++
@@ -575,9 +554,9 @@ func (fs *MacheFS) Opendir(path string) (int, uint64) {
 	entries := make([]string, 0, len(children)+6)
 	entries = append(entries, ".", "..")
 	if path == "/" {
-		entries = append(entries, "_schema.json")
+		entries = append(entries, graph.SchemaDotJSON)
 		if len(fs.promptContent) > 0 {
-			entries = append(entries, "PROMPT.txt")
+			entries = append(entries, graph.PromptFile)
 		}
 		if fs.queryFn != nil {
 			entries = append(entries, ".query")
@@ -585,23 +564,23 @@ func (fs *MacheFS) Opendir(path string) (int, uint64) {
 	}
 	// Add _diagnostics/ to writable non-root dirs
 	if fs.Writable && path != "/" {
-		entries = append(entries, "_diagnostics")
+		entries = append(entries, graph.DiagnosticsDir)
 	}
 	// Add context if available
 	if node != nil && len(node.Context) > 0 {
-		entries = append(entries, "context")
+		entries = append(entries, graph.ContextFile)
 	}
 	// Add callers/ if token has callers (non-root dirs only)
 	if path != "/" {
 		token := filepath.Base(path)
 		if callers, err := fs.Graph.GetCallers(token); err == nil && len(callers) > 0 {
-			entries = append(entries, "callers")
+			entries = append(entries, graph.CallersDir)
 		}
 	}
 	// Add callees/ if construct has outgoing calls (self-gating)
 	if path != "/" {
 		if callees, err := fs.Graph.GetCallees(path); err == nil && len(callees) > 0 {
-			entries = append(entries, "callees")
+			entries = append(entries, graph.CalleesDir)
 		}
 	}
 	for _, c := range children {
@@ -649,9 +628,9 @@ func (fs *MacheFS) Readdir(path string, fill func(name string, stat *fuse.Stat_t
 		entries := make([]string, 0, len(children)+4)
 		entries = append(entries, ".", "..")
 		if path == "/" {
-			entries = append(entries, "_schema.json")
+			entries = append(entries, graph.SchemaDotJSON)
 			if len(fs.promptContent) > 0 {
-				entries = append(entries, "PROMPT.txt")
+				entries = append(entries, graph.PromptFile)
 			}
 			if fs.queryFn != nil {
 				entries = append(entries, ".query")
@@ -711,7 +690,7 @@ func (fs *MacheFS) readdirStat(dirPath, name string) *fuse.Stat_t {
 		fullPath = dirPath + "/" + name
 	}
 
-	if name == "_schema.json" {
+	if name == graph.SchemaDotJSON {
 		stat.Ino = pathIno(fullPath)
 		stat.Mode = fuse.S_IFREG | 0o444
 		stat.Nlink = 1
@@ -719,7 +698,7 @@ func (fs *MacheFS) readdirStat(dirPath, name string) *fuse.Stat_t {
 		return stat
 	}
 
-	if name == "PROMPT.txt" && len(fs.promptContent) > 0 {
+	if name == graph.PromptFile && len(fs.promptContent) > 0 {
 		stat.Ino = pathIno(fullPath)
 		stat.Mode = fuse.S_IFREG | 0o444
 		stat.Nlink = 1
@@ -734,7 +713,7 @@ func (fs *MacheFS) readdirStat(dirPath, name string) *fuse.Stat_t {
 		return stat
 	}
 
-	if name == "context" {
+	if name == graph.ContextFile {
 		// Parent path is dirPath
 		node, err := fs.Graph.GetNode(dirPath)
 		if err == nil && len(node.Context) > 0 {
@@ -746,14 +725,14 @@ func (fs *MacheFS) readdirStat(dirPath, name string) *fuse.Stat_t {
 		}
 	}
 
-	if name == "callers" && !graph.IsCallersPath(dirPath) {
+	if name == graph.CallersDir && !graph.IsCallersPath(dirPath) {
 		stat.Ino = pathIno(fullPath)
 		stat.Mode = fuse.S_IFDIR | 0o555
 		stat.Nlink = 2
 		return stat
 	}
 
-	if name == "callees" && !graph.IsCalleesPath(dirPath) {
+	if name == graph.CalleesDir && !graph.IsCalleesPath(dirPath) {
 		stat.Ino = pathIno(fullPath)
 		stat.Mode = fuse.S_IFDIR | 0o555
 		stat.Nlink = 2
@@ -815,7 +794,7 @@ func (fs *MacheFS) Read(path string, buff []byte, ofst int64, fh uint64) int {
 
 	// _diagnostics/ virtual files
 	if fs.isDiagPath(path) {
-		parentDir, fileName := parseDiagPath(path)
+		parentDir, fileName := graph.ParseDiagPath(path)
 		content, ok := fs.diagContent(parentDir, fileName)
 		if !ok {
 			return -fuse.ENOENT

--- a/internal/graph/vdirpath.go
+++ b/internal/graph/vdirpath.go
@@ -6,7 +6,21 @@ import (
 )
 
 // Virtual directory path helpers shared by FUSE (internal/fs) and NFS (internal/nfsmount).
-// These parse callers/ and callees/ virtual directory paths without any Graph dependency.
+// These parse callers/, callees/, and _diagnostics/ virtual directory paths
+// without any Graph dependency.
+
+// Well-known virtual directory and file names.
+const (
+	SchemaDotJSON  = "_schema.json"
+	DiagnosticsDir = "_diagnostics"
+	ContextFile    = "context"
+	PromptFile     = "PROMPT.txt"
+	CallersDir     = "callers"
+	CalleesDir     = "callees"
+	DiagLastWrite  = "last-write-status"
+	DiagASTErrors  = "ast-errors"
+	DiagLint       = "lint"
+)
 
 // IsCallersPath returns true if the path contains a /callers segment boundary.
 func IsCallersPath(path string) bool {
@@ -55,6 +69,18 @@ func FindSourceChild(g Graph, dirID string) string {
 		}
 	}
 	return ""
+}
+
+// IsDiagPath returns true if the path contains a /_diagnostics segment.
+func IsDiagPath(path string) bool {
+	return strings.Contains(path, "/"+DiagnosticsDir)
+}
+
+// ParseDiagPath splits a diagnostics path into (parentDir, fileName).
+// E.g. "/vulns/func_a/_diagnostics/last-write-status" → ("/vulns/func_a", "last-write-status")
+// Returns ("", "") if not a valid diagnostics path.
+func ParseDiagPath(path string) (parentDir, fileName string) {
+	return parseVDirPath(path, "/"+DiagnosticsDir)
 }
 
 // parseVDirPath is the generic implementation for parsing virtual directory paths.

--- a/internal/nfsmount/graphfs.go
+++ b/internal/nfsmount/graphfs.go
@@ -121,18 +121,18 @@ func (fs *GraphFS) OpenFile(filename string, flag int, perm os.FileMode) (billy.
 	}
 
 	// Virtual: _schema.json
-	if filename == "/_schema.json" {
-		return &bytesFile{name: "_schema.json", data: fs.schemaJSON}, nil
+	if filename == "/"+graph.SchemaDotJSON {
+		return &bytesFile{name: graph.SchemaDotJSON, data: fs.schemaJSON}, nil
 	}
 
 	// Virtual: PROMPT.txt (agent mode)
-	if filename == "/PROMPT.txt" && len(fs.promptContent) > 0 {
-		return &bytesFile{name: "PROMPT.txt", data: fs.promptContent}, nil
+	if filename == "/"+graph.PromptFile && len(fs.promptContent) > 0 {
+		return &bytesFile{name: graph.PromptFile, data: fs.promptContent}, nil
 	}
 
 	// Virtual: _diagnostics/ files
-	if fs.writable && isDiagPath(filename) {
-		parentDir, diagFile := parseDiagPath(filename)
+	if fs.writable && graph.IsDiagPath(filename) {
+		parentDir, diagFile := graph.ParseDiagPath(filename)
 		if diagFile == "" {
 			return nil, &os.PathError{Op: "open", Path: filename, Err: fmt.Errorf("is a directory")}
 		}
@@ -144,11 +144,11 @@ func (fs *GraphFS) OpenFile(filename string, flag int, perm os.FileMode) (billy.
 	}
 
 	// Virtual: context file
-	if strings.HasSuffix(filename, "/context") {
+	if strings.HasSuffix(filename, "/"+graph.ContextFile) {
 		parentDir := filepath.Dir(filename)
 		node, err := fs.graph.GetNode(parentDir)
 		if err == nil && len(node.Context) > 0 {
-			return &bytesFile{name: "context", data: node.Context}, nil
+			return &bytesFile{name: graph.ContextFile, data: node.Context}, nil
 		}
 	}
 
@@ -236,7 +236,7 @@ func (fs *GraphFS) OpenFile(filename string, flag int, perm os.FileMode) (billy.
 
 // openWritable returns a writeFile for nodes that have a SourceOrigin.
 func (fs *GraphFS) openWritable(filename string, flag int) (billy.File, error) {
-	if filename == "/_schema.json" {
+	if filename == "/"+graph.SchemaDotJSON {
 		return nil, &os.PathError{Op: "open", Path: filename, Err: fmt.Errorf("read-only virtual file")}
 	}
 
@@ -325,14 +325,14 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 	path = cleanPath(path)
 
 	// Virtual: _diagnostics/ directory listing
-	if fs.writable && isDiagPath(path) {
-		_, fileName := parseDiagPath(path)
+	if fs.writable && graph.IsDiagPath(path) {
+		_, fileName := graph.ParseDiagPath(path)
 		if fileName == "" {
 			// List diagnostics dir contents
 			return []os.FileInfo{
-				&staticFileInfo{name: "last-write-status", mode: 0o444, modTime: fs.mountTime},
-				&staticFileInfo{name: "ast-errors", mode: 0o444, modTime: fs.mountTime},
-				&staticFileInfo{name: "lint", mode: 0o444, modTime: fs.mountTime},
+				&staticFileInfo{name: graph.DiagLastWrite, mode: 0o444, modTime: fs.mountTime},
+				&staticFileInfo{name: graph.DiagASTErrors, mode: 0o444, modTime: fs.mountTime},
+				&staticFileInfo{name: graph.DiagLint, mode: 0o444, modTime: fs.mountTime},
 			}, nil
 		}
 		return nil, &os.PathError{Op: "readdir", Path: path, Err: fmt.Errorf("not a directory")}
@@ -430,14 +430,14 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 	// Virtual files at root
 	if path == "/" {
 		infos = append(infos, &staticFileInfo{
-			name:    "_schema.json",
+			name:    graph.SchemaDotJSON,
 			size:    int64(len(fs.schemaJSON)),
 			mode:    0o444,
 			modTime: fs.mountTime,
 		})
 		if len(fs.promptContent) > 0 {
 			infos = append(infos, &staticFileInfo{
-				name:    "PROMPT.txt",
+				name:    graph.PromptFile,
 				size:    int64(len(fs.promptContent)),
 				mode:    0o444,
 				modTime: fs.mountTime,
@@ -448,7 +448,7 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 	// Add _diagnostics/ virtual dir to writable node directories
 	if fs.writable && path != "/" {
 		infos = append(infos, &staticFileInfo{
-			name:    "_diagnostics",
+			name:    graph.DiagnosticsDir,
 			mode:    os.ModeDir | 0o555,
 			modTime: fs.mountTime,
 		})
@@ -457,7 +457,7 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 	// Add context virtual file if available
 	if node != nil && len(node.Context) > 0 {
 		infos = append(infos, &staticFileInfo{
-			name:    "context",
+			name:    graph.ContextFile,
 			size:    int64(len(node.Context)),
 			mode:    0o444,
 			modTime: fs.mountTime,
@@ -469,7 +469,7 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 		token := filepath.Base(path)
 		if callers, err := fs.graph.GetCallers(token); err == nil && len(callers) > 0 {
 			infos = append(infos, &staticFileInfo{
-				name:    "callers",
+				name:    graph.CallersDir,
 				mode:    os.ModeDir | 0o555,
 				modTime: fs.mountTime,
 			})
@@ -480,7 +480,7 @@ func (fs *GraphFS) ReadDir(path string) ([]os.FileInfo, error) {
 	if path != "/" {
 		if callees, err := fs.graph.GetCallees(path); err == nil && len(callees) > 0 {
 			infos = append(infos, &staticFileInfo{
-				name:    "callees",
+				name:    graph.CalleesDir,
 				mode:    os.ModeDir | 0o555,
 				modTime: fs.mountTime,
 			})
@@ -517,9 +517,9 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 	}
 
 	// Virtual: _schema.json
-	if filename == "/_schema.json" {
+	if filename == "/"+graph.SchemaDotJSON {
 		return &staticFileInfo{
-			name:    "_schema.json",
+			name:    graph.SchemaDotJSON,
 			size:    int64(len(fs.schemaJSON)),
 			mode:    0o444,
 			modTime: fs.mountTime,
@@ -527,9 +527,9 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 	}
 
 	// Virtual: PROMPT.txt (agent mode)
-	if filename == "/PROMPT.txt" && len(fs.promptContent) > 0 {
+	if filename == "/"+graph.PromptFile && len(fs.promptContent) > 0 {
 		return &staticFileInfo{
-			name:    "PROMPT.txt",
+			name:    graph.PromptFile,
 			size:    int64(len(fs.promptContent)),
 			mode:    0o444,
 			modTime: fs.mountTime,
@@ -537,12 +537,12 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 	}
 
 	// Virtual: _diagnostics/
-	if fs.writable && isDiagPath(filename) {
-		parentDir, fileName := parseDiagPath(filename)
+	if fs.writable && graph.IsDiagPath(filename) {
+		parentDir, fileName := graph.ParseDiagPath(filename)
 		if fileName == "" {
 			// The _diagnostics directory itself
 			return &staticFileInfo{
-				name:    "_diagnostics",
+				name:    graph.DiagnosticsDir,
 				mode:    os.ModeDir | 0o555,
 				modTime: time.Now(), // Force refresh
 			}, nil
@@ -560,12 +560,12 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 	}
 
 	// Virtual: context
-	if strings.HasSuffix(filename, "/context") {
+	if strings.HasSuffix(filename, "/"+graph.ContextFile) {
 		parentDir := filepath.Dir(filename)
 		node, err := fs.graph.GetNode(parentDir)
 		if err == nil && len(node.Context) > 0 {
 			return &staticFileInfo{
-				name:    "context",
+				name:    graph.ContextFile,
 				size:    int64(len(node.Context)),
 				mode:    0o444,
 				modTime: fs.mountTime,
@@ -589,7 +589,7 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 		}
 		if entryName == "" {
 			return &staticFileInfo{
-				name:    "callers",
+				name:    graph.CallersDir,
 				mode:    os.ModeDir | 0o555,
 				modTime: fs.mountTime,
 			}, nil
@@ -627,7 +627,7 @@ func (fs *GraphFS) Lstat(filename string) (os.FileInfo, error) {
 		}
 		if entryName == "" {
 			return &staticFileInfo{
-				name:    "callees",
+				name:    graph.CalleesDir,
 				mode:    os.ModeDir | 0o555,
 				modTime: fs.mountTime,
 			}, nil
@@ -688,42 +688,17 @@ func (fs *GraphFS) Capabilities() billy.Capability {
 
 // --- _diagnostics/ virtual directory ---
 
-// isDiagPath returns true if the path contains a _diagnostics/ segment.
-func isDiagPath(path string) bool {
-	return strings.Contains(path, "/_diagnostics")
-}
-
-// parseDiagPath splits a diagnostics path into (parentDir, fileName).
-// E.g. "/vulns/func_a/_diagnostics/last-write-status" → ("/vulns/func_a", "last-write-status")
-// Returns ("", "") if not a valid diagnostics path.
-func parseDiagPath(path string) (parentDir, fileName string) {
-	idx := strings.Index(path, "/_diagnostics")
-	if idx < 0 {
-		return "", ""
-	}
-	parentDir = path[:idx]
-	if parentDir == "" {
-		parentDir = "/"
-	}
-	rest := path[idx+len("/_diagnostics"):]
-	if rest == "" || rest == "/" {
-		return parentDir, "" // the _diagnostics dir itself
-	}
-	fileName = strings.TrimPrefix(rest, "/")
-	return parentDir, fileName
-}
-
 // diagContent returns the content of a diagnostics virtual file.
 func (fs *GraphFS) diagContent(parentDir, fileName string) ([]byte, bool) {
 	switch fileName {
-	case "last-write-status":
+	case graph.DiagLastWrite:
 		// Look up status for any child node of parentDir
 		val, ok := fs.diagStatus.Load(parentDir)
 		if !ok {
 			return []byte("no writes yet\n"), true
 		}
 		return []byte(val.(string) + "\n"), true
-	case "ast-errors":
+	case graph.DiagASTErrors:
 		val, ok := fs.diagStatus.Load(parentDir)
 		if !ok {
 			return []byte("no errors\n"), true
@@ -733,8 +708,8 @@ func (fs *GraphFS) diagContent(parentDir, fileName string) ([]byte, bool) {
 			return []byte("no errors\n"), true
 		}
 		return []byte(msg + "\n"), true
-	case "lint":
-		val, ok := fs.diagStatus.Load(parentDir + "/lint")
+	case graph.DiagLint:
+		val, ok := fs.diagStatus.Load(parentDir + "/" + graph.DiagLint)
 		if !ok {
 			return []byte("clean\n"), true
 		}


### PR DESCRIPTION
## Summary
- Extract `IsDiagPath()` and `ParseDiagPath()` into `internal/graph/vdirpath.go` alongside existing callers/callees helpers
- Add 9 named constants for virtual directory/file names used across FUSE and NFS backends
- Delete duplicated `isDiagPath()` and `parseDiagPath()` from both `internal/fs/root.go` and `internal/nfsmount/graphfs.go`
- Replace 40+ scattered string literals with shared constants

## Details

`vdirpath.go` already shared callers/callees parsing between backends. This extends it with:
- `IsDiagPath(path)` / `ParseDiagPath(path)` — reuses the existing `parseVDirPath()` generic implementation
- Constants: `SchemaDotJSON`, `DiagnosticsDir`, `ContextFile`, `PromptFile`, `CallersDir`, `CalleesDir`, `DiagLastWrite`, `DiagASTErrors`, `DiagLint`

FUSE's `isDiagPath()` retains its `Writable &&` guard by wrapping the shared helper.

**Not touched** (intentionally): `diagContent()` stays per-backend (different backing stores), `.query/` stays FUSE-only, leyline pre-materializes into SQLite so has no path parsing.

Net: 3 files changed, 83 insertions, 103 deletions (-20 lines).

## Test plan
- [x] `task fmt && task vet && task lint` — clean
- [x] `task test` — all passing, zero failures