### PR TITLE
chore: add mdformat 1.0.0 pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
 repos:
+  # Markdown formatting
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-frontmatter
+        exclude: '^\.beads/'
+
   # Basic file hygiene
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## Summary
- Add mdformat 1.0.0 pre-commit hook with gfm + frontmatter plugins
- Excludes `.beads/` directory (beads markdown doesn't conform to mdformat style)

## Test plan
- [ ] `pre-commit run mdformat --all-files` passes