### PR TITLE
feat: find_smells untested_function rule

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -135,6 +135,32 @@ var smellRegistry = []SmellRule{
 		`,
 	},
 	{
+		ID:          "untested_function",
+		Languages:   []string{"go"},
+		Description: "Exported Go functions with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Excludes Test*/Benchmark*/Example* (they ARE tests) and main/init (entry points). The rule's heuristic is Go-specific — running it against a Python or Rust .db will produce mostly noise.",
+		ScopeColumn: "COALESCE(n.source_file, '')",
+		Query: `
+			SELECT COALESCE(n.source_file, '') AS source_id,
+			       d.node_id,
+			       0 AS start_byte,
+			       0 AS end_byte,
+			       0 AS start_row,
+			       0 AS start_col,
+			       0 AS metric
+			FROM node_defs d
+			JOIN nodes n ON n.id = d.node_id
+			LEFT JOIN node_defs t ON t.token = 'Test' || d.token
+			WHERE substr(d.token, 1, 1) GLOB '[A-Z]'
+			  AND d.token NOT LIKE 'Test%%'
+			  AND d.token NOT LIKE 'Benchmark%%'
+			  AND d.token NOT LIKE 'Example%%'
+			  AND d.token NOT IN ('main','init','String','Error')
+			  AND t.token IS NULL
+			%s
+			ORDER BY COALESCE(n.source_file, ''), d.token
+		`,
+	},
+	{
 		ID:          "long_file",
 		Description: "Source files exceeding 1500 lines (end_row reported on the source-file root AST node). Cross-language since the rule joins by node_kind = 'source_file' which most tree-sitter grammars use as the root kind. Threshold hard-coded today.",
 		ScopeColumn: "src.source_id",

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -426,6 +426,58 @@ func TestFindSmells_LongFunction(t *testing.T) {
 	assert.Equal(t, int64(100), resp.Findings[0].Metric)
 }
 
+// TestFindSmells_UntestedFunction seeds three exported Go-style defs:
+// one with a Test counterpart (covered), one without (untested), and
+// one whose name is on the skip list (excluded). Plus an unexported
+// def to prove the GLOB '[A-Z]' filter holds.
+func TestFindSmells_UntestedFunction(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Covered: TestFooBar exists, so FooBar is OK.
+		INSERT INTO node_defs VALUES ('FooBar', 'pkg/funcs/FooBar');
+		INSERT INTO node_defs VALUES ('TestFooBar', 'pkg/funcs/TestFooBar');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/FooBar',     'pkg/funcs', 'FooBar',     1, 0, 'foo.go',     ''),
+		  ('pkg/funcs/TestFooBar', 'pkg/funcs', 'TestFooBar', 1, 0, 'foo_test.go', '');
+
+		-- Uncovered: no TestOrphan anywhere.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/funcs/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/Orphan', 'pkg/funcs', 'Orphan', 1, 0, 'orphan.go', '');
+
+		-- Skip list: capitalized but excluded.
+		INSERT INTO node_defs VALUES ('String', 'pkg/funcs/String');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/String', 'pkg/funcs', 'String', 1, 0, 'stringer.go', '');
+
+		-- Unexported (lowercase): must NOT be flagged.
+		INSERT INTO node_defs VALUES ('helper', 'pkg/funcs/helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/helper', 'pkg/funcs', 'helper', 1, 0, 'helpers.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "untested_function",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only Orphan is uncovered + exported + not on skip list")
+	assert.Equal(t, "pkg/funcs/Orphan", resp.Findings[0].NodeID)
+	assert.Equal(t, "orphan.go", resp.Findings[0].SourceID)
+}
+
 // TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
 func TestFindSmells_LongFile(t *testing.T) {
 	tg := seedSmellAST(t)


### PR DESCRIPTION
## Summary
- Adds `untested_function` rule to `find_smells` MCP tool
- Go-specific: flags exported defs in `node_defs` with no `Test<Foo>` counterpart
- Skips `Test*`/`Benchmark*`/`Example*` prefixes plus `main`/`init`/`String`/`Error`

## Why
Static proxy for test coverage that runs against any indexed `.db` without needing `go test -cover` data. Surfaces candidates for review — false positives expected for table-driven tests, helpers, and integration-boundary tests.

## Test plan
- [x] `go test -run TestFindSmells_UntestedFunction ./cmd/` — covered (TestFooBar→FooBar), uncovered (Orphan), skip-listed (String), unexported (helper)
- [x] All `TestFindSmells*` pass
- [x] gofumpt + go vet + golangci-lint via pre-commit

Closes mache-vssv.