### PR TITLE
feat: expose location virtual file for source-origin orientation

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -689,13 +689,28 @@ func makeListDirHandler(g graph.Graph) server.ToolHandlerFunc {
 			})
 		}
 
-		// Surface callers/ and callees/ virtual dirs on construct directories
+		// Surface virtual entries on construct directories
 		// (skip if already materialized in the db)
 		if path != "" {
 			seen := make(map[string]bool, len(entries))
 			for _, e := range entries {
 				seen[e.Name] = true
 			}
+
+			// Location: source file coordinates for orientation
+			if !seen["location"] {
+				if node, err := g.GetNode(path); err == nil && node.Properties != nil {
+					if loc, ok := node.Properties["location"]; ok && len(loc) > 0 {
+						entries = append(entries, nodeEntry{
+							Name: "location",
+							Path: path + "/location",
+							Type: "virtual",
+							Size: int64(len(loc)),
+						})
+					}
+				}
+			}
+
 			token := filepath.Base(path)
 			if !seen["callers"] {
 				if callers, err := g.GetCallers(token); err == nil && len(callers) > 0 {
@@ -728,6 +743,17 @@ type fileReadResult struct {
 }
 
 func readOneFileWithOrigin(g graph.Graph, path string) (*fileReadResult, error) {
+	// Handle virtual location file
+	if filepath.Base(path) == graph.LocationFile {
+		parentDir := filepath.Dir(path)
+		if parent, err := g.GetNode(parentDir); err == nil && parent.Properties != nil {
+			if loc, ok := parent.Properties["location"]; ok && len(loc) > 0 {
+				return &fileReadResult{Content: string(loc)}, nil
+			}
+		}
+		return nil, fmt.Errorf("not found: %s", path)
+	}
+
 	node, err := g.GetNode(path)
 	if err != nil {
 		return nil, fmt.Errorf("not found: %s", path)

--- a/internal/fs/root.go
+++ b/internal/fs/root.go
@@ -116,12 +116,13 @@ func NewMacheFS(schema *api.Topology, g graph.Graph) *MacheFS {
 	diagH := &vfs.DiagnosticsHandler{DiagStatus: &sync.Map{}}
 	schemaH := &vfs.SchemaHandler{Content: sj}
 	contextH := &vfs.ContextHandler{Graph: g}
+	locationH := &vfs.LocationHandler{Graph: g}
 	callersH := &vfs.CallersHandler{Graph: g}
 	calleesH := &vfs.CalleesHandler{Graph: g}
 
 	// Order matters: query before callers/callees (both can have "/" paths).
 	resolver := vfs.NewResolver(
-		schemaH, promptH, queryH, diagH, contextH, callersH, calleesH,
+		schemaH, promptH, queryH, diagH, contextH, locationH, callersH, calleesH,
 	)
 
 	return &MacheFS{

--- a/internal/graph/vdirpath.go
+++ b/internal/graph/vdirpath.go
@@ -14,6 +14,7 @@ const (
 	SchemaDotJSON  = "_schema.json"
 	DiagnosticsDir = "_diagnostics"
 	ContextFile    = "context"
+	LocationFile   = "location"
 	PromptFile     = "PROMPT.txt"
 	CallersDir     = "callers"
 	CalleesDir     = "callees"

--- a/internal/nfsmount/graphfs.go
+++ b/internal/nfsmount/graphfs.go
@@ -60,11 +60,12 @@ func NewGraphFS(g graph.Graph, schema *api.Topology) *GraphFS {
 	diagH := &vfs.DiagnosticsHandler{DiagStatus: diagStatus}
 	schemaH := &vfs.SchemaHandler{Content: sj}
 	contextH := &vfs.ContextHandler{Graph: g}
+	locationH := &vfs.LocationHandler{Graph: g}
 	callersH := &vfs.CallersHandler{Graph: g}
 	calleesH := &vfs.CalleesHandler{Graph: g}
 
 	resolver := vfs.NewResolver(
-		schemaH, promptH, diagH, contextH, callersH, calleesH,
+		schemaH, promptH, diagH, contextH, locationH, callersH, calleesH,
 	)
 
 	return &GraphFS{

--- a/internal/vfs/handlers_test.go
+++ b/internal/vfs/handlers_test.go
@@ -177,6 +177,50 @@ func TestQueryHandler(t *testing.T) {
 	assert.Nil(t, h.DirExtras("/sub", nil))
 }
 
+func TestLocationHandler(t *testing.T) {
+	store := graph.NewMemoryStore()
+	store.AddNode(&graph.Node{
+		ID:   "pkg/Foo",
+		Mode: 0o40000,
+		Properties: map[string][]byte{
+			"location": []byte("internal/pkg/foo.go:10:25"),
+		},
+	})
+
+	h := &LocationHandler{Graph: store}
+
+	assert.True(t, h.Match("/pkg/Foo/location"))
+	assert.False(t, h.Match("/pkg/Foo/source"))
+
+	e := h.Stat("/pkg/Foo/location")
+	require.NotNil(t, e)
+	assert.Equal(t, KindFile, e.Kind)
+	assert.Equal(t, []byte("internal/pkg/foo.go:10:25"), e.Content)
+
+	data, ok := h.ReadContent("/pkg/Foo/location")
+	assert.True(t, ok)
+	assert.Equal(t, []byte("internal/pkg/foo.go:10:25"), data)
+
+	// No location → nil
+	store.AddNode(&graph.Node{ID: "pkg/Bar", Mode: 0o40000})
+	assert.Nil(t, h.Stat("/pkg/Bar/location"))
+
+	_, ok = h.ReadContent("/pkg/Bar/location")
+	assert.False(t, ok)
+}
+
+func TestLocationHandler_DirExtras(t *testing.T) {
+	h := &LocationHandler{Graph: graph.NewMemoryStore()}
+
+	node := &graph.Node{Properties: map[string][]byte{"location": []byte("foo.go:1:5")}}
+	extras := h.DirExtras("/pkg/Foo", node)
+	require.Len(t, extras, 1)
+	assert.Equal(t, "location", extras[0].Name)
+
+	assert.Nil(t, h.DirExtras("/pkg/Foo", &graph.Node{}))
+	assert.Nil(t, h.DirExtras("/pkg/Foo", nil))
+}
+
 func TestCallersHandler(t *testing.T) {
 	store := graph.NewMemoryStore()
 	store.AddNode(&graph.Node{ID: "funcs/Foo", Mode: 0o40000})

--- a/internal/vfs/location.go
+++ b/internal/vfs/location.go
@@ -1,0 +1,69 @@
+package vfs
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// LocationHandler serves the virtual "location" file inside directory nodes
+// that have a Properties["location"] value (e.g., "internal/ingest/engine.go:142:298").
+// This bridges the orientation gap between mache's construct-based paths and
+// the original source file coordinates.
+type LocationHandler struct {
+	Graph graph.Graph
+}
+
+func (h *LocationHandler) Match(path string) bool {
+	return strings.HasSuffix(path, "/"+graph.LocationFile)
+}
+
+func (h *LocationHandler) Stat(path string) *VEntry {
+	parentDir := filepath.Dir(path)
+	node, err := h.Graph.GetNode(parentDir)
+	if err != nil {
+		return nil
+	}
+	loc, ok := node.Properties["location"]
+	if !ok || len(loc) == 0 {
+		return nil
+	}
+	return &VEntry{
+		Kind:    KindFile,
+		Size:    int64(len(loc)),
+		Perm:    0o444,
+		Content: loc,
+	}
+}
+
+func (h *LocationHandler) ReadContent(path string) ([]byte, bool) {
+	parentDir := filepath.Dir(path)
+	node, err := h.Graph.GetNode(parentDir)
+	if err != nil {
+		return nil, false
+	}
+	loc, ok := node.Properties["location"]
+	if !ok || len(loc) == 0 {
+		return nil, false
+	}
+	return loc, true
+}
+
+func (h *LocationHandler) ListDir(_ string) ([]DirExtra, bool) {
+	return nil, false
+}
+
+func (h *LocationHandler) DirExtras(parentPath string, node *graph.Node) []DirExtra {
+	if node != nil && node.Properties != nil {
+		if loc, ok := node.Properties["location"]; ok && len(loc) > 0 {
+			return []DirExtra{{
+				Name: graph.LocationFile,
+				Kind: KindFile,
+				Size: int64(len(loc)),
+				Perm: 0o444,
+			}}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds a `location` virtual file to construct directories that bridges mache's construct-based paths back to original source file coordinates
- Reading `cat go/methods/processNode/location` returns `internal/ingest/engine.go:142:298`
- Closes the orientation gap: agents can now translate between mache paths and file:line coordinates (for stack traces, error messages, git diffs)
- Wired into all three presentation layers: NFS, FUSE, and MCP server (list_directory + read_file)

## Test plan

- [x] `TestLocationHandler` — Match, Stat, ReadContent for nodes with/without location
- [x] `TestLocationHandler_DirExtras` — virtual file appears in directory listings
- [x] Full test suite passes (`task test`)
- [x] `task lint` clean
- [ ] Manual: `mache --agent -d .` → `cat go/methods/processNode/location` shows file:line:line

🤖 Generated with [Claude Code](https://claude.com/claude-code)