### PR TITLE
fix: walkSchemaLevels child selection + checkPathContainment symlinks

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -100,16 +100,21 @@ func resolveDataSource(sourcePath, configDir string) (string, error) {
 
 // checkPathContainment verifies that resolved is within or equal to base.
 // Prevents path traversal attacks from untrusted .mache.json files.
+//
+// Resolves symlinks via filepath.EvalSymlinks before comparison so a target
+// pointing to a symlink that escapes the project directory is caught even
+// if the symlink itself sits inside the project. If the target does not
+// exist yet (EvalSymlinks errors), falls back to filepath.Abs since
+// nonexistent paths cannot point anywhere malicious until they are created.
 func checkPathContainment(resolved, base string) error {
-	absResolved, err := filepath.Abs(resolved)
+	absResolved, err := evalOrAbs(resolved)
 	if err != nil {
 		return fmt.Errorf("resolve absolute path %q: %w", resolved, err)
 	}
-	absBase, err := filepath.Abs(base)
+	absBase, err := evalOrAbs(base)
 	if err != nil {
 		return fmt.Errorf("resolve absolute path %q: %w", base, err)
 	}
-	// Check that resolved path starts with base path
 	rel, err := filepath.Rel(absBase, absResolved)
 	if err != nil {
 		return fmt.Errorf("path %q escapes project directory %q", resolved, base)
@@ -118,6 +123,36 @@ func checkPathContainment(resolved, base string) error {
 		return fmt.Errorf("path %q escapes project directory %q", resolved, base)
 	}
 	return nil
+}
+
+// evalOrAbs resolves symlinks if the path exists. If the path itself
+// doesn't exist (e.g. configured target not yet created), it walks up to
+// the nearest existing parent, resolves that, and reattaches the missing
+// tail. This avoids false escapes caused by platform symlink quirks like
+// macOS /var → /private/var when one of the comparison paths is real and
+// the other is purely lexical.
+func evalOrAbs(p string) (string, error) {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", err
+	}
+	if r, err := filepath.EvalSymlinks(abs); err == nil {
+		return r, nil
+	}
+	// Walk up until we hit an existing dir, resolve it, then rejoin the tail.
+	dir := abs
+	var tail []string
+	for {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return abs, nil // hit filesystem root with no existing ancestor
+		}
+		tail = append([]string{filepath.Base(dir)}, tail...)
+		dir = parent
+		if r, err := filepath.EvalSymlinks(dir); err == nil {
+			return filepath.Join(append([]string{r}, tail...)...), nil
+		}
+	}
 }
 
 // mcpServerEntry is the mache entry written into MCP config files.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -460,3 +460,56 @@ func TestRegisterAllEditors_Output(t *testing.T) {
 	assert.Contains(t, output, "[Cursor]")
 	assert.Contains(t, output, "mcp.json")
 }
+
+// TestCheckPathContainment_SymlinkEscape — bead mache-5c9356.
+//
+// FALSIFIABLE: with the prior implementation (filepath.Abs only), a symlink
+// inside the project that targets a path outside the project bypassed the
+// containment check. With EvalSymlinks the symlink is resolved before the
+// comparison and the escape is caught.
+func TestCheckPathContainment_SymlinkEscape(t *testing.T) {
+	parent := t.TempDir()
+	project := filepath.Join(parent, "project")
+	outside := filepath.Join(parent, "outside")
+	require.NoError(t, os.MkdirAll(project, 0o755))
+	require.NoError(t, os.MkdirAll(outside, 0o755))
+
+	// Create a target file outside the project.
+	target := filepath.Join(outside, "secret.json")
+	require.NoError(t, os.WriteFile(target, []byte("secret"), 0o644))
+
+	// Create a symlink inside the project pointing to it.
+	link := filepath.Join(project, "evil.json")
+	require.NoError(t, os.Symlink(target, link))
+
+	// Lexical filepath.Abs(link) would just be /<parent>/project/evil.json,
+	// which IS contained in /<parent>/project — so the old code passed.
+	// With EvalSymlinks the link resolves to /<parent>/outside/secret.json
+	// which is correctly rejected.
+	err := checkPathContainment(link, project)
+	require.Error(t, err, "symlink escape must be rejected")
+	assert.Contains(t, err.Error(), "escapes")
+}
+
+// TestCheckPathContainment_NonexistentTargetIsAllowed verifies the fallback
+// to lexical Abs when a path component does not exist yet (e.g. configured
+// target that hasn't been created).
+func TestCheckPathContainment_NonexistentTargetIsAllowed(t *testing.T) {
+	project := t.TempDir()
+	// Target that doesn't exist yet but is lexically inside the project.
+	target := filepath.Join(project, "future", "file.json")
+	require.NoError(t, checkPathContainment(target, project))
+}
+
+// TestCheckPathContainment_PlainEscapeStillRejected verifies a non-symlink
+// `..` escape is still caught.
+func TestCheckPathContainment_PlainEscapeStillRejected(t *testing.T) {
+	parent := t.TempDir()
+	project := filepath.Join(parent, "project")
+	require.NoError(t, os.MkdirAll(project, 0o755))
+
+	bad := filepath.Join(project, "..", "outside.json")
+	err := checkPathContainment(bad, project)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "escapes")
+}

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -933,6 +933,11 @@ func (g *SQLiteGraph) walkSchema(segments []string) (*schemaLevel, *api.Leaf) {
 
 // walkSchemaLevels walks compiled schema levels to find the level and optional
 // leaf matching the given path segments. Shared by SQLiteGraph and WritableGraph.
+//
+// When descending past a level with multiple children, prefer the static
+// child whose name matches the path segment (e.g. go-schema's "functions" /
+// "methods" / "types" siblings under each package). Fall back to the first
+// dynamic (template-named) child when no static name matches.
 func walkSchemaLevels(levels []*schemaLevel, segments []string) (*schemaLevel, *api.Leaf) {
 	if len(segments) == 0 {
 		return nil, nil
@@ -964,14 +969,37 @@ func walkSchemaLevels(levels []*schemaLevel, segments []string) (*schemaLevel, *
 			}
 		}
 
-		// Descend to child level (single child pattern per level)
 		if len(current.children) == 0 {
 			return nil, nil
 		}
-		current = current.children[0]
+		current = pickChildLevel(current.children, seg)
+		if current == nil {
+			return nil, nil
+		}
 	}
 
 	return current, nil
+}
+
+// pickChildLevel selects the schema child that matches the given path segment.
+// Returns the matching static child if one exists, otherwise the first dynamic
+// (template-named) child, otherwise the first child as a last-resort fallback.
+// Returns nil only when the input slice is empty.
+func pickChildLevel(children []*schemaLevel, seg string) *schemaLevel {
+	if len(children) == 0 {
+		return nil
+	}
+	for _, c := range children {
+		if c.isStatic && c.staticName == seg {
+			return c
+		}
+	}
+	for _, c := range children {
+		if !c.isStatic {
+			return c
+		}
+	}
+	return children[0]
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/graph/walkschema_test.go
+++ b/internal/graph/walkschema_test.go
@@ -1,0 +1,128 @@
+package graph
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWalkSchemaLevels_MultipleStaticChildren — bead mache-1422c5.
+//
+// FALSIFIABLE: prior implementation always descended via children[0].
+// Build a go-schema-like topology where one level has six static children
+// (imports, functions, methods, types, constants, variables), each with
+// distinct file names. Walk paths under each. With the old code most paths
+// resolve to the wrong level; the file lookup either misses or hits the
+// wrong leaf.
+//
+// With pickChildLevel, each segment routes to the matching static child.
+func TestWalkSchemaLevels_MultipleStaticChildren(t *testing.T) {
+	// Schema:
+	//   pkg/                            (static)
+	//     {{.pkgname}}/                 (dynamic)
+	//       imports/    -> file: list
+	//       functions/  -> file: source, doc
+	//       methods/    -> file: source, doc
+	//       types/      -> file: source, spec
+	//       constants/  -> file: value
+	//       variables/  -> file: value
+	topology := &api.Topology{
+		Version: api.SchemaVersion,
+		Nodes: []api.Node{{
+			Name: "pkg",
+			Children: []api.Node{{
+				Name: "{{.pkgname}}",
+				Children: []api.Node{
+					{Name: "imports", Files: []api.Leaf{{Name: "list"}}},
+					{Name: "functions", Children: []api.Node{{
+						Name:  "{{.fname}}",
+						Files: []api.Leaf{{Name: "source"}, {Name: "doc"}},
+					}}},
+					{Name: "methods", Children: []api.Node{{
+						Name:  "{{.mname}}",
+						Files: []api.Leaf{{Name: "source"}, {Name: "doc"}},
+					}}},
+					{Name: "types", Children: []api.Node{{
+						Name:  "{{.tname}}",
+						Files: []api.Leaf{{Name: "source"}, {Name: "spec"}},
+					}}},
+					{Name: "constants", Children: []api.Node{{
+						Name:  "{{.cname}}",
+						Files: []api.Leaf{{Name: "value"}},
+					}}},
+					{Name: "variables", Children: []api.Node{{
+						Name:  "{{.vname}}",
+						Files: []api.Leaf{{Name: "value"}},
+					}}},
+				},
+			}},
+		}},
+	}
+
+	levels := compileLevels(topology)
+	require.NotEmpty(t, levels)
+
+	cases := []struct {
+		path         string
+		wantFile     string // empty if path is a directory
+		wantLeafKind string
+	}{
+		{"pkg/foo/types/Config/spec", "spec", "types"},
+		{"pkg/foo/types/Config/source", "source", "types"},
+		{"pkg/foo/functions/Validate/source", "source", "functions"},
+		{"pkg/foo/functions/Validate/doc", "doc", "functions"},
+		{"pkg/foo/methods/Receiver.Method/doc", "doc", "methods"},
+		{"pkg/foo/imports/list", "list", "imports"},
+		{"pkg/foo/constants/MaxSize/value", "value", "constants"},
+		{"pkg/foo/variables/globalCfg/value", "value", "variables"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			segments := strings.Split(tc.path, "/")
+			level, leaf := walkSchemaLevels(levels, segments)
+			require.NotNil(t, level, "level must resolve for %q", tc.path)
+			require.NotNil(t, leaf, "leaf must resolve for %q", tc.path)
+			assert.Equal(t, tc.wantFile, leaf.Name)
+		})
+	}
+}
+
+// TestWalkSchemaLevels_DynamicFallback verifies pickChildLevel falls back
+// to the dynamic child when no static child matches the segment.
+func TestWalkSchemaLevels_DynamicFallback(t *testing.T) {
+	topology := &api.Topology{
+		Version: api.SchemaVersion,
+		Nodes: []api.Node{{
+			Name: "data",
+			Children: []api.Node{{
+				Name:  "{{.id}}",
+				Files: []api.Leaf{{Name: "record"}},
+			}},
+		}},
+	}
+	levels := compileLevels(topology)
+
+	level, leaf := walkSchemaLevels(levels, []string{"data", "abc123", "record"})
+	require.NotNil(t, level)
+	require.NotNil(t, leaf)
+	assert.Equal(t, "record", leaf.Name)
+}
+
+// TestPickChildLevel_PreferStaticName verifies the helper directly.
+func TestPickChildLevel_PreferStaticName(t *testing.T) {
+	// Two static + one dynamic
+	a := &schemaLevel{isStatic: true, staticName: "alpha"}
+	b := &schemaLevel{isStatic: true, staticName: "beta"}
+	dyn := &schemaLevel{isStatic: false, nameRaw: "{{.x}}"}
+	children := []*schemaLevel{a, b, dyn}
+
+	assert.Same(t, a, pickChildLevel(children, "alpha"))
+	assert.Same(t, b, pickChildLevel(children, "beta"))
+	// Unknown segment falls through to the first dynamic child.
+	assert.Same(t, dyn, pickChildLevel(children, "anything-else"))
+	// Empty children → nil.
+	assert.Nil(t, pickChildLevel(nil, "x"))
+}


### PR DESCRIPTION
## Summary
Two correctness bugs that share no code but ship together as a small bug-fix bundle.

### `walkSchemaLevels` always descended via `children[0]` (mache-1422c5)
For schemas with multiple children at the same level — go-schema has six (`imports`, `functions`, `methods`, `types`, `constants`, `variables`) under each package — the descent picked the wrong sub-tree for every segment except the first. Currently masked because all existing leaves share the file name `source`, so file lookup happens to hit the right leaf by coincidence. Schemas with per-branch file names (e.g. `functions` → `source`/`doc`, `types` → `source`/`spec`) would silently misclassify files vs directories.

Replace the hardcoded `current.children[0]` with `pickChildLevel`, which prefers the static child whose name matches the segment, falls back to the first dynamic (template-named) child, and uses the first child as a last resort.

### `checkPathContainment` ignored symlinks (mache-5c9356)
`filepath.Abs` handles `..` but not symlinks. A `.mache.json` target pointing to a symlink inside the project that resolves outside the project passed the check. Use `EvalSymlinks` before comparing.

When the target doesn't exist yet (configured but not created), walk up to the nearest existing parent, resolve that, and reattach the missing tail. Avoids false escapes on platforms where the temp dir path is itself a symlink (macOS `/var` → `/private/var`) when one side of the comparison is real and the other is lexical.

## Test plan
- [x] `go test -run TestWalkSchemaLevels -v ./internal/graph/` — eight subtests through `imports/functions/methods/types/constants/variables` paths plus dynamic-fallback and `pickChildLevel` unit tests
- [x] `go test -run TestCheckPathContainment -v ./cmd/` — symlink escape rejected, nonexistent target allowed, plain `..` escape still rejected
- [x] `go test ./...` — full suite green