### PR TITLE
feat: wire community topology push to ley-line daemon

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1230,6 +1230,23 @@ func makeGetCommunitiesHandler(g graph.Graph) server.ToolHandlerFunc {
 
 		result := graph.DetectCommunities(refs, minSize)
 
+		// Push topology to ley-line sheaf cache (fire-and-forget).
+		go func() {
+			sockPath, err := leyline.DiscoverOrStart()
+			if err != nil {
+				return // no daemon — skip silently
+			}
+			sock, err := leyline.DialSocket(sockPath)
+			if err != nil {
+				return
+			}
+			defer func() { _ = sock.Close() }()
+			sc := leyline.NewSheafClient(sock)
+			if pushErr := sc.PushTopology(result, refs); pushErr != nil {
+				log.Printf("sheaf topology push: %v", pushErr)
+			}
+		}()
+
 		if summary {
 			type communitySummary struct {
 				ID         int      `json:"id"`
@@ -1390,11 +1407,11 @@ func makeGetOverviewHandler(g graph.Graph) server.ToolHandlerFunc {
 		// system prompt — guidance is only in context after get_overview is called.
 		if ov.RefTokens > 0 {
 			ov.Usage = map[string]string{
-				"find_callers":   "who calls a symbol — use instead of grep for 'who uses X?'",
+				"find_callers":    "who calls a symbol — use instead of grep for 'who uses X?'",
 				"find_definition": "where a symbol is declared — use for 'where is X defined?'",
-				"find_callees":   "what a function invokes — note: generic names (String, New, Error) may have false positives",
-				"search":         "find symbols by name pattern, e.g. '%auth%' or 'Parse%' — use instead of grep -r",
-				"list_directory": "browse the tree structure — use instead of ls/find",
+				"find_callees":    "what a function invokes — note: generic names (String, New, Error) may have false positives",
+				"search":          "find symbols by name pattern, e.g. '%auth%' or 'Parse%' — use instead of grep -r",
+				"list_directory":  "browse the tree structure — use instead of ls/find",
 				"get_communities": "find clusters of related code (use summary=true for large repos; requires dense cross-references)",
 			}
 		}


### PR DESCRIPTION
## Summary

After `get_communities` MCP tool runs `DetectCommunities()`, fire-and-forget push the topology to ley-line's sheaf cache via `SheafClient.PushTopology()`.

This completes the integration loop from PR #105:
```
get_communities → DetectCommunities() → PushTopology() → ley-line sheaf cache
                                                              ↓
                              subsequent Invalidate() calls cascade structurally
```

Silently skipped if ley-line daemon is not available.

## Test plan

- [x] `task build` passes
- [x] `task test` passes (all existing sheaf tests still pass)
- [ ] Manual: run `leyline daemon --control-port 9003`, then mache, call get_communities, verify `sheaf_status` shows regions

🤖 Generated with [Claude Code](https://claude.com/claude-code)