### PR TITLE
feat: find_smells long_function + long_file rules

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -114,6 +114,45 @@ var smellRegistry = []SmellRule{
 			ORDER BY metric DESC, fn.source_id, fn.start_byte
 		`,
 	},
+	{
+		ID:          "long_function",
+		Languages:   []string{"go"},
+		Description: "Functions and methods whose body spans more than 80 source lines (end_row - start_row). Sorted descending by line count. Threshold is hard-coded today — use cyclomatic_complexity for a sister metric on the same nodes.",
+		ScopeColumn: "fn.source_id",
+		Query: `
+			SELECT fn.source_id,
+			       fn.node_id,
+			       fn.start_byte,
+			       fn.end_byte,
+			       fn.start_row,
+			       fn.start_col,
+			       (fn.end_row - fn.start_row) AS metric
+			FROM _ast fn
+			WHERE fn.node_kind IN ('function_declaration','method_declaration')
+			  AND (fn.end_row - fn.start_row) > 80
+			%s
+			ORDER BY metric DESC, fn.source_id, fn.start_byte
+		`,
+	},
+	{
+		ID:          "long_file",
+		Description: "Source files exceeding 1500 lines (end_row reported on the source-file root AST node). Cross-language since the rule joins by node_kind = 'source_file' which most tree-sitter grammars use as the root kind. Threshold hard-coded today.",
+		ScopeColumn: "src.source_id",
+		Query: `
+			SELECT src.source_id,
+			       src.node_id,
+			       src.start_byte,
+			       src.end_byte,
+			       src.start_row,
+			       src.start_col,
+			       src.end_row AS metric
+			FROM _ast src
+			WHERE src.node_kind = 'source_file'
+			  AND src.end_row > 1500
+			%s
+			ORDER BY metric DESC, src.source_id
+		`,
+	},
 }
 
 // smellFinding is one row of a smell scan. Byte ranges and (1-based)

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -391,6 +391,71 @@ func TestFindSmells_CyclomaticOnlyCountsBranchesUnderFunction(t *testing.T) {
 	assert.Equal(t, 2, len(got), "topif is not under any function — no extra finding")
 }
 
+// TestFindSmells_LongFunction seeds two functions of different sizes
+// and asserts the rule flags only the one over the threshold (80 lines).
+func TestFindSmells_LongFunction(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  -- Long: 100 lines (10 → 110), should fire.
+		  ('big_fn',   'main.go', 'function_declaration', 100, 200, 10, 0, 110, 0),
+		  -- Just under threshold: exactly 80 lines, should NOT fire (> 80).
+		  ('mid_fn',   'main.go', 'method_declaration',   300, 400, 200, 0, 280, 0),
+		  -- Tiny: 5 lines.
+		  ('small_fn', 'main.go', 'function_declaration', 500, 550, 300, 0, 305, 0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "long_function",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only big_fn (100 lines) is over the 80-line threshold")
+	assert.Equal(t, "big_fn", resp.Findings[0].NodeID)
+	assert.Equal(t, int64(100), resp.Findings[0].Metric)
+}
+
+// TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
+func TestFindSmells_LongFile(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('huge_file_root', 'huge.go',  'source_file', 0, 999999, 0, 0, 2000, 0),
+		  ('small_file_root','small.go', 'source_file', 0, 1234,   0, 0, 50,   0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "long_file",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only huge.go is over 1500 lines")
+	assert.Equal(t, "huge.go", resp.Findings[0].SourceID)
+	assert.Equal(t, int64(2000), resp.Findings[0].Metric)
+}
+
 func TestFindSmells_LimitCaps(t *testing.T) {
 	tg := seedSmellAST(t)
 	defer func() { _ = tg.db.Close() }()


### PR DESCRIPTION
## Summary
[\`mache-l1f4\`](#) — two rules, both one-liner registry entries riding on the Metric column landed in [\`#187\`](#187).

- **\`long_function\`** (Go) — \`function_declaration\` / \`method_declaration\` with \`end_row - start_row > 80\`. Sorted descending by metric. Pairs naturally with \`cyclomatic_complexity\` for a \"what's worst about this function\" combined report.
- **\`long_file\`** (any language) — \`_ast.source_file\` rows with \`end_row > 1500\`. Cross-language because most tree-sitter grammars use \`source_file\` as the root node kind.

Thresholds (80 lines, 1500 lines) are hard-coded today. The \`min_metric\` arg follow-up will let callers tune them per-call.

## Test plan
- [x] \`go test -run TestFindSmells_Long -v ./cmd/\` — long_function (long fires, exactly-80 doesn't, small doesn't), long_file (big fires, small doesn't)
- [x] \`go test ./...\` — full suite green