### PR TITLE
feat: dict/lookup/default template funcs, --out for .db sources, trivy-ghsa schema

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -299,7 +299,12 @@ var rootCmd = &cobra.Command{
 				// --out with .db source: ingest via SQLiteWriter, materialize, exit.
 				// Skip OpenSQLiteGraph/EagerScan entirely — no mount needed.
 				if outPath != "" {
-					indexPath := filepath.Join(os.TempDir(), fmt.Sprintf("mache-out-%d-index.db", os.Getpid()))
+					indexFile, err := os.CreateTemp("", "mache-out-*.db")
+					if err != nil {
+						return fmt.Errorf("create temp index: %w", err)
+					}
+					indexPath := indexFile.Name()
+					_ = indexFile.Close() // SQLiteWriter opens it by path
 					defer func() { _ = os.Remove(indexPath) }()
 
 					writer, err := ingest.NewSQLiteWriter(indexPath)

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -313,6 +313,38 @@ var rootCmd = &cobra.Command{
 					return fmt.Errorf("scan failed: %w", err)
 				}
 				log.Printf("Scanning records done in %v", time.Since(start))
+
+				// --out with .db source: ingest via SQLiteWriter (produces nodes table),
+				// then materialize to target format and exit. Skip the SQLiteGraph
+				// mount path entirely.
+				if outPath != "" {
+					indexPath := filepath.Join(os.TempDir(), fmt.Sprintf("mache-out-%d-index.db", os.Getpid()))
+					_ = os.Remove(indexPath)
+					writer, err := ingest.NewSQLiteWriter(indexPath)
+					if err != nil {
+						return fmt.Errorf("create sqlite writer: %w", err)
+					}
+					eng := ingest.NewEngine(schema, writer)
+					if err := eng.Ingest(dataPath); err != nil {
+						_ = writer.Close()
+						return fmt.Errorf("ingest for --out: %w", err)
+					}
+					if err := writer.Close(); err != nil {
+						return fmt.Errorf("close sqlite writer: %w", err)
+					}
+
+					mat, mErr := materialize.ForFormat(outFormat)
+					if mErr != nil {
+						return mErr
+					}
+					if mErr = mat.Materialize(indexPath, outPath); mErr != nil {
+						return fmt.Errorf("materialize (%s): %w", outFormat, mErr)
+					}
+					_ = os.Remove(indexPath)
+					log.Printf("Wrote %s (format: %s)", outPath, outFormat)
+					return nil
+				}
+
 				g = sg
 			} else if !writable && ingest.SchemaUsesTreeSitter(schema) {
 				// Read-only source: ingest to SQLite index, mount via SQLiteGraph (fast path).

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -296,41 +296,29 @@ var rootCmd = &cobra.Command{
 
 		if _, err := os.Stat(dataPath); err == nil {
 			if filepath.Ext(dataPath) == ".db" {
-				// SQLite source: eager scan before mount to avoid fuse-t NFS timeouts
-				log.Printf("Opening %s (direct SQL backend)...", dataPath)
-				sg, err := graph.OpenSQLiteGraph(dataPath, schema, ingest.RenderTemplate)
-				if err != nil {
-					return fmt.Errorf("open sqlite graph: %w", err)
-				}
-				defer func() { _ = sg.Close() }() // safe to ignore
-
-				// Wire call extractor for callees/ resolution
-				sg.SetCallExtractor(newCallExtractor())
-
-				start := time.Now()
-				log.Print("Scanning records...")
-				if err := sg.EagerScan(); err != nil {
-					return fmt.Errorf("scan failed: %w", err)
-				}
-				log.Printf("Scanning records done in %v", time.Since(start))
-
-				// --out with .db source: ingest via SQLiteWriter (produces nodes table),
-				// then materialize to target format and exit. Skip the SQLiteGraph
-				// mount path entirely.
+				// --out with .db source: ingest via SQLiteWriter, materialize, exit.
+				// Skip OpenSQLiteGraph/EagerScan entirely — no mount needed.
 				if outPath != "" {
 					indexPath := filepath.Join(os.TempDir(), fmt.Sprintf("mache-out-%d-index.db", os.Getpid()))
-					_ = os.Remove(indexPath)
+					defer func() { _ = os.Remove(indexPath) }()
+
 					writer, err := ingest.NewSQLiteWriter(indexPath)
 					if err != nil {
 						return fmt.Errorf("create sqlite writer: %w", err)
 					}
 					eng := ingest.NewEngine(schema, writer)
+					start := time.Now()
 					if err := eng.Ingest(dataPath); err != nil {
 						_ = writer.Close()
 						return fmt.Errorf("ingest for --out: %w", err)
 					}
 					if err := writer.Close(); err != nil {
 						return fmt.Errorf("close sqlite writer: %w", err)
+					}
+					log.Printf("Ingestion complete in %v", time.Since(start))
+
+					if err := materializeVirtuals(indexPath, schema, agentMode); err != nil {
+						return fmt.Errorf("materialize virtuals: %w", err)
 					}
 
 					mat, mErr := materialize.ForFormat(outFormat)
@@ -340,10 +328,26 @@ var rootCmd = &cobra.Command{
 					if mErr = mat.Materialize(indexPath, outPath); mErr != nil {
 						return fmt.Errorf("materialize (%s): %w", outFormat, mErr)
 					}
-					_ = os.Remove(indexPath)
 					log.Printf("Wrote %s (format: %s)", outPath, outFormat)
 					return nil
 				}
+
+				// SQLite source: eager scan before mount to avoid fuse-t NFS timeouts
+				log.Printf("Opening %s (direct SQL backend)...", dataPath)
+				sg, err := graph.OpenSQLiteGraph(dataPath, schema, ingest.RenderTemplate)
+				if err != nil {
+					return fmt.Errorf("open sqlite graph: %w", err)
+				}
+				defer func() { _ = sg.Close() }()
+
+				sg.SetCallExtractor(newCallExtractor())
+
+				start := time.Now()
+				log.Print("Scanning records...")
+				if err := sg.EagerScan(); err != nil {
+					return fmt.Errorf("scan failed: %w", err)
+				}
+				log.Printf("Scanning records done in %v", time.Since(start))
 
 				g = sg
 			} else if !writable && ingest.SchemaUsesTreeSitter(schema) {

--- a/cmd/out_db_test.go
+++ b/cmd/out_db_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"archive/zip"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// TestOutFlag_DBSource verifies that --out works with .db data sources.
+// This is a regression test: the .db branch in mount.go previously ignored
+// --out and attempted to NFS mount, causing a hang.
+func TestOutFlag_DBSource(t *testing.T) {
+	// Create a minimal test .db with results table
+	tmpDir := t.TempDir()
+	srcDB := filepath.Join(tmpDir, "test.db")
+
+	db, err := sql.Open("sqlite", srcDB)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE results (id TEXT PRIMARY KEY, record TEXT NOT NULL);
+		INSERT INTO results VALUES ('a', '{"schema":"test","identifier":"item-1","item":{"name":"foo","value":"bar"}}');
+		INSERT INTO results VALUES ('b', '{"schema":"test","identifier":"item-2","item":{"name":"baz","value":"qux"}}');
+	`)
+	require.NoError(t, err)
+	_ = db.Close()
+
+	outZip := filepath.Join(tmpDir, "out.zip")
+
+	// Schema: simple flat projection
+	schemaFile := filepath.Join(tmpDir, "schema.json")
+	require.NoError(t, os.WriteFile(schemaFile, []byte(`{
+		"version": "v1",
+		"nodes": [{
+			"name": "items",
+			"selector": "$",
+			"children": [{
+				"name": "{{.item.name}}",
+				"selector": "$[*]",
+				"files": [{"name": "value", "content_template": "{{.item.value}}"}]
+			}]
+		}]
+	}`), 0o644))
+
+	// Save and restore global flags
+	oldSchema := schemaPath
+	oldData := dataPath
+	oldOut := outPath
+	oldFormat := outFormat
+	defer func() {
+		schemaPath = oldSchema
+		dataPath = oldData
+		outPath = oldOut
+		outFormat = oldFormat
+	}()
+
+	schemaPath = schemaFile
+	dataPath = srcDB
+	outPath = outZip
+	outFormat = "zip"
+
+	// RunE should complete without hanging (the bug was a hang here)
+	err = rootCmd.RunE(rootCmd, []string{filepath.Join(tmpDir, "mnt")})
+	require.NoError(t, err)
+
+	// Verify ZIP was created with content
+	info, err := os.Stat(outZip)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+
+	// Verify ZIP contains expected entries
+	r, err := zip.OpenReader(outZip)
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+
+	var names []string
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	assert.Contains(t, names, "items/foo/value")
+	assert.Contains(t, names, "items/baz/value")
+}

--- a/cmd/out_db_test.go
+++ b/cmd/out_db_test.go
@@ -28,7 +28,7 @@ func TestOutFlag_DBSource(t *testing.T) {
 		INSERT INTO results VALUES ('b', '{"schema":"test","identifier":"item-2","item":{"name":"baz","value":"qux"}}');
 	`)
 	require.NoError(t, err)
-	_ = db.Close()
+	require.NoError(t, db.Close())
 
 	outZip := filepath.Join(tmpDir, "out.zip")
 

--- a/examples/trivy-ghsa-schema.json
+++ b/examples/trivy-ghsa-schema.json
@@ -15,7 +15,7 @@
               "selector": "$",
               "files": [
                 {
-                  "name": "{{default (index ._parent._parent.item.Advisory.CVE 0) ._parent._parent.item.Advisory.ghsaId}}",
+                  "name": "{{default (first ._parent._parent.item.Advisory.CVE) ._parent._parent.item.Advisory.ghsaId}}",
                   "content_template": "{{dict \"FixedVersion\" .identifier \"AffectedVersion\" .range \"Severity\" (lookup ._parent._parent.item.Advisory.Severity \"Critical\" 4 \"High\" 3 \"Medium\" 2 \"Low\" 1 0) | json}}"
                 }
               ]

--- a/examples/trivy-ghsa-schema.json
+++ b/examples/trivy-ghsa-schema.json
@@ -1,0 +1,28 @@
+{
+  "version": "v1",
+  "description": "Projects venturi GitHub Advisory data into trivy-db BoltDB layout. Usage: mache <mp> --data github.db --schema trivy-ghsa-schema.json --out trivy.db --format boltdb",
+  "nodes": [
+    {
+      "name": "advisories",
+      "selector": "$[*]",
+      "children": [
+        {
+          "name": "{{lookup ._parent.item.Advisory.namespace \"github:npm\" \"Npm\" \"github:python\" \"Pip\" \"github:go\" \"Go\" \"github:java\" \"Maven\" \"github:rust\" \"Cargo\" \"github:gem\" \"RubyGems\" \"github:composer\" \"Composer\" \"github:nuget\" \"NuGet\" \"github:swift\" \"Swift\" \"github:dart\" \"Dart\" \"github:erlang\" \"Erlang\" \"github:github-action\" \"GithubActions\" \"Other\"}}::ghsa",
+          "selector": "$[*].item.Advisory.FixedIn[*]",
+          "children": [
+            {
+              "name": "{{.name}}",
+              "selector": "$",
+              "files": [
+                {
+                  "name": "{{default (index ._parent._parent.item.Advisory.CVE 0) ._parent._parent.item.Advisory.ghsaId}}",
+                  "content_template": "{{dict \"FixedVersion\" .identifier \"AffectedVersion\" .range \"Severity\" (lookup ._parent._parent.item.Advisory.Severity \"Critical\" 4 \"High\" 3 \"Medium\" 2 \"Low\" 1 0) | json}}"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/internal/graph/sqlite_graph_test.go
+++ b/internal/graph/sqlite_graph_test.go
@@ -671,14 +671,21 @@ func BenchmarkScanRoot_Synthetic(b *testing.B) {
 	if _, err := db.Exec("CREATE TABLE results (id TEXT PRIMARY KEY, record TEXT NOT NULL)"); err != nil {
 		b.Fatal(err)
 	}
-	tx, _ := db.Begin()
+	tx, err := db.Begin()
+	if err != nil {
+		b.Fatal(err)
+	}
 	for id, rec := range records {
 		if _, err := tx.Exec("INSERT INTO results (id, record) VALUES (?, ?)", id, rec); err != nil {
 			b.Fatal(err)
 		}
 	}
-	_ = tx.Commit()
-	_ = db.Close()
+	if err := tx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		b.Fatal(err)
+	}
 
 	schema := kevSchema()
 

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -1699,14 +1699,17 @@ var tmplFuncs = template.FuncMap{
 	"trimPrefix": strings.TrimPrefix,
 	// trimSuffix: {{trimSuffix .s ".go"}} → "main" from "main.go".
 	"trimSuffix": strings.TrimSuffix,
-	// dict: construct a map from key-value pairs.
+	// dict: construct a map from key-value pairs. Errors on odd arg count.
 	// {{dict "PkgName" .name "Severity" 4 | json}} → {"PkgName":"curl","Severity":4}
-	"dict": func(pairs ...any) map[string]any {
+	"dict": func(pairs ...any) (map[string]any, error) {
+		if len(pairs)%2 != 0 {
+			return nil, fmt.Errorf("dict requires even number of args, got %d", len(pairs))
+		}
 		m := make(map[string]any, len(pairs)/2)
-		for i := 0; i+1 < len(pairs); i += 2 {
+		for i := 0; i < len(pairs); i += 2 {
 			m[fmt.Sprint(pairs[i])] = pairs[i+1]
 		}
-		return m
+		return m, nil
 	},
 	// lookup: key-value enum mapping. Last odd arg is default.
 	// {{lookup .Severity "Critical" 4 "High" 3 "Medium" 2 "Low" 1 0}}
@@ -1722,7 +1725,7 @@ var tmplFuncs = template.FuncMap{
 		}
 		return ""
 	},
-	// default: return fallback when value is empty, nil, or zero.
+	// default: return fallback when value is nil or empty string.
 	// {{default .name "unknown"}}
 	"default": func(val, fallback any) any {
 		if val == nil {

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -1087,9 +1087,14 @@ func processRecord(schema *api.Topology, walker Walker, dbPath string, job recor
 	wrapper := []any{parsed}
 	var result recordResult
 
+	// Expose the full record as _parent context for child selectors.
+	// In the streaming path, each record IS the top-level match — its fields
+	// should be accessible via {{._parent.item.Advisory.Severity}} etc.
+	recordValues, _ := parsed.(map[string]any)
+
 	for _, nodeSchema := range schema.Nodes {
 		for _, childSchema := range nodeSchema.Children {
-			collectNodes(&result, childSchema, walker, wrapper, nodeSchema.Name, dbPath, job.recordID, extraFuncs, tmplCache, nil)
+			collectNodes(&result, childSchema, walker, wrapper, nodeSchema.Name, dbPath, job.recordID, extraFuncs, tmplCache, recordValues)
 			if result.err != nil {
 				return result
 			}
@@ -1694,6 +1699,40 @@ var tmplFuncs = template.FuncMap{
 	"trimPrefix": strings.TrimPrefix,
 	// trimSuffix: {{trimSuffix .s ".go"}} → "main" from "main.go".
 	"trimSuffix": strings.TrimSuffix,
+	// dict: construct a map from key-value pairs.
+	// {{dict "PkgName" .name "Severity" 4 | json}} → {"PkgName":"curl","Severity":4}
+	"dict": func(pairs ...any) map[string]any {
+		m := make(map[string]any, len(pairs)/2)
+		for i := 0; i+1 < len(pairs); i += 2 {
+			m[fmt.Sprint(pairs[i])] = pairs[i+1]
+		}
+		return m
+	},
+	// lookup: key-value enum mapping. Last odd arg is default.
+	// {{lookup .Severity "Critical" 4 "High" 3 "Medium" 2 "Low" 1 0}}
+	"lookup": func(val any, pairs ...any) any {
+		s := fmt.Sprint(val)
+		for i := 0; i+1 < len(pairs); i += 2 {
+			if fmt.Sprint(pairs[i]) == s {
+				return pairs[i+1]
+			}
+		}
+		if len(pairs)%2 == 1 {
+			return pairs[len(pairs)-1]
+		}
+		return ""
+	},
+	// default: return fallback when value is empty, nil, or zero.
+	// {{default .name "unknown"}}
+	"default": func(val, fallback any) any {
+		if val == nil {
+			return fallback
+		}
+		if s, ok := val.(string); ok && s == "" {
+			return fallback
+		}
+		return val
+	},
 }
 
 // tmplCache stores parsed templates keyed by their source string.

--- a/internal/ingest/parent_context_test.go
+++ b/internal/ingest/parent_context_test.go
@@ -245,7 +245,7 @@ func TestEngine_ParentContext_SQLiteStreamingPath(t *testing.T) {
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO results VALUES ('a', '{"schema":"vuln","identifier":"CVE-1","item":{"name":"CVE-2024-001","affected":[{"pkg":"curl"},{"pkg":"wget"}]}}')`)
 	require.NoError(t, err)
-	_ = db.Close()
+	require.NoError(t, db.Close())
 
 	store := graph.NewMemoryStore()
 	engine := NewEngine(schema, store)

--- a/internal/ingest/template_funcs_test.go
+++ b/internal/ingest/template_funcs_test.go
@@ -165,3 +165,101 @@ func TestTemplateFuncs_TrimSuffix(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "main", out)
 }
+
+// ---------------------------------------------------------------------------
+// dict — construct a map inline
+// ---------------------------------------------------------------------------
+
+func TestTemplateFuncs_Dict(t *testing.T) {
+	out, err := RenderTemplate(`{{dict "name" "curl" "version" "7.88" | json}}`, map[string]any{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"name":"curl","version":"7.88"}`, out)
+}
+
+func TestTemplateFuncs_DictWithTemplateValues(t *testing.T) {
+	out, err := RenderTemplate(`{{dict "PkgName" .name "FixedVersion" .ver | json}}`, map[string]any{
+		"name": "openssl",
+		"ver":  "3.0.1",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"PkgName":"openssl","FixedVersion":"3.0.1"}`, out)
+}
+
+func TestTemplateFuncs_DictEmpty(t *testing.T) {
+	out, err := RenderTemplate(`{{dict | json}}`, map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, "{}", out)
+}
+
+func TestTemplateFuncs_DictWithIntValue(t *testing.T) {
+	out, err := RenderTemplate(`{{dict "Severity" 4 "Status" 3 | json}}`, map[string]any{})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Severity":4,"Status":3}`, out)
+}
+
+// ---------------------------------------------------------------------------
+// lookup — enum/key-value mapping
+// ---------------------------------------------------------------------------
+
+func TestTemplateFuncs_Lookup(t *testing.T) {
+	out, err := RenderTemplate(`{{lookup .sev "Critical" "4" "High" "3" "Medium" "2" "Low" "1"}}`, map[string]any{"sev": "High"})
+	require.NoError(t, err)
+	assert.Equal(t, "3", out)
+}
+
+func TestTemplateFuncs_LookupDefault(t *testing.T) {
+	// Odd number of args after value → last arg is default
+	out, err := RenderTemplate(`{{lookup .sev "Critical" "4" "High" "3" "0"}}`, map[string]any{"sev": "Unknown"})
+	require.NoError(t, err)
+	assert.Equal(t, "0", out)
+}
+
+func TestTemplateFuncs_LookupNoMatch(t *testing.T) {
+	// Even args, no match → empty string
+	out, err := RenderTemplate(`{{lookup .sev "Critical" "4" "High" "3"}}`, map[string]any{"sev": "Low"})
+	require.NoError(t, err)
+	assert.Equal(t, "", out)
+}
+
+func TestTemplateFuncs_LookupIntValues(t *testing.T) {
+	out, err := RenderTemplate(`{{lookup .sev "Critical" 4 "High" 3 "Medium" 2 "Low" 1 0}}`, map[string]any{"sev": "Critical"})
+	require.NoError(t, err)
+	assert.Equal(t, "4", out)
+}
+
+// ---------------------------------------------------------------------------
+// default — fallback for empty/nil values
+// ---------------------------------------------------------------------------
+
+func TestTemplateFuncs_Default(t *testing.T) {
+	out, err := RenderTemplate(`{{default .name "unknown"}}`, map[string]any{"name": "curl"})
+	require.NoError(t, err)
+	assert.Equal(t, "curl", out)
+}
+
+func TestTemplateFuncs_DefaultEmpty(t *testing.T) {
+	out, err := RenderTemplate(`{{default .name "unknown"}}`, map[string]any{"name": ""})
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", out)
+}
+
+func TestTemplateFuncs_DefaultNil(t *testing.T) {
+	out, err := RenderTemplate(`{{default .name "unknown"}}`, map[string]any{})
+	require.NoError(t, err)
+	assert.Equal(t, "unknown", out)
+}
+
+// ---------------------------------------------------------------------------
+// Composition — dict + lookup + json pipeline for trivy Advisory shape
+// ---------------------------------------------------------------------------
+
+func TestTemplateFuncs_TrivyAdvisoryShape(t *testing.T) {
+	// Simulates the trivy Advisory JSON construction from venturi GitHub Advisory fields
+	tmpl := `{{dict "FixedVersion" .ver "Severity" (lookup .sev "Critical" 4 "High" 3 "Medium" 2 "Low" 1 0) | json}}`
+	out, err := RenderTemplate(tmpl, map[string]any{
+		"ver": "3.0.1",
+		"sev": "High",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"FixedVersion":"3.0.1","Severity":3}`, out)
+}

--- a/internal/lattice/infer_test.go
+++ b/internal/lattice/infer_test.go
@@ -88,7 +88,7 @@ func TestInferFromSQLite_Synthetic(t *testing.T) {
 			fmt.Sprintf("rec-%d", i), string(data))
 		require.NoError(t, err)
 	}
-	_ = db.Close()
+	require.NoError(t, db.Close())
 
 	// Run full pipeline
 	inf := &Inferrer{Config: InferConfig{SampleSize: 100, RootName: "vulns"}}


### PR DESCRIPTION
## Summary
- **Template functions**: `dict`, `lookup`, `default` for inline map construction, enum mapping, and nil/empty fallbacks in projection schemas
- **--out fix for .db sources**: Skip `OpenSQLiteGraph`/`EagerScan` when `--out` is set — ingest via `SQLiteWriter` → materialize → exit (no mount needed)
- **_parent context**: Child selectors can now access parent record fields via `{{._parent.item.Field}}`
- **trivy-ghsa-schema.json**: Example schema projecting venturi GitHub Advisory data into trivy-db BoltDB layout using the new template funcs

## Test plan
- [x] `TestTemplateFuncs_Dict` — empty, with values, with int values, with template values
- [x] `TestTemplateFuncs_Lookup` — match, default, no-match, int values
- [x] `TestTemplateFuncs_Default` — present value, empty string, nil
- [x] `TestTemplateFuncs_TrivyAdvisoryShape` — composition test (dict + lookup + json pipeline)
- [x] `TestOutFlag_DBSource` — regression test for --out with .db data sources
- [x] `task check` passes (fmt + vet + lint + test + validate)

## Copilot review requested
Requesting Copilot review for automated feedback cycle.