### PR TITLE
chore: replace bare 0/1 with NodeKindFile/NodeKindDir

### DIFF
--- a/cmd/leyline.go
+++ b/cmd/leyline.go
@@ -382,6 +382,7 @@ func collectContentSources(schema *api.Topology) map[string]string {
 
 // buildNameToDirIndex builds a map from directory leaf name to directory IDs.
 func buildNameToDirIndex(tx *sql.Tx) (map[string][]string, error) {
+	// kind = 1 → graph.NodeKindDir.
 	rows, err := tx.Query(`SELECT id FROM nodes WHERE kind = 1`)
 	if err != nil {
 		return nil, fmt.Errorf("query dirs: %w", err)
@@ -558,6 +559,7 @@ func extractCallerDir(nodeID string) (dirID string) {
 // nodes, keeping only the directory structure and metadata (name, mtime).
 // This prevents raw project files from bloating the --out DB.
 func stripProjectFileContent(tx *sql.Tx) error {
+	// kind = 0 → graph.NodeKindFile (file nodes only).
 	_, err := tx.Exec(`UPDATE nodes SET record = NULL, size = 0 WHERE kind = 0 AND id LIKE '_project_files/%'`)
 	return err
 }

--- a/ext/boltdb/boltdb.go
+++ b/ext/boltdb/boltdb.go
@@ -12,6 +12,15 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// nodeKindFile and nodeKindDir mirror internal/graph.NodeKindFile/Dir.
+// Duplicated here because this is a workspace module that can't import
+// the internal package — the values are part of mache's on-disk schema
+// and must stay in sync.
+const (
+	nodeKindFile = 0
+	nodeKindDir  = 1
+)
+
 // Materialize reads the node tree from a mache SQLite DB and writes
 // directories as bbolt nested buckets and file content as bucket key/values.
 func Materialize(srcDB, outPath string) error {
@@ -67,7 +76,7 @@ func Materialize(srcDB, outPath string) error {
 			}
 			visited[n.id] = true
 
-			if n.kind == 1 {
+			if n.kind == nodeKindDir {
 				if n.name == "" && pb == nil {
 					if err := writeChildren(tx, pb, n.id, visited); err != nil {
 						return err
@@ -87,7 +96,7 @@ func Materialize(srcDB, outPath string) error {
 				if err := writeChildren(tx, bucket, n.id, visited); err != nil {
 					return err
 				}
-			} else if n.kind == 0 && n.content.Valid && n.name != "" {
+			} else if n.kind == nodeKindFile && n.content.Valid && n.name != "" {
 				if pb == nil {
 					root, err := tx.CreateBucketIfNotExists([]byte("_root"))
 					if err != nil {

--- a/graph/sqlite.go
+++ b/graph/sqlite.go
@@ -10,6 +10,16 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// nodeKindFile and nodeKindDir mirror the wire-format constants in
+// internal/graph (NodeKindFile/NodeKindDir). Duplicated here because
+// this is the public graph/ package and Go's import rules forbid
+// reaching into internal/. The values are part of mache's on-disk
+// schema and must stay in sync.
+const (
+	nodeKindFile = 0
+	nodeKindDir  = 1
+)
+
 // ExportSQLite writes all nodes from a MemoryStore to a SQLite database.
 // Creates the nodes table if it doesn't exist. Existing entries are overwritten.
 // The resulting file uses the standard mache nodes table schema.
@@ -63,9 +73,9 @@ func exportNode(store *MemoryStore, stmt *sql.Stmt, nodeID, parentID string) err
 		return err
 	}
 
-	kind := 0 // file
+	kind := nodeKindFile
 	if node.Mode.IsDir() {
-		kind = 1
+		kind = nodeKindDir
 	}
 
 	// Build record JSON: inline data + properties.
@@ -145,7 +155,7 @@ func ImportSQLite(dbPath string) (*MemoryStore, error) {
 			ID:      r.id,
 			ModTime: time.Unix(0, r.mtime),
 		}
-		if r.kind == 1 {
+		if r.kind == nodeKindDir {
 			node.Mode = fs.ModeDir
 			node.Children = []string{}
 		}

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -11,7 +11,18 @@ import (
 	"time"
 )
 
-// NodeKindFile and NodeKindDir are the kind values in the nodes table.
+// NodeKindFile and NodeKindDir are the integer values stored in the nodes
+// table's `kind` column (the wire format produced by mache build /
+// leyline parse). They are NOT a substitute for *Node.Mode at runtime —
+// Mode uses fs.FileMode and carries the IsDir() predicate. The kind
+// constants are used by ingestion writers when populating the column,
+// by readers when interpreting it, and as a comment marker next to
+// bare-int SQL literals like `kind = 1` (SQL can't reference Go
+// constants directly).
+//
+// These values are part of the on-disk schema and must not change.
+//
+// Bead mache-e7e9e5.
 const (
 	NodeKindFile = 0
 	NodeKindDir  = 1

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -628,6 +628,7 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 	var langName string
 	if g.useNodesTable {
 		var recordJSON sql.NullString
+		// kind = 1 → graph.NodeKindDir (constructs are dirs).
 		_ = g.db.QueryRow("SELECT record FROM nodes WHERE id = ? AND kind = 1", id).Scan(&recordJSON)
 		if recordJSON.Valid && recordJSON.String != "" {
 			var props map[string][]byte
@@ -733,6 +734,7 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 				continue
 			}
 			// Final fallback: name match in nodes table
+			// kind = 1 → graph.NodeKindDir (definition constructs are dirs).
 			err = g.db.QueryRow("SELECT id FROM nodes WHERE name = ? AND kind = 1 LIMIT 1", qc.Token).Scan(&defID)
 			if err == nil && defID != id && !seen[defID] {
 				seen[defID] = true

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -237,10 +237,11 @@ func (w *SQLiteWriter) AddNode(n *graph.Node) {
 		}
 	}
 
-	// Store full os.FileMode for fidelity (kind column: 1=dir, 0=file).
-	kind := 0
+	// Store full os.FileMode for fidelity. kind column uses the wire
+	// constants NodeKindFile/NodeKindDir.
+	kind := graph.NodeKindFile
 	if n.Mode.IsDir() {
-		kind = 1
+		kind = graph.NodeKindDir
 	}
 
 	// 3. Record ID (for lazy loading)
@@ -386,7 +387,7 @@ func (w *SQLiteWriter) GetNode(id string) (*graph.Node, error) {
 	}
 
 	mode := os.FileMode(0o444)
-	if kind == 1 {
+	if kind == graph.NodeKindDir {
 		mode = os.ModeDir | 0o555
 	}
 

--- a/internal/materialize/json.go
+++ b/internal/materialize/json.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/agentic-research/mache/internal/graph"
 	_ "modernc.org/sqlite"
 )
 
@@ -129,7 +130,7 @@ func buildJSONChildren(parentID string, nodes []jsonNode, childrenOf map[string]
 		}
 		visited[n.id] = true
 
-		if n.kind == 1 {
+		if n.kind == graph.NodeKindDir {
 			// Directory node.
 			if n.name == "" && parentID == "" {
 				// Transparent unnamed root — promote children.
@@ -143,7 +144,7 @@ func buildJSONChildren(parentID string, nodes []jsonNode, childrenOf map[string]
 				Children: buildJSONChildren(n.id, nodes, childrenOf, visited),
 			}
 			entries = append(entries, entry)
-		} else if n.kind == 0 {
+		} else if n.kind == graph.NodeKindFile {
 			// File node.
 			if n.name == "" {
 				continue

--- a/internal/materialize/materialize.go
+++ b/internal/materialize/materialize.go
@@ -92,6 +92,7 @@ func (m *ZIPMaterializer) Materialize(srcDB, outPath string) error {
 	}
 	defer func() { _ = db.Close() }()
 
+	// kind = 0 → graph.NodeKindFile (file nodes only).
 	rows, err := db.Query(`SELECT id, record FROM nodes WHERE kind = 0 AND record IS NOT NULL ORDER BY id`)
 	if err != nil {
 		return fmt.Errorf("query nodes: %w", err)


### PR DESCRIPTION
## Summary
[\`mache-e7e9e5\`](#) — \`sqlite_graph.go\` and a handful of other sites encoded the on-disk nodes-table \`kind\` column as bare \`0\` / \`1\` with each caller restating the \`file=0\`, \`dir=1\` convention in a comment. \`NodeKindFile\` and \`NodeKindDir\` already existed in \`internal/graph/nodes_table_reader.go\`; they just weren't used everywhere.

### Pure rename pass
| File | Change |
|------|--------|
| \`internal/graph/nodes_table_reader.go\` | Expand const doc — describe the wire-format contract, link the bead. |
| \`internal/graph/sqlite_graph.go\` | Marker comments next to \`kind = 1\` SQL literals (Go consts can't appear in SQL strings). |
| \`internal/ingest/sqlite_writer.go\` | Write path uses \`graph.NodeKindFile/Dir\`; read path's \`kind == 1\` check uses \`graph.NodeKindDir\`. |
| \`internal/materialize/json.go\` | \`n.kind == 1 / == 0\` → \`graph.NodeKindDir / NodeKindFile\`. |
| \`internal/materialize/materialize.go\` | Marker comment on the \`kind = 0\` SQL. |
| \`cmd/leyline.go\` | Marker comments on both \`kind = 0\` and \`kind = 1\` SQL queries. |
| \`ext/boltdb/boltdb.go\` | Workspace module can't import \`internal/\` — duplicates as \`nodeKindFile/Dir\` with a doc note. |
| \`graph/sqlite.go\` | Public package can't import \`internal/\` either — same local-const pattern. |

Wire format is unchanged.

## Test plan
- [x] \`go build ./...\` — clean.
- [x] \`go test ./...\` — full suite green.