### PR TITLE
chore: drop ext/boltdb from go.work — make bbolt truly opt-in

### DIFF
--- a/go.work
+++ b/go.work
@@ -1,6 +1,11 @@
 go 1.25.5
 
-use (
-	.
-	./ext/boltdb
-)
+use .
+
+// ext/boltdb intentionally NOT in the workspace — it's an optional add-on
+// that pulls in go.etcd.io/bbolt (which has open Dependabot alerts and is
+// only used by venturi/trivy-db projection workflows). To work on it:
+//
+//	cd ext/boltdb && go build ./...
+//
+// Or temporarily add `./ext/boltdb` to the `use` block above.


### PR DESCRIPTION
## Summary
- Remove `./ext/boltdb` from `go.work` — it was already a separate module, just pulled into the workspace for dev convenience
- Add an explanatory comment in `go.work` noting the build workflow (`cd ext/boltdb && go build ./...`)

## Why
`ext/boltdb` is the only thing pulling in `go.etcd.io/bbolt`, which has an open Dependabot alert (mache-fb423e) with no patched release yet. Because `go.work` listed it as a workspace member, scans of the repo root reported the alert even though the main `mache` binary doesn't link bbolt.

After this:
- `go list -m all` from root no longer reports bbolt
- The boltdb projection is a true add-on for venturi/trivy-db users
- Dependabot stops flagging the workspace
- The user explicitly asked for this approach (option 1)

## Test plan
- [x] `go build ./...` from root — clean
- [x] `go test ./...` from root — full suite green
- [x] `cd ext/boltdb && GOWORK=off go build ./...` — standalone build still works
- [x] `go list -m all | grep bbolt` from root — empty (no longer reported)

Related: mache-fb423e (will be commented to note the binary impact).