### PR TITLE
feat: find_smells duplicate_definitions rule

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -161,6 +161,38 @@ var smellRegistry = []SmellRule{
 		`,
 	},
 	{
+		ID:          "duplicate_definitions",
+		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Cross-language since node_defs is populated by every leyline parser.",
+		ScopeColumn: "COALESCE(n.source_file, '')",
+		Query: `
+			SELECT COALESCE(n.source_file, '') AS source_id,
+			       d.node_id,
+			       0 AS start_byte,
+			       0 AS end_byte,
+			       0 AS start_row,
+			       0 AS start_col,
+			       c.copies AS metric
+			FROM (
+				SELECT token, COUNT(*) AS copies
+				FROM node_defs
+				WHERE token NOT IN (
+					'main','init',
+					'String','Error','Format','Scan','GoString',
+					'Read','Write','Close','Open','Seek','ReadAt','WriteAt','ReadFrom','WriteTo',
+					'Len','Less','Swap',
+					'MarshalJSON','UnmarshalJSON','MarshalText','UnmarshalText','MarshalBinary','UnmarshalBinary',
+					'Marshal','Unmarshal','Reset','Clone','Copy','Equal','Hash','Validate'
+				)
+				GROUP BY token
+				HAVING copies > 1
+			) c
+			JOIN node_defs d ON d.token = c.token
+			JOIN nodes n ON n.id = d.node_id
+			%s
+			ORDER BY metric DESC, n.source_file, d.node_id
+		`,
+	},
+	{
 		ID:          "fan_out_skew",
 		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
 		ScopeColumn: "COALESCE(n.source_file, '')",

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -535,6 +535,57 @@ func TestFindSmells_FanOutSkew(t *testing.T) {
 	assert.Equal(t, int64(12), resp.Findings[0].Metric, "fan-out count is reported as metric")
 }
 
+// TestFindSmells_DuplicateDefinitions seeds three groups: a duplicated
+// helper (two defs, two source files — flagged twice), an interface
+// method on the skip list (two defs — excluded), and a unique symbol
+// (one def — excluded).
+func TestFindSmells_DuplicateDefinitions(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Duplicated helper — both should appear in findings.
+		INSERT INTO node_defs VALUES ('Helper', 'pkg/a/Helper'), ('Helper', 'pkg/b/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/Helper', 'pkg/a', 'Helper', 1, 0, 'a/helper.go', ''),
+		  ('pkg/b/Helper', 'pkg/b', 'Helper', 1, 0, 'b/helper.go', '');
+
+		-- Interface method — duplication is expected, must be excluded.
+		INSERT INTO node_defs VALUES ('String', 'pkg/a/String'), ('String', 'pkg/b/String');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/String', 'pkg/a', 'String', 1, 0, 'a/stringer.go', ''),
+		  ('pkg/b/String', 'pkg/b', 'String', 1, 0, 'b/stringer.go', '');
+
+		-- Unique symbol — must NOT be flagged.
+		INSERT INTO node_defs VALUES ('Solo', 'pkg/a/Solo');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/Solo', 'pkg/a', 'Solo', 1, 0, 'a/solo.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "duplicate_definitions",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 2, resp.Total, "both Helper defs flagged, String skipped, Solo not duplicated")
+
+	gotIDs := []string{resp.Findings[0].NodeID, resp.Findings[1].NodeID}
+	assert.ElementsMatch(t, []string{"pkg/a/Helper", "pkg/b/Helper"}, gotIDs)
+	for _, f := range resp.Findings {
+		assert.Equal(t, int64(2), f.Metric, "duplicate count reported as metric")
+	}
+}
+
 // TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
 func TestFindSmells_LongFile(t *testing.T) {
 	tg := seedSmellAST(t)


### PR DESCRIPTION
## Summary
- New `duplicate_definitions` smell rule: symbols defined under more than one `node_id` in `node_defs`
- Skip list for Go interface methods (`String`/`Error`/`Read`/`Write`/`Close`/`Len`/`Less`/`Swap`/`MarshalJSON`/etc.)
- Metric = duplicate count, sorted descending; cross-language

## Why
Same intent as bead mache-e49cc4: find genuinely-redundant helpers re-implemented per package — a common refactor candidate. Replaces ad-hoc `search` queries with a first-class smell rule that returns one finding per def site.

## Test plan
- [x] `go test -run TestFindSmells_DuplicateDefinitions ./cmd/` — duplicated helper flagged twice (one per def), skip-listed `String` excluded, unique `Solo` excluded
- [x] All `TestFindSmells*` pass
- [x] gofumpt + go vet + golangci-lint via pre-commit

Closes mache-e49cc4.