### PR TITLE
feat: write_file format opt-out (validate always, format when asked)

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -165,9 +165,10 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("write_file",
-			mcp.WithDescription("Write new content to a source file node. Uses the splice pipeline: validate (tree-sitter) → format (gofumpt/hclwrite) → atomic splice into source file → update graph. The node must have a source origin (i.e., was ingested from a real file). Returns the result including any validation errors."),
+			mcp.WithDescription("Write new content to a source file node. Pipeline: validate (tree-sitter, always) → format (gofumpt/hclwrite, opt-out via format=false) → atomic splice into source file → update graph. The node must have a source origin. Set format=false when the caller (LLM, pre-commit) already owns formatting and wants mache to splice verbatim."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("File node path (e.g. 'go/graph/methods/MemoryStore.GetCallees/source')")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("New content to write")),
+			mcp.WithBoolean("format", mcp.Description("Run the language formatter (gofumpt for Go, hclwrite for HCL) before splicing. Default true. Set false when formatting is owned upstream — validation still runs.")),
 		),
 		r.wrapHandler(makeWriteFileHandler),
 	)

--- a/cmd/serve_write.go
+++ b/cmd/serve_write.go
@@ -14,7 +14,7 @@ import (
 )
 
 func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
-	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		path := request.GetString("path", "")
 		if path == "" {
 			return mcp.NewToolResultError("path is required"), nil
@@ -23,6 +23,13 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 		if content == "" {
 			return mcp.NewToolResultError("content is required"), nil
 		}
+		// Default true preserves the prior behavior (gofumpt for Go,
+		// hclwrite for HCL). Bead mache-2a7605: callers that own
+		// formatting upstream (pre-commit, the LLM itself) can pass
+		// format=false so mache only validates structure and splices
+		// the content verbatim. Validation is non-negotiable; formatting
+		// is now opt-out.
+		format := request.GetBool("format", true)
 
 		node, err := g.GetNode(path)
 		if err != nil {
@@ -38,7 +45,9 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 		origin := *node.Origin
 		newContent := []byte(content)
 
-		// 1. Validate syntax
+		// 1. Validate syntax — always runs. Type/structure diagnostics are
+		// the mache write path's contract; we never let invalid bytes
+		// through to the splice.
 		if err := writeback.Validate(newContent, origin.FilePath); err != nil {
 			type valResult struct {
 				Status string `json:"status"`
@@ -55,8 +64,11 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultText(string(data)), nil
 		}
 
-		// 2. Format (gofumpt for Go, hclwrite for HCL)
-		formatted := writeback.FormatBuffer(newContent, origin.FilePath)
+		// 2. Format (gofumpt for Go, hclwrite for HCL) — opt-out.
+		formatted := newContent
+		if format {
+			formatted = writeback.FormatBuffer(newContent, origin.FilePath)
+		}
 
 		// 3. Splice into source file
 		oldLen := origin.EndByte - origin.StartByte
@@ -84,18 +96,20 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 		g.Invalidate(path)
 
 		type writeResult struct {
-			Status     string              `json:"status"`
-			Path       string              `json:"path"`
-			Origin     *graph.SourceOrigin `json:"origin"`
-			Formatted  bool                `json:"formatted"`
-			BytesDelta int32               `json:"bytes_delta"`
+			Status        string              `json:"status"`
+			Path          string              `json:"path"`
+			Origin        *graph.SourceOrigin `json:"origin"`
+			FormatApplied bool                `json:"format_applied"`           // formatter ran (format=true)
+			FormatChanged bool                `json:"format_changed,omitempty"` // formatter actually altered the bytes
+			BytesDelta    int32               `json:"bytes_delta"`
 		}
 		data, _ := json.MarshalIndent(writeResult{
-			Status:     "ok",
-			Path:       path,
-			Origin:     newOrigin,
-			Formatted:  string(formatted) != content,
-			BytesDelta: delta,
+			Status:        "ok",
+			Path:          path,
+			Origin:        newOrigin,
+			FormatApplied: format,
+			FormatChanged: format && string(formatted) != content,
+			BytesDelta:    delta,
 		}, "", "  ")
 		return mcp.NewToolResultText(string(data)), nil
 	}

--- a/cmd/serve_write_test.go
+++ b/cmd/serve_write_test.go
@@ -1,0 +1,213 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Bead mache-2a7605 — write_file used to bundle formatting (gofumpt /
+// hclwrite) with validation. These tests pin the new contract:
+// validation always runs; formatting is opt-out via format=false.
+
+// buildWriteGraph creates a MemoryStore plus a real source file on disk
+// so the splice pipeline (validate → optional format → splice → update)
+// has something to write into. Returns the graph, the node path, and
+// the source file path.
+func buildWriteGraph(t *testing.T) (*graph.MemoryStore, string, string) {
+	t.Helper()
+
+	// Source file with deliberately-unformatted Go that gofumpt will
+	// rewrite (extra blank lines + tabs vs spaces in the body).
+	original := "package main\n\nfunc Hello() {\n\treturn\n}\n"
+	srcPath := filepath.Join(t.TempDir(), "main.go")
+	require.NoError(t, os.WriteFile(srcPath, []byte(original), 0o644))
+
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{
+		ID:       "pkg",
+		Mode:     fs.ModeDir,
+		Children: []string{"pkg/Hello"},
+	})
+	store.AddNode(&graph.Node{
+		ID:   "pkg/Hello",
+		Mode: 0,
+		Origin: &graph.SourceOrigin{
+			FilePath:  srcPath,
+			StartByte: 14, // start of "func Hello() {"
+			EndByte:   uint32(len(original)),
+		},
+		Data: []byte(original[14:]),
+	})
+	return store, "pkg/Hello", srcPath
+}
+
+func TestWriteFile_FormatTrue_AppliesFormatter(t *testing.T) {
+	store, nodePath, _ := buildWriteGraph(t)
+	handler := makeWriteFileHandler(store)
+
+	// Syntactically valid Go fragment. The crucial assertion is that
+	// FormatApplied is reported true — whether the formatter actually
+	// changes the bytes depends on whether gofumpt accepts a fragment,
+	// which is brittle; covered separately with HCL.
+	content := "func Hello() {\n\treturn\n}\n"
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    nodePath,
+		"content": content,
+		// format defaults to true
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var resp struct {
+		Status        string `json:"status"`
+		FormatApplied bool   `json:"format_applied"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "ok", resp.Status)
+	assert.True(t, resp.FormatApplied, "format=true (default) must report FormatApplied")
+}
+
+// TestWriteFile_FormatTrue_HCLNormalizes uses a Terraform file because
+// hclwrite.Format works on fragments and reliably normalizes spacing,
+// giving a stable signal for the FormatChanged assertion that gofumpt
+// can't provide for partial Go files.
+func TestWriteFile_FormatTrue_HCLNormalizes(t *testing.T) {
+	original := "resource \"aws_vpc\" \"this\" {\n  cidr_block = \"10.0.0.0/16\"\n}\n"
+	srcPath := filepath.Join(t.TempDir(), "main.tf")
+	require.NoError(t, os.WriteFile(srcPath, []byte(original), 0o644))
+
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{
+		ID:       "tf",
+		Mode:     fs.ModeDir,
+		Children: []string{"tf/vpc"},
+	})
+	store.AddNode(&graph.Node{
+		ID:   "tf/vpc",
+		Mode: 0,
+		Origin: &graph.SourceOrigin{
+			FilePath:  srcPath,
+			StartByte: 0,
+			EndByte:   uint32(len(original)),
+		},
+	})
+
+	handler := makeWriteFileHandler(store)
+
+	// Misaligned HCL — hclwrite.Format will normalize the indentation.
+	misaligned := "resource \"aws_vpc\" \"this\" {\ncidr_block      =     \"10.0.0.0/16\"\n}\n"
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    "tf/vpc",
+		"content": misaligned,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var resp struct {
+		Status        string `json:"status"`
+		FormatApplied bool   `json:"format_applied"`
+		FormatChanged bool   `json:"format_changed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "ok", resp.Status)
+	assert.True(t, resp.FormatApplied)
+	assert.True(t, resp.FormatChanged, "hclwrite must normalize misaligned terraform")
+}
+
+func TestWriteFile_FormatFalse_SplicesVerbatim(t *testing.T) {
+	store, nodePath, srcPath := buildWriteGraph(t)
+	handler := makeWriteFileHandler(store)
+
+	// Valid Go but with extra spaces gofumpt would normalize. With
+	// format=false the bytes must land on disk exactly as written.
+	verbatim := "func Hello()  {\n\treturn\n}\n"
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    nodePath,
+		"content": verbatim,
+		"format":  false,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var resp struct {
+		Status        string `json:"status"`
+		FormatApplied bool   `json:"format_applied"`
+		FormatChanged bool   `json:"format_changed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "ok", resp.Status)
+	assert.False(t, resp.FormatApplied, "format=false must skip the formatter")
+	assert.False(t, resp.FormatChanged, "format_changed must be false when formatter never ran")
+
+	// On-disk content must contain the verbatim spacing. (We sliced the
+	// last node, so the file ends with our exact replacement region.)
+	got, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.True(t, strings.HasSuffix(string(got), verbatim),
+		"source file did not end with the verbatim content; got: %q", string(got))
+}
+
+func TestWriteFile_ValidationStillRunsWhenFormatFalse(t *testing.T) {
+	store, nodePath, srcPath := buildWriteGraph(t)
+	handler := makeWriteFileHandler(store)
+
+	// Syntactically broken Go — missing closing brace. Validation must
+	// reject regardless of the format flag.
+	broken := "func Hello() { return\n"
+	original, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    nodePath,
+		"content": broken,
+		"format":  false,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var resp struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "validation_error", resp.Status,
+		"broken syntax must be rejected even with format=false")
+
+	// File must be unchanged on disk.
+	after, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, after, "validation failure must not touch the source file")
+}
+
+func TestWriteFile_FormatChangedFalseWhenAlreadyClean(t *testing.T) {
+	// When format=true but the input is already gofumpt-clean,
+	// FormatApplied is true (we ran the formatter) but FormatChanged
+	// should be false (no actual change).
+	store, nodePath, _ := buildWriteGraph(t)
+	handler := makeWriteFileHandler(store)
+
+	clean := "func Hello() {\n\treturn\n}\n"
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    nodePath,
+		"content": clean,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	var resp struct {
+		FormatApplied bool `json:"format_applied"`
+		FormatChanged bool `json:"format_changed"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.True(t, resp.FormatApplied)
+	assert.False(t, resp.FormatChanged, "clean input must not be reported as format-changed")
+}


### PR DESCRIPTION
## Summary
[\`mache-2a7605\`](#) — \`write_file\` forced \`gofumpt\` / \`hclwrite\` on every splice. The argument: formatting is the LLM's responsibility (or pre-commit's), not mache's. Validation is non-negotiable; formatting is opt-out.

### Changes
- New \`format\` boolean param (default \`true\`, preserves prior behavior). When \`false\`, mache validates structure but splices the content verbatim — no \`gofumpt\`, no \`hclwrite\`.
- Response now reports **two** flags instead of one:
  - \`format_applied\` — formatter ran (= the \`format\` param).
  - \`format_changed\` — formatter actually altered the bytes.

  Old \`formatted\` field was ambiguous (could mean \"format was requested\" *or* \"formatter changed bytes\"). Replaced with the pair so callers don't have to guess.
- Tool description spells out the layered model and recommends \`format=false\` when an upstream formatter (pre-commit, LLM) already owns formatting.

### Tests
- \`FormatTrue_AppliesFormatter\` — default path reports \`FormatApplied\`.
- \`FormatTrue_HCLNormalizes\` — hclwrite reliably reformats fragment, so \`FormatChanged=true\` is testable.
- \`FormatFalse_SplicesVerbatim\` — bytes on disk match the input exactly.
- \`ValidationStillRunsWhenFormatFalse\` — broken Go is rejected even with \`format=false\`; source file untouched.
- \`FormatChangedFalseWhenAlreadyClean\` — clean input with \`format=true\` reports \`FormatApplied=true\`, \`FormatChanged=false\`.

## Test plan
- [x] \`go test -run TestWriteFile -v ./cmd/\` — 5 tests pass
- [x] \`go test ./...\` — full suite green