### PR TITLE
fix: 5 preset schemas with broken tree-sitter selectors (typescript/cpp/swift/kotlin/scala)

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -86,13 +86,7 @@ func TestResolveSchema_AllPresets(t *testing.T) {
 //
 // Remove an entry when the corresponding bead is closed and the selector
 // compiles cleanly.
-var knownBrokenPresets = map[string]string{
-	"typescript": "mache-co9f",
-	"cpp":        "mache-y1ay",
-	"swift":      "mache-k6vj",
-	"kotlin":     "mache-uzjb",
-	"scala":      "mache-vtkl",
-}
+var knownBrokenPresets = map[string]string{}
 
 // TestPresetSchemas_SelectorsCompile loads every preset schema whose key
 // matches a registered tree-sitter language and verifies that each

--- a/cmd/schemas/cpp.json
+++ b/cmd/schemas/cpp.json
@@ -173,7 +173,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(namespace_definition name: (identifier) @name) @scope",
+          "selector": "(namespace_definition (namespace_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {

--- a/cmd/schemas/kotlin.json
+++ b/cmd/schemas/kotlin.json
@@ -31,7 +31,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(class_declaration (type_identifier) @name) @scope",
+          "selector": "(class_declaration \"class\" (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {
@@ -84,7 +84,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(interface_declaration (type_identifier) @name) @scope",
+          "selector": "(class_declaration \"interface\" (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {

--- a/cmd/schemas/scala.json
+++ b/cmd/schemas/scala.json
@@ -15,7 +15,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(import_declaration (stable_identifier) @name) @scope",
+          "selector": "(import_declaration (identifier) @name) @scope",
           "files": [
             {
               "name": "source",

--- a/cmd/schemas/swift.json
+++ b/cmd/schemas/swift.json
@@ -31,7 +31,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(class_declaration name: (type_identifier) @name) @scope",
+          "selector": "(class_declaration \"class\" (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {
@@ -84,7 +84,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(struct_declaration name: (type_identifier) @name) @scope",
+          "selector": "(class_declaration \"struct\" (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {
@@ -118,7 +118,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(enum_declaration name: (type_identifier) @name) @scope",
+          "selector": "(class_declaration \"enum\" (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {

--- a/cmd/schemas/typescript.json
+++ b/cmd/schemas/typescript.json
@@ -58,7 +58,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(class_declaration name: (identifier) @name) @scope",
+          "selector": "(class_declaration name: (type_identifier) @name) @scope",
           "include": ["lsp"],
           "files": [
             {
@@ -156,7 +156,7 @@
         },
         {
           "name": "{{.name}}",
-          "selector": "(export_statement declaration: (class_declaration name: (identifier) @name)) @scope",
+          "selector": "(export_statement declaration: (class_declaration name: (type_identifier) @name)) @scope",
           "include": ["lsp"],
           "files": [
             {


### PR DESCRIPTION
## Summary
Closes the five \`knownBrokenPresets\` entries from #175 by rewriting each broken selector against the actual tree-sitter grammar.

| Preset      | Bead       | Fix |
| ----------- | ---------- | --- |
| typescript  | mache-co9f | Class names are \`type_identifier\`, not \`identifier\`. Updated 3 selectors. |
| cpp         | mache-y1ay | \`namespace_definition\`'s child is \`namespace_identifier\`; field name \`name:\` isn't valid on this node. |
| swift       | mache-k6vj | tree-sitter-swift folds struct/enum/class into \`class_declaration\` with the keyword as an anonymous token. Use \`(class_declaration \"struct\" ...)\` / \`(class_declaration \"enum\" ...)\` / \`(class_declaration \"class\" ...)\`. |
| kotlin      | mache-uzjb | Same pattern as swift — interface and class are both \`class_declaration\`. |
| scala       | mache-vtkl | \`import_declaration\` emits \`identifier\` children, not \`stable_identifier\`. |

The new node kinds were discovered with a small \`TestDiscoverNodeKinds\` helper (parses canned samples per language and dumps the tree-sitter AST). The helper isn't checked in — it served its purpose.

\`knownBrokenPresets\` is now empty; all preset selectors compile against their grammar.

## Test plan
- [x] \`go test -run TestPresetSchemas_SelectorsCompile -v ./cmd/\` — all preset subtests pass
- [x] \`go test ./...\` — full suite green