### PR TITLE
test: stop TestWatcher_NewSubdirectory flaking on macOS

### DIFF
--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -169,19 +169,24 @@ func TestWatcher_NewSubdirectory(t *testing.T) {
 	require.NoError(t, err)
 	defer w.Stop()
 
-	// Create a new subdirectory with a source file.
+	// Create a new subdirectory with a source file. macOS FSEvents has
+	// higher latency than Linux inotify, so the sub-watcher install can
+	// take >50ms — wait long enough for it to settle before the file
+	// write, otherwise the watcher misses the create event entirely.
 	subDir := filepath.Join(tmpDir, "pkg")
 	require.NoError(t, os.MkdirAll(subDir, 0o755))
-
-	// Small delay to let the watcher pick up the new dir.
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(250 * time.Millisecond)
 
 	goFile := filepath.Join(subDir, "lib.go")
 	require.NoError(t, os.WriteFile(goFile, []byte("package pkg"), 0o644))
 
-	time.Sleep(200 * time.Millisecond)
+	// Poll for the callback instead of sleeping a fixed window — bounded
+	// at 2s with 25ms ticks, which is generous on inotify and tolerable
+	// on FSEvents without making the happy path slow.
+	require.Eventually(t, func() bool {
+		return callCount.Load() >= 1
+	}, 2*time.Second, 25*time.Millisecond, "should detect file in new subdirectory")
 
-	assert.GreaterOrEqual(t, callCount.Load(), int32(1), "should detect file in new subdirectory")
 	mu.Lock()
 	assert.Equal(t, goFile, lastPath)
 	mu.Unlock()


### PR DESCRIPTION
## Summary
- Replace fixed-sleep wait with `require.Eventually` (2s budget, 25ms tick)
- Bump post-MkdirAll wait from 50ms → 250ms so FSEvents has time to install the sub-watcher before the file write

## Why
macOS FSEvents has higher latency than Linux inotify. The 200ms sleep window was occasionally too short, costing a re-run on PR #189 already. Polling-based assertions are the standard fix; ID-stable timing on the happy path stays fast.

## Test plan
- [x] `go test -run TestWatcher_NewSubdirectory ./internal/ingest/ -count=10` — 10/10 pass
- [x] `go test -race -run TestWatcher ./internal/ingest/` — full suite passes with race detector
- [x] gofumpt + go vet + golangci-lint via pre-commit

Closes mache-1jin.