### PR TITLE
test+fix: preset selector compilation + landing page hardening

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/internal/lang"
+	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -73,6 +76,79 @@ func TestResolveSchema_AllPresets(t *testing.T) {
 			require.NotNil(t, topo)
 			assert.Equal(t, "v1", topo.Version)
 		})
+	}
+}
+
+// knownBrokenPresets maps preset name → tracking bead for selectors that
+// don't compile against their tree-sitter grammar. The test skips these
+// so CI stays green while the schemas are being repaired. Each bead lists
+// the specific selector(s) involved.
+//
+// Remove an entry when the corresponding bead is closed and the selector
+// compiles cleanly.
+var knownBrokenPresets = map[string]string{
+	"typescript": "mache-co9f",
+	"cpp":        "mache-y1ay",
+	"swift":      "mache-k6vj",
+	"kotlin":     "mache-uzjb",
+	"scala":      "mache-vtkl",
+}
+
+// TestPresetSchemas_SelectorsCompile loads every preset schema whose key
+// matches a registered tree-sitter language and verifies that each
+// selector in the schema tree compiles as a tree-sitter query against
+// that language. Bead mache-a21b69 — `TestResolveSchema_AllPresets`
+// only validates JSON parsing, so a broken selector silently routes
+// files to `_project_files/` instead of failing loudly.
+//
+// Data-format presets (cli, mcp, mcp-registry) use JSONPath selectors
+// rather than tree-sitter and are skipped. Presets in
+// knownBrokenPresets are skipped pending the linked beads.
+func TestPresetSchemas_SelectorsCompile(t *testing.T) {
+	dataPresets := map[string]bool{"cli": true, "mcp": true, "mcp-registry": true}
+
+	for name := range presetSchemas {
+		if dataPresets[name] {
+			continue
+		}
+		l := lang.ForName(name)
+		if l == nil || l.Grammar() == nil {
+			continue
+		}
+		t.Run(name, func(t *testing.T) {
+			if bead, broken := knownBrokenPresets[name]; broken {
+				t.Skipf("known-broken selectors — see %s", bead)
+			}
+			topo, err := loadPresetSchema(name)
+			require.NoError(t, err)
+			require.NotNil(t, topo)
+
+			grammar := l.Grammar()
+			walkPresetNodes(t, topo.Nodes, name, func(node api.Node, path string) {
+				if node.Selector == "" {
+					return
+				}
+				if node.Selector == "$" {
+					return
+				}
+				q, err := sitter.NewQuery([]byte(node.Selector), grammar)
+				if err != nil {
+					t.Errorf("preset %q selector at %s failed to compile:\n  selector: %s\n  error: %v",
+						name, path, node.Selector, err)
+					return
+				}
+				q.Close()
+			})
+		})
+	}
+}
+
+func walkPresetNodes(t *testing.T, nodes []api.Node, parentPath string, fn func(api.Node, string)) {
+	t.Helper()
+	for i := range nodes {
+		path := parentPath + "/" + nodes[i].Name
+		fn(nodes[i], path)
+		walkPresetNodes(t, nodes[i].Children, path, fn)
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -215,12 +215,29 @@ func defaultLandingPagePath() string {
 	return "/app/static/mache-landing.html"
 }
 
+// landingPageCacheControl is the Cache-Control header sent with the landing
+// page response. The HTML file is static at deploy time; a 5-minute cache
+// is plenty for a status page and reduces disk reads on every "/" hit.
+const landingPageCacheControl = "public, max-age=300"
+
 // serveLandingPage serves the rig-managed HTML landing page if available,
-// falling back to plain text with the connect URL.
+// falling back to plain text with the connect URL. Bead mache-ef3de2:
+// rejects non-GET/HEAD methods with 405 and sets Cache-Control on the
+// response so a CDN or browser can cache the static page.
 func serveLandingPage(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet, http.MethodHead:
+		// continue
+	default:
+		w.Header().Set("Allow", "GET, HEAD")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
 	data, err := os.ReadFile(landingPagePath)
 	if err == nil {
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", landingPageCacheControl)
 		_, _ = w.Write(data)
 		return
 	}
@@ -232,6 +249,7 @@ func serveLandingPage(w http.ResponseWriter, r *http.Request) {
 	// Fallback: plain text with connect instructions
 	scheme := requestScheme(r)
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Cache-Control", landingPageCacheControl)
 	_, _ = fmt.Fprintln(w, "mache MCP server")
 	_, _ = fmt.Fprintln(w)
 	_, _ = fmt.Fprintf(w, "Connect: claude mcp add --transport http mache \"%s://%s/mcp?repo=<your-repo-url>\"\n", scheme, r.Host)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -2262,6 +2262,72 @@ func TestServeLandingPage_ReadErrorReturns500(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 }
 
+// TestServeLandingPage_RejectsNonGet — bead mache-ef3de2.
+func TestServeLandingPage_RejectsNonGet(t *testing.T) {
+	for _, method := range []string{"POST", "PUT", "DELETE", "PATCH", "OPTIONS"} {
+		t.Run(method, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(method, "/", nil)
+			serveLandingPage(rec, req)
+
+			assert.Equal(t, http.StatusMethodNotAllowed, rec.Code,
+				"%s should return 405", method)
+			assert.Equal(t, "GET, HEAD", rec.Header().Get("Allow"),
+				"405 response must include Allow header")
+		})
+	}
+}
+
+// TestServeLandingPage_HEADAllowed verifies that HEAD is treated like GET.
+func TestServeLandingPage_HEADAllowed(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "landing.html")
+	require.NoError(t, os.WriteFile(tmp, []byte("<h1>mache</h1>"), 0o644))
+
+	orig := landingPagePath
+	landingPagePath = tmp
+	defer func() { landingPagePath = orig }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("HEAD", "/", nil)
+	serveLandingPage(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Header().Get("Content-Type"), "text/html")
+}
+
+// TestServeLandingPage_SetsCacheControl — bead mache-ef3de2.
+func TestServeLandingPage_SetsCacheControl(t *testing.T) {
+	tmp := filepath.Join(t.TempDir(), "landing.html")
+	require.NoError(t, os.WriteFile(tmp, []byte("<h1>mache</h1>"), 0o644))
+
+	orig := landingPagePath
+	landingPagePath = tmp
+	defer func() { landingPagePath = orig }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	serveLandingPage(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, landingPageCacheControl, rec.Header().Get("Cache-Control"))
+}
+
+// TestServeLandingPage_FallbackSetsCacheControl ensures the plain-text
+// fallback path also benefits from caching.
+func TestServeLandingPage_FallbackSetsCacheControl(t *testing.T) {
+	orig := landingPagePath
+	landingPagePath = "/nonexistent/landing.html"
+	defer func() { landingPagePath = orig }()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Host = "mache.rosary.bot"
+	serveLandingPage(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, landingPageCacheControl, rec.Header().Get("Cache-Control"))
+}
+
 func TestRequestScheme_Defaults(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	assert.Equal(t, "http", requestScheme(req))


### PR DESCRIPTION
## Summary
Two unrelated cleanup beads bundled into one small PR.

### Preset selector compilation test (mache-a21b69)
\`TestResolveSchema_AllPresets\` only validated JSON parsing, so a schema with a broken tree-sitter selector silently routed source files to \`_project_files/\` instead of failing loudly. Adds \`TestPresetSchemas_SelectorsCompile\` that loads each preset whose name matches a registered tree-sitter language, walks the schema tree, and tries to compile every selector against the grammar.

The new test caught **five** existing schemas with selectors that don't compile against their grammar. Each is filed as a separate bead and listed in \`knownBrokenPresets\` so the test stays green while the schemas are repaired:

| Preset       | Bead          | Selector(s) |
|--------------|---------------|-------------|
| typescript   | mache-co9f    | \`class_declaration\`, \`export_statement\` |
| cpp          | mache-y1ay    | \`namespace_definition\` |
| swift        | mache-k6vj    | \`struct_declaration\`, \`enum_declaration\` |
| kotlin       | mache-uzjb    | \`interface_declaration\` |
| scala        | mache-vtkl    | \`import_declaration\` |

Removing an entry from \`knownBrokenPresets\` makes the test enforce that selector again — handy when fixing each schema.

### Landing page hardening (mache-ef3de2)
\`serveLandingPage\` was wide open to any HTTP method and re-read the static HTML from disk on every request. Now:

- Rejects non-GET/HEAD methods with **405** + \`Allow: GET, HEAD\`.
- Sets \`Cache-Control: public, max-age=300\` on both the static-file and fallback paths so a CDN or browser can cache the landing page.

The bead noted these belong at the CF/WAF layer, but the in-process implementation is small and avoids depending on a CDN being in front. Either layer can apply them; the redundancy is fine.

## Test plan
- [x] \`go test -run TestPresetSchemas_SelectorsCompile -v ./cmd/\` — known-broken presets skip; the rest compile clean
- [x] \`go test -run TestServeLandingPage -v ./cmd/\` — RejectsNonGet (POST/PUT/DELETE/PATCH/OPTIONS), HEADAllowed, SetsCacheControl, FallbackSetsCacheControl all pass
- [x] \`go test ./...\` — full suite green