### PR TITLE
feat: find_smells — dead_code rule + per-rule ScopeColumn

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -14,21 +14,34 @@ import (
 
 // SmellRule describes one structural code-smell pattern. Rules are
 // language-aware: each carries the language(s) it applies to plus a
-// SQL query template that runs against the `_ast` and `nodes` tables
-// produced by `leyline parse`.
+// SQL query template that runs against the `_ast` / `nodes` /
+// `node_defs` / `node_refs` tables produced by `leyline parse`.
 //
-// The query MUST select the columns: source_id, node_id, start_byte,
-// end_byte, start_row, start_col (in that order). The handler shapes
-// them into a uniform response.
+// The query MUST select exactly six columns:
+//
+//	source_id, node_id, start_byte, end_byte, start_row, start_col
+//
+// in that order. The handler shapes them into a uniform response with
+// 1-based line/column and an optional snippet.
+//
+// `ScopeColumn` is the SQL expression the handler will compare to
+// source_id when the caller passes `source_id` to find_smells (e.g.
+// "lit.source_id" for AST-walking rules; "n.source_file" for rules
+// that join via nodes). The query template MUST contain a single
+// `%s` placeholder where the scope clause should be spliced in;
+// rules unconcerned with scoping can keep the placeholder empty by
+// leaving ScopeColumn blank.
 //
 // Bead mache-6z2e tracks the broader "machelint" idea — declarative
 // rules consumed via this tool. Today the registry is hard-coded; in
-// the future it becomes user-extensible.
+// the future it becomes user-extensible (declarative JSON, per-repo
+// overrides, etc.).
 type SmellRule struct {
 	ID          string   // stable identifier, used as the MCP tool argument
 	Languages   []string // matches `_source.language` values; empty = any
 	Description string   // shown in the help payload
-	Query       string   // SQL with one optional placeholder for source_id
+	Query       string   // SQL with one `%s` placeholder for the optional scope clause
+	ScopeColumn string   // SQL expression to compare to source_id; empty disables source_id scoping
 }
 
 // smellRegistry holds the built-in rules.
@@ -37,6 +50,7 @@ var smellRegistry = []SmellRule{
 		ID:          "magic_int_in_comparison",
 		Languages:   []string{"go"},
 		Description: "Go binary expressions where an int_literal appears as a direct operand. Each match is a candidate magic constant — replace with a named const if the value carries domain meaning.",
+		ScopeColumn: "lit.source_id",
 		Query: `
 			SELECT lit.source_id, lit.node_id, lit.start_byte, lit.end_byte, lit.start_row, lit.start_col
 			FROM _ast lit
@@ -47,6 +61,26 @@ var smellRegistry = []SmellRule{
 			  AND pa.node_kind   = 'binary_expression'
 			%s
 			ORDER BY lit.source_id, lit.start_byte
+		`,
+	},
+	{
+		ID:          "dead_code",
+		Description: "Symbols defined in node_defs that have no entries in node_refs — nothing in the indexed graph references them. False positives expected for entry points (main, init), interface methods invoked dynamically (String, Error), and exported API consumed outside the indexed scope. The skip list at the top of the rule excludes the most common offenders; tune by editing the rule.",
+		ScopeColumn: "COALESCE(n.source_file, '')",
+		Query: `
+			SELECT COALESCE(n.source_file, '') AS source_id,
+			       defs.node_id,
+			       0  AS start_byte,
+			       0  AS end_byte,
+			       0  AS start_row,
+			       0  AS start_col
+			FROM node_defs defs
+			JOIN nodes n ON n.id = defs.node_id
+			LEFT JOIN node_refs refs ON refs.token = defs.token
+			WHERE refs.token IS NULL
+			  AND defs.token NOT IN ('main','init','String','Error','Read','Write','Close','Len','Less','Swap','MarshalJSON','UnmarshalJSON','Format','Scan')
+			%s
+			ORDER BY COALESCE(n.source_file, ''), defs.node_id
 		`,
 	},
 }
@@ -151,8 +185,8 @@ func rulesListing() any {
 func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) ([]smellFinding, error) {
 	scope := ""
 	args := []any{}
-	if sourceID != "" {
-		scope = "AND lit.source_id = ?"
+	if sourceID != "" && rule.ScopeColumn != "" {
+		scope = "AND " + rule.ScopeColumn + " = ?"
 		args = append(args, sourceID)
 	}
 	query := fmt.Sprintf(rule.Query, scope) + fmt.Sprintf(" LIMIT %d", limit)

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -227,6 +227,88 @@ func TestFindSmells_SourceIDFilterScopes(t *testing.T) {
 	assert.Equal(t, "other.go", resp.Findings[0].SourceID)
 }
 
+// TestFindSmells_DeadCode seeds node_defs + node_refs and asserts that
+// only the unreferenced symbol is flagged. Excludes one symbol on the
+// rule's skip list (init) to verify that filter still works.
+func TestFindSmells_DeadCode(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Defined + referenced — alive.
+		INSERT INTO node_defs VALUES ('LiveFn', 'pkg/funcs/LiveFn');
+		INSERT INTO node_refs VALUES ('LiveFn', 'pkg/funcs/Caller/source');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/LiveFn',         'pkg/funcs',        'LiveFn',  1, 0, 'live.go',   ''),
+		  ('pkg/funcs/Caller/source',  'pkg/funcs/Caller', 'source',  0, 0, 'caller.go', '');
+
+		-- Defined, never referenced — DEAD.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/funcs/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/Orphan', 'pkg/funcs', 'Orphan', 1, 0, 'orphan.go', '');
+
+		-- Defined + on the skip list — must NOT be flagged.
+		INSERT INTO node_defs VALUES ('init', 'pkg/funcs/init');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/init', 'pkg/funcs', 'init', 1, 0, 'startup.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "dead_code",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only Orphan is unreferenced and not on the skip list")
+	assert.Equal(t, "pkg/funcs/Orphan", resp.Findings[0].NodeID)
+	assert.Equal(t, "orphan.go", resp.Findings[0].SourceID,
+		"source_id comes from the construct dir's source_file column")
+}
+
+// TestFindSmells_DeadCodeSourceIDFilter exercises the per-rule
+// ScopeColumn — for dead_code that's `COALESCE(n.source_file, ”)`,
+// not the magic-int rule's `lit.source_id`.
+func TestFindSmells_DeadCodeSourceIDFilter(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO node_defs VALUES ('OrphanA', 'pkg/A'), ('OrphanB', 'pkg/B');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/A', 'pkg', 'A', 1, 0, 'a.go', ''),
+		  ('pkg/B', 'pkg', 'B', 1, 0, 'b.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":      "dead_code",
+		"source_id": "a.go",
+	}))
+	require.NoError(t, err)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total)
+	assert.Equal(t, "a.go", resp.Findings[0].SourceID)
+}
+
 func TestFindSmells_LimitCaps(t *testing.T) {
 	tg := seedSmellAST(t)
 	defer func() { _ = tg.db.Close() }()


### PR DESCRIPTION
## Summary
Second installment after [\`#185\`](#185). Adds the next rule and pushes on the contract just enough to support it.

### Changes
- **New rule: \`dead_code\`** — \`node_defs\` with no entries in \`node_refs\`. Excludes a small skip list of common false positives (\`main\`, \`init\`, \`String\`, \`Error\`, \`Read\`, \`Write\`, \`Close\`, \`Len\`, \`Less\`, \`Swap\`, \`Marshal*\`, \`Format\`, \`Scan\`). \`source_id\` comes from \`nodes.source_file\`. Byte ranges are zeroed — the construct dir isn't an AST node; users navigate via \`list_directory\`.
- **\`SmellRule.ScopeColumn\`** — each rule names its own SQL column for \`source_id\` filtering (\`lit.source_id\` for the AST walker, \`COALESCE(n.source_file, '')\` for the dead-code joiner). The handler's scope splice was previously hardcoded to one alias.

### Followups filed
- \`mache-carj\` cyclomatic_complexity (needs \`Metric\` column on \`smellFinding\` — the design fork for metric-style rules)
- \`mache-l1f4\` long_function / long_file (one-line entries once Metric lands)
- \`mache-unm5\` dep_cycles (motivates Go-callback rules beyond pure SQL)
- \`mache-vssv\` untested_function (static proxy for coverage)
- \`mache-q9ee\` fan_out_skew (god-function detector)

The pattern: each new rule that needs a different output shape pushes on the contract — exactly the feedback we want before locking in user-defined-rules format.

## Test plan
- [x] \`go test -run TestFindSmells -v ./cmd/\` — 8 tests pass (added \`DeadCode\`, \`DeadCodeSourceIDFilter\`)
- [x] \`go test ./...\` — full suite green