### PR TITLE
feat: find_smells min_metric arg

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -33,10 +33,9 @@ import (
 // `%s` placeholder where the scope clause should be spliced in;
 // rules unconcerned with scoping can leave ScopeColumn blank.
 //
-// Threshold filtering on the metric column is intentionally
-// client-side today — agents sort/filter the response. A server-side
-// min_metric arg is filed as a follow-up; we'll add it once two or
-// more rules need it.
+// Threshold filtering on the metric column is server-side via the
+// `min_metric` request arg — handler drops findings whose metric
+// is below the cutoff before returning. Default 0 keeps every row.
 //
 // Bead mache-6z2e tracks the broader "machelint" idea — declarative
 // rules consumed via this tool. Today the registry is hard-coded; in
@@ -93,7 +92,7 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "cyclomatic_complexity",
 		Languages:   []string{"go"},
-		Description: "Per-function cyclomatic complexity, computed as the count of control-flow AST nodes (if/for/case/select-case) inside each function or method body. Findings are sorted descending by metric — agents typically only care about the top N. Use min_metric (TODO) once the threshold arg lands; today, filter client-side. Rule scopes via fn.source_id when source_id is provided.",
+		Description: "Per-function cyclomatic complexity, computed as the count of control-flow AST nodes (if/for/case/select-case) inside each function or method body. Findings are sorted descending by metric — agents typically only care about the top N, so pair with `min_metric` to set a cutoff (e.g. 10 for 'noteworthy', 20 for 'review now'). Rule scopes via fn.source_id when source_id is provided.",
 		ScopeColumn: "fn.source_id",
 		Query: `
 			SELECT fn.source_id,
@@ -269,6 +268,7 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 		if limit <= 0 {
 			limit = 200
 		}
+		minMetric := int64(request.GetFloat("min_metric", 0))
 
 		if ruleID == "" {
 			// Discovery mode — list rules.
@@ -296,6 +296,19 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 		findings, err := runSmellRule(qg, rule, sourceID, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("rule %q: %v", ruleID, err)), nil
+		}
+
+		// Server-side metric threshold. Drops findings below the cutoff
+		// before snippet population so we don't waste reads on rows the
+		// agent will discard. min_metric=0 keeps the historical default.
+		if minMetric > 0 {
+			filtered := findings[:0]
+			for _, f := range findings {
+				if f.Metric >= minMetric {
+					filtered = append(filtered, f)
+				}
+			}
+			findings = filtered
 		}
 
 		// Snippet population is best-effort. If `_source` isn't there
@@ -336,7 +349,7 @@ func rulesListing() any {
 		Help  string        `json:"help"`
 		Rules []ruleSummary `json:"rules"`
 	}{
-		Help:  "find_smells runs structural pattern queries against the _ast table. Pass `rule` to scan; omit it (this response) to list available rules. Optional `source_id` filters to one parsed file; `limit` caps results (default 200).",
+		Help:  "find_smells runs structural pattern queries against the _ast table. Pass `rule` to scan; omit it (this response) to list available rules. Optional `source_id` filters to one parsed file; `limit` caps results (default 200); `min_metric` drops findings whose metric column is below the threshold (default 0).",
 		Rules: out,
 	}
 }

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -633,3 +633,49 @@ func TestFindSmells_LimitCaps(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
 	assert.Equal(t, 1, resp.Total)
 }
+
+// TestFindSmells_MinMetricFilters seeds a long_file rule run with
+// three source files of escalating size and asserts the min_metric
+// arg gates findings on the metric column.
+func TestFindSmells_MinMetricFilters(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('a_root', 'a.go', 'source_file', 0, 100, 0, 0, 1600, 0),
+		  ('b_root', 'b.go', 'source_file', 0, 100, 0, 0, 2000, 0),
+		  ('c_root', 'c.go', 'source_file', 0, 100, 0, 0, 5000, 0);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+
+	// No threshold: all three files (>1500 lines) come back.
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "long_file"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var unfiltered struct {
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &unfiltered))
+	require.Equal(t, 3, unfiltered.Total, "all three files exceed the rule's 1500-line floor")
+
+	// min_metric=2500 should keep only c.go (5000 lines).
+	res, err = handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "long_file",
+		"min_metric": float64(2500),
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var filtered struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &filtered))
+	require.Equal(t, 1, filtered.Total, "only c.go passes the 2500-line cutoff")
+	assert.Equal(t, "c.go", filtered.Findings[0].SourceID)
+	assert.Equal(t, int64(5000), filtered.Findings[0].Metric)
+}


### PR DESCRIPTION
## Summary
- Add `min_metric` int arg to `find_smells` MCP tool
- Drops findings whose metric column is below the cutoff before snippet population
- Default 0 keeps historical behavior
- Removes the `min_metric (TODO)` note in `cyclomatic_complexity` description

## Why
Metric rules (cyclomatic_complexity, long_function, fan_out_skew, duplicate_definitions, long_file) sort descending by metric — agents typically only care about the top N. Server-side threshold avoids round-tripping the long tail.

## Test plan
- [x] `go test -run TestFindSmells ./cmd/` — 14 tests, all pass
- [x] New `TestFindSmells_MinMetricFilters` — seeds 3 source files (1600/2000/5000 lines), asserts unfiltered=3 and `min_metric=2500` returns just c.go
- [x] gofumpt + go vet + golangci-lint via pre-commit