### PR TITLE
docs: clarify SQLiteGraph's legacy-only sizeCache + cache fields

### DIFF
--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -81,11 +81,21 @@ type SQLiteGraph struct {
 	nextFileID  uint32
 	fileIDMap   map[string]uint32 // path → file ID (in-memory during ingestion)
 
-	// Size cache: file path → rendered byte length (legacy scan path only).
-	// The nodes-table fast path uses ntr.SizeCache instead.
+	// Size cache: file path → rendered byte length.
+	// Used ONLY by the legacy scan path (useNodesTable = false). The
+	// nodes-table fast path stores sizes inside its NodesTableReader
+	// (ntr.SizeCache) and never writes here. Invalidate still calls
+	// .Delete on this map for both paths — it's a no-op on the fast
+	// path because nothing was ever stored — but the spurious call is
+	// cheap and keeps Invalidate uniform across both backends.
+	// See bead mache-033cc9.
 	sizeCache sync.Map // file path (string) → int64
 
-	cache *ContentCache // FIFO-bounded rendered content (legacy scan path only)
+	// FIFO-bounded rendered content cache. Same legacy-only story as
+	// sizeCache above: nil on the nodes-table fast path (initialized
+	// only by the legacy OpenSQLiteGraph branch), and Invalidate's
+	// nil check guards the delete.
+	cache *ContentCache
 
 	// Nodes-table fast path: when non-nil, all read methods delegate here.
 	// Initialized only when the DB has a "nodes" table (built by mache build).


### PR DESCRIPTION
## Summary
[\`mache-033cc9\`](#) — \`SQLiteGraph.sizeCache\` and \`SQLiteGraph.cache\` are populated only by the legacy scan path (\`useNodesTable = false\`). On the fast path, \`NodesTableReader\` owns the equivalent state and these struct fields are never written. The existing comments noted \"legacy scan path only\" tersely; the audit suggested making the no-op-on-fast-path behaviour explicit so future readers don't try to chase \"why doesn't this cache work on the new path?\"

\`Invalidate\` still calls \`.Delete\` on both for both paths. On the fast path that's a no-op (nothing was stored). The spurious call keeps \`Invalidate\` uniform across backends and is cheap, so the fix here is documentation rather than removal — pulling the fields out should wait until the legacy scan path itself is removed (separate epic).

## Test plan
- [x] \`go test ./...\` — full suite green (no behaviour change)