### PR TITLE
fix: add noac to NFS mount options for dynamic graphs

### DIFF
--- a/internal/nfsmount/server.go
+++ b/internal/nfsmount/server.go
@@ -52,7 +52,9 @@ func Mount(port int, mountpoint string, writable bool) error {
 
 	switch runtime.GOOS {
 	case "darwin":
-		opts := fmt.Sprintf("port=%d,mountport=%d,vers=3,tcp,locallocks,noresvport", port, port)
+		// noac: disable attribute caching so dynamic graph changes (new tabs, schema updates)
+		// are visible immediately. Without this, macOS NFS client caches empty dir listings.
+		opts := fmt.Sprintf("port=%d,mountport=%d,vers=3,tcp,locallocks,noresvport,noac", port, port)
 		if !writable {
 			opts += ",rdonly"
 		}
@@ -61,7 +63,7 @@ func Mount(port int, mountpoint string, writable bool) error {
 			"localhost:/", mountpoint)
 
 	case "linux":
-		opts := fmt.Sprintf("port=%d,mountport=%d,vers=3,tcp,local_lock=all,nolock", port, port)
+		opts := fmt.Sprintf("port=%d,mountport=%d,vers=3,tcp,local_lock=all,nolock,noac", port, port)
 		if !writable {
 			opts += ",ro"
 		}


### PR DESCRIPTION
## Summary
- Adds `noac` to macOS and Linux NFS mount options
- Without this, NFS client caches empty directory listings and never sees dynamic graph updates (new tabs, schema changes)
- Required for x-ray's single-mount architecture where tabs appear/disappear as subdirectories

## Test plan
- [x] `go build ./mount/ ./internal/nfsmount/` passes
- [ ] Manual: `ls /tmp/xray-mache/tab-*/` shows zones after Cartographer runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)