### PR TITLE
feat(mount): public mount package for external NFS consumers

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -1,0 +1,41 @@
+// Package mount provides the public NFS mount API for mache.
+//
+// Types are defined in internal/nfsmount and re-exported here so that
+// external consumers (e.g. x-ray) can mount a graph as a real NFS
+// filesystem without importing internal packages.
+package mount
+
+import (
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/graph"
+	"github.com/agentic-research/mache/internal/nfsmount"
+)
+
+// Server wraps an NFS server lifecycle.
+type Server struct{ inner *nfsmount.Server }
+
+// Port returns the TCP port the NFS server is listening on.
+func (s *Server) Port() int { return s.inner.Port() }
+
+// Close stops the NFS server.
+func (s *Server) Close() error { return s.inner.Close() }
+
+// NFS starts an NFS server for the given graph and mounts it at mountPoint.
+// The caller must Close() the server and Unmount() the mountPoint on cleanup.
+func NFS(g graph.Graph, mountPoint string) (*Server, error) {
+	gfs := nfsmount.NewGraphFS(g, &api.Topology{Version: "v1"})
+	srv, err := nfsmount.NewServer(gfs)
+	if err != nil {
+		return nil, err
+	}
+	if err := nfsmount.Mount(srv.Port(), mountPoint, false); err != nil {
+		_ = srv.Close()
+		return nil, err
+	}
+	return &Server{inner: srv}, nil
+}
+
+// Unmount unmounts the given mount point.
+func Unmount(mountPoint string) error {
+	return nfsmount.Unmount(mountPoint)
+}


### PR DESCRIPTION
## Summary
- Adds `mount/` public package that re-exports `internal/nfsmount` types (same pattern as `graph/graph.go`)
- Enables external consumers (e.g. x-ray) to mount a `graph.Graph` as a real NFS filesystem without importing internal packages
- API: `mount.NFS(graph, mountPoint)` → `*Server`, `mount.Unmount(mountPoint)`

## Test plan
- [x] `go build ./mount/` passes
- [x] golangci-lint passes
- [ ] Manual: x-ray mounts CompositeGraph via `mount.NFS()`, verified with `ls /tmp/xray-mache/tab-*/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)