### PR TITLE
perf: deleteFileNodes targeted parent pruning (O(N) → O(K))

### DIFF
--- a/internal/graph/delete_file_nodes_perf_test.go
+++ b/internal/graph/delete_file_nodes_perf_test.go
@@ -1,0 +1,128 @@
+package graph
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestParentOfNodeID covers the small helper that derives a parent ID
+// by stripping the last `/segment`. Required for the targeted child
+// pruning in deleteFileNodes (bead mache-07f9ca).
+func TestParentOfNodeID(t *testing.T) {
+	cases := map[string]string{
+		"":                     "",
+		"top":                  "",
+		"a/b":                  "a",
+		"a/b/c":                "a/b",
+		"a/b/c/d":              "a/b/c",
+		"pkg/auth/source":      "pkg/auth",
+		"single/":              "single", // trailing slash → parent is "single"
+		"/leading":             "",
+		"/":                    "",
+		"x/y/z/very/deep/leaf": "x/y/z/very/deep",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, parentOfNodeID(in), "parentOfNodeID(%q)", in)
+	}
+}
+
+// buildBenchStore creates a synthetic store with `nFiles` source files,
+// each contributing `perFile` nodes under a parent dir. Used by the
+// DeleteFileNodes benchmark to measure the targeted-pruning win.
+func buildBenchStore(b *testing.B, nFiles, perFile int) (*MemoryStore, []string) {
+	b.Helper()
+	store := NewMemoryStore()
+
+	parentID := "pkg"
+	parent := &Node{ID: parentID, Mode: fs.ModeDir}
+	parent.Children = make([]string, 0, nFiles*perFile)
+	store.AddRoot(parent)
+
+	files := make([]string, 0, nFiles)
+	for f := 0; f < nFiles; f++ {
+		filePath := fmt.Sprintf("/src/file_%04d.go", f)
+		files = append(files, filePath)
+		for i := 0; i < perFile; i++ {
+			id := fmt.Sprintf("%s/file%04d_node%03d", parentID, f, i)
+			parent.Children = append(parent.Children, id)
+			store.AddNode(&Node{
+				ID:   id,
+				Mode: 0,
+				Origin: &SourceOrigin{
+					FilePath:  filePath,
+					StartByte: uint32(i * 10),
+					EndByte:   uint32(i*10 + 9),
+				},
+			})
+		}
+	}
+	return store, files
+}
+
+// BenchmarkDeleteFileNodes_OneFile measures the cost of deleting one
+// file's worth of nodes from a store with `nFiles` total files. Bead
+// mache-07f9ca: prior implementation iterated all remaining nodes to
+// prune Children references; targeted version only touches the deleted
+// nodes' parent.
+//
+// Each b.N iteration deletes one file. The store is rebuilt once per
+// sub-bench (outside the timer) and we re-add the deleted file before
+// the next iteration so the working set stays at `nFiles`.
+func BenchmarkDeleteFileNodes_OneFile(b *testing.B) {
+	const perFile = 20
+	for _, nFiles := range []int{100, 1_000, 10_000} {
+		b.Run(fmt.Sprintf("files=%d", nFiles), func(b *testing.B) {
+			store, files := buildBenchStore(b, nFiles, perFile)
+			target := files[len(files)/2]
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				store.DeleteFileNodes(target)
+				b.StopTimer()
+				readdFile(store, target, perFile)
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// readdFile re-creates the perFile nodes for filePath after a delete,
+// so the next benchmark iteration has the same working-set size as the
+// first. The added nodes are wired back into the same parent (`pkg`).
+func readdFile(store *MemoryStore, filePath string, perFile int) {
+	parent, err := store.GetNode("pkg")
+	if err != nil {
+		return
+	}
+	parentClone := *parent
+	parentClone.Children = append([]string(nil), parent.Children...)
+
+	idPrefix := fmt.Sprintf("pkg/%s_node", lastSegment(filePath))
+	for i := 0; i < perFile; i++ {
+		id := fmt.Sprintf("%s%03d", idPrefix, i)
+		parentClone.Children = append(parentClone.Children, id)
+		store.AddNode(&Node{
+			ID:   id,
+			Mode: 0,
+			Origin: &SourceOrigin{
+				FilePath:  filePath,
+				StartByte: uint32(i * 10),
+				EndByte:   uint32(i*10 + 9),
+			},
+		})
+	}
+	store.AddNode(&parentClone)
+}
+
+func lastSegment(p string) string {
+	for i := len(p) - 1; i >= 0; i-- {
+		if p[i] == '/' {
+			return p[i+1:]
+		}
+	}
+	return p
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -179,6 +179,18 @@ func NormalizeID(id string) string {
 	return id
 }
 
+// parentOfNodeID returns the parent ID by stripping the last `/segment`.
+// Top-level IDs (no `/`) return "". Used by deleteFileNodes to find the
+// minimal set of parents whose Children slices need pruning.
+func parentOfNodeID(id string) string {
+	for i := len(id) - 1; i >= 0; i-- {
+		if id[i] == '/' {
+			return id[:i]
+		}
+	}
+	return ""
+}
+
 // SliceContent copies content bytes into buf at the given offset.
 // Returns the number of bytes copied. Shared by all ReadContent implementations.
 func SliceContent(data, buf []byte, offset int64) int {
@@ -557,21 +569,31 @@ func (s *MemoryStore) deleteFileNodes(filePath string) {
 		delete(s.fileToNodes, filePath)
 	}
 
-	// 3. Clean up children pointers in remaining nodes
-	for _, n := range s.nodes {
-		if n.Mode.IsDir() && len(n.Children) > 0 {
-			newChildren := n.Children[:0]
-			changed := false
-			for _, c := range n.Children {
-				if _, del := deleteSet[c]; del {
-					changed = true
-				} else {
-					newChildren = append(newChildren, c)
-				}
+	// 3. Clean up Children pointers in just the parents of deleted nodes.
+	// Was an O(N) scan over the whole store (bead mache-07f9ca); now
+	// O(K) over the unique parent paths derived from the deleted IDs.
+	parentsTouched := make(map[string]struct{}, len(deleteSet))
+	for id := range deleteSet {
+		if pid := parentOfNodeID(id); pid != "" {
+			parentsTouched[pid] = struct{}{}
+		}
+	}
+	for pid := range parentsTouched {
+		n, ok := s.nodes[pid]
+		if !ok || !n.Mode.IsDir() || len(n.Children) == 0 {
+			continue
+		}
+		newChildren := n.Children[:0]
+		changed := false
+		for _, c := range n.Children {
+			if _, del := deleteSet[c]; del {
+				changed = true
+			} else {
+				newChildren = append(newChildren, c)
 			}
-			if changed {
-				n.Children = newChildren
-			}
+		}
+		if changed {
+			n.Children = newChildren
 		}
 	}
 


### PR DESCRIPTION
## Summary
[\`mache-07f9ca\`](#) — step 3 of \`deleteFileNodes\` iterated every node in the store to prune stale \`Children\` references. For a 50k-node store deleting 20 nodes, that's 50,000 map iterations just to update **one** parent's slice.

The deleted IDs already encode their parent paths (mache IDs are slash-delimited paths). Derive the unique set of parents and prune only those.

### Changes
- New \`parentOfNodeID(id)\` helper (last-slash split, returns \`\"\"\` for top-level).
- step 3 collects parent IDs into a map, iterates that set instead of \`s.nodes\`.
- \`TestParentOfNodeID\` covers the corner cases (empty, top-level, trailing/leading slash, deep paths).
- \`BenchmarkDeleteFileNodes_OneFile\` across 100 / 1k / 10k files for future regression detection.

The existing correctness tests (\`TestMemoryStore_DeleteFileNodes_UsesBitmap\`, \`_CleansRefsAndDefs\`) continue to pass — they already pinned the parent-cleanup contract.

## Test plan
- [x] \`go test -run \"TestParentOfNodeID|TestMemoryStore_DeleteFileNodes\" -v ./internal/graph/\` — green
- [x] \`go test ./...\` — full suite green