### PR TITLE
feat: find_smells fan_out_skew rule

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -161,6 +161,35 @@ var smellRegistry = []SmellRule{
 		`,
 	},
 	{
+		ID:          "fan_out_skew",
+		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
+		ScopeColumn: "COALESCE(n.source_file, '')",
+		Query: `
+			WITH fanout AS (
+				SELECT node_id AS caller_id, COUNT(DISTINCT token) AS n
+				FROM node_refs
+				GROUP BY node_id
+			),
+			proj AS (
+				SELECT AVG(n) AS mu FROM fanout
+			)
+			SELECT COALESCE(n.source_file, '') AS source_id,
+			       f.caller_id AS node_id,
+			       0 AS start_byte,
+			       0 AS end_byte,
+			       0 AS start_row,
+			       0 AS start_col,
+			       f.n AS metric
+			FROM fanout f
+			JOIN nodes n ON n.id = f.caller_id
+			CROSS JOIN proj p
+			WHERE f.n >= 5
+			  AND CAST(f.n AS REAL) > 3.0 * p.mu
+			%s
+			ORDER BY metric DESC, source_id, node_id
+		`,
+	},
+	{
 		ID:          "long_file",
 		Description: "Source files exceeding 1500 lines (end_row reported on the source-file root AST node). Cross-language since the rule joins by node_kind = 'source_file' which most tree-sitter grammars use as the root kind. Threshold hard-coded today.",
 		ScopeColumn: "src.source_id",

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -478,6 +478,63 @@ func TestFindSmells_UntestedFunction(t *testing.T) {
 	assert.Equal(t, "orphan.go", resp.Findings[0].SourceID)
 }
 
+// TestFindSmells_FanOutSkew seeds a god-function and several normal
+// callers and asserts only the god-function is flagged. Mean fan-out
+// is (12 + 6×1) / 7 ≈ 2.57; 3×mean ≈ 7.7, well below the god's 12.
+// The 5-call floor would also gate out smaller outliers if they crept
+// past the mean check.
+func TestFindSmells_FanOutSkew(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- God-function: 12 distinct callees.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/god/Dispatcher', 'pkg/god', 'Dispatcher', 1, 0, 'dispatcher.go', '');
+		INSERT INTO node_refs VALUES
+		  ('A','pkg/god/Dispatcher'),('B','pkg/god/Dispatcher'),('C','pkg/god/Dispatcher'),
+		  ('D','pkg/god/Dispatcher'),('E','pkg/god/Dispatcher'),('F','pkg/god/Dispatcher'),
+		  ('G','pkg/god/Dispatcher'),('H','pkg/god/Dispatcher'),('I','pkg/god/Dispatcher'),
+		  ('J','pkg/god/Dispatcher'),('K','pkg/god/Dispatcher'),('L','pkg/god/Dispatcher');
+
+		-- Six normal callers, 1 callee each — dilutes the project mean
+		-- so the god's fan-out exceeds 3× mean. Nodes rows aren't
+		-- required since they fail the threshold and never hit the JOIN.
+		INSERT INTO node_refs VALUES
+		  ('Z1','pkg/ok/N1'),('Z2','pkg/ok/N2'),('Z3','pkg/ok/N3'),
+		  ('Z4','pkg/ok/N4'),('Z5','pkg/ok/N5'),('Z6','pkg/ok/N6');
+
+		-- A caller with 6 callees — over the 5-call floor, but still
+		-- under 3×mean. Asserts the threshold isn't trivially met.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/ok/Borderline', 'pkg/ok', 'Borderline', 1, 0, 'borderline.go', '');
+		INSERT INTO node_refs VALUES
+		  ('M1','pkg/ok/Borderline'),('M2','pkg/ok/Borderline'),
+		  ('M3','pkg/ok/Borderline'),('M4','pkg/ok/Borderline'),
+		  ('M5','pkg/ok/Borderline'),('M6','pkg/ok/Borderline');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "fan_out_skew",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only Dispatcher exceeds 3×mean and the 5-call floor")
+	assert.Equal(t, "pkg/god/Dispatcher", resp.Findings[0].NodeID)
+	assert.Equal(t, "dispatcher.go", resp.Findings[0].SourceID)
+	assert.Equal(t, int64(12), resp.Findings[0].Metric, "fan-out count is reported as metric")
+}
+
 // TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
 func TestFindSmells_LongFile(t *testing.T) {
 	tg := seedSmellAST(t)


### PR DESCRIPTION
## Summary
- New `fan_out_skew` smell rule: callers whose distinct callee count exceeds 3× project mean, with a 5-call floor
- Pure SQL via CTEs (no Go callbacks); language-agnostic via `node_refs`
- Metric column carries the fan-out count, sorted desc

## Why
Surfaces god-functions / orchestrators — constructs that touch too many neighbors are usually candidates for decomposition. Pairs with `get_communities` for "this construct sprawls across community boundaries" analysis.

## Heuristics
- 3× mean: simple multiplier, works once distribution has enough callers to dilute outliers
- 5-call floor: prevents tiny-project noise where mean is dominated by a single caller
- Stddev / median refinement deferred (needs math extension or Go-callback path)

## Test plan
- [x] `go test -run TestFindSmells_FanOutSkew ./cmd/` — god-function (12 callees) flagged; borderline (6, under 3×mean) and trivial callers (1 each) excluded
- [x] All `TestFindSmells*` pass
- [x] gofumpt + go vet + golangci-lint via pre-commit

Closes mache-q9ee.