### PR TITLE
docs: refresh ROADMAP.md to reflect post-v0.7.0 reality

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,51 +1,56 @@
 # Roadmap
 
-## Current State (as of Feb 2026)
+## Current state (as of April 2026, post-v0.7.0)
 
-**What's landed:**
-- Schema-driven ingestion for JSON, SQLite, Go, Python, JavaScript, TypeScript, SQL, Rust, HCL/Terraform, YAML
-- Two graph backends: `MemoryStore` (in-memory map) and `SQLiteGraph` (zero-copy SQL)
-- Two mount backends: NFS (macOS default, `go-nfs`/`billy`) and FUSE (Linux default, `cgofuse`/`fuse-t`)
-- Write-back pipeline: validate (tree-sitter) → format (gofumpt for Go, hclwrite for HCL/Terraform) → splice → surgical node update + ShiftOrigins (no re-ingest)
-- Draft mode: invalid writes save as drafts, node path stays stable, errors via `_diagnostics/`
+**Stable today:**
+
+- 28-language tree-sitter parsing via the standalone CGO path; pure-Go path via [ley-line-open](https://github.com/agentic-research/ley-line-open) `.db` files (see [ARCHITECTURE.md § Interplay with ley-line-open](ARCHITECTURE.md#interplay-with-ley-line-open))
+- Two graph backends: `MemoryStore` (in-memory map for source ingestion) and `SQLiteGraph` (zero-copy SQL over LLO `.db`)
+- NFS-only mount via `go-nfs` + `billy` (FUSE was removed in v0.7.0 per ADR-0006; for FUSE today, use `leyline serve` from LLO)
+- MCP server with 16 tools: 13 work standalone, 3 require LLO enrichment (`semantic_search`, `get_type_info`, `get_diagnostics`); `find_smells` partially degrades on tree-sitter-only mounts (rules requiring `_ast` need an LLO-built `.db`)
+- Write-back pipeline: validate (tree-sitter) → format (gofumpt for Go, hclwrite for HCL/Terraform) → splice → surgical node update + `ShiftOrigins` (no re-ingest)
+- Draft mode: invalid writes save as drafts, node path stays stable, errors surface via `_diagnostics/`
 - Context awareness: virtual `context` files expose imports/globals to agents
-- Cross-reference indexing: roaring bitmap inverted index for token → file lookups
-- `callers/` virtual directory: exposes cross-references as browsable entries (NFS: graphFiles, FUSE: symlinks). Self-gating — only appears when callers exist
+- Cross-reference indexing: `node_refs`/`node_defs` SQLite tables backed by tree-sitter (standalone) or LLO (`.db` path)
+- `callers/` and `callees/` virtual directories — self-gating, NFS-served as `graphFile`s
 - `.query/` Plan 9-style SQL query directory with symlink results
-- Go schema captures: functions, methods, types, constants, variables, imports
-- Init dedup: same-name constructs get `.from_<filename>` suffixes (`engine.go:dedupSuffix`)
-- FCA schema inference: `--infer` auto-generates topology from data via Formal Concept Analysis
-- Greedy entropy inference: information-theoretic field scoring for better schema quality
+- `find_smells` MCP tool: 8 structural rules (`magic_int_in_comparison`, `dead_code`, `cyclomatic_complexity`, `long_function`, `untested_function`, `duplicate_definitions`, `fan_out_skew`, `long_file`) with optional `min_metric` and `source_id` filters
+- FCA + greedy entropy schema inference: `--infer` auto-generates topology from data
 - Virtual `_schema.json` at mount root exposing the active topology
 - HotSwap graph with control block for live schema reload
 
 **Known limitations:**
-- Memory: ~2GB peak for 323K NVD records (1.6M graph nodes with string IDs)
-- Write-back formatting is Go and HCL/Terraform only (other languages validate but don't auto-format)
-- No offset-based readdir pagination (fuse-t requires auto-mode, see `fs/root.go:Readdir`)
 
-## Near-Term: Construct Creation via FUSE
+- Memory: ~2GB peak for 323K NVD records (1.6M graph nodes with string IDs) — addressable via [GenerationalGraph](https://github.com/agentic-research/mache) (mache-2f1287)
+- Write-back formatting is Go and HCL/Terraform only; other languages validate but don't auto-format
+- Standalone (CGO) path produces `node_defs`/`node_refs` but not `_ast` — 4 of 8 `find_smells` rules require an LLO-built `.db`
+- bbolt-backed `ext/boltdb` projection is opt-in (not in default `go.work`); used by venturi/trivy-db workflows
 
-**Problem:** You can edit existing nodes but not create new ones. `mkdir {pkg}/functions/NewFunc` doesn't work.
+## Near-term
 
-**What exists:** `SourceOrigin` (`graph.go`) tracks which file owns each construct. The engine knows all files per package. Both backends already have `writeHandle`/`writeFile` tracking.
+- **Eliminate CGO tree-sitter** (mache-37ae8b, epic mache-36d961) — once LLO covers all standalone-path use cases, delete `SitterWalker` + tree-sitter build tags. Ship a pure-Go `mache` binary by default.
+- **Bundle leyline binary in mache release** (mache-33dc5f) — auto-detect tiers so the LLO-paired path works without a separate install
+- **`detect_changes` MCP tool** (mache-bsq) — git diff → affected AST nodes → blast radius via callers/callees BFS
+- **`dep_cycles` smell rule** (mache-unm5) — Tarjan SCC over node_refs; motivates extending `SmellRule` beyond pure SQL (Go-callback rules)
+- **Construct creation via NFS** — agents can write directly to source files today (`echo >> file.go`) and mache re-ingests on next writable file close. A first-class `Mkdir`/`Create` handler that generates stubs from templates is the next ergonomic step.
 
-**What's needed:** A `Mkdir` + `Create` handler that:
-1. Resolves the parent node's `SourceOrigin.FilePath` to find the target source file
-2. Generates a stub from a template (e.g. empty function signature)
-3. Appends to the source file (reuse `writeback/splice.go` with `EndByte` = file length)
-4. Surgical update via `UpdateNodeContent`
+## Medium-term
 
-**Pragmatic alternative:** Agents can write directly to source files (`echo >> file.go`) and mache re-ingests on the next writable file close. This works today without any changes.
+- **Additional formatters** — Python (black/ruff), TypeScript (prettier). Validation works for all tree-sitter languages; formatting needs per-language wiring in `internal/writeback/format.go`
+- **`_diagnostics/doc-drift`** (mache-8zq) — cross-reference docstrings vs signatures, READMEs vs symbols, ADRs vs constants
+- **Public `pkg/` API** (mache-734971) — expose ingest engine + materializers as a Go library, not just a CLI
+- **Self-referential schema pipeline** (mache-1cee2f) — read mache's own `nodes` table as a data source, enabling meta-projections
+- **`trace/` virtual dir** (mache-ok2) — transitive call-path traversal as a navigable directory
 
-## Medium-Term
+## Long-term
 
-- **Additional walkers** — TOML and more tree-sitter grammars. Adding a grammar requires: a `smacker/go-tree-sitter` language binding + a file extension case in `engine.go:ingestFile` + a ref/context query in `engine_languages.go`
-- **Additional formatters** — Python (black/ruff), TypeScript (prettier). Validation works for all tree-sitter languages; formatting needs per-language wiring in `writeback/format.go`
-
-## Long-Term (ADR-Described, No Code)
-
-- **Content-addressed storage** (ADR-0003) — Store data by hash, hard links for dedup
+- **Content-addressed storage** (ADR-0003) — store data by hash, hard links for dedup
 - **Layered overlays** (ADR-0003) — Docker-style composable layers for versioned views
-- **SQLite virtual tables** (ADR-0004) — SQL queries over the projected filesystem
-- **MVCC memory ledger** (ADR-0004) — Wait-free RCU + ECS for 10M+ entities, gated on profiling
+- **MVCC memory ledger** (ADR-0004) — wait-free RCU + ECS for 10M+ entities, gated on profiling
+- **R2 storage backend** (mache-2f0075, mache-d45da8, mache-ae2432) — persist mache graph as SQLite on Cloudflare R2 for BYO-storage tier
+- **D1 backend** (mache-d44509) — project mache graph to Cloudflare D1 for edge-cached queries
+- **Cross-language reference graph** (mache-q43l, epic) — typed locators that span languages (e.g., a Python call referencing a Rust FFI symbol)
+
+## Tracking
+
+All work items live as beads in `.beads/` (Dolt-backed). Use `bd list --json` or the `rsry` MCP server to browse open work. Earlier `INVESTIGATION_LOG.md` and `_agent_log/` files are historical journals retained for context but no longer the active source of truth.


### PR DESCRIPTION
## Summary
- Rewrite `docs/ROADMAP.md` to reflect current state (April 2026, post-v0.7.0)
- Drop FUSE-as-current and FUSE-specific near-term goals (FUSE removed in v0.7.0 per ADR-0006)
- Add LLO-paired path, 16-tool MCP inventory, `find_smells` rule list, bbolt opt-in note
- Replace forward-looking sections with bead IDs (mache-37ae8b, mache-36d961, mache-bsq, mache-unm5, etc.) so the doc references live tracking instead of going stale

## Why
ROADMAP.md was last touched February 2026 and described two mount backends (NFS + FUSE), referenced deleted files (`internal/fs/root.go`), and listed FUSE-specific near-term goals. Bringing it in line with current reality matters most for new contributors landing here from the README.

## Test plan
- [x] No code changes
- [x] All bead IDs referenced exist in `.beads/`
- [x] Pre-commit hooks pass

Closes mache-4ahe.