### PR TITLE
feat: BDR beads schema + generic markdown schema

### DIFF
--- a/examples/bdr-schema.json
+++ b/examples/bdr-schema.json
@@ -1,0 +1,112 @@
+{
+  "version": "v1",
+  "table": "issues",
+  "file_sets": {
+    "bead_core": [
+      {"name": "title", "content_template": "{{.title}}"},
+      {"name": "description", "content_template": "{{.description}}"},
+      {"name": "status", "content_template": "{{.status}}"},
+      {"name": "priority", "content_template": "{{.priority}}"},
+      {"name": "issue_type", "content_template": "{{.issue_type}}"},
+      {"name": "owner", "content_template": "{{.owner}}"},
+      {"name": "created_at", "content_template": "{{.created_at}}"},
+      {"name": "raw.json", "content_template": "{{. | json}}"}
+    ],
+    "bead_refs": [
+      {"name": "external_ref", "content_template": "{{.external_ref}}"},
+      {"name": "branch", "content_template": "{{.branch}}"},
+      {"name": "pr_url", "content_template": "{{.pr_url}}"}
+    ]
+  },
+  "nodes": [
+    {
+      "name": "by-status",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.status}}",
+          "selector": "$[*]",
+          "children": [
+            {
+              "name": "{{.id}}",
+              "selector": "$",
+              "refs": ["status-{{.status}}", "type-{{.issue_type}}"],
+              "include": ["bead_core", "bead_refs"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "by-type",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.issue_type}}",
+          "selector": "$[*]",
+          "children": [
+            {
+              "name": "{{.id}}",
+              "selector": "$",
+              "refs": ["type-{{.issue_type}}"],
+              "include": ["bead_core"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "by-priority",
+      "selector": "$",
+      "children": [
+        {
+          "name": "P{{.priority}}",
+          "selector": "$[*]",
+          "children": [
+            {
+              "name": "{{.id}}",
+              "selector": "$",
+              "include": ["bead_core"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "by-repo",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.source_repo}}",
+          "selector": "$[*]",
+          "children": [
+            {
+              "name": "{{.id}}",
+              "selector": "$",
+              "refs": ["repo-{{.source_repo}}", "xref-{{.external_ref}}"],
+              "include": ["bead_core", "bead_refs"]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "threads",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.external_ref}}",
+          "selector": "$[?(@.external_ref)]",
+          "refs": ["thread-{{.external_ref}}"],
+          "children": [
+            {
+              "name": "{{.id}}",
+              "selector": "$",
+              "include": ["bead_core"]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/examples/markdown-schema.json
+++ b/examples/markdown-schema.json
@@ -1,0 +1,89 @@
+{
+  "version": "v1",
+  "file_sets": {
+    "block_files": [
+      {"name": "source", "content_template": "{{.record}}"}
+    ]
+  },
+  "nodes": [
+    {
+      "name": "sections",
+      "selector": "$",
+      "language": "markdown",
+      "children": [
+        {
+          "name": "{{.name}}",
+          "selector": "(section (atx_heading (inline) @name))",
+          "language": "markdown",
+          "refs": ["heading-{{.name}}"],
+          "children": [
+            {
+              "name": "{{.name}}",
+              "selector": "(section (atx_heading (inline) @name))",
+              "language": "markdown",
+              "refs": ["heading-{{.name}}"],
+              "include": ["block_files"]
+            },
+            {
+              "name": "lists",
+              "selector": "(list)",
+              "language": "markdown",
+              "children": [
+                {
+                  "name": "item-{{.index}}",
+                  "selector": "(list_item)",
+                  "language": "markdown",
+                  "include": ["block_files"]
+                }
+              ]
+            },
+            {
+              "name": "code-blocks",
+              "selector": "(fenced_code_block)",
+              "language": "markdown",
+              "include": ["block_files"]
+            }
+          ],
+          "include": ["block_files"]
+        }
+      ]
+    },
+    {
+      "name": "blocks",
+      "selector": "$",
+      "language": "markdown",
+      "children": [
+        {
+          "name": "paragraphs",
+          "selector": "(paragraph)",
+          "language": "markdown",
+          "include": ["block_files"]
+        },
+        {
+          "name": "code",
+          "selector": "(fenced_code_block (info_string) @name)",
+          "language": "markdown",
+          "include": ["block_files"]
+        },
+        {
+          "name": "quotes",
+          "selector": "(block_quote)",
+          "language": "markdown",
+          "include": ["block_files"]
+        },
+        {
+          "name": "tables",
+          "selector": "(pipe_table)",
+          "language": "markdown",
+          "include": ["block_files"]
+        },
+        {
+          "name": "html",
+          "selector": "(html_block)",
+          "language": "markdown",
+          "include": ["block_files"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **bdr-schema.json**: Projects beads from Dolt `issues` table with BDR lattice views (by-status, by-type, by-priority, by-repo, threads via external_ref). Cross-reference tokens enable `callers/` virtual dirs and community detection across beads.
- **markdown-schema.json**: Generic markdown projection using tree-sitter-markdown node types (`section`, `atx_heading`, `list_item`, `fenced_code_block`, `block_quote`, `pipe_table`, `html_block`). Schema-driven decomposition of any markdown doc — ADRs, READMEs, changelogs.

Part of BDR (Bead Decision Records) — replaces hardcoded ADR parsing with declarative schemas. See `agentic-research/bdr` ADR-001.

Related beads: `mache-85t` (beads as filesystem), `rsry-036686` (schema-driven classification)

## Test plan

- [ ] `mache build --schema examples/bdr-schema.json <beads.db>` projects beads correctly
- [ ] `mache build --schema examples/markdown-schema.json <dir-with-md-files>` projects markdown sections
- [ ] Verify ref tokens generate callers/ virtual dirs
- [ ] Validate tree-sitter markdown selectors against actual tree-sitter-markdown grammar

🤖 Generated with [Claude Code](https://claude.com/claude-code)