### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/agentic-research/mache/security/code-scanning/1](https://github.com/agentic-research/mache/security/code-scanning/1)

In general, the fix is to define an explicit `permissions` block for the workflow or the specific job so that the `GITHUB_TOKEN` is limited to the least privilege required. For this workflow, the steps only need to read repository contents (for `actions/checkout`) and possibly packages; there is no evidence of needing write access (no pushes, releases, or issue operations). The safest minimal permission set is `contents: read` at the workflow or job level, which is exactly what CodeQL suggests as a starting point.

The best fix without changing existing functionality is to add a `permissions` block at the top level of the workflow (so it applies to all current and future jobs unless overridden). Concretely, in `.github/workflows/integration.yml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 10 and before line 11 in the provided snippet). No additional imports or methods are required because this is a pure configuration change in a YAML workflow. All existing steps will continue to work, and `actions/checkout` will still be able to read the repository contents with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
