### PR TITLE
fix: P3 cleanup — compactSorted aliasing + 3 stale beads triaged

### DIFF
--- a/internal/graph/sliceutil.go
+++ b/internal/graph/sliceutil.go
@@ -35,12 +35,20 @@ func mergeSortedDedup(a, b []string) []string {
 	return result
 }
 
-// compactSorted removes consecutive duplicates from a sorted slice.
-// For slices of length 0 or 1, returns the input as-is (no allocation).
-// For longer slices, returns a new slice.
+// compactSorted removes consecutive duplicates from a sorted slice and
+// always returns a slice that does not alias the input — callers may
+// freely append to the result without stomping the source's backing
+// array.
+//
+// Bead mache-ad17c1: previous implementation aliased for len<=1, which
+// matched the caller's current usage in mergeSortedDedup but was a
+// latent hazard if the function gets reused.
 func compactSorted(s []string) []string {
-	if len(s) <= 1 {
-		return s
+	if len(s) == 0 {
+		return nil
+	}
+	if len(s) == 1 {
+		return []string{s[0]}
 	}
 	out := make([]string, 0, len(s))
 	for _, v := range s {

--- a/internal/graph/sliceutil_test.go
+++ b/internal/graph/sliceutil_test.go
@@ -84,6 +84,30 @@ func TestCompactSorted_SingleElement(t *testing.T) {
 	assert.Equal(t, []string{"a"}, got)
 }
 
+// TestCompactSorted_NoAliasing — bead mache-ad17c1.
+//
+// FALSIFIABLE: prior implementation returned the input slice directly
+// for len<=1, so a caller appending to the result could stomp the
+// source's backing array. With the fresh-slice fix, mutating the
+// returned slice must not leak back into the input.
+func TestCompactSorted_NoAliasing(t *testing.T) {
+	src := []string{"only"}
+	out := compactSorted(src)
+
+	// Mutate the result. If out aliases src, this would change src too.
+	out[0] = "mutated"
+
+	assert.Equal(t, "only", src[0],
+		"compactSorted must return a slice that does not alias the input")
+}
+
+// TestCompactSorted_EmptyReturnsNil pins the contract for empty input —
+// nil rather than an aliased empty slice, so callers can branch on it.
+func TestCompactSorted_EmptyReturnsNil(t *testing.T) {
+	assert.Nil(t, compactSorted(nil))
+	assert.Nil(t, compactSorted([]string{}))
+}
+
 func TestCompactSorted_NoDupes(t *testing.T) {
 	s := []string{"a", "b", "c"}
 	assert.Equal(t, s, compactSorted(s))


### PR DESCRIPTION
## Summary
Audit pass on the four open P3 bug beads. Three turn out to be no-ops in the current code; the fourth (\`compactSorted\` aliasing) was real and is fixed here.

| Bead | Status | Why |
|------|--------|-----|
| \`mache-02e497\` (double NormalizeID) | closed (no-op) | \`SQLiteGraph\`'s legacy \`NormalizeID\` calls only run when \`useNodesTable=false\`, AFTER the ntr early-return. The two paths never compound; \"//double\" reaches \`ntr\` once, gets normalized once. |
| \`mache-1456aa\` (misplaced doc comments) | closed (no-op) | \`graphfs.go\`'s \`statToFileInfo\` and \`nodeToFileInfo\` each have correct, separate doc blocks today. |
| \`mache-143ae1\` (dead \`dirHandle.stats\`) | closed (obsolete) | \`internal/fs/\` no longer exists — FUSE was removed in v0.7.0 (ADR-0006), and \`dirHandle\` with it. |
| \`mache-ad17c1\` (compactSorted aliasing) | **fixed here** | Returned the input slice directly for \`len<=1\`, leaving callers exposed if they ever appended to the result. Now always allocates fresh (\`nil\` for empty, single-element copy for \`len==1\`). |

### compactSorted change
```go
// Before
if len(s) <= 1 {
    return s
}
// After
if len(s) == 0 {
    return nil
}
if len(s) == 1 {
    return []string{s[0]}
}
```

### Tests
- \`TestCompactSorted_NoAliasing\` — falsifiable: writes to the returned single-element slice and asserts the input is unchanged.
- \`TestCompactSorted_EmptyReturnsNil\` — pins the nil-vs-empty contract for the empty input.
- Existing \`TestCompactSorted_*\` and \`TestMergeSortedDedup_*\` tests continue to pass.

## Test plan
- [x] \`go test -run \"TestCompactSorted|TestMergeSortedDedup\" -v ./internal/graph/\` — green
- [x] \`go test ./...\` — full suite green