### PR TITLE
fix: pre-release review — 7 surgical fixes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.tag != ''
+    if: startsWith(github.ref, 'refs/tags/v') || inputs.tag != '' || github.event.client_payload.tag != ''
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,9 +8,11 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/agentic-research/mache/api"
@@ -56,6 +58,7 @@ func init() {
 
 func runServe(cmd *cobra.Command, args []string) error {
 	registry := newGraphRegistry(servePath, args)
+	defer registry.Close()
 
 	// Clean up session → root mapping on disconnect.
 	// Root discovery happens lazily on the first tool call (see wrapHandler)
@@ -87,8 +90,17 @@ Call get_overview first when exploring a new codebase.`),
 		source = args[0]
 	}
 
-	// Clean up any auto-spawned leyline daemon on exit
+	// Clean up any auto-spawned leyline daemon on exit.
+	// Defer handles normal returns; signal handler covers SIGTERM/SIGINT.
 	defer leyline.StopManaged()
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		leyline.StopManaged()
+		registry.Close()
+		os.Exit(0)
+	}()
 
 	if serveStdio {
 		meta := registerServeSidecar(source, "mcp-stdio", "")
@@ -195,6 +207,18 @@ func (r *graphRegistry) registerSession(sessionID, rootPath string) {
 
 func (r *graphRegistry) unregisterSession(sessionID string) {
 	r.sessions.Delete(sessionID)
+}
+
+// Close calls the cleanup function on every lazily-built graph.
+// Use on server shutdown to release SQLite connections and temp files.
+func (r *graphRegistry) Close() {
+	r.graphs.Range(func(_, v any) bool {
+		lg := v.(*lazyGraph)
+		if lg.cleanup != nil {
+			lg.cleanup()
+		}
+		return true
+	})
 }
 
 // getOrCreateGraph returns an existing graph for rootPath or creates a new one.
@@ -804,6 +828,10 @@ func makeReadFileHandler(g graph.Graph) server.ToolHandlerFunc {
 			if err := json.Unmarshal([]byte(pathsRaw), &paths); err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("invalid paths array: %v", err)), nil
 			}
+			const maxBatchPaths = 100
+			if len(paths) > maxBatchPaths {
+				return mcp.NewToolResultError(fmt.Sprintf("batch read limited to %d paths, got %d", maxBatchPaths, len(paths))), nil
+			}
 
 			type fileResult struct {
 				Path    string              `json:"path"`
@@ -1301,7 +1329,6 @@ func makeGetDiagnosticsHandler(g graph.Graph) server.ToolHandlerFunc {
 	}
 }
 
-
 // enrichAndQueryTypeInfo triggers LSP enrichment and queries hover data
 // directly from the ley-line daemon's arena via UDS, bypassing mache's
 // in-memory graph (which doesn't have _lsp* tables).
@@ -1332,8 +1359,9 @@ func enrichAndQueryTypeInfo(filePath, symbol string) (*mcp.CallToolResult, error
 		return nil, fmt.Errorf("set query deadline: %w", err)
 	}
 
+	sanitized := strings.ReplaceAll(symbol, "'", "''")
 	rows, err := client.Query(fmt.Sprintf(
-		`SELECT node_id, hover_text FROM _lsp_hover WHERE node_id LIKE '%%%s'`, symbol))
+		`SELECT node_id, hover_text FROM _lsp_hover WHERE node_id LIKE '%%%s'`, sanitized))
 	if err != nil {
 		return nil, fmt.Errorf("query _lsp_hover via daemon: %w", err)
 	}
@@ -1356,7 +1384,7 @@ func enrichAndQueryTypeInfo(filePath, symbol string) (*mcp.CallToolResult, error
 	// Fallback: broader match
 	if len(results) == 0 {
 		rows, err = client.Query(fmt.Sprintf(
-			`SELECT node_id, hover_text FROM _lsp_hover WHERE node_id LIKE '%%%s%%'`, symbol))
+			`SELECT node_id, hover_text FROM _lsp_hover WHERE node_id LIKE '%%%s%%'`, sanitized))
 		if err == nil {
 			for _, row := range rows {
 				if len(row) >= 2 {
@@ -1457,9 +1485,10 @@ func enrichAndQueryDiagnostics(filePath, symbol string, limit int) (*mcp.CallToo
 
 	var query string
 	if symbol != "" {
+		sanitized := strings.ReplaceAll(symbol, "'", "''")
 		query = fmt.Sprintf(
 			`SELECT node_id, symbol_kind, diagnostics FROM _lsp WHERE diagnostics IS NOT NULL AND diagnostics != '' AND node_id LIKE '%%%s%%' LIMIT %d`,
-			symbol, limit)
+			sanitized, limit)
 	} else {
 		query = fmt.Sprintf(
 			`SELECT node_id, symbol_kind, diagnostics FROM _lsp WHERE diagnostics IS NOT NULL AND diagnostics != '' LIMIT %d`,

--- a/internal/graph/writable_graph.go
+++ b/internal/graph/writable_graph.go
@@ -139,9 +139,9 @@ func (g *WritableGraph) ListChildren(id string) ([]string, error) {
 	var rows *sql.Rows
 	var err error
 	if id == "" {
-		rows, err = g.db.Query("SELECT name FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
+		rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
 	} else {
-		rows, err = g.db.Query("SELECT name FROM nodes WHERE parent_id = ? ORDER BY name", id)
+		rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
 	}
 	if err != nil {
 		return nil, err

--- a/internal/vfs/resolver.go
+++ b/internal/vfs/resolver.go
@@ -73,30 +73,39 @@ func (r *Resolver) SetWritable(writable bool, diagStatus *sync.Map) {
 }
 
 // Resolve returns a VEntry for the path, or nil if no handler matches.
+// When a handler matches but Stat returns nil (e.g., a node named "context"
+// that has no virtual content), resolution continues to the next handler
+// so the path can fall through to the graph lookup.
 func (r *Resolver) Resolve(path string) *VEntry {
 	for _, h := range r.handlers {
 		if h.Match(path) {
-			return h.Stat(path)
+			if entry := h.Stat(path); entry != nil {
+				return entry
+			}
 		}
 	}
 	return nil
 }
 
-// ReadContent delegates to the first matching handler.
+// ReadContent delegates to the first matching handler that returns content.
 func (r *Resolver) ReadContent(path string) ([]byte, bool) {
 	for _, h := range r.handlers {
 		if h.Match(path) {
-			return h.ReadContent(path)
+			if data, ok := h.ReadContent(path); ok {
+				return data, true
+			}
 		}
 	}
 	return nil, false
 }
 
-// ListDir delegates to the first matching handler.
+// ListDir delegates to the first matching handler that returns entries.
 func (r *Resolver) ListDir(path string) ([]DirExtra, bool) {
 	for _, h := range r.handlers {
 		if h.Match(path) {
-			return h.ListDir(path)
+			if entries, ok := h.ListDir(path); ok {
+				return entries, true
+			}
 		}
 	}
 	return nil, false


### PR DESCRIPTION
## Summary
Pre-release audit found 7 issues (3 blockers, 4 should-fix). All resolved in this PR:

1. **SQL injection in daemon query path** (P0) — `symbol` parameter sanitized before interpolation into SQL sent over UDS
2. **VFS handler hides graph nodes named "context"/"location"** (P0) — Resolver now falls through when `Match` succeeds but `Stat` returns nil
3. **release.yml `repository_dispatch` never creates a release** (P0) — Condition now checks `client_payload.tag`
4. **WritableGraph.ListChildren selects `name` instead of `id`** (P1) — Fixed to match SQLiteGraph
5. **lazyGraph.cleanup never called** (P1) — Added `graphRegistry.Close()`, deferred in `runServe`
6. **Managed leyline daemon orphaned on exit** (P1) — Signal handler for SIGTERM/SIGINT
7. **Unbounded batch read_file** (P1) — Capped at 100 paths

Beads: mache-5c416f, mache-5c4c3b, mache-5c5366, mache-5c5a44, mache-5c6836, mache-5c6f1b, mache-5c76b3

## Changes since v0.5.6 (24 commits)
- feat: Elixir tree-sitter support (#99)
- feat: BDR hierarchy + beads schemas (#97, #98)
- feat(ci): release workflow with ley-line fat binary (#96)
- feat: overnight agent fixes — engine, lattice, writeback, vfs (#95)
- docs: README rewrite (#93, #94)
- fix: correctness debt — 4 surgical bug fixes (#92)
- feat: UDS LSP query + auto-enrichment (#88, #91)
- perf: Louvain community detection pre-computed degrees (#89)
- feat: location virtual file (#87)
- fix: lazy ListRoots (#86)
- feat: --path flag, MCP sidecar lifecycle (#85)
- feat: Streamable HTTP default transport (#84)
- refactor: VHandler chain + Streamable HTTP (#83)
- feat: LSP defs/refs all schemas + Rust/Terraform presets (#82)
- feat: schema-driven LSP materialization (#81)
- feat: consume leyline LSP tables (#80)
- feat: GraphCache write-through (#79)
- feat: MCP project config, multi-editor install (#78)
- feat: agent field report fixes + live graph (#73)
- feat: public tree-sitter validation API (#71)
- build(deps): golang.org/x/sys 0.41→0.42 (#90)

## Test plan
- [x] `task build` — compiles clean
- [x] `task test` — all tests pass
- [ ] CI passes
- [ ] Verify VFS fallthrough with a Go project containing a `context` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)