### PR TITLE
feat(graph): export HotSwapGraph for external consumers

### DIFF
--- a/graph/graph.go
+++ b/graph/graph.go
@@ -42,11 +42,19 @@ type CompositeGraph = ig.CompositeGraph
 // ActionResult is returned when an action is performed on a graph node.
 type ActionResult = ig.ActionResult
 
+// HotSwapGraph is a thread-safe wrapper that allows atomically swapping the
+// underlying graph. Readers hold an RLock during each call; Swap acquires a
+// write lock. Use this instead of hand-rolled mutex+pointer patterns.
+type HotSwapGraph = ig.HotSwapGraph
+
 // NewMemoryStore creates a new in-memory graph store.
 var NewMemoryStore = ig.NewMemoryStore
 
 // NewCompositeGraph creates an empty composite graph for multi-mount routing.
 var NewCompositeGraph = ig.NewCompositeGraph
+
+// NewHotSwapGraph creates a thread-safe graph wrapper that supports atomic Swap.
+var NewHotSwapGraph = ig.NewHotSwapGraph
 
 // ErrNotFound is returned when a node ID does not exist in the graph.
 var ErrNotFound = ig.ErrNotFound


### PR DESCRIPTION
## Summary
- Re-exports `HotSwapGraph` and `NewHotSwapGraph` from the public `graph/` package
- Allows x-ray (and other consumers) to use thread-safe atomic graph swaps instead of hand-rolled mutex+pointer patterns
- Fixes CRITICAL data race (C1) in x-ray where `Agent.SetGraph()` writes 7 struct fields without synchronization

## Context
Adversarial concurrency review of x-ray found that `internal/graph/hotswap.go` already solves the exact problem — it just wasn't exported. Two lines added to `graph/graph.go`.

## Test plan
- [x] `task build` passes
- [x] `go test ./...` passes
- [x] Pre-commit hooks (gofumpt, go vet, golangci-lint) pass