### PR TITLE
chore: untrack bd runtime files (interactions.jsonl, credential key)

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -35,6 +35,27 @@ dolt-server.port
 # Backup data (auto-exported JSONL, local-only)
 backup/
 
+# Per-bd-command audit log (runtime, not a review artifact). Stays on
+# disk for local inspection; just shouldn't fight git on every bd call.
+interactions.jsonl
+
+# Credentials (per-clone, never committed)
+.beads-credential-key
+
+# Daemon state and activity logs
+daemon.*
+dolt-server.activity
+
+# Lockfiles + quarantined backups
+*.lock
+*.corrupt.backup/
+
+# Environment files
+.env
+
+# Sync export state (local-only)
+export-state.json
+
 # Legacy files (from pre-Dolt versions)
 *.db
 *.db?*

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,7 @@ tools/KNOWN_ISSUES.md
 
 # Test fixture databases are committed (override the *.db rule above)
 !testdata/*.db
+
+# Beads credential key (per-clone, never committed)
+.beads-credential-key
+.beads/.beads-credential-key


### PR DESCRIPTION
## Summary
- Untrack `.beads/interactions.jsonl` and `.beads/.beads-credential-key` via `git rm --cached`
- Add bd doctor's recommended runtime patterns to `.beads/.gitignore` (`interactions.jsonl`, `.beads-credential-key`, `daemon.*`, `dolt-server.activity`, `*.lock`, `*.corrupt.backup/`, `.env`, `export-state.json`)
- Add `.beads-credential-key` to project `.gitignore`

## Why
`bd doctor` warns that `.beads/interactions.jsonl` is a tracked runtime file. Every `bd` command appends to it, which means every git operation in this session needed an auto-stash dance. User-flagged as a "huge problem" and personal pet peeve.

The file content stays on disk — `git rm --cached` only removes it from the index. bd keeps writing to it; reviewers can still tail it for local inspection. We just stop fighting git on every bd call.

Same treatment for `.beads-credential-key` (per-clone secret that obviously shouldn't be tracked).

Bonus: the runtime patterns added to `.beads/.gitignore` (daemons, locks, corrupt backups, env, export state) catch future bd artifacts without per-file additions.

## Test plan
- [x] `git check-ignore -v .beads/interactions.jsonl .beads/.beads-credential-key` confirms both match the new rules
- [x] `git status` shows the file is no longer flagged as `M` after a bd command (it's properly ignored)
- [x] File content preserved on disk
- [x] No code changes