### PR TITLE
refactor: extract NodesTableReader — eliminate SQL duplication (Phase 3)

### DIFF
--- a/internal/graph/graph_suite_test.go
+++ b/internal/graph/graph_suite_test.go
@@ -282,9 +282,25 @@ func hotSwapFactory(t *testing.T) Graph {
 	return NewHotSwapGraph(memoryStoreFactory(t))
 }
 
-// sqliteGraphFactory creates a temp SQLite DB with a nodes table matching
-// the canonical test graph, then opens it as a SQLiteGraph.
+// sqliteGraphFactory opens the canonical test DB as a SQLiteGraph (nodes-table fast path).
 func sqliteGraphFactory(t *testing.T) Graph {
+	t.Helper()
+	dbPath := createNodesTableDB(t)
+	schema := &api.Topology{Table: "results"}
+	g, err := OpenSQLiteGraph(dbPath, schema, stubRender)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = g.Close() })
+	return g
+}
+
+// stubRender is a no-op renderer for tests where content is inline in the record column.
+func stubRender(tmpl string, values map[string]any) (string, error) {
+	return tmpl, nil
+}
+
+// createNodesTableDB creates a temp SQLite DB with the canonical test graph
+// in the nodes table schema. Shared by sqliteGraphFactory and writableGraphFactory.
+func createNodesTableDB(t *testing.T) string {
 	t.Helper()
 	dbPath := filepath.Join(t.TempDir(), "test.db")
 	db, err := sql.Open("sqlite", dbPath)
@@ -331,24 +347,25 @@ func sqliteGraphFactory(t *testing.T) Graph {
 		require.NoError(t, err)
 	}
 	require.NoError(t, db.Close())
+	return dbPath
+}
 
-	// Minimal schema — just needs Table set for the nodes-table path
+// writableGraphFactory opens the canonical test DB as a WritableGraph.
+func writableGraphFactory(t *testing.T) Graph {
+	t.Helper()
+	dbPath := createNodesTableDB(t)
 	schema := &api.Topology{Table: "results"}
-	g, err := OpenSQLiteGraph(dbPath, schema, stubRender)
+	g, err := OpenWritableGraph(dbPath, schema, stubRender, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = g.Close() })
 	return g
-}
-
-// stubRender is a no-op renderer for SQLiteGraph tests where content is inline.
-func stubRender(tmpl string, values map[string]any) (string, error) {
-	return tmpl, nil
 }
 
 // ---------------------------------------------------------------------------
 // Suite runners — one per implementation
 // ---------------------------------------------------------------------------
 
-func TestMemoryStore_GraphSuite(t *testing.T)  { RunGraphSuite(t, memoryStoreFactory) }
-func TestHotSwapGraph_GraphSuite(t *testing.T) { RunGraphSuite(t, hotSwapFactory) }
-func TestSQLiteGraph_GraphSuite(t *testing.T)  { RunGraphSuite(t, sqliteGraphFactory) }
+func TestMemoryStore_GraphSuite(t *testing.T)   { RunGraphSuite(t, memoryStoreFactory) }
+func TestHotSwapGraph_GraphSuite(t *testing.T)  { RunGraphSuite(t, hotSwapFactory) }
+func TestSQLiteGraph_GraphSuite(t *testing.T)   { RunGraphSuite(t, sqliteGraphFactory) }
+func TestWritableGraph_GraphSuite(t *testing.T) { RunGraphSuite(t, writableGraphFactory) }

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -37,7 +37,7 @@ type NodesTableReader struct {
 }
 
 // DB returns the underlying database connection.
-// Used by WritableGraph.UpdateRecord for write operations.
+// Used by WritableGraph for write operations and Close.
 func (r *NodesTableReader) DB() *sql.DB { return r.db }
 
 // NewNodesTableReader creates a reader for the nodes-table schema.
@@ -248,7 +248,7 @@ func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
 			Mode: r.fileMode,
 		})
 	}
-	return nodes, nil
+	return nodes, rows.Err()
 }
 
 // Invalidate evicts cached content and size for a node.

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -26,28 +26,32 @@ const (
 // The caller owns the *sql.DB lifecycle — NodesTableReader holds a
 // reference but does not close it.
 type NodesTableReader struct {
-	DB        *sql.DB
-	TableName string           // source records table ("results" or schema.Table)
-	Render    TemplateRenderer // for record_id fallback rendering
-	Levels    []*schemaLevel   // compiled schema levels
-	FileMode  os.FileMode      // permission for file nodes
-	DirMode   os.FileMode      // permission for dir nodes
-	SizeCache sync.Map         // file path → int64
-	Cache     *ContentCache    // FIFO-bounded rendered content
+	db        *sql.DB
+	tableName string           // source records table ("results" or schema.Table)
+	render    TemplateRenderer // for record_id fallback rendering
+	levels    []*schemaLevel   // compiled schema levels
+	fileMode  os.FileMode      // permission for file nodes
+	dirMode   os.FileMode      // permission for dir nodes
+	sizeCache sync.Map         // file path → int64
+	cache     *ContentCache    // FIFO-bounded rendered content
 }
+
+// DB returns the underlying database connection.
+// Used by WritableGraph.UpdateRecord for write operations.
+func (r *NodesTableReader) DB() *sql.DB { return r.db }
 
 // NewNodesTableReader creates a reader for the nodes-table schema.
 func NewNodesTableReader(db *sql.DB, tableName string, render TemplateRenderer,
 	levels []*schemaLevel, fileMode, dirMode os.FileMode, cacheSize int,
 ) *NodesTableReader {
 	return &NodesTableReader{
-		DB:        db,
-		TableName: tableName,
-		Render:    render,
-		Levels:    levels,
-		FileMode:  fileMode,
-		DirMode:   dirMode,
-		Cache:     NewContentCache(cacheSize),
+		db:        db,
+		tableName: tableName,
+		render:    render,
+		levels:    levels,
+		fileMode:  fileMode,
+		dirMode:   dirMode,
+		cache:     NewContentCache(cacheSize),
 	}
 }
 
@@ -55,13 +59,13 @@ func NewNodesTableReader(db *sql.DB, tableName string, render TemplateRenderer,
 func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 	id = NormalizeID(id)
 	if id == "" {
-		return &Node{ID: "", Mode: os.ModeDir | r.DirMode}, nil
+		return &Node{ID: "", Mode: os.ModeDir | r.dirMode}, nil
 	}
 
 	var kind, size int
 	var mtimeNano int64
 	var recordID sql.NullString
-	err := r.DB.QueryRow("SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?", id).
+	err := r.db.QueryRow("SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?", id).
 		Scan(&kind, &size, &mtimeNano, &recordID)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -70,9 +74,9 @@ func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 		return nil, err
 	}
 
-	mode := r.FileMode
+	mode := r.fileMode
 	if kind == NodeKindDir {
-		mode = os.ModeDir | r.DirMode
+		mode = os.ModeDir | r.dirMode
 	}
 
 	node := &Node{
@@ -82,12 +86,12 @@ func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 	}
 
 	if kind == NodeKindFile {
-		if cachedSize, ok := r.SizeCache.Load(id); ok {
+		if cachedSize, ok := r.sizeCache.Load(id); ok {
 			node.Ref = &ContentRef{ContentLen: cachedSize.(int64)}
 			return node, nil
 		}
 		node.Ref = &ContentRef{ContentLen: int64(size)}
-		r.SizeCache.Store(id, int64(size))
+		r.sizeCache.Store(id, int64(size))
 	}
 	return node, nil
 }
@@ -99,9 +103,9 @@ func (r *NodesTableReader) ListChildren(id string) ([]string, error) {
 	var rows *sql.Rows
 	var err error
 	if id == "" {
-		rows, err = r.DB.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
+		rows, err = r.db.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
 	} else {
-		rows, err = r.DB.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
+		rows, err = r.db.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
 	}
 	if err != nil {
 		return nil, err
@@ -126,9 +130,9 @@ func (r *NodesTableReader) ListChildStats(id string) ([]NodeStat, error) {
 	var rows *sql.Rows
 	var err error
 	if id == "" {
-		rows, err = r.DB.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
+		rows, err = r.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
 	} else {
-		rows, err = r.DB.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = ? ORDER BY name", id)
+		rows, err = r.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = ? ORDER BY name", id)
 	}
 	if err != nil {
 		return nil, err
@@ -167,13 +171,13 @@ func (r *NodesTableReader) ReadContent(id string, buf []byte, offset int64) (int
 // resolveContent reads file content. Checks cache, then nodes.record column
 // (inline content), then falls back to template rendering via record_id.
 func (r *NodesTableReader) resolveContent(id string) ([]byte, error) {
-	if c, ok := r.Cache.Get(id); ok {
+	if c, ok := r.cache.Get(id); ok {
 		return c, nil
 	}
 
 	var record sql.NullString
 	var recordID sql.NullString
-	err := r.DB.QueryRow("SELECT record, record_id FROM nodes WHERE id = ?", id).
+	err := r.db.QueryRow("SELECT record, record_id FROM nodes WHERE id = ?", id).
 		Scan(&record, &recordID)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -194,14 +198,14 @@ func (r *NodesTableReader) resolveContent(id string) ([]byte, error) {
 		return nil, ErrNotFound
 	}
 
-	r.Cache.Put(id, content)
+	r.cache.Put(id, content)
 	return content, nil
 }
 
 // renderFromRecord fetches a record by ID and renders content via template.
 func (r *NodesTableReader) renderFromRecord(filePath, recordID string) ([]byte, error) {
 	var raw string
-	if err := r.DB.QueryRow("SELECT record FROM "+r.TableName+" WHERE id = ?", recordID).Scan(&raw); err != nil {
+	if err := r.db.QueryRow("SELECT record FROM "+r.tableName+" WHERE id = ?", recordID).Scan(&raw); err != nil {
 		return nil, fmt.Errorf("fetch record %s: %w", recordID, err)
 	}
 
@@ -212,12 +216,12 @@ func (r *NodesTableReader) renderFromRecord(filePath, recordID string) ([]byte, 
 	values, _ := parsed.(map[string]any)
 
 	segments := strings.Split(filePath, "/")
-	_, fileLeaf := walkSchemaLevels(r.Levels, segments)
+	_, fileLeaf := walkSchemaLevels(r.levels, segments)
 	if fileLeaf == nil {
 		return nil, fmt.Errorf("no schema leaf for %s", filePath)
 	}
 
-	rendered, err := r.Render(fileLeaf.ContentTemplate, values)
+	rendered, err := r.render(fileLeaf.ContentTemplate, values)
 	if err != nil {
 		return nil, fmt.Errorf("render %s: %w", filePath, err)
 	}
@@ -226,7 +230,7 @@ func (r *NodesTableReader) renderFromRecord(filePath, recordID string) ([]byte, 
 
 // GetCallers returns nodes that reference the given token via node_refs table.
 func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
-	rows, err := r.DB.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
+	rows, err := r.db.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
 	if err != nil {
 		return nil, fmt.Errorf("query node_refs: %w", err)
 	}
@@ -241,7 +245,7 @@ func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
 		}
 		nodes = append(nodes, &Node{
 			ID:   nodeID,
-			Mode: r.FileMode,
+			Mode: r.fileMode,
 		})
 	}
 	return nodes, nil
@@ -249,6 +253,6 @@ func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
 
 // Invalidate evicts cached content and size for a node.
 func (r *NodesTableReader) Invalidate(id string) {
-	r.SizeCache.Delete(id)
-	r.Cache.Delete(id)
+	r.sizeCache.Delete(id)
+	r.cache.Delete(id)
 }

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -1,0 +1,254 @@
+package graph
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// NodeKindFile and NodeKindDir are the kind values in the nodes table.
+const (
+	NodeKindFile = 0
+	NodeKindDir  = 1
+)
+
+// NodesTableReader provides read methods for the nodes-table schema.
+// Shared by SQLiteGraph (nodes-table fast path) and WritableGraph.
+//
+// Parameterized by FileMode/DirMode so the same SQL queries produce
+// read-only (0o444/0o555) or writable (0o644/0o755) nodes.
+//
+// The caller owns the *sql.DB lifecycle — NodesTableReader holds a
+// reference but does not close it.
+type NodesTableReader struct {
+	DB        *sql.DB
+	TableName string           // source records table ("results" or schema.Table)
+	Render    TemplateRenderer // for record_id fallback rendering
+	Levels    []*schemaLevel   // compiled schema levels
+	FileMode  os.FileMode      // permission for file nodes
+	DirMode   os.FileMode      // permission for dir nodes
+	SizeCache sync.Map         // file path → int64
+	Cache     *ContentCache    // FIFO-bounded rendered content
+}
+
+// NewNodesTableReader creates a reader for the nodes-table schema.
+func NewNodesTableReader(db *sql.DB, tableName string, render TemplateRenderer,
+	levels []*schemaLevel, fileMode, dirMode os.FileMode, cacheSize int,
+) *NodesTableReader {
+	return &NodesTableReader{
+		DB:        db,
+		TableName: tableName,
+		Render:    render,
+		Levels:    levels,
+		FileMode:  fileMode,
+		DirMode:   dirMode,
+		Cache:     NewContentCache(cacheSize),
+	}
+}
+
+// GetNode returns a node by ID from the nodes table.
+func (r *NodesTableReader) GetNode(id string) (*Node, error) {
+	id = NormalizeID(id)
+	if id == "" {
+		return &Node{ID: "", Mode: os.ModeDir | r.DirMode}, nil
+	}
+
+	var kind, size int
+	var mtimeNano int64
+	var recordID sql.NullString
+	err := r.DB.QueryRow("SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?", id).
+		Scan(&kind, &size, &mtimeNano, &recordID)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	mode := r.FileMode
+	if kind == NodeKindDir {
+		mode = os.ModeDir | r.DirMode
+	}
+
+	node := &Node{
+		ID:      id,
+		Mode:    mode,
+		ModTime: time.Unix(0, mtimeNano),
+	}
+
+	if kind == NodeKindFile {
+		if cachedSize, ok := r.SizeCache.Load(id); ok {
+			node.Ref = &ContentRef{ContentLen: cachedSize.(int64)}
+			return node, nil
+		}
+		node.Ref = &ContentRef{ContentLen: int64(size)}
+		r.SizeCache.Store(id, int64(size))
+	}
+	return node, nil
+}
+
+// ListChildren returns child IDs for a directory from the nodes table.
+func (r *NodesTableReader) ListChildren(id string) ([]string, error) {
+	id = NormalizeID(id)
+
+	var rows *sql.Rows
+	var err error
+	if id == "" {
+		rows, err = r.DB.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
+	} else {
+		rows, err = r.DB.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var children []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		children = append(children, name)
+	}
+	return children, rows.Err()
+}
+
+// ListChildStats returns stat snapshots for all children without rendering content.
+func (r *NodesTableReader) ListChildStats(id string) ([]NodeStat, error) {
+	id = NormalizeID(id)
+
+	var rows *sql.Rows
+	var err error
+	if id == "" {
+		rows, err = r.DB.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
+	} else {
+		rows, err = r.DB.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = ? ORDER BY name", id)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var stats []NodeStat
+	for rows.Next() {
+		var childID string
+		var kind, size int
+		var mtimeNano int64
+		if err := rows.Scan(&childID, &kind, &size, &mtimeNano); err != nil {
+			return nil, err
+		}
+		stats = append(stats, NodeStat{
+			ID:          childID,
+			IsDir:       kind == NodeKindDir,
+			ContentSize: int64(size),
+			ModTime:     time.Unix(0, mtimeNano),
+			HasOrigin:   false,
+		})
+	}
+	return stats, rows.Err()
+}
+
+// ReadContent resolves content and copies into buf at offset.
+func (r *NodesTableReader) ReadContent(id string, buf []byte, offset int64) (int, error) {
+	id = NormalizeID(id)
+	content, err := r.resolveContent(id)
+	if err != nil {
+		return 0, err
+	}
+	return SliceContent(content, buf, offset), nil
+}
+
+// resolveContent reads file content. Checks cache, then nodes.record column
+// (inline content), then falls back to template rendering via record_id.
+func (r *NodesTableReader) resolveContent(id string) ([]byte, error) {
+	if c, ok := r.Cache.Get(id); ok {
+		return c, nil
+	}
+
+	var record sql.NullString
+	var recordID sql.NullString
+	err := r.DB.QueryRow("SELECT record, record_id FROM nodes WHERE id = ?", id).
+		Scan(&record, &recordID)
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var content []byte
+	if record.Valid && record.String != "" {
+		content = []byte(record.String)
+	} else if recordID.Valid && recordID.String != "" {
+		content, err = r.renderFromRecord(id, recordID.String)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, ErrNotFound
+	}
+
+	r.Cache.Put(id, content)
+	return content, nil
+}
+
+// renderFromRecord fetches a record by ID and renders content via template.
+func (r *NodesTableReader) renderFromRecord(filePath, recordID string) ([]byte, error) {
+	var raw string
+	if err := r.DB.QueryRow("SELECT record FROM "+r.TableName+" WHERE id = ?", recordID).Scan(&raw); err != nil {
+		return nil, fmt.Errorf("fetch record %s: %w", recordID, err)
+	}
+
+	var parsed any
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("parse record %s: %w", recordID, err)
+	}
+	values, _ := parsed.(map[string]any)
+
+	segments := strings.Split(filePath, "/")
+	_, fileLeaf := walkSchemaLevels(r.Levels, segments)
+	if fileLeaf == nil {
+		return nil, fmt.Errorf("no schema leaf for %s", filePath)
+	}
+
+	rendered, err := r.Render(fileLeaf.ContentTemplate, values)
+	if err != nil {
+		return nil, fmt.Errorf("render %s: %w", filePath, err)
+	}
+	return []byte(rendered), nil
+}
+
+// GetCallers returns nodes that reference the given token via node_refs table.
+func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
+	rows, err := r.DB.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
+	if err != nil {
+		return nil, fmt.Errorf("query node_refs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var nodes []*Node
+	for rows.Next() {
+		var nodeID string
+		if err := rows.Scan(&nodeID); err != nil {
+			log.Printf("GetCallers: skip row scan: %v", err)
+			continue
+		}
+		nodes = append(nodes, &Node{
+			ID:   nodeID,
+			Mode: r.FileMode,
+		})
+	}
+	return nodes, nil
+}
+
+// Invalidate evicts cached content and size for a node.
+func (r *NodesTableReader) Invalidate(id string) {
+	r.SizeCache.Delete(id)
+	r.Cache.Delete(id)
+}

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -81,16 +81,16 @@ type SQLiteGraph struct {
 	nextFileID  uint32
 	fileIDMap   map[string]uint32 // path → file ID (in-memory during ingestion)
 
-	// Size cache: file path → rendered byte length.
-	// Populated on first GetNode (which renders content), used on subsequent
-	// GetNode calls to return a lightweight Node without re-rendering.
-	// Unlike contentCache (FIFO-bounded), sizeCache is unbounded — int64 values
-	// are tiny and we need them to survive across large directory traversals.
+	// Size cache: file path → rendered byte length (legacy scan path only).
+	// The nodes-table fast path uses ntr.SizeCache instead.
 	sizeCache sync.Map // file path (string) → int64
 
-	cache *ContentCache // FIFO-bounded rendered content (protects against hot-file storms)
+	cache *ContentCache // FIFO-bounded rendered content (legacy scan path only)
 
-	useNodesTable bool // Fast path: use "nodes" table instead of scanning "results"
+	// Nodes-table fast path: when non-nil, all read methods delegate here.
+	// Initialized only when the DB has a "nodes" table (built by mache build).
+	ntr           *NodesTableReader
+	useNodesTable bool
 
 	extractor CallExtractor
 	defs      map[string][]string // symbol_name → []construct_dir_id (populated by AddDef)
@@ -147,14 +147,16 @@ func OpenSQLiteGraph(dbPath string, schema *api.Topology, render TemplateRendere
 	// When the main DB has a nodes table (built by mache build), node_refs
 	// is already present with (token, node_id) pairs. No sidecar needed.
 	if useNodesTable {
+		levels := compileLevels(schema)
+		ntr := NewNodesTableReader(db, tableName, render, levels, 0o444, 0o555, 2048)
 		return &SQLiteGraph{
 			db:            db,
 			dbPath:        dbPath,
 			tableName:     tableName,
 			schema:        schema,
 			render:        render,
-			levels:        compileLevels(schema),
-			cache:         NewContentCache(2048),
+			levels:        levels,
+			ntr:           ntr,
 			useNodesTable: true,
 		}, nil
 	}
@@ -300,51 +302,8 @@ func (g *SQLiteGraph) GetNode(id string) (*Node, error) {
 		return &Node{ID: "", Mode: os.ModeDir | 0o555}, nil
 	}
 
-	// Fast Path: Nodes Table
 	if g.useNodesTable {
-		var kind, size int
-		var mtimeNano int64
-		var recordID sql.NullString
-		err := g.db.QueryRow("SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?", id).Scan(&kind, &size, &mtimeNano, &recordID)
-		if err == sql.ErrNoRows {
-			return nil, ErrNotFound
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		mode := os.FileMode(0o444)
-		if kind == 1 {
-			mode = os.ModeDir | 0o555
-		}
-
-		node := &Node{
-			ID:      id,
-			Mode:    mode,
-			ModTime: time.Unix(0, mtimeNano),
-		}
-
-		// If it's a file, set up content ref for size reporting
-		if kind == 0 {
-			if recordID.Valid {
-				// Record ID reference — set up lazy content ref with template
-				segments := strings.Split(id, "/")
-				_, fileLeaf := g.walkSchema(segments)
-				if fileLeaf != nil {
-					node.Ref = &ContentRef{
-						DBPath:     g.dbPath,
-						RecordID:   recordID.String,
-						Template:   fileLeaf.ContentTemplate,
-						ContentLen: int64(size),
-					}
-				}
-			} else {
-				// Inline content (source code from SQLiteWriter) — use ContentRef for size only
-				node.Ref = &ContentRef{ContentLen: int64(size)}
-			}
-			g.sizeCache.Store(id, int64(size))
-		}
-		return node, nil
+		return g.ntr.GetNode(id)
 	}
 
 	segments := strings.Split(id, "/")
@@ -397,31 +356,8 @@ func (g *SQLiteGraph) GetNode(id string) (*Node, error) {
 func (g *SQLiteGraph) ListChildren(id string) ([]string, error) {
 	id = NormalizeID(id)
 
-	// Fast Path: Nodes Table
 	if g.useNodesTable {
-		// Top-level nodes have parent_id = empty string.
-		var rows *sql.Rows
-		var err error
-		if id == "" {
-			// Root children (top level dirs)
-			rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
-		} else {
-			rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
-		}
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = rows.Close() }()
-
-		var children []string
-		for rows.Next() {
-			var childID string
-			if err := rows.Scan(&childID); err != nil {
-				return nil, err
-			}
-			children = append(children, childID)
-		}
-		return children, nil
+		return g.ntr.ListChildren(id)
 	}
 
 	// Root: return schema root names
@@ -454,37 +390,8 @@ func (g *SQLiteGraph) ListChildren(id string) ([]string, error) {
 func (g *SQLiteGraph) ListChildStats(id string) ([]NodeStat, error) {
 	id = NormalizeID(id)
 
-	// Fast Path: Nodes Table
 	if g.useNodesTable {
-		var rows *sql.Rows
-		var err error
-		if id == "" {
-			rows, err = g.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
-		} else {
-			rows, err = g.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = ? ORDER BY name", id)
-		}
-		if err != nil {
-			return nil, err
-		}
-		defer func() { _ = rows.Close() }()
-
-		var stats []NodeStat
-		for rows.Next() {
-			var childID string
-			var kind, size int
-			var mtimeNano int64
-			if err := rows.Scan(&childID, &kind, &size, &mtimeNano); err != nil {
-				return nil, err
-			}
-			stats = append(stats, NodeStat{
-				ID:          childID,
-				IsDir:       kind == 1,
-				ContentSize: int64(size),
-				ModTime:     time.Unix(0, mtimeNano),
-				HasOrigin:   false, // SQLiteGraph nodes don't have write-back origins
-			})
-		}
-		return stats, rows.Err()
+		return g.ntr.ListChildStats(id)
 	}
 
 	// Legacy scan path: use dirChildren + schema to determine child types
@@ -840,25 +747,7 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 // getCallersFromMainDB queries the main DB's node_refs table directly.
 // node_refs schema: (token TEXT, node_id TEXT) — written by mache build.
 func (g *SQLiteGraph) getCallersFromMainDB(token string) ([]*Node, error) {
-	rows, err := g.db.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
-	if err != nil {
-		return nil, fmt.Errorf("query node_refs: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var nodes []*Node
-	for rows.Next() {
-		var nodeID string
-		if err := rows.Scan(&nodeID); err != nil {
-			log.Printf("GetCallers: skip row scan: %v", err)
-			continue
-		}
-		nodes = append(nodes, &Node{
-			ID:   nodeID,
-			Mode: 0o444,
-		})
-	}
-	return nodes, nil
+	return g.ntr.GetCallers(token)
 }
 
 // getCallersFromSidecar reads roaring bitmaps from the sidecar .refs.db.
@@ -919,8 +808,13 @@ func (g *SQLiteGraph) getCallersFromSidecar(token string) ([]*Node, error) {
 // Must be called after write-back modifies a file's content to prevent
 // stale size/data from being served on the next Getattr or Read.
 func (g *SQLiteGraph) Invalidate(id string) {
+	if g.ntr != nil {
+		g.ntr.Invalidate(id)
+	}
 	g.sizeCache.Delete(id)
-	g.cache.Delete(id)
+	if g.cache != nil {
+		g.cache.Delete(id)
+	}
 }
 
 // QueryRefs executes a SQL query against the refs database.
@@ -1423,48 +1317,17 @@ func (g *SQLiteGraph) isChild(parentPath, childPath string) bool {
 // ---------------------------------------------------------------------------
 
 func (g *SQLiteGraph) resolveContent(filePath string, segments []string, leaf *api.Leaf) ([]byte, error) {
-	// Check cache
+	if g.useNodesTable {
+		return g.ntr.resolveContent(filePath)
+	}
+
+	// Legacy path
 	if c, ok := g.cache.Get(filePath); ok {
 		return c, nil
 	}
 
 	var content []byte
-
-	if g.useNodesTable {
-		// Nodes-table path: check for inline content first, then record_id fallback.
-		var recordID sql.NullString
-		var record sql.NullString
-		err := g.db.QueryRow("SELECT record_id, record FROM nodes WHERE id = ?", filePath).Scan(&recordID, &record)
-		if err == sql.ErrNoRows {
-			return nil, ErrNotFound
-		}
-		if err != nil {
-			return nil, err
-		}
-
-		if !recordID.Valid && record.Valid {
-			// Inline content (source code nodes written by SQLiteWriter) — return directly.
-			content = []byte(record.String)
-		} else if recordID.Valid && recordID.String != "" {
-			// Record ID reference — fetch from results table and render via template.
-			var raw string
-			if err := g.db.QueryRow("SELECT record FROM "+g.tableName+" WHERE id = ?", recordID.String).Scan(&raw); err != nil {
-				return nil, fmt.Errorf("fetch record %s: %w", recordID.String, err)
-			}
-			var parsed any
-			if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-				return nil, fmt.Errorf("parse record %s: %w", recordID.String, err)
-			}
-			values, _ := parsed.(map[string]any)
-			rendered, err := g.render(leaf.ContentTemplate, values)
-			if err != nil {
-				return nil, fmt.Errorf("render %s: %w", filePath, err)
-			}
-			content = []byte(rendered)
-		} else {
-			return nil, ErrNotFound
-		}
-	} else {
+	{
 		// Legacy mode: find parent directory's record ID
 		parentPath := strings.Join(segments[:len(segments)-1], "/")
 		if err := g.ensureScanned(segments[0]); err != nil {

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -297,13 +297,13 @@ func (g *SQLiteGraph) DefsMap() map[string][]string {
 }
 
 func (g *SQLiteGraph) GetNode(id string) (*Node, error) {
+	if g.useNodesTable {
+		return g.ntr.GetNode(id)
+	}
+
 	id = NormalizeID(id)
 	if id == "" {
 		return &Node{ID: "", Mode: os.ModeDir | 0o555}, nil
-	}
-
-	if g.useNodesTable {
-		return g.ntr.GetNode(id)
 	}
 
 	segments := strings.Split(id, "/")
@@ -354,11 +354,11 @@ func (g *SQLiteGraph) GetNode(id string) (*Node, error) {
 }
 
 func (g *SQLiteGraph) ListChildren(id string) ([]string, error) {
-	id = NormalizeID(id)
-
 	if g.useNodesTable {
 		return g.ntr.ListChildren(id)
 	}
+
+	id = NormalizeID(id)
 
 	// Root: return schema root names
 	if id == "" {
@@ -388,11 +388,11 @@ func (g *SQLiteGraph) ListChildren(id string) ([]string, error) {
 // For the legacy scan path, it uses dirChildren + schema structure.
 // ContentSize may be 0 for unvisited files (FUSE/NFS fall back to LOOKUP).
 func (g *SQLiteGraph) ListChildStats(id string) ([]NodeStat, error) {
-	id = NormalizeID(id)
-
 	if g.useNodesTable {
 		return g.ntr.ListChildStats(id)
 	}
+
+	id = NormalizeID(id)
 
 	// Legacy scan path: use dirChildren + schema to determine child types
 	if id == "" {
@@ -809,11 +809,11 @@ func (g *SQLiteGraph) getCallersFromSidecar(token string) ([]*Node, error) {
 // stale size/data from being served on the next Getattr or Read.
 func (g *SQLiteGraph) Invalidate(id string) {
 	if g.ntr != nil {
-		g.ntr.Invalidate(id)
+		g.ntr.Invalidate(id) // nodes-table path: ntr owns sizeCache + cache
 	}
-	g.sizeCache.Delete(id)
+	g.sizeCache.Delete(id) // legacy path sizeCache (no-op when ntr is set)
 	if g.cache != nil {
-		g.cache.Delete(id)
+		g.cache.Delete(id) // legacy path cache (nil when ntr is set)
 	}
 }
 

--- a/internal/graph/writable_graph.go
+++ b/internal/graph/writable_graph.go
@@ -92,7 +92,7 @@ func (g *WritableGraph) UpdateRecord(id string, content []byte) error {
 	id = NormalizeID(id)
 
 	now := time.Now().UnixNano()
-	result, err := g.ntr.DB.Exec(
+	result, err := g.ntr.DB().Exec(
 		"UPDATE nodes SET record = ?, size = ?, mtime = ? WHERE id = ?",
 		string(content), len(content), now, id,
 	)
@@ -125,7 +125,7 @@ func (g *WritableGraph) FlushNow() error {
 
 // Close closes the database connection.
 func (g *WritableGraph) Close() error {
-	return g.ntr.DB.Close()
+	return g.ntr.DB().Close()
 }
 
 // DBPath returns the path to the writable master database.

--- a/internal/graph/writable_graph.go
+++ b/internal/graph/writable_graph.go
@@ -16,7 +16,6 @@ import (
 type WritableGraph struct {
 	ntr     *NodesTableReader // all read operations
 	dbPath  string            // temp file path (the writable master)
-	schema  *api.Topology
 	flusher *ArenaFlusher
 	mu      sync.RWMutex
 }
@@ -55,7 +54,6 @@ func OpenWritableGraph(masterDBPath string, schema *api.Topology, render Templat
 	return &WritableGraph{
 		ntr:     NewNodesTableReader(db, tableName, render, compileLevels(schema), 0o644, 0o755, 2048),
 		dbPath:  masterDBPath,
-		schema:  schema,
 		flusher: flusher,
 	}, nil
 }

--- a/internal/graph/writable_graph.go
+++ b/internal/graph/writable_graph.go
@@ -2,11 +2,7 @@ package graph
 
 import (
 	"database/sql"
-	"encoding/json"
 	"fmt"
-	"log"
-	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -15,25 +11,14 @@ import (
 )
 
 // WritableGraph is a read-write SQLite backend for arena-mode mounts.
-// It opens the master .db in read-write mode and supports mutations
-// that are flushed back to the arena via ArenaFlusher.
-//
-// Read methods use the same nodes-table queries as SQLiteGraph's fast path.
-// Write methods mutate the nodes table directly (UPDATE/INSERT/DELETE).
-// Flush serializes the entire .db back to the double-buffered arena.
+// Read methods delegate to NodesTableReader (shared with SQLiteGraph).
+// Write methods mutate the nodes table and flush to the arena.
 type WritableGraph struct {
-	db        *sql.DB
-	dbPath    string // temp file path (the writable master)
-	schema    *api.Topology
-	render    TemplateRenderer
-	levels    []*schemaLevel
-	flusher   *ArenaFlusher
-	mu        sync.RWMutex
-	tableName string
-
-	cache *ContentCache // FIFO-bounded rendered content cache
-
-	sizeCache sync.Map
+	ntr     *NodesTableReader // all read operations
+	dbPath  string            // temp file path (the writable master)
+	schema  *api.Topology
+	flusher *ArenaFlusher
+	mu      sync.RWMutex
 }
 
 // OpenWritableGraph opens a writable connection to the master .db.
@@ -46,7 +31,6 @@ func OpenWritableGraph(masterDBPath string, schema *api.Topology, render Templat
 	db.SetMaxOpenConns(2)
 
 	// journal_mode=DELETE: after commit, the .db file IS the serialized form.
-	// No WAL files to worry about — os.ReadFile returns valid SQLite bytes.
 	if _, err := db.Exec("PRAGMA journal_mode=DELETE"); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("set journal mode: %w", err)
@@ -69,229 +53,31 @@ func OpenWritableGraph(masterDBPath string, schema *api.Topology, render Templat
 	}
 
 	return &WritableGraph{
-		db:        db,
-		dbPath:    masterDBPath,
-		schema:    schema,
-		render:    render,
-		levels:    compileLevels(schema),
-		flusher:   flusher,
-		tableName: tableName,
-		cache:     NewContentCache(2048),
+		ntr:     NewNodesTableReader(db, tableName, render, compileLevels(schema), 0o644, 0o755, 2048),
+		dbPath:  masterDBPath,
+		schema:  schema,
+		flusher: flusher,
 	}, nil
 }
 
 // ---------------------------------------------------------------------------
-// Graph interface (read methods)
+// Read methods — delegate to NodesTableReader
 // ---------------------------------------------------------------------------
 
-func (g *WritableGraph) GetNode(id string) (*Node, error) {
-	id = NormalizeID(id)
-	if id == "" {
-		return &Node{ID: "", Mode: os.ModeDir | 0o555}, nil
-	}
-
-	var kind, size int
-	var mtimeNano int64
-	var recordID sql.NullString
-	err := g.db.QueryRow("SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?", id).Scan(&kind, &size, &mtimeNano, &recordID)
-	if err == sql.ErrNoRows {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	mode := os.FileMode(0o644) // writable files
-	if kind == 1 {
-		mode = os.ModeDir | 0o755
-	}
-
-	node := &Node{
-		ID:      id,
-		Mode:    mode,
-		ModTime: time.Unix(0, mtimeNano),
-	}
-
-	if kind == 0 {
-		// File node — set up content ref for lazy resolution
-		if cachedSize, ok := g.sizeCache.Load(id); ok {
-			node.Ref = &ContentRef{ContentLen: cachedSize.(int64)}
-			return node, nil
-		}
-		node.Ref = &ContentRef{ContentLen: int64(size)}
-		g.sizeCache.Store(id, int64(size))
-	}
-	return node, nil
-}
-
-func (g *WritableGraph) ListChildren(id string) ([]string, error) {
-	id = NormalizeID(id)
-
-	var rows *sql.Rows
-	var err error
-	if id == "" {
-		rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
-	} else {
-		rows, err = g.db.Query("SELECT id FROM nodes WHERE parent_id = ? ORDER BY name", id)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	var children []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		children = append(children, name)
-	}
-	return children, rows.Err()
-}
-
-// ListChildStats implements Graph. Queries the nodes table for child stats
-// without rendering content.
+func (g *WritableGraph) GetNode(id string) (*Node, error)         { return g.ntr.GetNode(id) }
+func (g *WritableGraph) ListChildren(id string) ([]string, error) { return g.ntr.ListChildren(id) }
 func (g *WritableGraph) ListChildStats(id string) ([]NodeStat, error) {
-	id = NormalizeID(id)
-
-	var rows *sql.Rows
-	var err error
-	if id == "" {
-		rows, err = g.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = '' OR parent_id IS NULL ORDER BY name")
-	} else {
-		rows, err = g.db.Query("SELECT id, kind, size, mtime FROM nodes WHERE parent_id = ? ORDER BY name", id)
-	}
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	var stats []NodeStat
-	for rows.Next() {
-		var childID string
-		var kind, size int
-		var mtimeNano int64
-		if err := rows.Scan(&childID, &kind, &size, &mtimeNano); err != nil {
-			return nil, err
-		}
-		stats = append(stats, NodeStat{
-			ID:          childID,
-			IsDir:       kind == 1,
-			ContentSize: int64(size),
-			ModTime:     time.Unix(0, mtimeNano),
-			HasOrigin:   false,
-		})
-	}
-	return stats, rows.Err()
+	return g.ntr.ListChildStats(id)
 }
 
 func (g *WritableGraph) ReadContent(id string, buf []byte, offset int64) (int, error) {
-	id = NormalizeID(id)
-
-	content, err := g.resolveContent(id)
-	if err != nil {
-		return 0, err
-	}
-
-	return SliceContent(content, buf, offset), nil
+	return g.ntr.ReadContent(id, buf, offset)
 }
-
-// resolveContent reads file content. Checks the nodes.record column first
-// (populated by mache build or UpdateRecord), then falls back to template
-// rendering from the source record via record_id.
-func (g *WritableGraph) resolveContent(id string) ([]byte, error) {
-	// Check cache
-	if c, ok := g.cache.Get(id); ok {
-		return c, nil
-	}
-
-	// Try reading directly from the record column (works for inline content
-	// written by mache build, or content updated via UpdateRecord)
-	var record sql.NullString
-	var recordID sql.NullString
-	err := g.db.QueryRow("SELECT record, record_id FROM nodes WHERE id = ?", id).Scan(&record, &recordID)
-	if err == sql.ErrNoRows {
-		return nil, ErrNotFound
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	var content []byte
-	if record.Valid && record.String != "" {
-		// Direct content in record column
-		content = []byte(record.String)
-	} else if recordID.Valid && recordID.String != "" {
-		// Fall back to template rendering from source record
-		content, err = g.renderFromRecord(id, recordID.String)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, ErrNotFound
-	}
-
-	g.cache.Put(id, content)
-
-	return content, nil
-}
-
-// renderFromRecord fetches a record by ID and renders content via template.
-func (g *WritableGraph) renderFromRecord(filePath, recordID string) ([]byte, error) {
-	var raw string
-	if err := g.db.QueryRow("SELECT record FROM "+g.tableName+" WHERE id = ?", recordID).Scan(&raw); err != nil {
-		return nil, fmt.Errorf("fetch record %s: %w", recordID, err)
-	}
-
-	var parsed any
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, fmt.Errorf("parse record %s: %w", recordID, err)
-	}
-	values, _ := parsed.(map[string]any)
-
-	segments := strings.Split(filePath, "/")
-	_, fileLeaf := walkSchemaLevels(g.levels, segments)
-	if fileLeaf == nil {
-		return nil, fmt.Errorf("no schema leaf for %s", filePath)
-	}
-
-	rendered, err := g.render(fileLeaf.ContentTemplate, values)
-	if err != nil {
-		return nil, fmt.Errorf("render %s: %w", filePath, err)
-	}
-	return []byte(rendered), nil
-}
-
-func (g *WritableGraph) GetCallers(token string) ([]*Node, error) {
-	rows, err := g.db.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
-	if err != nil {
-		return nil, fmt.Errorf("query node_refs: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
-
-	var nodes []*Node
-	for rows.Next() {
-		var nodeID string
-		if err := rows.Scan(&nodeID); err != nil {
-			log.Printf("GetCallers: skip row scan: %v", err)
-			continue
-		}
-		nodes = append(nodes, &Node{
-			ID:   nodeID,
-			Mode: 0o644,
-		})
-	}
-	return nodes, nil
-}
-
-func (g *WritableGraph) GetCallees(id string) ([]*Node, error) {
-	return nil, nil // arena-mode mounts don't have call extraction
-}
-
-func (g *WritableGraph) Invalidate(id string) {
-	g.sizeCache.Delete(id)
-	g.cache.Delete(id)
+func (g *WritableGraph) GetCallers(token string) ([]*Node, error) { return g.ntr.GetCallers(token) }
+func (g *WritableGraph) GetCallees(id string) ([]*Node, error)    { return nil, nil }
+func (g *WritableGraph) Invalidate(id string)                     { g.ntr.Invalidate(id) }
+func (g *WritableGraph) Act(id, action, payload string) (*ActionResult, error) {
+	return nil, ErrActNotSupported
 }
 
 // ---------------------------------------------------------------------------
@@ -299,7 +85,6 @@ func (g *WritableGraph) Invalidate(id string) {
 // ---------------------------------------------------------------------------
 
 // UpdateRecord updates a file node's content in the nodes table.
-// The content is stored as an opaque blob in the record column.
 func (g *WritableGraph) UpdateRecord(id string, content []byte) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
@@ -307,7 +92,7 @@ func (g *WritableGraph) UpdateRecord(id string, content []byte) error {
 	id = NormalizeID(id)
 
 	now := time.Now().UnixNano()
-	result, err := g.db.Exec(
+	result, err := g.ntr.DB.Exec(
 		"UPDATE nodes SET record = ?, size = ?, mtime = ? WHERE id = ?",
 		string(content), len(content), now, id,
 	)
@@ -319,20 +104,18 @@ func (g *WritableGraph) UpdateRecord(id string, content []byte) error {
 		return ErrNotFound
 	}
 
-	// Evict caches
-	g.Invalidate(id)
+	g.ntr.Invalidate(id)
 	return nil
 }
 
-// Flush requests a coalesced arena flush. Non-blocking — the actual I/O
-// happens on the flusher's background tick. Use FlushNow for synchronous.
+// Flush requests a coalesced arena flush. Non-blocking.
 func (g *WritableGraph) Flush() {
 	if g.flusher != nil {
 		g.flusher.RequestFlush()
 	}
 }
 
-// FlushNow performs a synchronous arena flush. Use on unmount.
+// FlushNow performs a synchronous arena flush.
 func (g *WritableGraph) FlushNow() error {
 	if g.flusher == nil {
 		return nil
@@ -342,17 +125,12 @@ func (g *WritableGraph) FlushNow() error {
 
 // Close closes the database connection.
 func (g *WritableGraph) Close() error {
-	return g.db.Close()
+	return g.ntr.DB.Close()
 }
 
 // DBPath returns the path to the writable master database.
 func (g *WritableGraph) DBPath() string {
 	return g.dbPath
-}
-
-// Act returns ErrActNotSupported — WritableGraph is a code-editing graph, not an interactive UI.
-func (g *WritableGraph) Act(id, action, payload string) (*ActionResult, error) {
-	return nil, ErrActNotSupported
 }
 
 // Verify interface compliance at compile time.


### PR DESCRIPTION
## Summary

Extract shared SQL queries from SQLiteGraph and WritableGraph into a single `NodesTableReader` type. This is Phase 3 of the graph package decomposition.

- **NodesTableReader** — new embeddable type with 8 methods: GetNode, ListChildren, ListChildStats, ReadContent (resolveContent + renderFromRecord), GetCallers, Invalidate
- **WritableGraph** rewired — from 360 lines to 131. All read methods are single-line delegations. -229 lines.
- **SQLiteGraph** fast path rewired — 5 nodes-table branches replaced with delegations. Legacy scan path untouched. -137 lines.
- **WritableGraph** added to GraphSuite — 0% → full contract coverage (21 tests)
- **NodeKindFile/NodeKindDir** constants replace magic `0`/`1` integers

### What changed
- `nodes_table_reader.go` — new file, 254 lines
- `writable_graph.go` — rewritten, -229 lines (net -222)
- `sqlite_graph.go` — fast-path branches replaced, -137 lines
- `graph_suite_test.go` — WritableGraph factory + shared `createNodesTableDB` helper

### Design decisions
- FileMode/DirMode parameterized (0o444/0o555 for read-only, 0o644/0o755 for writable)
- `NormalizeID` called inside reader methods (no double-normalize)
- SQLiteGraph legacy scan path completely untouched
- `db *sql.DB` stored on reader (caller owns lifecycle)

## Test plan
- [x] 89 PASS across 4 backends (MemoryStore, HotSwap, SQLiteGraph, WritableGraph)
- [x] `task check` (fmt + vet + lint + test + validate) — 18 packages, zero failures
- [x] `task build` succeeds
- [x] WritableGraph: 0% → full contract coverage via GraphSuite