### PR TITLE
fix(ci): release workflow tolerates partial builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: macos-latest
@@ -107,7 +108,7 @@ jobs:
           path: ${{ matrix.artifact }}
 
   release:
-    if: startsWith(github.ref, 'refs/tags/v') || inputs.tag != '' || github.event.client_payload.tag != ''
+    if: always() && (startsWith(github.ref, 'refs/tags/v') || inputs.tag != '' || github.event.client_payload.tag != '')
     needs: build
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Set `fail-fast: false` so macOS build completes even if linux fails (missing ley-line artifacts)
- Release job uses `if: always()` to run with whatever artifacts succeeded

## Context
ley-line is private with no CI minutes, so linux `.a` artifacts aren't published yet. This lets us ship darwin-arm64 builds independently.

## Test plan
- [ ] Re-trigger release after merge — macOS build should succeed and create a partial release