### PR TITLE
feat: find_smells — mache as a static-analysis substrate (rule registry + MCP tool)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// SmellRule describes one structural code-smell pattern. Rules are
+// language-aware: each carries the language(s) it applies to plus a
+// SQL query template that runs against the `_ast` and `nodes` tables
+// produced by `leyline parse`.
+//
+// The query MUST select the columns: source_id, node_id, start_byte,
+// end_byte, start_row, start_col (in that order). The handler shapes
+// them into a uniform response.
+//
+// Bead mache-6z2e tracks the broader "machelint" idea — declarative
+// rules consumed via this tool. Today the registry is hard-coded; in
+// the future it becomes user-extensible.
+type SmellRule struct {
+	ID          string   // stable identifier, used as the MCP tool argument
+	Languages   []string // matches `_source.language` values; empty = any
+	Description string   // shown in the help payload
+	Query       string   // SQL with one optional placeholder for source_id
+}
+
+// smellRegistry holds the built-in rules.
+var smellRegistry = []SmellRule{
+	{
+		ID:          "magic_int_in_comparison",
+		Languages:   []string{"go"},
+		Description: "Go binary expressions where an int_literal appears as a direct operand. Each match is a candidate magic constant — replace with a named const if the value carries domain meaning.",
+		Query: `
+			SELECT lit.source_id, lit.node_id, lit.start_byte, lit.end_byte, lit.start_row, lit.start_col
+			FROM _ast lit
+			JOIN nodes n   ON n.id = lit.node_id
+			JOIN nodes p   ON p.id = n.parent_id
+			JOIN _ast pa   ON pa.node_id = p.id
+			WHERE lit.node_kind  = 'int_literal'
+			  AND pa.node_kind   = 'binary_expression'
+			%s
+			ORDER BY lit.source_id, lit.start_byte
+		`,
+	},
+}
+
+// smellFinding is one row of a smell scan. Byte ranges and (1-based)
+// line/column let editors jump straight to the offending span.
+type smellFinding struct {
+	RuleID    string `json:"rule_id"`
+	SourceID  string `json:"source_id"`
+	NodeID    string `json:"node_id,omitempty"`
+	StartByte int    `json:"start_byte"`
+	EndByte   int    `json:"end_byte"`
+	Line      int    `json:"line"`              // 1-based
+	Column    int    `json:"column"`            // 1-based
+	Snippet   string `json:"snippet,omitempty"` // up to ~80 chars of source
+}
+
+// makeFindSmellsHandler returns the MCP handler. With no `rule` arg
+// it lists all registered rules; with a rule it runs the scan.
+func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
+	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ruleID := strings.TrimSpace(request.GetString("rule", ""))
+		sourceID := strings.TrimSpace(request.GetString("source_id", ""))
+		limitFloat := request.GetFloat("limit", 200)
+		limit := int(limitFloat)
+		if limit <= 0 {
+			limit = 200
+		}
+
+		if ruleID == "" {
+			// Discovery mode — list rules.
+			return mcp.NewToolResultText(jsonOrPanic(rulesListing())), nil
+		}
+
+		var rule *SmellRule
+		for i := range smellRegistry {
+			if smellRegistry[i].ID == ruleID {
+				rule = &smellRegistry[i]
+				break
+			}
+		}
+		if rule == nil {
+			return mcp.NewToolResultError(fmt.Sprintf("unknown rule %q. Call this tool with no rule for the registry listing.", ruleID)), nil
+		}
+
+		// Need a *sql.DB to run the rule. Today we hand-shake via the
+		// refsQuerier interface that other handlers already use.
+		qg, ok := g.(refsQuerier)
+		if !ok {
+			return mcp.NewToolResultError("the active graph backend doesn't expose a SQL handle; find_smells requires a leyline-parsed .db"), nil
+		}
+
+		findings, err := runSmellRule(qg, rule, sourceID, limit)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("rule %q: %v", ruleID, err)), nil
+		}
+
+		// Snippet population is best-effort. If `_source` isn't there
+		// (older .dbs) we just leave Snippet empty.
+		populateSnippets(qg, findings)
+
+		resp := struct {
+			Rule     string         `json:"rule"`
+			Total    int            `json:"total"`
+			Findings []smellFinding `json:"findings"`
+		}{
+			Rule:     rule.ID,
+			Total:    len(findings),
+			Findings: findings,
+		}
+		return mcp.NewToolResultText(jsonOrPanic(resp)), nil
+	}
+}
+
+// rulesListing produces the JSON returned when find_smells is called
+// without a rule. Stable order so agents can cache the listing.
+func rulesListing() any {
+	type ruleSummary struct {
+		ID          string   `json:"id"`
+		Languages   []string `json:"languages,omitempty"`
+		Description string   `json:"description"`
+	}
+	out := make([]ruleSummary, 0, len(smellRegistry))
+	for _, r := range smellRegistry {
+		out = append(out, ruleSummary{
+			ID:          r.ID,
+			Languages:   r.Languages,
+			Description: r.Description,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return struct {
+		Help  string        `json:"help"`
+		Rules []ruleSummary `json:"rules"`
+	}{
+		Help:  "find_smells runs structural pattern queries against the _ast table. Pass `rule` to scan; omit it (this response) to list available rules. Optional `source_id` filters to one parsed file; `limit` caps results (default 200).",
+		Rules: out,
+	}
+}
+
+// runSmellRule executes the rule's SQL, optionally scoped to one source.
+func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) ([]smellFinding, error) {
+	scope := ""
+	args := []any{}
+	if sourceID != "" {
+		scope = "AND lit.source_id = ?"
+		args = append(args, sourceID)
+	}
+	query := fmt.Sprintf(rule.Query, scope) + fmt.Sprintf(" LIMIT %d", limit)
+
+	rows, err := qg.QueryRefs(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []smellFinding
+	for rows.Next() {
+		var (
+			src       string
+			nodeID    string
+			startByte int
+			endByte   int
+			startRow  int
+			startCol  int
+		)
+		if err := rows.Scan(&src, &nodeID, &startByte, &endByte, &startRow, &startCol); err != nil {
+			return nil, fmt.Errorf("scan: %w", err)
+		}
+		out = append(out, smellFinding{
+			RuleID:    rule.ID,
+			SourceID:  src,
+			NodeID:    nodeID,
+			StartByte: startByte,
+			EndByte:   endByte,
+			Line:      startRow + 1, // tree-sitter is 0-indexed; agents expect 1-based
+			Column:    startCol + 1,
+		})
+	}
+	return out, rows.Err()
+}
+
+// populateSnippets fills the Snippet field on each finding. We batch by
+// source_id so a file's _source bytes are read at most once.
+func populateSnippets(qg refsQuerier, findings []smellFinding) {
+	if len(findings) == 0 {
+		return
+	}
+	sources := make(map[string][]byte)
+	for i := range findings {
+		src, hit := sources[findings[i].SourceID]
+		if !hit {
+			rows, err := qg.QueryRefs(
+				"SELECT content FROM _source WHERE id = ?", findings[i].SourceID,
+			)
+			if err != nil {
+				sources[findings[i].SourceID] = nil
+				continue
+			}
+			if rows.Next() {
+				var content []byte
+				if scanErr := rows.Scan(&content); scanErr == nil {
+					src = content
+				}
+			}
+			_ = rows.Close()
+			sources[findings[i].SourceID] = src
+		}
+		if src == nil {
+			continue
+		}
+		const padding = 30
+		s := findings[i].StartByte - padding
+		if s < 0 {
+			s = 0
+		}
+		e := findings[i].EndByte + padding
+		if e > len(src) {
+			e = len(src)
+		}
+		if s < e {
+			snippet := string(src[s:e])
+			snippet = strings.ReplaceAll(snippet, "\n", " ")
+			findings[i].Snippet = strings.TrimSpace(snippet)
+		}
+	}
+}
+
+func jsonOrPanic(v any) string {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf(`{"error": "marshal: %v"}`, err)
+	}
+	return string(b)
+}

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// smellTestGraph is a tiny graph backend that delegates QueryRefs to a
+// caller-supplied *sql.DB. It exists only for these tests because we
+// don't want to spin up a full SQLiteGraph just to run a SQL pattern.
+type smellTestGraph struct {
+	*graph.MemoryStore
+	db *sql.DB
+}
+
+func (s *smellTestGraph) QueryRefs(query string, args ...any) (*sql.Rows, error) {
+	return s.db.Query(query, args...)
+}
+
+// seedSmellAST creates a minimal _ast database modeling the Go statements
+//
+//	if x == 42 { ... }       // magic int — should be flagged
+//	if y == 0 { ... }        // technically magic too — should be flagged
+//	a := someFunc()           // no magic int → should NOT be flagged
+//
+// We don't represent the full AST — only the binary_expression and
+// int_literal rows that the rule needs, plus their parent_id wiring.
+func seedSmellAST(t *testing.T) *smellTestGraph {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "smells.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL, record_id TEXT, record JSON,
+			source_file TEXT
+		);
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT NOT NULL, content BLOB NOT NULL);
+	`)
+	require.NoError(t, err)
+
+	const src = "package main\nfunc main() {\n\tx := 1\n\tif x == 42 { return }\n\tif x == 0 { return }\n}\n"
+	_, err = db.Exec("INSERT INTO _source VALUES ('main.go', 'go', ?)", []byte(src))
+	require.NoError(t, err)
+
+	type row struct {
+		id, parentID string
+		kind         int
+	}
+	for _, r := range []row{
+		{"src", "", 1},
+		{"src/binexpr_42", "src", 1},
+		{"src/binexpr_42/lit_42", "src/binexpr_42", 0},
+		{"src/binexpr_0", "src", 1},
+		{"src/binexpr_0/lit_0", "src/binexpr_0", 0},
+		// A bare int literal NOT under a binary_expression — must be skipped.
+		{"src/assignment", "src", 1},
+		{"src/assignment/lit_1", "src/assignment", 0},
+	} {
+		_, err = db.Exec("INSERT INTO nodes (id, parent_id, name, kind, mtime, record) VALUES (?, ?, ?, ?, 0, '')",
+			r.id, r.parentID, filepath.Base(r.id), r.kind)
+		require.NoError(t, err)
+	}
+
+	type ast struct {
+		id, kind string
+		s, e     int
+		row, col int
+	}
+	for _, a := range []ast{
+		{"src/binexpr_42", "binary_expression", 38, 45, 3, 4},
+		{"src/binexpr_42/lit_42", "int_literal", 43, 45, 3, 9},
+		{"src/binexpr_0", "binary_expression", 60, 66, 4, 4},
+		{"src/binexpr_0/lit_0", "int_literal", 65, 66, 4, 9},
+		{"src/assignment", "short_var_declaration", 20, 26, 2, 1},
+		{"src/assignment/lit_1", "int_literal", 25, 26, 2, 6},
+	} {
+		_, err = db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, 'main.go', ?, ?, ?, ?, ?, 0, 0)",
+			a.id, a.kind, a.s, a.e, a.row, a.col,
+		)
+		require.NoError(t, err)
+	}
+
+	return &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+}
+
+func TestFindSmells_ListsRulesWhenNoRule(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Help  string `json:"help"`
+		Rules []struct {
+			ID          string   `json:"id"`
+			Languages   []string `json:"languages"`
+			Description string   `json:"description"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.NotEmpty(t, resp.Help)
+
+	gotIDs := make([]string, 0, len(resp.Rules))
+	for _, r := range resp.Rules {
+		gotIDs = append(gotIDs, r.ID)
+	}
+	assert.Contains(t, gotIDs, "magic_int_in_comparison")
+}
+
+func TestFindSmells_MagicIntInComparison(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "magic_int_in_comparison",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Rule     string         `json:"rule"`
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	assert.Equal(t, "magic_int_in_comparison", resp.Rule)
+	assert.Equal(t, 2, resp.Total, "should flag the two int_literals under binary_expression, not the assignment one")
+
+	// Findings come back sorted by start_byte: lit_42 (byte 43) then lit_0 (byte 65).
+	require.Len(t, resp.Findings, 2)
+	assert.Equal(t, "main.go", resp.Findings[0].SourceID)
+	assert.Equal(t, 4, resp.Findings[0].Line, "tree-sitter row+1 should be 1-based line 4 (3+1)")
+	assert.Equal(t, "src/binexpr_42/lit_42", resp.Findings[0].NodeID)
+	assert.Contains(t, resp.Findings[0].Snippet, "42")
+
+	assert.Equal(t, "src/binexpr_0/lit_0", resp.Findings[1].NodeID)
+	assert.Equal(t, 5, resp.Findings[1].Line)
+}
+
+func TestFindSmells_UnknownRuleErrors(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "no_such_rule",
+	}))
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	assert.Contains(t, resultText(t, res), "unknown rule")
+}
+
+func TestFindSmells_BackendWithoutAstReturnsError(t *testing.T) {
+	// MemoryStore implements refsQuerier (its sidecar DB only has
+	// node_refs — no _ast). Running the smell rule must surface a
+	// clear error rather than crashing or returning empty success.
+	store := graph.NewMemoryStore()
+	handler := makeFindSmellsHandler(store)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "magic_int_in_comparison",
+	}))
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+	// We don't pin a specific message — different backends fail at
+	// different points (no refs DB, no _ast table, etc.). The
+	// invariant is that the user sees an error result.
+	assert.NotEmpty(t, resultText(t, res))
+}
+
+func TestFindSmells_SourceIDFilterScopes(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	// Add a second source file with one magic int — make sure source_id
+	// filter excludes it.
+	_, err := tg.db.Exec(`
+		INSERT INTO _source VALUES ('other.go', 'go', '');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, record) VALUES
+		  ('other_root', '', 'other_root', 1, 0, ''),
+		  ('other_root/binexpr', 'other_root', 'binexpr', 1, 0, ''),
+		  ('other_root/binexpr/lit', 'other_root/binexpr', 'lit', 0, 0, '');
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES
+		  ('other_root/binexpr', 'other.go', 'binary_expression', 0, 5, 0, 0, 0, 0),
+		  ('other_root/binexpr/lit', 'other.go', 'int_literal', 4, 5, 0, 0, 0, 0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":      "magic_int_in_comparison",
+		"source_id": "other.go",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.Equal(t, 1, resp.Total)
+	assert.Equal(t, "other.go", resp.Findings[0].SourceID)
+}
+
+func TestFindSmells_LimitCaps(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":  "magic_int_in_comparison",
+		"limit": float64(1),
+	}))
+	require.NoError(t, err)
+
+	var resp struct {
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.Equal(t, 1, resp.Total)
+}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -181,6 +181,16 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 		),
 		r.wrapHandler(makeResolveRefHandler),
 	)
+
+	s.AddTool(
+		mcp.NewTool("find_smells",
+			mcp.WithDescription("Run structural code-smell rules against the parsed _ast table. Call with no arguments for the registry listing; call with `rule` to scan. Rules look for patterns like 'magic int literal in a binary expression' (Go) — useful for sweeping a monorepo before adding named constants. Each finding includes line/column and a short snippet so editors can jump to it. Requires a leyline-parsed .db (the _ast table)."),
+			mcp.WithString("rule", mcp.Description("Rule ID to run. Omit to list available rules.")),
+			mcp.WithString("source_id", mcp.Description("Limit the scan to one parsed source file (matches _source.id, e.g. 'main.go').")),
+			mcp.WithNumber("limit", mcp.Description("Max findings (default 200).")),
+		),
+		r.wrapHandler(makeFindSmellsHandler),
+	)
 }
 
 type nodeEntry struct {


### PR DESCRIPTION
## Summary
mache already stores \`_ast\` + \`nodes\` + \`node_refs\` from \`leyline parse\` — a structural code DB we've never exposed as one. \`find_smells\` is the first concrete consumer, intended as a small proof of the rules-engine model captured in [\`mache-6z2e\`](#) (the \"machelint\" idea).

The user-facing pitch:
> Pass \`rule\` to scan, omit it to discover. Each rule is one SQL pattern against \`_ast\`; findings come back with 1-based line/column and a short snippet so editors can jump to them.

### Pieces
- **\`SmellRule\`** type — \`id\`, \`languages\`, \`description\`, \`Query\` (SQL template). The SQL must select \`(source_id, node_id, start_byte, end_byte, start_row, start_col)\`. The handler shapes that into uniform findings — no per-rule Go code.
- **\`smellRegistry\`** — built-in rules. Today just one:
  - \`magic_int_in_comparison\` (Go): \`int_literal\` whose direct parent is \`binary_expression\`.
- **MCP tool \`find_smells(rule?, source_id?, limit?)\`** — discovery mode (no rule) returns the registry listing with help text; scan mode runs the rule and shapes findings.
- **Snippet population** — best-effort, batched per source, ~30 chars of padding around the byte range with newlines flattened.
- **Backend gate** — requires \`refsQuerier\` (i.e. \`_ast\` available). Other backends get a clear error rather than empty success.

### Tests
\`smellTestGraph\` wires \`QueryRefs\` to a temp SQLite seeded with three \`int_literal\` nodes — two under \`binary_expression\`, one under a \`short_var_declaration\`. The rule flags the two and skips the assignment. Plus rule listing, unknown-rule error, \`source_id\` scoping (second source file with one literal — only that file's findings come back), and \`limit\` capping.

### What's deliberately out of scope
- User-defined rules (declarative JSON loaded at startup) — straightforward extension once the shape is settled.
- Type-aware rules using \`_lsp_*\` tables — unlocks ideas like \"\`==\` against an interface value\" (potential nil-comparison gotcha).
- Severity / fix suggestions / autofix — the rule emits a location; the fix is the agent's job (or pre-commit's).

## Test plan
- [x] \`go test -run TestFindSmells -v ./cmd/\` — 6 tests pass
- [x] \`go test ./...\` — full suite green