### PR TITLE
feat: add GraphCache — write-through MemoryStore with SQLite persistence

### DIFF
--- a/graph/cache.go
+++ b/graph/cache.go
@@ -217,10 +217,30 @@ func (c *GraphCache) RootIDs() []string {
 	return c.store.RootIDs()
 }
 
-// --- Persistence ---
+// --- Batch & Persistence ---
+
+// Batch acquires the write lock, calls fn with the underlying MemoryStore,
+// then persists once. Use this for multi-step mutations that must be atomic
+// (no concurrent readers see intermediate state) and persist as a single
+// SQLite write instead of N individual writes.
+//
+// This is the correct way to implement complex operations like "backup
+// sections, clear zones, rebuild zones, restore matching sections" —
+// the entire sequence runs under one lock with one persist at the end.
+func (c *GraphCache) Batch(fn func(*MemoryStore)) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	fn(c.store)
+
+	if c.dbPath == "" {
+		return nil
+	}
+	return ExportSQLite(c.store, c.dbPath)
+}
 
 // Persist flushes the entire graph to SQLite. Called automatically by mutation
-// methods. Use explicitly after batch operations via Store().
+// methods. Use explicitly after direct Store() access.
 func (c *GraphCache) Persist() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/graph/cache_test.go
+++ b/graph/cache_test.go
@@ -280,6 +280,84 @@ func TestGraphCache_ConcurrentAccess(t *testing.T) {
 	}
 }
 
+func TestGraphCache_Batch_Atomic(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "batch.db")
+	c := graph.NewGraphCache(dbPath)
+
+	// Batch: multiple mutations, one persist, atomic to readers.
+	err := c.Batch(func(store *graph.MemoryStore) {
+		store.AddRoot(&graph.Node{
+			ID:       "url-key",
+			Mode:     fs.ModeDir,
+			Children: []string{"url-key/zones"},
+		})
+		store.AddNode(&graph.Node{
+			ID:       "url-key/zones",
+			Mode:     fs.ModeDir,
+			Children: []string{"url-key/zones/header"},
+		})
+		store.AddNode(&graph.Node{
+			ID:   "url-key/zones/header",
+			Mode: fs.ModeDir,
+			Children: []string{
+				"url-key/zones/header/fingerprint",
+				"url-key/zones/header/mount_json",
+			},
+		})
+		store.AddNode(&graph.Node{
+			ID:   "url-key/zones/header/fingerprint",
+			Data: []byte("abc123"),
+		})
+		store.AddNode(&graph.Node{
+			ID:   "url-key/zones/header/mount_json",
+			Data: []byte(`{"path":"/header"}`),
+		})
+	})
+	if err != nil {
+		t.Fatalf("Batch() = %v", err)
+	}
+
+	// Reload from disk — verify all nodes persisted in one shot.
+	c2 := graph.NewGraphCache(dbPath)
+
+	fp, ok := c2.GetData("url-key/zones/header/fingerprint")
+	if !ok || string(fp) != "abc123" {
+		t.Errorf("fingerprint = %q, want %q", fp, "abc123")
+	}
+
+	mj, ok := c2.GetData("url-key/zones/header/mount_json")
+	if !ok || string(mj) != `{"path":"/header"}` {
+		t.Errorf("mount_json = %q, want %q", mj, `{"path":"/header"}`)
+	}
+
+	children, ok := c2.ListChildren("url-key/zones")
+	if !ok || len(children) != 1 || children[0] != "url-key/zones/header" {
+		t.Errorf("zones children = %v, want [url-key/zones/header]", children)
+	}
+}
+
+func TestGraphCache_Batch_InMemory(t *testing.T) {
+	c := graph.NewGraphCache("")
+
+	// Batch on in-memory cache should not error.
+	err := c.Batch(func(store *graph.MemoryStore) {
+		store.AddRoot(&graph.Node{
+			ID:       "root",
+			Mode:     fs.ModeDir,
+			Children: []string{"root/file"},
+		})
+		store.AddNode(&graph.Node{ID: "root/file", Data: []byte("hello")})
+	})
+	if err != nil {
+		t.Fatalf("Batch() = %v, want nil for in-memory", err)
+	}
+
+	data, ok := c.GetData("root/file")
+	if !ok || string(data) != "hello" {
+		t.Errorf("data = %q, want %q", data, "hello")
+	}
+}
+
 func TestGraphCache_StoreEscapeHatch(t *testing.T) {
 	c := graph.NewGraphCache("")
 


### PR DESCRIPTION
## Summary
- Adds `graph.GraphCache` — a thread-safe `MemoryStore` wrapper with automatic SQLite write-through persistence via `ExportSQLite`/`ImportSQLite`
- Provides tree manipulation helpers: `PutDir`, `PutFile`, `AppendChild`, `RemoveChild`, `ClearChildren`, plus read methods and a `Store()` escape hatch for batch operations
- Extracted from x-ray's `SchemaCache` pattern (808 LOC domain-specific cache) — this is the generic ~240-line core that any mache consumer can reuse

## Motivation
x-ray's `internal/api/schemacache.go` mixes generic caching logic (mutex + MemoryStore + persist-on-write) with domain-specific code (URL keys, fingerprints, NavSections). Extracting the generic part into mache means:
- x-ray can compose `GraphCache` with its domain logic instead of reimplementing the plumbing
- Other consumers (hotsheaf, cairn, any tool caching structured data) get the same pattern for free

## API
```go
c := graph.NewGraphCache("/path/to/cache.db") // or "" for in-memory
c.PutDir("root", true)
c.PutFile("root/key", []byte("value"))
c.AppendChild("root", "root/key")

data, ok := c.GetData("root/key")       // read
children, ok := c.ListChildren("root")  // list

store := c.Store()  // escape hatch for batch ops
// ... mutate store directly ...
c.Persist()         // flush once
```

## Test plan
- [x] 14 tests in `graph/cache_test.go` covering CRUD, SQLite persistence reload, dedup, concurrency, escape hatch
- [x] All existing `graph/` tests still pass
- [x] Race detector clean (`go test -race`)
- [x] All pre-commit hooks pass (gofumpt, go vet, golangci-lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)