### PR TITLE
test: add find_smells benchmarks

### DIFF
--- a/cmd/serve_find_smells_bench_test.go
+++ b/cmd/serve_find_smells_bench_test.go
@@ -1,0 +1,190 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	_ "modernc.org/sqlite"
+)
+
+// seedSmellBench builds a synthetic find_smells fixture at scale.
+// nDefs defines how many tokens get a def + matching node; nRefs is the
+// number of distinct callers in node_refs (each pointing at a random
+// def). For _ast we synthesize one source_file per "package" (10 defs
+// per package) plus one function_declaration per def — enough to make
+// cyclomatic_complexity non-trivial.
+func seedSmellBench(b *testing.B, nDefs int) *smellTestGraph {
+	b.Helper()
+	dbPath := filepath.Join(b.TempDir(), "smells.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if _, err := db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL, record_id TEXT, record JSON,
+			source_file TEXT
+		);
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT NOT NULL, content BLOB NOT NULL);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE INDEX idx_nodes_parent ON nodes(parent_id);
+		CREATE INDEX idx_node_refs_token ON node_refs(token);
+	`); err != nil {
+		b.Fatal(err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// One source_file per 10 defs; gives _ast a believable shape.
+	pkgSize := 10
+	for i := range nDefs {
+		token := fmt.Sprintf("Func%05d", i)
+		nodeID := fmt.Sprintf("pkg/%d/%s", i/pkgSize, token)
+		sourceID := fmt.Sprintf("pkg/%d/file.go", i/pkgSize)
+
+		if _, err := tx.Exec(
+			"INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES (?, ?, ?, 1, 0, ?, '')",
+			nodeID, fmt.Sprintf("pkg/%d", i/pkgSize), token, sourceID,
+		); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := tx.Exec("INSERT INTO node_defs VALUES (?, ?)", token, nodeID); err != nil {
+			b.Fatal(err)
+		}
+		// _ast: one function_declaration per def with a few branches.
+		if _, err := tx.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, ?, 'function_declaration', ?, ?, ?, ?, ?, 0)",
+			nodeID, sourceID, i*1000, i*1000+400, i*30, 0, i*30+25,
+		); err != nil {
+			b.Fatal(err)
+		}
+		// Three branches per function — hits cyclomatic_complexity sweet spot.
+		for j, kind := range []string{"if_statement", "for_statement", "case_clause"} {
+			if _, err := tx.Exec(
+				"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0)",
+				fmt.Sprintf("%s/branch_%d", nodeID, j), sourceID, kind, i*1000+j*50, i*1000+j*50+30, i*30+j*5, 0,
+			); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		// 60% of defs get one ref so dead_code finds the other 40%.
+		if i%5 < 3 {
+			caller := fmt.Sprintf("pkg/%d/Caller%05d/source", i/pkgSize, i)
+			if _, err := tx.Exec("INSERT INTO node_refs VALUES (?, ?)", token, caller); err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		b.Fatal(err)
+	}
+	return &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+}
+
+// BenchmarkFindSmells_DeadCode exercises the node_defs/node_refs path,
+// which is the rule with the largest scan surface for standalone mache
+// (no _ast required).
+func BenchmarkFindSmells_DeadCode(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{"rule": "dead_code", "limit": float64(10000)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindSmells_CyclomaticComplexity exercises the _ast self-join
+// path. Worth measuring separately because the LIKE prefix join is the
+// expensive operation in metric-style rules.
+func BenchmarkFindSmells_CyclomaticComplexity(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{
+				"rule":       "cyclomatic_complexity",
+				"limit":      float64(10000),
+				"min_metric": float64(1),
+			})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindSmells_FanOutSkew exercises the CTE-with-aggregate path.
+// Caller distribution dominates the cost (one row per distinct caller
+// in node_refs).
+func BenchmarkFindSmells_FanOutSkew(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{"rule": "fan_out_skew", "limit": float64(10000)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindSmells_RulesListing measures the discovery-mode call —
+// no rule arg, just returns the registry. This is the hot path for
+// agents pre-flighting the tool against a backend.
+func BenchmarkFindSmells_RulesListing(b *testing.B) {
+	tg := seedSmellBench(b, 0)
+	defer func() { _ = tg.db.Close() }()
+	handler := makeFindSmellsHandler(tg)
+	req := makeRequest(map[string]any{})
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, err := handler(context.Background(), req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- New `cmd/serve_find_smells_bench_test.go` with 4 benchmarks covering the 3 structural query shapes plus the discovery-mode listing
- Synthetic graph builder seeds N defs (one `function_declaration` per def with 3 branch `_ast` nodes), 60% with a single ref so `dead_code` finds realistic dead/live ratios
- Establishes a perf baseline so future rule changes don't silently regress

## Why
Partial step on mache-9b4d8a (Benchmarks: MCP tool latency, ingestion throughput, mount readdir perf). `find_smells` is the most recently-grown surface — 8 rules, `min_metric` filter, `requires` listing — so locking in its perf shape now is the natural starting point.

## Local measurements (M3 Max, 10K defs, single iter)

| Bench                     | Time    | B/op   | Allocs/op |
| ------------------------- | ------- | ------ | --------- |
| DeadCode                  | ~26 ms  | 8 MB   | 58 K      |
| CyclomaticComplexity      | ~140 ms | 19 MB  | 188 K     |
| FanOutSkew                | ~4 ms   | 9 KB   | 48        |
| RulesListing              | ~44 µs  | 26 KB  | 22        |

Cyclomatic is the obvious hotspot — the `LIKE fn.node_id || '/%'` self-join dominates. That's a known SQL shape, just now measurable.

## Test plan
- [x] `go test -bench BenchmarkFindSmells -benchtime=1x ./cmd/` — all 4 benches run cleanly at small/medium/large scales
- [x] gofumpt + go vet + golangci-lint via pre-commit
- [x] No production-code changes