### PR TITLE
feat: find_smells pre-flight required-tables check

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -339,6 +339,19 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("the active graph backend doesn't expose a SQL handle; find_smells requires a leyline-parsed .db"), nil
 		}
 
+		// Pre-flight: every rule declares the tables it reads in
+		// rule.Requires. If any are missing on this backend, return a
+		// friendly tool error instead of letting the SQL fail with
+		// "no such table" — agents can then call the tool again with
+		// a different rule, or stop.
+		if missing, err := missingTables(qg, rule.Requires); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("rule %q: pre-flight table check failed: %v", ruleID, err)), nil
+		} else if len(missing) > 0 {
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"rule %q requires SQL tables [%s] which aren't present on the active backend. _ast / _source / _imports / _lsp* are produced by ley-line-open's `leyline parse`; node_defs / node_refs / nodes are produced by both standalone mache and LLO. See docs/ARCHITECTURE.md#interplay-with-ley-line-open for the full table.",
+				ruleID, strings.Join(missing, ", "))), nil
+		}
+
 		findings, err := runSmellRule(qg, rule, sourceID, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("rule %q: %v", ruleID, err)), nil
@@ -400,6 +413,49 @@ func rulesListing() any {
 		Help:  "find_smells runs structural pattern queries against the _ast / nodes / node_defs / node_refs tables. Pass `rule` to scan; omit it (this response) to list available rules. Each rule entry includes a `requires` list of SQL tables it reads — agents can use it to skip rules whose tables aren't present on the active backend (e.g. _ast is only populated by ley-line-open's leyline parse). Optional `source_id` filters to one parsed file; `limit` caps results (default 200); `min_metric` drops findings whose metric column is below the threshold (default 0).",
 		Rules: out,
 	}
+}
+
+// missingTables returns the subset of `required` that's not in
+// sqlite_master on the active backend. Returns nil if everything is
+// present (or `required` is empty). The query uses placeholders for
+// the IN list so it works with arbitrary SQLite drivers.
+func missingTables(qg refsQuerier, required []string) ([]string, error) {
+	if len(required) == 0 {
+		return nil, nil
+	}
+	placeholders := strings.Repeat("?,", len(required))
+	placeholders = placeholders[:len(placeholders)-1]
+	args := make([]any, len(required))
+	for i, t := range required {
+		args[i] = t
+	}
+	rows, err := qg.QueryRefs(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name IN ("+placeholders+")",
+		args...,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	present := make(map[string]struct{}, len(required))
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		present[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	var missing []string
+	for _, t := range required {
+		if _, ok := present[t]; !ok {
+			missing = append(missing, t)
+		}
+	}
+	return missing, nil
 }
 
 // runSmellRule executes the rule's SQL, optionally scoped to one source.

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -215,6 +215,42 @@ func TestFindSmells_BackendWithoutAstReturnsError(t *testing.T) {
 	assert.NotEmpty(t, resultText(t, res))
 }
 
+// TestFindSmells_PreflightFlagsMissingTables ensures that running an
+// _ast-required rule against a backend without _ast surfaces a friendly
+// error naming the missing table — the agent shouldn't have to parse a
+// raw SQL "no such table" string.
+func TestFindSmells_PreflightFlagsMissingTables(t *testing.T) {
+	// Backend with nodes/node_defs/node_refs but NO _ast table.
+	dbPath := filepath.Join(t.TempDir(), "no_ast.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE nodes (id TEXT PRIMARY KEY, parent_id TEXT, name TEXT, kind INTEGER, mtime INTEGER, source_file TEXT, record TEXT);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+	`)
+	require.NoError(t, err)
+	tg := &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "cyclomatic_complexity",
+	}))
+	require.NoError(t, err)
+	require.True(t, res.IsError)
+
+	msg := resultText(t, res)
+	assert.Contains(t, msg, "_ast", "error must name the missing table")
+	assert.Contains(t, msg, "ley-line-open", "error should point users at LLO docs")
+
+	// Sanity: a rule that only needs node_defs/node_refs/nodes runs
+	// fine on the same backend.
+	res, err = handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "dead_code only needs node_defs/node_refs/nodes; pre-flight should pass")
+}
+
 func TestFindSmells_SourceIDFilterScopes(t *testing.T) {
 	tg := seedSmellAST(t)
 	defer func() { _ = tg.db.Close() }()


### PR DESCRIPTION
## Summary
- Use `rule.Requires` (from #199) to verify the active backend has every table a rule reads before running its SQL
- On missing tables, return a friendly tool error naming the missing tables and pointing at `docs/ARCHITECTURE.md#interplay-with-ley-line-open`
- Helper `missingTables()` queries `sqlite_master` once with an IN-list of placeholders

## Why
The 9 smell rules split into:
- _ast-required (LLO-only): magic_int_in_comparison, cyclomatic_complexity, long_function, long_file
- node_defs/node_refs (any backend): dead_code, untested_function, duplicate_definitions, god_file, fan_out_skew

Before this PR, running an `_ast` rule on a standalone-mache `.db` returned a raw SQL error like `"no such table: _ast"`. Agents had to string-match to recover. Now the error is structured:

```
rule "cyclomatic_complexity" requires SQL tables [_ast] which aren't present on the active backend. _ast / _source / _imports / _lsp* are produced by ley-line-open's `leyline parse`; node_defs / node_refs / nodes are produced by both standalone mache and LLO. See docs/ARCHITECTURE.md#interplay-with-ley-line-open for the full table.
```

Pairs naturally with the discoverability angle in #199 — agents that read `requires` upfront skip rules that won't run; agents that try anyway get a clean error pointing at docs.

## Test plan
- [x] New `TestFindSmells_PreflightFlagsMissingTables` — backend with `nodes`/`node_defs`/`node_refs` but no `_ast`: cyclomatic_complexity returns error naming `_ast` + `ley-line-open`; dead_code runs fine
- [x] All `TestFindSmells*` pass (16 tests)
- [x] gofumpt + go vet + golangci-lint via pre-commit