### PR TITLE
feat: cross-language refs vertical slice — terraform mod: scheme + resolve_ref MCP tool

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -170,6 +170,15 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 		),
 		r.wrapHandler(makeWriteFileHandler),
 	)
+
+	s.AddTool(
+		mcp.NewTool("resolve_ref",
+			mcp.WithDescription("Resolve a typed cross-language ref token (scheme:locator) to its target. First milestone of the cross-language ref graph (mache-q43l). Today supports the `mod:` scheme with local-relative paths (./X, ../Y) — returns the resolved absolute path plus a directory listing with detected languages. Other schemes return a `remote_hint` so the caller knows resolution was skipped. Useful for following Terraform `module { source = ... }` references into the projected target."),
+			mcp.WithString("token", mcp.Required(), mcp.Description("Typed ref token in `scheme:locator` form (e.g. `mod:./modules/vpc`).")),
+			mcp.WithString("base_path", mcp.Description("File or directory the locator is interpreted relative to. Required for local-relative locators.")),
+		),
+		r.wrapHandler(makeResolveRefHandler),
+	)
 }
 
 type nodeEntry struct {

--- a/cmd/serve_resolve_ref.go
+++ b/cmd/serve_resolve_ref.go
@@ -1,0 +1,154 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/lang"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// resolveRefResponse is the shape returned by the resolve_ref MCP tool.
+// It covers both the local-path case (Files populated, Resolved set) and
+// the remote case (RemoteHint set, Files empty) so callers can choose to
+// follow up with a clone or skip.
+type resolveRefResponse struct {
+	Scheme     string            `json:"scheme"`
+	Locator    string            `json:"locator"`
+	Resolved   string            `json:"resolved,omitempty"`    // absolute filesystem path (local locators only)
+	Exists     bool              `json:"exists"`                // resolved path exists on disk
+	IsDir      bool              `json:"is_dir"`                // resolved path is a directory
+	Files      []resolveRefEntry `json:"files,omitempty"`       // direct children when Resolved is a dir
+	RemoteHint string            `json:"remote_hint,omitempty"` // non-empty for non-local schemes the resolver can't follow yet
+	Error      string            `json:"error,omitempty"`       // human-readable error, when Exists is false despite a recognized locator
+}
+
+type resolveRefEntry struct {
+	Name  string `json:"name"`
+	IsDir bool   `json:"is_dir"`
+	Size  int64  `json:"size,omitempty"`
+	Lang  string `json:"lang,omitempty"` // detected language for files
+}
+
+// makeResolveRefHandler returns the MCP handler for resolve_ref. It takes a
+// scheme:locator token and an optional base_path (the file or directory the
+// locator is interpreted relative to) and returns the resolved target.
+//
+// First milestone of mache-q43l (cross-language ref graph). Currently
+// supports the `mod:` scheme with local relative paths (./foo, ../bar).
+// Other schemes return RemoteHint so callers know the resolver passed them
+// over rather than mis-resolving.
+func makeResolveRefHandler(_ graph.Graph) server.ToolHandlerFunc {
+	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		token := strings.TrimSpace(request.GetString("token", ""))
+		basePath := strings.TrimSpace(request.GetString("base_path", ""))
+		if token == "" {
+			return mcp.NewToolResultError("token is required (e.g. \"mod:./modules/vpc\")"), nil
+		}
+
+		scheme, locator, ok := strings.Cut(token, ":")
+		if !ok || scheme == "" || locator == "" {
+			return mcp.NewToolResultError(fmt.Sprintf("token must be scheme:locator, got %q", token)), nil
+		}
+
+		resp := resolveRefResponse{Scheme: scheme, Locator: locator}
+
+		switch scheme {
+		case "mod":
+			resp = resolveModScheme(locator, basePath)
+		default:
+			resp.RemoteHint = fmt.Sprintf("scheme %q not yet supported by resolve_ref", scheme)
+		}
+
+		body, err := json.MarshalIndent(resp, "", "  ")
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("encode response: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(body)), nil
+	}
+}
+
+// resolveModScheme handles the `mod:` scheme. Local-relative locators (./X
+// or ../X) resolve against base_path; everything else returns RemoteHint.
+func resolveModScheme(locator, basePath string) resolveRefResponse {
+	resp := resolveRefResponse{Scheme: "mod", Locator: locator}
+
+	if !isLocalRelativeLocator(locator) {
+		resp.RemoteHint = fmt.Sprintf("locator %q is not a local relative path; remote resolution not yet implemented", locator)
+		return resp
+	}
+
+	if basePath == "" {
+		resp.Error = "local-relative locators require base_path (the file or directory the locator is relative to)"
+		return resp
+	}
+
+	baseDir := basePath
+	if info, err := os.Stat(basePath); err == nil && !info.IsDir() {
+		baseDir = filepath.Dir(basePath)
+	}
+
+	resolved, err := filepath.Abs(filepath.Join(baseDir, locator))
+	if err != nil {
+		resp.Error = fmt.Sprintf("resolve %q: %v", locator, err)
+		return resp
+	}
+	resp.Resolved = resolved
+
+	info, err := os.Stat(resolved)
+	if err != nil {
+		resp.Error = fmt.Sprintf("stat %s: %v", resolved, err)
+		return resp
+	}
+	resp.Exists = true
+	resp.IsDir = info.IsDir()
+
+	if !info.IsDir() {
+		return resp
+	}
+
+	entries, err := os.ReadDir(resolved)
+	if err != nil {
+		resp.Error = fmt.Sprintf("read dir %s: %v", resolved, err)
+		return resp
+	}
+	for _, e := range entries {
+		entry := resolveRefEntry{Name: e.Name(), IsDir: e.IsDir()}
+		if !e.IsDir() {
+			if fi, err := e.Info(); err == nil {
+				entry.Size = fi.Size()
+			}
+			entry.Lang = detectLang(e.Name())
+		}
+		resp.Files = append(resp.Files, entry)
+	}
+	return resp
+}
+
+// isLocalRelativeLocator reports whether the locator should be resolved
+// against the local filesystem. Conservative: only ./ and ../ prefixes.
+// Bare paths like "foo/bar" are ambiguous (could be a registry slug); we
+// treat them as remote until a registry resolver is added.
+func isLocalRelativeLocator(locator string) bool {
+	return strings.HasPrefix(locator, "./") || strings.HasPrefix(locator, "../")
+}
+
+// detectLang returns a coarse language label for a filename based on its
+// extension, leaning on the same registry mache uses elsewhere. Empty
+// string when the extension isn't a recognized source language.
+func detectLang(name string) string {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == "" {
+		return ""
+	}
+	if l := lang.ForExt(ext); l != nil {
+		return l.Name
+	}
+	return ""
+}

--- a/cmd/serve_resolve_ref_test.go
+++ b/cmd/serve_resolve_ref_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests cover the resolveModScheme branch directly so we don't need an
+// MCP transport spun up — the handler is a thin JSON wrapper.
+
+func TestResolveModScheme_LocalDir(t *testing.T) {
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte("resource \"aws_vpc\" \"this\" {}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "outputs.tf"), []byte("output \"vpc_id\" {}"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(moduleDir, "README.md"), []byte("# VPC"), 0o644))
+
+	// base_path is a terraform file in the project root.
+	basePath := filepath.Join(root, "main.tf")
+	require.NoError(t, os.WriteFile(basePath, []byte("module \"vpc\" { source = \"./modules/vpc\" }"), 0o644))
+
+	got := resolveModScheme("./modules/vpc", basePath)
+	assert.Equal(t, "mod", got.Scheme)
+	assert.Equal(t, "./modules/vpc", got.Locator)
+	assert.True(t, got.Exists, "module dir should exist")
+	assert.True(t, got.IsDir)
+	assert.Empty(t, got.Error)
+	assert.Empty(t, got.RemoteHint)
+
+	resolved, err := filepath.EvalSymlinks(got.Resolved)
+	require.NoError(t, err)
+	expected, err := filepath.EvalSymlinks(moduleDir)
+	require.NoError(t, err)
+	assert.Equal(t, expected, resolved)
+
+	// Files should include both .tf entries with terraform language
+	// detected, plus the README.md without a lang tag.
+	names := map[string]resolveRefEntry{}
+	for _, f := range got.Files {
+		names[f.Name] = f
+	}
+	require.Contains(t, names, "main.tf")
+	require.Contains(t, names, "outputs.tf")
+	require.Contains(t, names, "README.md")
+	assert.Equal(t, "terraform", names["main.tf"].Lang)
+	assert.Equal(t, "terraform", names["outputs.tf"].Lang)
+}
+
+func TestResolveModScheme_LocalDirRelativeToDir(t *testing.T) {
+	// Same as above but base_path is a directory rather than a file —
+	// the resolver should still anchor relative locators against it.
+	root := t.TempDir()
+	moduleDir := filepath.Join(root, "modules", "vpc")
+	require.NoError(t, os.MkdirAll(moduleDir, 0o755))
+
+	got := resolveModScheme("./modules/vpc", root)
+	assert.True(t, got.Exists)
+	assert.True(t, got.IsDir)
+	assert.Empty(t, got.Error)
+}
+
+func TestResolveModScheme_RemoteLocatorReturnsHint(t *testing.T) {
+	got := resolveModScheme("github.com/foo/bar", t.TempDir())
+	assert.Equal(t, "github.com/foo/bar", got.Locator)
+	assert.False(t, got.Exists)
+	assert.NotEmpty(t, got.RemoteHint, "remote locator must surface a hint")
+	assert.Empty(t, got.Resolved)
+	assert.Empty(t, got.Files)
+}
+
+func TestResolveModScheme_LocalLocatorRequiresBasePath(t *testing.T) {
+	got := resolveModScheme("./modules/vpc", "")
+	assert.Empty(t, got.Resolved)
+	assert.NotEmpty(t, got.Error)
+	assert.Contains(t, got.Error, "base_path")
+}
+
+func TestResolveModScheme_TargetMissing(t *testing.T) {
+	got := resolveModScheme("./does/not/exist", t.TempDir())
+	assert.False(t, got.Exists)
+	assert.NotEmpty(t, got.Error, "missing target must surface an error")
+	assert.NotEmpty(t, got.Resolved, "Resolved should still be set so the caller can see what was tried")
+}
+
+func TestResolveModScheme_DotSlashFile(t *testing.T) {
+	// When the locator points at a single file (not a directory), Files is
+	// empty and IsDir is false.
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "shared.tf"), []byte("variable \"x\" {}"), 0o644))
+
+	got := resolveModScheme("./shared.tf", root)
+	assert.True(t, got.Exists)
+	assert.False(t, got.IsDir)
+	assert.Empty(t, got.Files)
+}
+
+func TestResolveResponseSerializesCleanly(t *testing.T) {
+	// JSON roundtrip catches struct-tag typos and exported-field issues.
+	resp := resolveRefResponse{
+		Scheme:   "mod",
+		Locator:  "./vpc",
+		Resolved: "/abs/vpc",
+		Exists:   true,
+		IsDir:    true,
+		Files: []resolveRefEntry{
+			{Name: "main.tf", IsDir: false, Size: 42, Lang: "terraform"},
+			{Name: "subdir", IsDir: true},
+		},
+	}
+	b, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var back resolveRefResponse
+	require.NoError(t, json.Unmarshal(b, &back))
+	assert.Equal(t, resp, back)
+}
+
+func TestIsLocalRelativeLocator(t *testing.T) {
+	cases := map[string]bool{
+		"./modules/vpc":    true,
+		"../shared":        true,
+		"github.com/x/y":   false,
+		"foo/bar":          false,
+		"":                 false,
+		"git::https://...": false,
+		"./":               true,
+	}
+	for in, want := range cases {
+		t.Run(in, func(t *testing.T) {
+			assert.Equal(t, want, isLocalRelativeLocator(in))
+		})
+	}
+}

--- a/internal/ingest/address_refs_test.go
+++ b/internal/ingest/address_refs_test.go
@@ -181,6 +181,47 @@ resource "aws_instance" "web" {
 	assert.Len(t, refs, 2, "should find exactly two variable env refs")
 }
 
+// TestExtractAddressRefs_HCLModuleSource — bead mache-q43l first milestone.
+// Module blocks with a `source = "..."` attribute emit `mod:<value>` tokens.
+// Variable defaults / resource attributes must NOT match.
+func TestExtractAddressRefs_HCLModuleSource(t *testing.T) {
+	code := []byte(`module "vpc" {
+  source = "./modules/vpc"
+  version = "1.0.0"
+}
+
+module "remote_app" {
+  source = "github.com/foo/bar"
+}
+
+variable "DB" {
+  default = "postgres://localhost:5432/mydb"
+}
+
+resource "aws_instance" "web" {
+  source = "this should not match — wrong block type"
+}
+`)
+	lang := hcl.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	w := NewSitterWalker()
+	defer w.Close()
+
+	refs, err := w.ExtractAddressRefs(tree.RootNode(), code, lang, "terraform")
+	require.NoError(t, err)
+
+	assert.Contains(t, refs, "mod:./modules/vpc")
+	assert.Contains(t, refs, "mod:github.com/foo/bar")
+	for _, ref := range refs {
+		assert.NotContains(t, ref, "aws_instance", "resource source attributes must not produce mod refs")
+		assert.NotContains(t, ref, "this should not match", "non-module block sources must not match")
+	}
+}
+
 func TestExtractAddressRefs_NoRegistry(t *testing.T) {
 	// Languages with no registered address ref queries should return nil.
 	w := NewSitterWalker()

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -105,4 +105,16 @@ func init() {
 			(string_lit) @ref
 			(#eq? @_type "variable"))
 	`)
+
+	// HCL: module "X" { source = "..." } → mod:<source-value>
+	// First milestone of mache-q43l (cross-language ref graph). The emitted
+	// token is consumed by the resolver layer: local-path locators project
+	// the target directory; remote locators are recorded as edges only.
+	RegisterAddressRefQuery("terraform", "mod", `
+		(block
+			(identifier) @_type
+			(body (attribute (identifier) @_key (expression (literal_value (string_lit) @ref))))
+			(#eq? @_type "module")
+			(#eq? @_key "source"))
+	`)
 }


### PR DESCRIPTION
## Summary
First milestone of [\`mache-q43l\`](#) (cross-language reference graph). Picks **one pair end-to-end** so the model is concrete before generalizing to npm / go-mod / docker / etc.

### Pieces
- **Address-ref query for Terraform module sources** — Adds a \`mod:\` scheme query that captures \`module { source = \"...\" }\` (filtered with \`#eq?\` so resource-block \`source\` attributes and variable defaults don't get swept in). The existing \`RegisterAddressRefQuery\` infrastructure already routes typed tokens into \`node_refs\`, so these refs immediately surface in \`callers/\` — no plumbing needed.
- **\`resolve_ref(token, base_path)\` MCP tool** — Takes a \`scheme:locator\` token plus the file/dir the locator is interpreted relative to. Today resolves \`mod:\` with local-relative locators (\`./X\`, \`../Y\`); returns the absolute path, existence, and a directory listing with language tags. Non-local locators return a \`remote_hint\` so callers know resolution was skipped (no network surface in this PR).
- **Tests**:
  - \`TestExtractAddressRefs_HCLModuleSource\` — module sources matched, resource \`source\` attrs and variable defaults correctly skipped.
  - \`resolveModScheme\` cases: local dir, dir-as-base-path, single-file target, missing target, remote-locator-returns-hint, missing-base-path, JSON serialization roundtrip, locator predicate matrix.

### Why this slice
- **Concrete enough to use today**: agents inspecting a Terraform repo can call \`find_callers mod:./modules/vpc\` (works without this PR after schema ingest, returns terraform files referencing it) and now \`resolve_ref mod:./modules/vpc base_path=./main.tf\` to see what's actually at the target.
- **Zero network surface**: registry/git resolution is intentionally deferred. Allowlists, sandboxing, caching are all design questions to settle before remote schemes land.
- **Reuses existing infra**: scheme registry, refs table, MCP tool surface, language detection — nothing new architecturally, just new wiring.

### Adjacent beads
Filed/known but explicitly out of scope:
- [\`mache-q43l\`](#) — parent epic with full design space.
- [\`mache-734971\`](#) — expose ingest engine as \`pkg/\` API. Will matter once we want to project a resolved target in-process.
- [\`mache-107500\`](#) — split \`internal/graph\` god cluster. Touched-but-not-broken; will cross paths if the resolver grows into a sub-graph mount.

## Test plan
- [x] \`go test ./internal/ingest/\` — \`TestExtractAddressRefs_HCLModuleSource\` + existing terraform/Go env tests pass
- [x] \`go test ./cmd/\` — all 7 \`TestResolveModScheme*\` + JSON + predicate tests pass
- [x] \`go test ./...\` — full mache suite green