### PR TITLE
perf: list_directory — skip caller/callee probes at schema container paths

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -179,35 +179,63 @@ type nodeEntry struct {
 	Size int64  `json:"size,omitempty"`
 }
 
+// containerNames are schema-level dir names that group constructs but are
+// never themselves a callable token. Skipping the GetCallers/GetCallees
+// virtual-entry check at these paths avoids an O(N) SQL query and a
+// tree-sitter parse per directory listing — the dominant cost on large
+// monorepos (bead mache-og26).
+//
+// Adding a new schema container here is safe; the worst case is missing a
+// virtual `callers/` or `callees/` entry on a dir that wasn't going to
+// have meaningful refs anyway.
+var containerNames = map[string]bool{
+	"methods":    true,
+	"functions":  true,
+	"types":      true,
+	"interfaces": true,
+	"structs":    true,
+	"classes":    true,
+	"imports":    true,
+	"constants":  true,
+	"variables":  true,
+	"namespaces": true,
+	"enums":      true,
+	"protocols":  true,
+	"objects":    true,
+	"traits":     true,
+	"exports":    true,
+	"fields":     true,
+}
+
 func makeListDirHandler(g graph.Graph) server.ToolHandlerFunc {
-	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		path := request.GetString("path", "")
 		excludeTests := request.GetBool("exclude_tests", false)
 
-		children, err := g.ListChildren(path)
+		// Single-RLock snapshot of all children. Replaces the prior
+		// pattern of ListChildren + N×GetNode (one lookup per child).
+		// On a large dir (300+ children) this is the difference between
+		// one map iteration and 300 lock acquisitions.
+		stats, err := g.ListChildStats(path)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("list %q: %v", path, err)), nil
 		}
 
-		entries := make([]nodeEntry, 0, len(children))
-		for _, childID := range children {
-			name := filepath.Base(childID)
+		entries := make([]nodeEntry, 0, len(stats))
+		for _, s := range stats {
+			name := filepath.Base(s.ID)
 			if excludeTests && (strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Benchmark")) {
 				continue
 			}
-			node, err := g.GetNode(childID)
-			if err != nil {
-				continue
-			}
 			typ := "file"
-			if node.Mode.IsDir() {
+			if s.IsDir {
 				typ = "dir"
 			}
 			entries = append(entries, nodeEntry{
 				Name: name,
-				Path: childID,
+				Path: s.ID,
 				Type: typ,
-				Size: node.ContentSize(),
+				Size: s.ContentSize,
 			})
 		}
 
@@ -233,8 +261,14 @@ func makeListDirHandler(g graph.Graph) server.ToolHandlerFunc {
 				}
 			}
 
+			// Skip GetCallers / GetCallees probes at schema container
+			// levels (methods/, functions/, types/, ...). Their basename
+			// is never a callable token, so the SQL/parse cost is wasted
+			// every readdir.
 			token := filepath.Base(path)
-			if !seen["callers"] {
+			isContainer := containerNames[token]
+
+			if !isContainer && !seen["callers"] {
 				if callers, err := g.GetCallers(token); err == nil && len(callers) > 0 {
 					entries = append(entries, nodeEntry{
 						Name: "callers",
@@ -243,7 +277,7 @@ func makeListDirHandler(g graph.Graph) server.ToolHandlerFunc {
 					})
 				}
 			}
-			if !seen["callees"] {
+			if !isContainer && !seen["callees"] {
 				if callees, err := g.GetCallees(path); err == nil && len(callees) > 0 {
 					entries = append(entries, nodeEntry{
 						Name: "callees",

--- a/cmd/serve_listdir_bench_test.go
+++ b/cmd/serve_listdir_bench_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// buildBenchGraph constructs a directory with `nChildren` subdirs, each
+// holding a single source file. Mirrors the shape mache projects for a
+// large package or a monorepo top-level layout (where the bottleneck
+// reported in mache-og26 was observed).
+func buildBenchGraph(b *testing.B, nChildren int) *graph.MemoryStore {
+	b.Helper()
+	store := graph.NewMemoryStore()
+
+	rootID := "pkg"
+	root := &graph.Node{ID: rootID, Mode: fs.ModeDir}
+	root.Children = make([]string, nChildren)
+	for i := 0; i < nChildren; i++ {
+		root.Children[i] = fmt.Sprintf("%s/child_%04d", rootID, i)
+	}
+	store.AddRoot(root)
+
+	for i := 0; i < nChildren; i++ {
+		dirID := fmt.Sprintf("%s/child_%04d", rootID, i)
+		store.AddNode(&graph.Node{
+			ID:       dirID,
+			Mode:     fs.ModeDir,
+			Children: []string{dirID + "/source"},
+		})
+		store.AddNode(&graph.Node{
+			ID:   dirID + "/source",
+			Mode: 0,
+			Data: fmt.Appendf(nil, "func F%04d() {}", i),
+		})
+	}
+	return store
+}
+
+// BenchmarkListDirectory_LegacyShape mirrors the prior handler
+// (ListChildren + N×GetNode + entry build + JSON marshal). Apples-to-
+// apples comparison with BenchmarkListDirectory below.
+//
+// On MemoryStore the two shapes are within ~10% of each other — the
+// real bead-mache-og26 win is the container-name skip in the new
+// handler, which avoids per-readdir GetCallers/GetCallees probes
+// (those are SQL queries on SQLiteGraph and tree-sitter parses on
+// MemoryStore source files).
+func BenchmarkListDirectory_LegacyShape(b *testing.B) {
+	for _, n := range []int{50, 500, 5000} {
+		b.Run(fmt.Sprintf("children=%d", n), func(b *testing.B) {
+			store := buildBenchGraph(b, n)
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if err := legacyListDirShape(store, "pkg"); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// legacyListDirShape replays the pre-mache-og26 handler shape — same
+// final entries[]+JSON output as the new handler, but using the N+1
+// GetNode pattern instead of ListChildStats. Used by the baseline
+// benchmark above.
+func legacyListDirShape(g graph.Graph, path string) error {
+	children, err := g.ListChildren(path)
+	if err != nil {
+		return err
+	}
+	entries := make([]nodeEntry, 0, len(children))
+	for _, childID := range children {
+		node, err := g.GetNode(childID)
+		if err != nil {
+			continue
+		}
+		typ := "file"
+		if node.Mode.IsDir() {
+			typ = "dir"
+		}
+		entries = append(entries, nodeEntry{
+			Name: filenameOf(childID),
+			Path: childID,
+			Type: typ,
+			Size: node.ContentSize(),
+		})
+	}
+	_, err = json.MarshalIndent(entries, "", "  ")
+	return err
+}
+
+// filenameOf returns the basename of a slash-delimited graph node ID.
+// Avoids dragging filepath.Base into a hot loop.
+func filenameOf(id string) string {
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '/' {
+			return id[i+1:]
+		}
+	}
+	return id
+}
+
+// BenchmarkListDirectory measures the cost of one list_directory call
+// over a parent with `n` children. Bead mache-og26: prior to the
+// ListChildStats refactor, this was an N+1-GetNode pattern that scaled
+// poorly under lock contention.
+func BenchmarkListDirectory(b *testing.B) {
+	for _, n := range []int{50, 500, 5000} {
+		b.Run(fmt.Sprintf("children=%d", n), func(b *testing.B) {
+			store := buildBenchGraph(b, n)
+			handler := makeListDirHandler(store)
+			req := makeRequest(map[string]any{"path": "pkg"})
+			ctx := context.Background()
+
+			if _, err := handler(ctx, req); err != nil {
+				b.Fatal(err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				result, err := handler(ctx, req)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if result == nil || result.IsError {
+					b.Fatal("list_directory returned an error result")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
[\`mache-og26\`](#) — \`list_directory\` was hanging in large monorepos to the point users fell back to shell \`find\`. Investigation found two costs per readdir:

### 1. \`ListChildren\` + N×\`GetNode\` loop
Replaced with a single \`ListChildStats\` call (introduced for FUSE in PR #149). Structurally cleaner — one RLock acquisition vs N+1 — though on \`MemoryStore\` with a hot cache the two shapes bench within ~10% of each other. The real win materializes on \`SQLiteGraph\` where each \`GetNode\` is a SQL query and \`ListChildStats\` is a single nodes-table scan.

### 2. Unconditional \`GetCallers\`/\`GetCallees\` probes (the actual fix)
Every readdir was probing for the virtual \`callers/\` and \`callees/\` entries — both real work:
- \`GetCallers(token=basename)\` → SQL query against \`node_refs\`.
- \`GetCallees(path)\` → re-fetch source content + invoke the call extractor (tree-sitter parse).

Schema container dirs (\`methods/\`, \`functions/\`, \`types/\`, \`imports/\`, \`interfaces/\`, \`structs/\`, \`classes/\`, \`constants/\`, \`variables/\`, \`namespaces/\`, \`enums/\`, \`protocols/\`, \`objects/\`, \`traits/\`, \`exports/\`, \`fields/\`) are *never* callable tokens — their basename is a grouping label. Skipping the probe at those paths cuts a SQL query + a parse off every walk that descends through them. On a monorepo where every navigation passes through 2-3 container levels, that's the difference between hangs and instant.

Worst case for the skip: missing a virtual \`callers/\` entry on a dir whose basename happens to coincide with a real symbol named e.g. \`methods\`. Acceptable trade — \`containerNames\` is one map; adding/removing entries is trivial.

### Benchmark output (Apple M3 Max, MemoryStore, in-memory)

| children | LegacyShape (ListChildren+N×GetNode) | New (ListChildStats) | Notes |
|----------|--------------------------------------|----------------------|-------|
| 50       | 20.5 µs                              | 24.2 µs              | parity with bigger marshaling |
| 500      | 201 µs                               | 223 µs               | parity |
| 5000     | 2.04 ms                              | 2.24 ms              | parity |

The MemoryStore bench is honest — the shape change alone doesn't pay off. The container-skip is what kills the user-visible hang on SQLiteGraph.

## Test plan
- [x] \`go test ./cmd/\` — full handler suite green
- [x] \`go test -bench BenchmarkListDirectory ./cmd/\` — both new + legacy shapes complete cleanly, comparable timings
- [x] \`go test ./...\` — full mache suite green