### PR TITLE
feat: find_smells cyclomatic_complexity rule + Metric column

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -17,20 +17,26 @@ import (
 // SQL query template that runs against the `_ast` / `nodes` /
 // `node_defs` / `node_refs` tables produced by `leyline parse`.
 //
-// The query MUST select exactly six columns:
+// The query MUST select exactly seven columns:
 //
-//	source_id, node_id, start_byte, end_byte, start_row, start_col
+//	source_id, node_id, start_byte, end_byte, start_row, start_col, metric
 //
-// in that order. The handler shapes them into a uniform response with
-// 1-based line/column and an optional snippet.
+// in that order. `metric` is an integer score (cyclomatic complexity,
+// fan-out count, line length, etc.); binary rules that don't carry
+// a metric emit `0 AS metric`. The handler shapes the row into a
+// uniform response with 1-based line/column and an optional snippet.
 //
 // `ScopeColumn` is the SQL expression the handler will compare to
 // source_id when the caller passes `source_id` to find_smells (e.g.
 // "lit.source_id" for AST-walking rules; "n.source_file" for rules
 // that join via nodes). The query template MUST contain a single
 // `%s` placeholder where the scope clause should be spliced in;
-// rules unconcerned with scoping can keep the placeholder empty by
-// leaving ScopeColumn blank.
+// rules unconcerned with scoping can leave ScopeColumn blank.
+//
+// Threshold filtering on the metric column is intentionally
+// client-side today — agents sort/filter the response. A server-side
+// min_metric arg is filed as a follow-up; we'll add it once two or
+// more rules need it.
 //
 // Bead mache-6z2e tracks the broader "machelint" idea — declarative
 // rules consumed via this tool. Today the registry is hard-coded; in
@@ -52,7 +58,7 @@ var smellRegistry = []SmellRule{
 		Description: "Go binary expressions where an int_literal appears as a direct operand. Each match is a candidate magic constant — replace with a named const if the value carries domain meaning.",
 		ScopeColumn: "lit.source_id",
 		Query: `
-			SELECT lit.source_id, lit.node_id, lit.start_byte, lit.end_byte, lit.start_row, lit.start_col
+			SELECT lit.source_id, lit.node_id, lit.start_byte, lit.end_byte, lit.start_row, lit.start_col, 0 AS metric
 			FROM _ast lit
 			JOIN nodes n   ON n.id = lit.node_id
 			JOIN nodes p   ON p.id = n.parent_id
@@ -73,7 +79,8 @@ var smellRegistry = []SmellRule{
 			       0  AS start_byte,
 			       0  AS end_byte,
 			       0  AS start_row,
-			       0  AS start_col
+			       0  AS start_col,
+			       0  AS metric
 			FROM node_defs defs
 			JOIN nodes n ON n.id = defs.node_id
 			LEFT JOIN node_refs refs ON refs.token = defs.token
@@ -83,10 +90,36 @@ var smellRegistry = []SmellRule{
 			ORDER BY COALESCE(n.source_file, ''), defs.node_id
 		`,
 	},
+	{
+		ID:          "cyclomatic_complexity",
+		Languages:   []string{"go"},
+		Description: "Per-function cyclomatic complexity, computed as the count of control-flow AST nodes (if/for/case/select-case) inside each function or method body. Findings are sorted descending by metric — agents typically only care about the top N. Use min_metric (TODO) once the threshold arg lands; today, filter client-side. Rule scopes via fn.source_id when source_id is provided.",
+		ScopeColumn: "fn.source_id",
+		Query: `
+			SELECT fn.source_id,
+			       fn.node_id,
+			       fn.start_byte,
+			       fn.end_byte,
+			       fn.start_row,
+			       fn.start_col,
+			       COUNT(branch.node_id) AS metric
+			FROM _ast fn
+			LEFT JOIN _ast branch
+			  ON branch.source_id = fn.source_id
+			  AND branch.node_id LIKE fn.node_id || '/%%'
+			  AND branch.node_kind IN ('if_statement','for_statement','case_clause','expression_case','type_case','communication_case','default_case')
+			WHERE fn.node_kind IN ('function_declaration','method_declaration')
+			%s
+			GROUP BY fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col
+			ORDER BY metric DESC, fn.source_id, fn.start_byte
+		`,
+	},
 }
 
 // smellFinding is one row of a smell scan. Byte ranges and (1-based)
-// line/column let editors jump straight to the offending span.
+// line/column let editors jump straight to the offending span. Metric
+// carries a numeric score for rules that compute one (cyclomatic
+// complexity, fan-out count, line length, etc.); binary rules emit 0.
 type smellFinding struct {
 	RuleID    string `json:"rule_id"`
 	SourceID  string `json:"source_id"`
@@ -95,7 +128,8 @@ type smellFinding struct {
 	EndByte   int    `json:"end_byte"`
 	Line      int    `json:"line"`              // 1-based
 	Column    int    `json:"column"`            // 1-based
-	Snippet   string `json:"snippet,omitempty"` // up to ~80 chars of source
+	Metric    int64  `json:"metric,omitempty"`  // rule-specific score (0 omitted)
+	Snippet   string `json:"snippet,omitempty"` // short source preview
 }
 
 // makeFindSmellsHandler returns the MCP handler. With no `rule` arg
@@ -206,8 +240,9 @@ func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) (
 			endByte   int
 			startRow  int
 			startCol  int
+			metric    int64
 		)
-		if err := rows.Scan(&src, &nodeID, &startByte, &endByte, &startRow, &startCol); err != nil {
+		if err := rows.Scan(&src, &nodeID, &startByte, &endByte, &startRow, &startCol, &metric); err != nil {
 			return nil, fmt.Errorf("scan: %w", err)
 		}
 		out = append(out, smellFinding{
@@ -218,6 +253,7 @@ func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) (
 			EndByte:   endByte,
 			Line:      startRow + 1, // tree-sitter is 0-indexed; agents expect 1-based
 			Column:    startCol + 1,
+			Metric:    metric,
 		})
 	}
 	return out, rows.Err()

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -309,6 +309,88 @@ func TestFindSmells_DeadCodeSourceIDFilter(t *testing.T) {
 	assert.Equal(t, "a.go", resp.Findings[0].SourceID)
 }
 
+// TestFindSmells_CyclomaticComplexity seeds two functions with
+// different control-flow counts and asserts the rule returns them
+// ranked by metric DESC.
+//
+// fnA has 3 branches (1 if + 1 for + 1 case) → metric 3.
+// fnB has 0 branches → metric 0.
+// Both should appear; fnA first.
+func TestFindSmells_CyclomaticComplexity(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('fnA',                'main.go', 'function_declaration', 100, 200, 10, 0, 30, 0),
+		  ('fnA/if_a',           'main.go', 'if_statement',         110, 120, 11, 1, 12, 0),
+		  ('fnA/for_a',          'main.go', 'for_statement',        130, 150, 13, 1, 16, 0),
+		  ('fnA/switch/case_a',  'main.go', 'case_clause',          160, 180, 17, 2, 18, 0),
+		  ('fnB',                'main.go', 'function_declaration', 250, 280, 31, 0, 35, 0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "cyclomatic_complexity",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	require.Equal(t, 2, resp.Total)
+	assert.Equal(t, "fnA", resp.Findings[0].NodeID, "highest-complexity function ranks first")
+	assert.Equal(t, int64(3), resp.Findings[0].Metric, "1 if + 1 for + 1 case = 3")
+	assert.Equal(t, "fnB", resp.Findings[1].NodeID)
+	assert.Equal(t, int64(0), resp.Findings[1].Metric)
+}
+
+// TestFindSmells_CyclomaticOnlyCountsBranchesUnderFunction proves
+// the LIKE 'fn.node_id || /%' filter — branches in OTHER functions
+// or top-level branches outside any function don't get attributed.
+func TestFindSmells_CyclomaticOnlyCountsBranchesUnderFunction(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('foo',         'main.go', 'function_declaration', 100, 200, 10, 0, 20, 0),
+		  ('foo/if_1',    'main.go', 'if_statement',         110, 120, 11, 1, 12, 0),
+		  ('bar',         'main.go', 'function_declaration', 300, 400, 31, 0, 40, 0),
+		  ('bar/if_1',    'main.go', 'if_statement',         310, 320, 32, 1, 33, 0),
+		  ('bar/if_2',    'main.go', 'if_statement',         330, 340, 34, 1, 35, 0),
+		  -- A naked top-level if outside any function — must NOT be attributed.
+		  ('topif',       'main.go', 'if_statement',         500, 510, 50, 0, 51, 0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "cyclomatic_complexity",
+	}))
+	require.NoError(t, err)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	got := map[string]int64{}
+	for _, f := range resp.Findings {
+		got[f.NodeID] = f.Metric
+	}
+	assert.Equal(t, int64(2), got["bar"], "bar has 2 ifs as descendants")
+	assert.Equal(t, int64(1), got["foo"], "foo has 1 if")
+	assert.Equal(t, 2, len(got), "topif is not under any function — no extra finding")
+}
+
 func TestFindSmells_LimitCaps(t *testing.T) {
 	tg := seedSmellAST(t)
 	defer func() { _ = tg.db.Close() }()

--- a/internal/graph/graph_suite_test.go
+++ b/internal/graph/graph_suite_test.go
@@ -47,24 +47,53 @@ var (
 // The factory is responsible for cleanup (use t.Cleanup or t.TempDir).
 type GraphFactory func(t *testing.T) Graph
 
+// SuiteOpts pins implementation-specific behaviour the Graph contract
+// allows but where each backend has a definite answer. The suite's
+// permissive defaults match older code; setting these lets the suite
+// catch regressions in a specific backend instead of accepting the
+// other valid behaviour silently.
+//
+// Bead mache-035f19 — without RootEmptyReturnsDir set, a regression
+// where ntr.GetNode("") flipped to ErrNotFound would silently pass
+// the WritableGraph suite while breaking FUSE/NFS root lookups in
+// production.
+type SuiteOpts struct {
+	// RootEmptyReturnsDir asserts GetNode("") returns a synthetic dir
+	// node. Backends backed by NodesTableReader (SQLiteGraph,
+	// WritableGraph, HotSwapGraph) set this true; MemoryStore does
+	// not — it returns ErrNotFound for the empty key.
+	RootEmptyReturnsDir bool
+}
+
 // RunGraphSuite runs the full Graph interface contract suite against any
 // implementation. Each test is independent — failures are isolated.
 func RunGraphSuite(t *testing.T, factory GraphFactory) {
+	RunGraphSuiteWithOpts(t, factory, SuiteOpts{})
+}
+
+// RunGraphSuiteWithOpts is the explicit form. Prefer this for new
+// implementations so the contract assertion is precise.
+func RunGraphSuiteWithOpts(t *testing.T, factory GraphFactory, opts SuiteOpts) {
 	t.Helper()
 
 	// -- GetNode ----------------------------------------------------------
 
 	t.Run("GetNode/root_empty_string", func(t *testing.T) {
 		g := factory(t)
-		// Contract: GetNode("") returns a root-level directory node or ErrNotFound.
-		// MemoryStore returns ErrNotFound (no "" key in map).
-		// SQLiteGraph/WritableGraph return a synthetic root Node{ID:"", Mode:dir}.
-		// Both behaviors are valid — the FUSE/NFS layer handles root specially.
 		n, err := g.GetNode("")
-		if err == nil {
-			assert.True(t, n.Mode.IsDir(), "root should be a directory")
+		if opts.RootEmptyReturnsDir {
+			require.NoError(t, err, "this backend MUST return a synthetic root node for empty id")
+			assert.Equal(t, "", n.ID)
+			assert.True(t, n.Mode.IsDir(), "root must be a directory")
 		} else {
-			assert.ErrorIs(t, err, ErrNotFound)
+			// Permissive default — kept so existing tests stay green
+			// while we tighten implementations one at a time. Either
+			// answer is allowed; FUSE/NFS layers handle root specially.
+			if err == nil {
+				assert.True(t, n.Mode.IsDir(), "root should be a directory")
+			} else {
+				assert.ErrorIs(t, err, ErrNotFound)
+			}
 		}
 	})
 
@@ -126,6 +155,12 @@ func RunGraphSuite(t *testing.T, factory GraphFactory) {
 		children, err := g.ListChildren("pkg/empty")
 		require.NoError(t, err)
 		assert.Empty(t, children)
+		// Bead mache-0375fe — pin the nil-vs-empty contract.
+		// Backends are free to return nil OR an empty slice; both
+		// satisfy len() == 0. Pinning len explicitly catches silent
+		// shape changes that would surprise JSON consumers.
+		assert.Zero(t, len(children),
+			"empty dir must return nil or zero-length slice (got non-empty %v)", children)
 	})
 
 	// -- ListChildStats ---------------------------------------------------
@@ -365,7 +400,23 @@ func writableGraphFactory(t *testing.T) Graph {
 // Suite runners — one per implementation
 // ---------------------------------------------------------------------------
 
-func TestMemoryStore_GraphSuite(t *testing.T)   { RunGraphSuite(t, memoryStoreFactory) }
-func TestHotSwapGraph_GraphSuite(t *testing.T)  { RunGraphSuite(t, hotSwapFactory) }
-func TestSQLiteGraph_GraphSuite(t *testing.T)   { RunGraphSuite(t, sqliteGraphFactory) }
-func TestWritableGraph_GraphSuite(t *testing.T) { RunGraphSuite(t, writableGraphFactory) }
+func TestMemoryStore_GraphSuite(t *testing.T) {
+	// MemoryStore returns ErrNotFound for GetNode("") — no synthetic root.
+	RunGraphSuite(t, memoryStoreFactory)
+}
+
+func TestHotSwapGraph_GraphSuite(t *testing.T) {
+	// HotSwapGraph wraps MemoryStore in this fixture, so it inherits
+	// MemoryStore's ErrNotFound behaviour for empty id. If a future
+	// caller swaps in an SQLiteGraph the contract flips — that's
+	// the point of HotSwap.
+	RunGraphSuite(t, hotSwapFactory)
+}
+
+func TestSQLiteGraph_GraphSuite(t *testing.T) {
+	RunGraphSuiteWithOpts(t, sqliteGraphFactory, SuiteOpts{RootEmptyReturnsDir: true})
+}
+
+func TestWritableGraph_GraphSuite(t *testing.T) {
+	RunGraphSuiteWithOpts(t, writableGraphFactory, SuiteOpts{RootEmptyReturnsDir: true})
+}

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -108,6 +108,15 @@ func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 }
 
 // ListChildren returns child IDs for a directory from the nodes table.
+//
+// Empty-result contract: when the directory has no children, the
+// returned slice is nil (not an empty slice). All callers must handle
+// nil correctly — len(nil) is 0, range over nil is a no-op, and
+// JSON-encoding nil produces null. Don't change to []string{} without
+// auditing JSON consumers (the MCP serve_handlers list_directory
+// shapes its own non-nil response).
+//
+// Bead mache-0375fe.
 func (r *NodesTableReader) ListChildren(id string) ([]string, error) {
 	id = NormalizeID(id)
 


### PR DESCRIPTION
## Summary
Two related improvements bundled in one PR.

### 1. cyclomatic_complexity rule + Metric column ([mache-carj](#))
Adds the third rule for the find_smells engine and the contract change that unlocks the metric-style rules (long_function, fan_out_skew) without further plumbing.

**Contract change**
- `SmellRule.Query` now selects 7 columns; the new last column is the metric (`int64`). Binary rules emit `0 AS metric`.
- `smellFinding.Metric` carries the value in the response (`omitempty` so binary rules don't pollute JSON).

**New rule: `cyclomatic_complexity` (Go)**
- Per-function count of `if_statement`, `for_statement`, `case_clause`, `expression_case`, `type_case`, `communication_case`, `default_case` AST nodes inside the body.
- Sorted descending by metric so agents see the worst offenders first.
- `LIKE fn.node_id || '/%'` restricts the count to descendants of each function — top-level branches and branches in sibling functions don't get attributed.

Threshold filtering (`min_metric` arg) deferred to a follow-up — ship after a second metric rule needs the same arg shape.

### 2. Graph suite contract tightening ([mache-035f19](#) + [mache-0375fe](#))
Two small audit findings on the GraphSuite + NodesTableReader.

**Strict root assertion** — the suite's `GetNode("")` test was permissive (synthetic dir OR ErrNotFound). WritableGraph delegates to `ntr.GetNode("")` which returns the synthetic root; if a refactor flipped that to ErrNotFound, the test would still pass while production FUSE/NFS root lookups silently broke.

- New `SuiteOpts{RootEmptyReturnsDir bool}` + `RunGraphSuiteWithOpts`. SQLiteGraph and WritableGraph factories opt into the strict assertion. HotSwap stays permissive (its fixture wraps MemoryStore which legitimately returns ErrNotFound).

**Nil-vs-empty contract** — `NodesTableReader.ListChildren` returns nil (not an empty slice) for an empty dir. The contract was implicit and the suite only checked `assert.Empty` (passes for both).

- Doc comment on `ListChildren` spells out the contract and warns against silent shape changes (JSON consumers see null vs []).
- Suite empty-dir test asserts `len == 0` explicitly with a bead pointer.

Audited and closed [mache-032939](#) separately — `NodesTableReader` fields were already unexported in current code.

## Test plan
- [x] `go test -run TestFindSmells -v ./cmd/` — 10 tests pass (added Cyclomatic + OnlyCountsBranchesUnderFunction)
- [x] `go test ./internal/graph/` — all four `*_GraphSuite` runners green; the new strict assertion catches the regression it's pinning
- [x] `go test ./...` — full suite green