### PR TITLE
feat: ASTWalker.ExtractCalls + ExtractQualifiedCalls

### DIFF
--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
+	"github.com/agentic-research/mache/internal/graph"
 	_ "modernc.org/sqlite"
 )
 
@@ -239,6 +241,108 @@ func (w *ASTWalker) ExtractGoImports(sourceID string) (map[string]string, error)
 		imports[alias] = path
 	}
 	return imports, rows.Err()
+}
+
+// callQueryRegistry stores per-language call extraction selectors for the
+// pure-Go ASTWalker. These are the same tree-sitter S-expressions used by
+// SitterWalker, separated into individual patterns since parseSelector only
+// understands one (outerKind ...) per call.
+var callQueryRegistry sync.Map // langName → []string (one selector per pattern)
+
+// RegisterASTCallQuery registers per-language selector patterns for use by
+// ASTWalker.ExtractCalls. Each pattern must be a single S-expression rooted
+// at the language's call-node kind.
+func RegisterASTCallQuery(langName string, patterns []string) {
+	callQueryRegistry.Store(langName, patterns)
+}
+
+// ExtractCalls finds function-call tokens in the given source file by
+// running per-language selectors against the _ast table. Returns
+// deduplicated bare tokens (e.g. "Validate", "Println"). Mirrors
+// SitterWalker.ExtractCalls but uses SQL instead of CGO.
+//
+// If no patterns are registered for the language, returns (nil, nil) — the
+// caller treats that as "no calls" and falls through to other extraction
+// paths. langName must match the value used at RegisterASTCallQuery time.
+func (w *ASTWalker) ExtractCalls(sourcePath, langName string) ([]string, error) {
+	raw, ok := callQueryRegistry.Load(langName)
+	if !ok {
+		return nil, nil
+	}
+	patterns := raw.([]string)
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+
+	sourceID := filepath.Base(sourcePath)
+	root := ASTRoot{DB: w.db, SourceID: sourceID, ParentPrefix: ""}
+
+	seen := make(map[string]bool)
+	var calls []string
+	for _, sel := range patterns {
+		matches, err := w.Query(root, sel)
+		if err != nil {
+			// Selector unsupported by ASTWalker — skip and try the next.
+			continue
+		}
+		for _, m := range matches {
+			if v, ok := m.Values()["call"].(string); ok && v != "" && !seen[v] {
+				seen[v] = true
+				calls = append(calls, v)
+			}
+		}
+	}
+	return calls, nil
+}
+
+// ExtractQualifiedCalls finds call tokens with optional package qualifiers,
+// mirroring SitterWalker.ExtractQualifiedCalls. Patterns that capture both
+// @call and @pkg produce QualifiedCall{Token, Qualifier}; patterns that only
+// capture @call produce QualifiedCall{Token}.
+//
+// If no qualified patterns are registered, falls back to ExtractCalls and
+// returns bare tokens with empty qualifiers.
+func (w *ASTWalker) ExtractQualifiedCalls(sourcePath, langName string) ([]graph.QualifiedCall, error) {
+	raw, ok := callQueryRegistry.Load(langName)
+	if !ok {
+		bare, err := w.ExtractCalls(sourcePath, langName)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]graph.QualifiedCall, len(bare))
+		for i, t := range bare {
+			out[i] = graph.QualifiedCall{Token: t}
+		}
+		return out, nil
+	}
+	patterns := raw.([]string)
+
+	sourceID := filepath.Base(sourcePath)
+	root := ASTRoot{DB: w.db, SourceID: sourceID, ParentPrefix: ""}
+
+	seen := make(map[string]bool)
+	var calls []graph.QualifiedCall
+	for _, sel := range patterns {
+		matches, err := w.Query(root, sel)
+		if err != nil {
+			continue
+		}
+		for _, m := range matches {
+			vals := m.Values()
+			token, _ := vals["call"].(string)
+			if token == "" {
+				continue
+			}
+			pkg, _ := vals["pkg"].(string)
+			key := pkg + "." + token
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			calls = append(calls, graph.QualifiedCall{Token: token, Qualifier: pkg})
+		}
+	}
+	return calls, nil
 }
 
 // SelectWalker inspects a SQLite database and returns the best Walker.
@@ -586,9 +690,11 @@ func (w *ASTWalker) findChildByKindAST(db *sql.DB, parentID, kind, sourceID stri
 	var args []any
 
 	if len(ancestry) == 0 {
-		// No ancestry — match any descendant at any depth.
-		query = baseCols + "n.id LIKE ? AND a.node_kind = ?"
-		args = []any{parentID + "/%", kind}
+		// No ancestry — direct child only (depth 1 below parent).
+		// Tree-sitter S-expressions like `(parent (child) @cap)` mean
+		// child is a direct child; we mirror that by constraining depth.
+		query = baseCols + "n.id LIKE ? AND n.id NOT LIKE ? AND a.node_kind = ?"
+		args = []any{parentID + "/%", parentID + "/%/%", kind}
 	} else {
 		// Ancestry constraint — restrict to exact depth.
 		// For ancestry=["parameter_list","parameter_declaration"], build:

--- a/internal/ingest/ast_walker_calls_test.go
+++ b/internal/ingest/ast_walker_calls_test.go
@@ -1,0 +1,176 @@
+package ingest
+
+import (
+	"database/sql"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// seedCallExtractionAST creates a minimal _ast database modeling a Go file
+// shaped like the output of `leyline parse`, where node IDs encode the
+// kind chain (so matchAncestry compares correctly).
+//
+//	package main
+//	func A() {
+//	    fmt.Println("x")  // qualified: pkg=fmt, call=Println
+//	    Helper()          // bare: call=Helper
+//	}
+func seedCallExtractionAST(t *testing.T) *sql.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "calls.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL, record_id TEXT, record JSON,
+			source_file TEXT
+		);
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL, start_byte INTEGER NOT NULL,
+			end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE INDEX idx_ast_source ON _ast(source_id);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT NOT NULL, content BLOB NOT NULL);
+
+		INSERT INTO _source VALUES ('main.go', 'go', '');
+	`)
+	require.NoError(t, err)
+
+	type row struct {
+		id, parentID string
+		kind         int
+		record       string
+	}
+	// Path scheme mirrors LLO output: each segment is the kind (with _N
+	// disambiguator when siblings repeat).
+	rows := []row{
+		// Qualified call: fmt.Println
+		{"call_expression", "", 1, ""},
+		{"call_expression/selector_expression", "call_expression", 1, ""},
+		{"call_expression/selector_expression/identifier", "call_expression/selector_expression", 0, "fmt"},
+		{"call_expression/selector_expression/field_identifier", "call_expression/selector_expression", 0, "Println"},
+		// Bare call: Helper
+		{"call_expression_1", "", 1, ""},
+		{"call_expression_1/identifier", "call_expression_1", 0, "Helper"},
+	}
+	for _, r := range rows {
+		_, err := db.Exec(
+			"INSERT INTO nodes (id, parent_id, name, kind, mtime, record) VALUES (?, ?, ?, ?, 0, ?)",
+			r.id, r.parentID, filepath.Base(r.id), r.kind, r.record,
+		)
+		require.NoError(t, err)
+	}
+
+	type ast struct {
+		id, kind  string
+		startByte int
+	}
+	asts := []ast{
+		// Qualified: byte ranges chosen so start_byte sort is intuitive
+		{"call_expression", "call_expression", 0},
+		{"call_expression/selector_expression", "selector_expression", 0},
+		{"call_expression/selector_expression/identifier", "identifier", 0},
+		{"call_expression/selector_expression/field_identifier", "field_identifier", 4},
+		// Bare
+		{"call_expression_1", "call_expression", 100},
+		{"call_expression_1/identifier", "identifier", 100},
+	}
+	for _, a := range asts {
+		_, err := db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, 'main.go', ?, ?, 0, 0, 0, 0, 0)",
+			a.id, a.kind, a.startByte,
+		)
+		require.NoError(t, err)
+	}
+	return db
+}
+
+func TestASTWalker_ExtractCalls_Go(t *testing.T) {
+	db := seedCallExtractionAST(t)
+	defer func() { _ = db.Close() }()
+
+	w := NewASTWalker(db)
+	calls, err := w.ExtractCalls("main.go", "go")
+	require.NoError(t, err)
+
+	sort.Strings(calls)
+	assert.Equal(t, []string{"Helper", "Println"}, calls,
+		"both bare and qualified calls should be returned by ExtractCalls")
+}
+
+func TestASTWalker_ExtractQualifiedCalls_Go(t *testing.T) {
+	db := seedCallExtractionAST(t)
+	defer func() { _ = db.Close() }()
+
+	w := NewASTWalker(db)
+	calls, err := w.ExtractQualifiedCalls("main.go", "go")
+	require.NoError(t, err)
+
+	sort.Slice(calls, func(i, j int) bool {
+		if calls[i].Token != calls[j].Token {
+			return calls[i].Token < calls[j].Token
+		}
+		return calls[i].Qualifier < calls[j].Qualifier
+	})
+
+	require.Len(t, calls, 2)
+	assert.Equal(t, graph.QualifiedCall{Token: "Helper", Qualifier: ""}, calls[0],
+		"bare call has no qualifier")
+	assert.Equal(t, graph.QualifiedCall{Token: "Println", Qualifier: "fmt"}, calls[1],
+		"qualified call captures pkg=fmt")
+}
+
+func TestASTWalker_ExtractCalls_UnknownLanguageReturnsNil(t *testing.T) {
+	db := seedCallExtractionAST(t)
+	defer func() { _ = db.Close() }()
+
+	w := NewASTWalker(db)
+	calls, err := w.ExtractCalls("main.go", "unknown-lang")
+	require.NoError(t, err)
+	assert.Nil(t, calls, "unregistered language returns nil, not error")
+}
+
+func TestASTWalker_ExtractCalls_Dedupes(t *testing.T) {
+	db := seedCallExtractionAST(t)
+	defer func() { _ = db.Close() }()
+
+	// Add a second bare call to the same name "Helper" (call_expression_2).
+	_, err := db.Exec(`
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, record)
+		VALUES
+		  ('call_expression_2', '', 'call_expression_2', 1, 0, ''),
+		  ('call_expression_2/identifier', 'call_expression_2', 'identifier', 0, 0, 'Helper')
+	`)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('call_expression_2', 'main.go', 'call_expression', 200, 0, 0, 0, 0, 0),
+		  ('call_expression_2/identifier', 'main.go', 'identifier', 200, 0, 0, 0, 0, 0)
+	`)
+	require.NoError(t, err)
+
+	w := NewASTWalker(db)
+	calls, err := w.ExtractCalls("main.go", "go")
+	require.NoError(t, err)
+
+	helperCount := 0
+	for _, c := range calls {
+		if c == "Helper" {
+			helperCount++
+		}
+	}
+	assert.Equal(t, 1, helperCount, "duplicate Helper calls must be deduplicated")
+}

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -19,6 +19,32 @@ func init() {
 			field: (field_identifier) @call))
 	`)
 
+	// ASTWalker (pure-Go path) parses one S-expression per call.
+	// Bare calls + qualified calls in two separate patterns.
+	RegisterASTCallQuery("go", []string{
+		`(call_expression function: (identifier) @call) @scope`,
+		`(call_expression function: (selector_expression operand: (identifier) @pkg field: (field_identifier) @call)) @scope`,
+	})
+
+	// Python: 'call' parent, identifier or attribute child.
+	RegisterASTCallQuery("python", []string{
+		`(call function: (identifier) @call) @scope`,
+		`(call function: (attribute attribute: (identifier) @call)) @scope`,
+	})
+
+	// Rust: function calls and method calls.
+	RegisterASTCallQuery("rust", []string{
+		`(call_expression function: (identifier) @call) @scope`,
+		`(call_expression function: (scoped_identifier name: (identifier) @call)) @scope`,
+		`(call_expression function: (field_expression field: (field_identifier) @call)) @scope`,
+	})
+
+	// Elixir: local and qualified function calls.
+	RegisterASTCallQuery("elixir", []string{
+		`(call target: (identifier) @call) @scope`,
+		`(call target: (dot right: (identifier) @call)) @scope`,
+	})
+
 	// Register HCL/Terraform queries — narrow to semantic references:
 	// module sources, variable defaults, and provider/resource references.
 	RegisterRefQuery("terraform", `


### PR DESCRIPTION
## Summary
Closes the last big gap in ASTWalker parity with SitterWalker for the callers/callees graph. Both new methods read the \`_ast\` + \`nodes\` tables that \`leyline parse\` populates — no CGO.

- New \`callQueryRegistry\` holds per-language selector patterns split one-S-expression-per-call-shape (the existing \`parseSelector\` handles one \`outerKind\` per call). Registered for **go**, **python**, **rust**, **elixir**.
- \`ExtractCalls(sourcePath, langName)\` returns deduplicated bare tokens.
- \`ExtractQualifiedCalls(sourcePath, langName)\` returns \`[]graph.QualifiedCall\` with \`@pkg\` captured for selector-style calls (\`auth.Validate\` → \`{auth, Validate}\`). Patterns that only emit \`@call\` yield empty \`Qualifier\`.

### Drive-by fix
\`findChildByKindAST\`: empty ancestry now means **direct child only** (matches the documented S-expression contract \`(parent (child) @cap)\`) instead of \"any descendant.\" The previous behavior was masking the bug where a Go bare-call selector matched the operand identifier nested inside a \`selector_expression\`. The full ASTWalker suite still passes — existing fixtures already encode direct-child relationships.

Bead: mache-377c4a.

## Test plan
- [x] \`go test -run TestASTWalker_ExtractCalls -v ./internal/ingest/\` — bare + qualified extraction, dedup, unknown-lang nil
- [x] \`go test ./internal/ingest/\` — full ASTWalker suite passes (parity, ancestry, predicates, race, etc.)
- [x] \`go test ./...\` — full mache suite green