### PR TITLE
chore: clean up untracked git status — gitignore runtime, commit design docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,22 @@ tools/KNOWN_ISSUES.md
 # Beads credential key (per-clone, never committed)
 .beads-credential-key
 .beads/.beads-credential-key
+
+# Root-level dolt server runtime (when bd's dolt server is started here)
+/dolt/
+/dolt-server.lock
+/dolt-server.log
+/dolt-server.pid
+/dolt-server.port
+/dolt-server.activity
+
+# Locally-built helper binaries (not part of the shipped binary)
+/gen-lsp-fixture
+
+# get_diagram MCP tool outputs — generated to current directory on demand
+/diagram.mermaid
+/diagram-*.mermaid
+
+# Session-resume scratch notes (per-clone, ad hoc)
+/resume.txt
+/mache-distrib-resume.txt

--- a/docs/superpowers/plans/2026-03-24-unified-language-registry.md
+++ b/docs/superpowers/plans/2026-03-24-unified-language-registry.md
@@ -1,0 +1,720 @@
+# Unified Language Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace 10 independent language/extension switch statements with a single `internal/lang` registry that every consumer derives from — zero duplication, zero drift.
+
+**Architecture:** A `Language` struct holds all per-language data (name, extensions, grammar factory, preset schema key, display name, sentinel files). A package-level registry slice built at init time provides derived lookups: `ForExt()`, `ForName()`, `Extensions()`, `IsSourceExt()`. All 9 consumers rewrite to call these lookups. The `internal/lang` package imports tree-sitter grammars (CGO) so `api/` stays pure Go. Circular deps avoided because `lang` depends only on tree-sitter — nothing in `internal/` depends on `lang` upward.
+
+**Tech Stack:** Go, tree-sitter CGO bindings, testify
+
+**Bead:** mache-7gp
+
+______________________________________________________________________
+
+## Current State: 10 Registries, 9+ Bugs
+
+| #   | Registry                  | File:Lines                               | Languages     | Bugs                                                                  |
+| --- | ------------------------- | ---------------------------------------- | ------------- | --------------------------------------------------------------------- |
+| 1   | `langForExt()`            | `internal/ingest/engine.go:135-176`      | 18            | Duplicate of #2                                                       |
+| 2   | `DetectLanguageFromExt()` | `internal/ingest/language.go:28-69`      | 18            | Duplicate of #1                                                       |
+| 3   | `GetLanguage()`           | `internal/ingest/engine.go:1686-1727`    | 18            | Third copy (by name)                                                  |
+| 4   | `GetLanguageProfile()`    | `internal/ingest/language.go:79-88`      | 1 (hcl)       | 10th switch, not addressed until now                                  |
+| 5   | `sourceExtensions`        | `internal/ingest/watcher.go:289-305`     | 14 + .json    | **Missing 8 langs** (.java .c .h .cpp .rb .php .kt .swift .scala etc) |
+| 6   | `LanguageForPath()`       | `internal/writeback/validate.go:141-163` | 8             | **Missing 10 langs** (claims "single source of truth")                |
+| 7   | `presetSchemas`           | `cmd/schemas.go:15-39`                   | 18 + data     | OK (complete)                                                         |
+| 8   | `sourceCodePresets`       | `cmd/infer.go:22-41`                     | 18            | OK (complete)                                                         |
+| 9   | mount.go infer switch     | `cmd/mount.go:179-216`                   | 16            | **Missing elixir, toml**                                              |
+| 10  | `detectProjectType()`     | `cmd/config.go:408-417`                  | 3 (go/py/sql) | **Missing 15 langs**                                                  |
+
+**Additional missed consumers** (direct grammar imports, no registry):
+
+- `cmd/build.go:15` — imports `golang` directly
+- `internal/linter/linter.go:9` — imports `golang` directly
+- `internal/lattice/project_ast.go:53` — uses `"hcl"` as key (must work after rename)
+
+Additional bugs in `ingestTreeSitter` vs `ingestTreeSitterParallel`:
+
+- Broken file ID uses basename (collision) vs SHA256 (correct)
+- Missing `_project_files` fallback in sequential path
+- Missing `RecordFile` in sequential path
+
+## File Structure
+
+### New files
+
+- `internal/lang/lang.go` — `Language` struct, registry, derived lookups
+- `internal/lang/lang_test.go` — exhaustive tests for registry completeness
+
+### Modified files (consumers → one-liner rewrites)
+
+- `internal/ingest/engine.go` — delete `langForExt()`, `GetLanguage()`; call `lang.ForExt()`, `lang.ForName()`
+- `internal/ingest/language.go` — delete `DetectLanguageFromExt()`; re-export as thin wrapper over `lang.ForExt()`
+- `internal/ingest/watcher.go` — delete `sourceExtensions`; call `lang.IsSourceExt()`
+- `internal/writeback/validate.go` — delete `LanguageForPath()`; call `lang.ForPath()`
+- `cmd/schemas.go` — derive `presetSchemas` from `lang.Registry`
+- `cmd/infer.go` — derive `sourceCodePresets` from `lang.Registry`
+- `cmd/mount.go` — replace infer switch with `lang.ForExt()`
+- `cmd/config.go` — replace `detectProjectType` hardcoded exts with `lang.Extensions()`
+
+### Modified files (ingest dedup)
+
+- `internal/ingest/engine.go` — extract `processTreeSitterResult()`, fix 3 bugs
+
+______________________________________________________________________
+
+### Task 1: Create `internal/lang` package — the single source of truth
+
+**Files:**
+
+- Create: `internal/lang/lang.go`
+
+- Create: `internal/lang/lang_test.go`
+
+- [ ] **Step 1: Write the failing test — registry completeness**
+
+```go
+// internal/lang/lang_test.go
+package lang
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistry_Has18Languages(t *testing.T) {
+	expected := []string{
+		"go", "python", "javascript", "typescript", "sql", "terraform",
+		"yaml", "rust", "toml", "elixir", "java", "c", "cpp",
+		"ruby", "php", "kotlin", "swift", "scala",
+	}
+	for _, name := range expected {
+		l := ForName(name)
+		require.NotNil(t, l, "missing language: %s", name)
+		assert.Equal(t, name, l.Name)
+		assert.NotNil(t, l.Grammar(), "nil grammar for %s", name)
+		assert.NotEmpty(t, l.Extensions, "no extensions for %s", name)
+	}
+}
+
+func TestForExt_AllExtensions(t *testing.T) {
+	cases := map[string]string{
+		".go": "go", ".py": "python", ".js": "javascript",
+		".ts": "typescript", ".tsx": "typescript",
+		".sql": "sql", ".tf": "terraform", ".hcl": "terraform",
+		".yaml": "yaml", ".yml": "yaml",
+		".rs": "rust", ".toml": "toml",
+		".ex": "elixir", ".exs": "elixir",
+		".java": "java", ".c": "c", ".h": "c",
+		".cpp": "cpp", ".cc": "cpp", ".cxx": "cpp",
+		".hpp": "cpp", ".hxx": "cpp", ".hh": "cpp",
+		".rb": "ruby", ".php": "php",
+		".kt": "kotlin", ".kts": "kotlin",
+		".swift": "swift", ".scala": "scala", ".sc": "scala",
+	}
+	for ext, wantName := range cases {
+		l := ForExt(ext)
+		require.NotNil(t, l, "no language for ext %s", ext)
+		assert.Equal(t, wantName, l.Name, "wrong language for ext %s", ext)
+	}
+}
+
+func TestForExt_Unknown(t *testing.T) {
+	assert.Nil(t, ForExt(".xyz"))
+	assert.Nil(t, ForExt(".md"))
+	assert.Nil(t, ForExt(""))
+}
+
+func TestForName_Unknown(t *testing.T) {
+	assert.Nil(t, ForName("brainfuck"))
+}
+
+func TestIsSourceExt(t *testing.T) {
+	assert.True(t, IsSourceExt(".go"))
+	assert.True(t, IsSourceExt(".java"))
+	assert.True(t, IsSourceExt(".swift"))
+	assert.True(t, IsSourceExt(".json")) // special case: data format
+	assert.False(t, IsSourceExt(".md"))
+	assert.False(t, IsSourceExt(".o"))
+}
+
+func TestExtensions_ReturnsAll(t *testing.T) {
+	exts := Extensions()
+	assert.Contains(t, exts, ".go")
+	assert.Contains(t, exts, ".scala")
+	assert.Contains(t, exts, ".hh")
+	assert.True(t, len(exts) >= 28, "expected at least 28 extensions, got %d", len(exts))
+}
+
+func TestForPath(t *testing.T) {
+	l := ForPath("/foo/bar/main.go")
+	require.NotNil(t, l)
+	assert.Equal(t, "go", l.Name)
+
+	assert.Nil(t, ForPath("/foo/README.md"))
+}
+
+func TestNoDuplicateExtensions(t *testing.T) {
+	seen := map[string]string{}
+	for _, l := range Registry {
+		for _, ext := range l.Extensions {
+			if prev, ok := seen[ext]; ok {
+				t.Errorf("extension %s claimed by both %s and %s", ext, prev, l.Name)
+			}
+			seen[ext] = l.Name
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestRegistry ./internal/lang/`
+Expected: FAIL — package doesn't exist yet
+
+- [ ] **Step 3: Write minimal implementation**
+
+```go
+// internal/lang/lang.go
+package lang
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	treec "github.com/smacker/go-tree-sitter/c"
+	"github.com/smacker/go-tree-sitter/cpp"
+	"github.com/smacker/go-tree-sitter/golang"
+	"github.com/smacker/go-tree-sitter/hcl"
+	"github.com/smacker/go-tree-sitter/java"
+	"github.com/smacker/go-tree-sitter/javascript"
+	"github.com/smacker/go-tree-sitter/kotlin"
+	"github.com/smacker/go-tree-sitter/php"
+	"github.com/smacker/go-tree-sitter/python"
+	"github.com/smacker/go-tree-sitter/ruby"
+	"github.com/smacker/go-tree-sitter/rust"
+	"github.com/smacker/go-tree-sitter/scala"
+	"github.com/smacker/go-tree-sitter/sql"
+	"github.com/smacker/go-tree-sitter/swift"
+	"github.com/smacker/go-tree-sitter/toml"
+	"github.com/smacker/go-tree-sitter/typescript/typescript"
+	"github.com/smacker/go-tree-sitter/yaml"
+
+	"github.com/agentic-research/mache/internal/treesitter/elixir"
+)
+
+// Language is the single source of truth for a supported language.
+type Language struct {
+	Name          string                              // canonical name: "go", "python", "terraform"
+	Aliases       []string                            // backward-compat names: e.g. "hcl" for terraform
+	DisplayName   string                              // human label: "Go", "Python", "HCL/Terraform"
+	Extensions    []string                            // file extensions including dot: ".go", ".py"
+	Grammar       func() *sitter.Language             // tree-sitter grammar factory (lazy, CGO-safe)
+	PresetSchema  string                              // embedded schema key (empty = no preset)
+	SentinelFiles []string                            // files that identify a project: "go.mod", "Cargo.toml"
+	EnrichNode    func(n *sitter.Node, rec map[string]any) // language-specific AST enrichment (nil for most)
+}
+
+// Registry is the authoritative list of all supported languages.
+// Add a language here and every consumer picks it up automatically.
+var Registry = []Language{
+	{Name: "go", DisplayName: "Go", Extensions: []string{".go"}, Grammar: golang.GetLanguage, PresetSchema: "go", SentinelFiles: []string{"go.mod", "go.sum"}},
+	{Name: "python", DisplayName: "Python", Extensions: []string{".py"}, Grammar: python.GetLanguage, PresetSchema: "python", SentinelFiles: []string{"pyproject.toml", "requirements.txt", "setup.py"}},
+	{Name: "javascript", DisplayName: "JavaScript", Extensions: []string{".js"}, Grammar: javascript.GetLanguage, PresetSchema: "javascript", SentinelFiles: []string{"package.json"}},
+	{Name: "typescript", DisplayName: "TypeScript", Extensions: []string{".ts", ".tsx"}, Grammar: typescript.GetLanguage, PresetSchema: "typescript"},
+	{Name: "sql", DisplayName: "SQL", Extensions: []string{".sql"}, Grammar: sql.GetLanguage, PresetSchema: "sql"},
+	{Name: "terraform", Aliases: []string{"hcl"}, DisplayName: "HCL/Terraform", Extensions: []string{".tf", ".hcl"}, Grammar: hcl.GetLanguage, PresetSchema: "terraform", EnrichNode: enrichHCLNode},
+	{Name: "yaml", DisplayName: "YAML", Extensions: []string{".yaml", ".yml"}, Grammar: yaml.GetLanguage, PresetSchema: "yaml"},
+	{Name: "rust", DisplayName: "Rust", Extensions: []string{".rs"}, Grammar: rust.GetLanguage, PresetSchema: "rust", SentinelFiles: []string{"Cargo.toml"}},
+	{Name: "toml", DisplayName: "TOML", Extensions: []string{".toml"}, Grammar: toml.GetLanguage, PresetSchema: "toml"},
+	{Name: "elixir", DisplayName: "Elixir", Extensions: []string{".ex", ".exs"}, Grammar: elixir.GetLanguage, PresetSchema: "elixir", SentinelFiles: []string{"mix.exs"}},
+	{Name: "java", DisplayName: "Java", Extensions: []string{".java"}, Grammar: java.GetLanguage, PresetSchema: "java", SentinelFiles: []string{"pom.xml", "build.gradle"}},
+	{Name: "c", DisplayName: "C", Extensions: []string{".c", ".h"}, Grammar: treec.GetLanguage, PresetSchema: "c"},
+	{Name: "cpp", DisplayName: "C++", Extensions: []string{".cpp", ".cc", ".cxx", ".hpp", ".hxx", ".hh"}, Grammar: cpp.GetLanguage, PresetSchema: "cpp", SentinelFiles: []string{"CMakeLists.txt"}},
+	{Name: "ruby", DisplayName: "Ruby", Extensions: []string{".rb"}, Grammar: ruby.GetLanguage, PresetSchema: "ruby", SentinelFiles: []string{"Gemfile"}},
+	{Name: "php", DisplayName: "PHP", Extensions: []string{".php"}, Grammar: php.GetLanguage, PresetSchema: "php", SentinelFiles: []string{"composer.json"}},
+	{Name: "kotlin", DisplayName: "Kotlin", Extensions: []string{".kt", ".kts"}, Grammar: kotlin.GetLanguage, PresetSchema: "kotlin"},
+	{Name: "swift", DisplayName: "Swift", Extensions: []string{".swift"}, Grammar: swift.GetLanguage, PresetSchema: "swift", SentinelFiles: []string{"Package.swift"}},
+	{Name: "scala", DisplayName: "Scala", Extensions: []string{".scala", ".sc"}, Grammar: scala.GetLanguage, PresetSchema: "scala", SentinelFiles: []string{"build.sbt"}},
+}
+
+// Derived indexes — built once at init, never mutated.
+var (
+	byExt  map[string]*Language
+	byName map[string]*Language
+	srcSet map[string]bool // all extensions + .json
+)
+
+func init() {
+	byExt = make(map[string]*Language, 32)
+	byName = make(map[string]*Language, len(Registry))
+	srcSet = make(map[string]bool, 32)
+
+	for i := range Registry {
+		l := &Registry[i]
+		byName[l.Name] = l
+		for _, alias := range l.Aliases {
+			byName[alias] = l // backward compat: ForName("hcl") → terraform
+		}
+		for _, ext := range l.Extensions {
+			byExt[ext] = l
+			srcSet[ext] = true
+		}
+	}
+	// Data format extensions are source files but not tree-sitter languages.
+	srcSet[".json"] = true
+}
+
+// ForExt returns the language for a file extension (including dot), or nil.
+// Case-insensitive to handle ".Go", ".PY" etc.
+func ForExt(ext string) *Language {
+	return byExt[strings.ToLower(ext)]
+}
+
+// ForName returns the language by canonical name, or nil.
+func ForName(name string) *Language {
+	return byName[name]
+}
+
+// ForPath returns the language for a file path (by extension), or nil.
+func ForPath(path string) *Language {
+	return byExt[strings.ToLower(filepath.Ext(path))]
+}
+
+// IsSourceExt returns true if the extension is a recognized source file
+// (tree-sitter languages + .json).
+func IsSourceExt(ext string) bool {
+	return srcSet[ext]
+}
+
+// Extensions returns all recognized file extensions in sorted order.
+func Extensions() []string {
+	out := make([]string, 0, len(srcSet))
+	for ext := range srcSet {
+		out = append(out, ext)
+	}
+	sort.Strings(out)
+	return out
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `task test -- -run 'TestRegistry|TestForExt|TestForName|TestIsSourceExt|TestExtensions|TestForPath|TestNoDuplicate' ./internal/lang/`
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/lang/
+git commit -m "feat: internal/lang — single source of truth for all language registries"
+```
+
+______________________________________________________________________
+
+### Task 2: Wire `internal/ingest` — delete 3 duplicates
+
+**Files:**
+
+- Modify: `internal/ingest/engine.go:135-176` (delete `langForExt`), `:1686-1727` (delete `GetLanguage`)
+
+- Modify: `internal/ingest/language.go:28-69` (rewrite `DetectLanguageFromExt` as thin wrapper)
+
+- Modify: `internal/ingest/watcher.go:289-305` (delete `sourceExtensions`, `isSourceFile`)
+
+- Modify: `internal/ingest/engine_test.go`, `watcher_test.go` as needed
+
+- [ ] **Step 1: Replace `langForExt` with `lang.ForExt`**
+
+In `engine.go`, delete the `langForExt` function (lines 135-176). Replace all call sites:
+
+```go
+// Before:
+lang, langName := langForExt(ext)
+// After:
+l := lang.ForExt(ext)
+var grammar *sitter.Language
+var langName string
+if l != nil {
+    grammar, langName = l.Grammar(), l.Name
+}
+```
+
+There are 2 call sites: `ingestTreeSitterParallel` (~line 550) and `ingestFile` (~line 759).
+
+- [ ] **Step 2: Replace `GetLanguage` with `lang.ForName`**
+
+Delete `GetLanguage` (lines 1686-1727). Replace the one external call site:
+
+```go
+// cmd/mount.go:922 — the only external caller
+// Before:
+grammar := ingest.GetLanguage(langName)
+// After:
+l := lang.ForName(langName)
+if l != nil { grammar = l.Grammar() }
+```
+
+- [ ] **Step 2b: Replace `GetLanguageProfile` with `lang.ForName`**
+
+Delete `GetLanguageProfile` (language.go:79-88). Replace call sites:
+
+```go
+// Before:
+profile := GetLanguageProfile(langName)
+if profile != nil { profile.EnrichNode(n, rec) }
+// After:
+l := lang.ForName(langName)
+if l != nil && l.EnrichNode != nil { l.EnrichNode(n, rec) }
+```
+
+Move `enrichHCLNode` function from `language.go` to `internal/lang/lang.go` (or keep in `language.go` and pass as function reference — prefer the latter to avoid pulling HCL-specific logic into `lang`).
+
+- [ ] **Step 3: Rewrite `DetectLanguageFromExt` as thin wrapper**
+
+In `language.go`, replace the 40-line switch with:
+
+```go
+func DetectLanguageFromExt(ext string) (langName string, grammar *sitter.Language, ok bool) {
+	l := lang.ForExt(ext)
+	if l == nil {
+		return "", nil, false
+	}
+	return l.Name, l.Grammar(), true
+}
+```
+
+Keep it exported for backward compat — external callers (lattice, cmd) use it.
+
+- [ ] **Step 4: Replace `sourceExtensions` and `isSourceFile`**
+
+In `watcher.go`, delete the `sourceExtensions` map (lines 289-305) and rewrite:
+
+```go
+func isSourceFile(path string) bool {
+	return lang.IsSourceExt(filepath.Ext(path))
+}
+```
+
+This fixes the 8-language gap bug immediately.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ingest/ internal/lang/
+git commit -m "refactor: wire internal/ingest to lang registry — delete 3 duplicate switches"
+```
+
+______________________________________________________________________
+
+### Task 3: Wire `internal/writeback` — fix 10-language gap
+
+**Files:**
+
+- Modify: `internal/writeback/validate.go:141-163`
+
+- [ ] **Step 1: Write test for newly-supported languages**
+
+```go
+func TestLanguageForPath_AllLanguages(t *testing.T) {
+	cases := map[string]bool{
+		"main.go": true, "app.py": true, "index.js": true,
+		"app.ts": true, "query.sql": true, "main.tf": true,
+		"config.yaml": true, "lib.rs": true,
+		// These were previously broken:
+		"config.toml": true, "mix.ex": true, "App.java": true,
+		"main.c": true, "lib.cpp": true, "app.rb": true,
+		"index.php": true, "Main.kt": true, "App.swift": true,
+		"Main.scala": true,
+		// Non-languages:
+		"README.md": false, "data.csv": false,
+	}
+	for file, wantNonNil := range cases {
+		result := LanguageForPath(file)
+		if wantNonNil {
+			assert.NotNil(t, result, "expected language for %s", file)
+		} else {
+			assert.Nil(t, result, "expected nil for %s", file)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Rewrite `LanguageForPath`**
+
+Replace the 22-line switch (lines 141-163) with:
+
+```go
+func LanguageForPath(filePath string) *sitter.Language {
+	l := lang.ForPath(filePath)
+	if l == nil {
+		return nil
+	}
+	return l.Grammar()
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `task test -- -run TestLanguageForPath ./internal/writeback/`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/writeback/
+git commit -m "fix: LanguageForPath now supports all 18 languages via lang registry"
+```
+
+______________________________________________________________________
+
+### Task 4: Wire `cmd/` consumers — schemas, infer, mount, config
+
+**Files:**
+
+- Modify: `cmd/schemas.go:15-39`
+
+- Modify: `cmd/infer.go:22-41`
+
+- Modify: `cmd/mount.go:179-216`
+
+- Modify: `cmd/config.go:408-417`
+
+- [ ] **Step 1: Derive `presetSchemas` from registry**
+
+In `schemas.go`, replace the hardcoded map with:
+
+```go
+var presetSchemas map[string]string
+
+func init() {
+	presetSchemas = make(map[string]string)
+	for _, l := range lang.Registry {
+		if l.PresetSchema != "" {
+			presetSchemas[l.Name] = "schemas/" + l.PresetSchema + ".json"
+		}
+	}
+	// Data-format presets (not auto-detected from file extensions)
+	presetSchemas["cli"] = "schemas/cli.json"
+	presetSchemas["mcp"] = "schemas/mcp.json"
+	presetSchemas["mcp-registry"] = "schemas/mcp-registry.json"
+}
+```
+
+- [ ] **Step 2: Derive `sourceCodePresets` from registry**
+
+In `infer.go`, replace the hardcoded map with:
+
+```go
+var sourceCodePresets map[string]string
+
+func init() {
+	sourceCodePresets = make(map[string]string)
+	for _, l := range lang.Registry {
+		if l.PresetSchema != "" {
+			sourceCodePresets[l.Name] = l.PresetSchema
+		}
+	}
+}
+```
+
+- [ ] **Step 3: Replace mount.go infer switch**
+
+Replace the 40-line switch (lines 179-216) with:
+
+```go
+l := lang.ForExt(ext)
+if l != nil {
+	inferred, err = inferFromTreeSitterFile(inf, dataPath, l.Grammar(), l.DisplayName)
+}
+```
+
+Keep the `.db` and `.git` cases as-is (they're not language-specific).
+
+- [ ] **Step 4: Replace `detectProjectType` with registry-driven detection**
+
+In `config.go`, replace the hardcoded 3-language switch with:
+
+```go
+ext := strings.ToLower(filepath.Ext(name))
+if l := lang.ForExt(ext); l != nil {
+	counts[l.Name]++
+}
+```
+
+Also add sentinel file detection using `Language.SentinelFiles`.
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS — existing tests for `TestDetectProjectType_GoProject` etc still pass, plus new languages now detected
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/
+git commit -m "refactor: wire cmd/ consumers to lang registry — all derived, zero hardcoded"
+```
+
+______________________________________________________________________
+
+### Task 5: Deduplicate `ingestTreeSitter` — fix 3 bugs (depends on Task 2)
+
+**Files:**
+
+- Modify: `internal/ingest/engine.go`
+
+- [ ] **Step 1: Write tests for the 3 bugs**
+
+```go
+func TestIngestTreeSitter_BrokenFileID_UsesHash(t *testing.T) {
+	// Two broken files with same basename in different dirs
+	// should NOT overwrite each other
+	// ... create temp dir with dir1/broken.go and dir2/broken.go
+	// ... both with invalid syntax
+	// ... assert both nodes exist with different IDs
+}
+
+func TestIngestTreeSitter_UnmatchedFile_RoutesToProjectFiles(t *testing.T) {
+	// A file whose language has no matching schema nodes
+	// should end up in _project_files/, not silently dropped
+}
+
+func TestReIngestFile_RecordsFileMetadata(t *testing.T) {
+	// After ReIngestFile, the file should be recorded in the index
+	// so subsequent re-ingest with same mtime is skipped
+}
+```
+
+- [ ] **Step 2: Extract `processTreeSitterResult` method**
+
+Create a shared struct and method that both paths use:
+
+```go
+type treeSitterResult struct {
+	path      string
+	realPath  string
+	content   []byte
+	tree      *sitter.Tree
+	lang      *sitter.Language
+	langName  string
+	modTime   time.Time
+	context   []byte
+	readErr   error
+	parseErr  error
+}
+
+func (e *Engine) processTreeSitterResult(r *treeSitterResult) error {
+	// 1. Handle read errors
+	// 2. Handle parse errors → BROKEN_ with SHA256(fullpath) ID
+	// 3. Filter schema nodes by language
+	// 4. No applicable nodes → route to _project_files
+	// 5. processNode for each applicable schema node
+	// 6. No nodes produced → route to _project_files
+	// 7. Atomic swap via ReplaceFileNodes
+	// 8. RecordFile for incremental re-ingestion
+	// 9. Extract and store address refs
+}
+```
+
+- [ ] **Step 3: Rewrite `ingestTreeSitter` (sequential) to use it**
+
+```go
+func (e *Engine) ingestTreeSitter(path string, grammar *sitter.Language, langName string, modTime time.Time) error {
+	r := &treeSitterResult{langName: langName, lang: grammar, modTime: modTime}
+	// ... resolve path, read file, parse ...
+	return e.processTreeSitterResult(r)
+}
+```
+
+- [ ] **Step 4: Rewrite `ingestTreeSitterParallel` phase 2 to use it**
+
+The parallel path's phase 2 loop (lines 608-740) becomes:
+
+```go
+for _, result := range results {
+	if err := e.processTreeSitterResult(&result); err != nil {
+		if firstErr == nil { firstErr = err }
+	}
+}
+```
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: ALL PASS — the 3 new bug-fix tests pass, all existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/ingest/
+git commit -m "fix: deduplicate ingestTreeSitter — fix broken file ID collision, missing fallback, missing RecordFile"
+```
+
+______________________________________________________________________
+
+### Task 6: Delete dead code, final cleanup
+
+**Files:**
+
+- Modify: `internal/ingest/engine.go` — remove unused tree-sitter imports
+
+- Modify: `internal/ingest/language.go` — remove unused tree-sitter imports (now in `lang`)
+
+- Modify: `internal/writeback/validate.go` — remove unused tree-sitter imports
+
+- Modify: `cmd/mount.go` — remove unused tree-sitter imports
+
+- Modify: `cmd/build.go` — replace direct `golang.GetLanguage()` with `lang.ForName("go").Grammar()`
+
+- Modify: `internal/linter/linter.go` — replace direct `golang.GetLanguage()` with `lang.ForName("go").Grammar()`
+
+- Modify: `internal/lattice/project_ast.go` — ensure `"hcl"` key works via alias
+
+- [ ] **Step 1: Remove all tree-sitter imports from consumers**
+
+Every file that previously imported grammar packages directly (golang, python, rust, etc.) should now only import `internal/lang`. The grammar imports live exclusively in `internal/lang/lang.go`.
+
+Exception: `internal/ingest/language.go` may still need direct imports if `GetLanguageProfile` references grammar-specific logic. Check and clean.
+
+- [ ] **Step 2: Run lint**
+
+Run: `task lint`
+Expected: No unused import errors
+
+- [ ] **Step 3: Run full test suite one final time**
+
+Run: `task check`
+Expected: fmt + vet + lint + test + validate ALL PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .
+git commit -m "chore: remove dead tree-sitter imports — all grammars via internal/lang"
+```
+
+______________________________________________________________________
+
+## Verification Checklist
+
+After all tasks complete, verify:
+
+- [ ] `grep -r "case \".go\"" internal/ cmd/` returns ONLY `internal/lang/lang.go` (no more switches)
+- [ ] `grep -r "GetLanguage()" internal/ingest/` returns zero results (deleted)
+- [ ] `grep -r "GetLanguageProfile" internal/` returns zero results (deleted)
+- [ ] `grep -r "langForExt" internal/` returns zero results (deleted)
+- [ ] `grep -r "sourceExtensions" internal/` returns zero results (deleted)
+- [ ] `grep -r "golang.GetLanguage" cmd/ internal/` returns zero results (all via `lang` now)
+- [ ] `lang.ForName("hcl")` returns terraform language (backward compat alias)
+- [ ] `task check` passes (fmt + vet + lint + test + validate)
+- [ ] Adding a new language requires editing exactly ONE file: `internal/lang/lang.go`

--- a/docs/superpowers/plans/2026-03-30-lsp-enrichment-from-leyline-db.md
+++ b/docs/superpowers/plans/2026-03-30-lsp-enrichment-from-leyline-db.md
@@ -1,0 +1,723 @@
+# LSP Enrichment from Ley-line Pre-baked DBs
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make mache's LSP-powered MCP tools (`get_type_info`, `get_diagnostics`, `find_definition`) work from pre-baked `.db` files that ley-line produces — no runtime daemon needed.
+
+**Architecture:** Ley-line's `ll-open/lsp` crate already projects LSP data into 5 SQLite tables (`_lsp`, `_lsp_hover`, `_lsp_defs`, `_lsp_refs`, `_lsp_completions`). Mache's `SQLiteGraph.QueryRefs()` already queries the main DB when `useNodesTable=true`. The work is: (1) generate a test fixture `.db` with AST + LSP tables, (2) extend `find_definition` to use `_lsp_defs` as a fallback, (3) extend `find_callers` to use `_lsp_refs` as a supplement, (4) end-to-end integration test.
+
+**Tech Stack:** Go, SQLite (modernc.org/sqlite), mcp-go, Rust (ley-line fixture generation)
+
+**Bead:** `mache-6060ab`
+
+______________________________________________________________________
+
+## File Structure
+
+| File                            | Action | Responsibility                                                                                            |
+| ------------------------------- | ------ | --------------------------------------------------------------------------------------------------------- |
+| `cmd/serve_lsp.go`              | Modify | Add `_lsp_defs`/`_lsp_refs` query helpers                                                                 |
+| `cmd/serve_handlers.go`         | Modify | Wire LSP fallback into `find_definition`, `find_callers`                                                  |
+| `cmd/serve_test.go`             | Modify | Integration test with pre-baked fixture                                                                   |
+| `testdata/lsp-fixture.db`       | Create | Pre-baked DB with `nodes` + `_ast` + `_source` + `_lsp` + `_lsp_hover` + `_lsp_defs` + `_lsp_refs` tables |
+| `tools/gen-lsp-fixture/main.go` | Create | Go script to generate the fixture DB (pure Go, no ley-line runtime needed)                                |
+
+The fixture generator builds the same tables ley-line would produce, using Go's `database/sql`. This avoids requiring Rust toolchain to run tests.
+
+______________________________________________________________________
+
+### Task 1: Generate LSP fixture DB
+
+The fixture simulates what `ley-line` produces: a Go file parsed into `nodes` + `_ast` + `_source` tables (for ASTWalker), plus LSP enrichment in `_lsp` + `_lsp_hover` + `_lsp_defs` + `_lsp_refs`.
+
+**Files:**
+
+- Create: `tools/gen-lsp-fixture/main.go`
+
+- Create: `testdata/lsp-fixture.db` (generated output)
+
+- [ ] **Step 1: Write the fixture generator**
+
+```go
+// tools/gen-lsp-fixture/main.go
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"os"
+
+	_ "modernc.org/sqlite"
+)
+
+func main() {
+	outPath := "testdata/lsp-fixture.db"
+	if len(os.Args) > 1 {
+		outPath = os.Args[1]
+	}
+	_ = os.Remove(outPath)
+
+	db, err := sql.Open("sqlite", outPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer db.Close()
+
+	// Schema: matches ley-line's leyline-schema + ll-open/ts + ll-open/lsp
+	must(db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY,
+			parent_id TEXT,
+			name TEXT NOT NULL,
+			kind INTEGER NOT NULL,
+			size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL,
+			record_id TEXT,
+			record JSON,
+			source_file TEXT
+		);
+		CREATE INDEX idx_parent_name ON nodes(parent_id, name);
+
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY,
+			source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL,
+			end_byte INTEGER NOT NULL,
+			start_row INTEGER NOT NULL,
+			start_col INTEGER NOT NULL,
+			end_row INTEGER NOT NULL,
+			end_col INTEGER NOT NULL
+		);
+		CREATE INDEX idx_ast_source ON _ast(source_id);
+
+		CREATE TABLE _source (
+			id TEXT PRIMARY KEY,
+			language TEXT NOT NULL,
+			content BLOB NOT NULL
+		);
+
+		CREATE TABLE _lsp (
+			node_id TEXT PRIMARY KEY,
+			symbol_kind TEXT,
+			detail TEXT,
+			start_line INTEGER NOT NULL,
+			start_col INTEGER NOT NULL,
+			end_line INTEGER NOT NULL,
+			end_col INTEGER NOT NULL,
+			diagnostics TEXT
+		);
+		CREATE INDEX idx_lsp_kind ON _lsp(symbol_kind);
+
+		CREATE TABLE _lsp_hover (
+			node_id TEXT PRIMARY KEY,
+			hover_text TEXT NOT NULL
+		);
+
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL,
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL,
+			def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL,
+			def_end_col INTEGER NOT NULL
+		);
+		CREATE INDEX idx_lsp_defs_node ON _lsp_defs(node_id);
+
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL,
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL,
+			ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL,
+			ref_end_col INTEGER NOT NULL
+		);
+		CREATE INDEX idx_lsp_refs_node ON _lsp_refs(node_id);
+
+		CREATE TABLE node_refs (
+			token TEXT NOT NULL,
+			node_id TEXT NOT NULL
+		);
+		CREATE INDEX idx_node_refs_token ON node_refs(token);
+	`))
+
+	src := []byte("package main\n\nimport \"fmt\"\n\nfunc Validate(x int) error {\n\treturn fmt.Errorf(\"invalid: %d\", x)\n}\n\nfunc Helper() string {\n\treturn \"ok\"\n}\n\ntype Config struct {\n\tName string\n}\n")
+	must(db.Exec("INSERT INTO _source VALUES (?, ?, ?)", "main.go", "go", src))
+
+	// nodes — root + source_file + functions + type
+	nodes := [][5]any{
+		{"", "", "", 1, ""},
+		{"source_file", "", "source_file", 1, ""},
+		{"source_file/function_declaration", "source_file", "function_declaration", 1, ""},
+		{"source_file/function_declaration/identifier", "source_file/function_declaration", "identifier", 0, "Validate"},
+		{"source_file/function_declaration/parameter_list", "source_file/function_declaration", "parameter_list", 1, ""},
+		{"source_file/function_declaration/block", "source_file/function_declaration", "block", 1, ""},
+		{"source_file/function_declaration_1", "source_file", "function_declaration_1", 1, ""},
+		{"source_file/function_declaration_1/identifier", "source_file/function_declaration_1", "identifier", 0, "Helper"},
+		{"source_file/function_declaration_1/parameter_list", "source_file/function_declaration_1", "parameter_list", 1, ""},
+		{"source_file/function_declaration_1/block", "source_file/function_declaration_1", "block", 1, ""},
+		{"source_file/type_declaration", "source_file", "type_declaration", 1, ""},
+		{"source_file/type_declaration/type_spec", "source_file/type_declaration", "type_spec", 1, ""},
+		{"source_file/type_declaration/type_spec/type_identifier", "source_file/type_declaration/type_spec", "type_identifier", 0, "Config"},
+	}
+	for _, n := range nodes {
+		must(db.Exec("INSERT INTO nodes (id, parent_id, name, kind, size, mtime, record) VALUES (?,?,?,?,0,0,?)", n[0], n[1], n[2], n[3], n[4]))
+	}
+
+	// _ast rows
+	astRows := [][4]any{
+		{"source_file/function_declaration", "function_declaration", 28, 94},
+		{"source_file/function_declaration/identifier", "identifier", 33, 41},
+		{"source_file/function_declaration_1", "function_declaration", 96, 134},
+		{"source_file/function_declaration_1/identifier", "identifier", 101, 107},
+		{"source_file/type_declaration", "type_declaration", 136, 171},
+		{"source_file/type_declaration/type_spec", "type_spec", 141, 171},
+		{"source_file/type_declaration/type_spec/type_identifier", "type_identifier", 146, 152},
+	}
+	for _, a := range astRows {
+		must(db.Exec("INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, 'main.go', ?, ?, ?, 0, 0, 0, 0)", a[0], a[1], a[2], a[3]))
+	}
+
+	// LSP enrichment — simulate what gopls would produce
+	// _lsp: symbol metadata with line ranges
+	must(db.Exec(`INSERT INTO _lsp VALUES ('source_file/function_declaration', 'function', 'func Validate(x int) error', 4, 0, 6, 1, NULL)`))
+	must(db.Exec(`INSERT INTO _lsp VALUES ('source_file/function_declaration_1', 'function', 'func Helper() string', 8, 0, 10, 1, NULL)`))
+	must(db.Exec(`INSERT INTO _lsp VALUES ('source_file/type_declaration', 'struct', 'type Config struct', 12, 0, 14, 1, NULL)`))
+
+	// _lsp_hover: hover text per symbol
+	must(db.Exec(`INSERT INTO _lsp_hover VALUES ('source_file/function_declaration', 'func Validate(x int) error')`))
+	must(db.Exec(`INSERT INTO _lsp_hover VALUES ('source_file/function_declaration_1', 'func Helper() string')`))
+	must(db.Exec(`INSERT INTO _lsp_hover VALUES ('source_file/type_declaration', 'type Config struct {\n\tName string\n}')`))
+
+	// _lsp_defs: go-to-definition results
+	must(db.Exec(`INSERT INTO _lsp_defs VALUES ('source_file/function_declaration', 'file:///main.go', 4, 5, 6, 1)`))
+	must(db.Exec(`INSERT INTO _lsp_defs VALUES ('source_file/type_declaration', 'file:///main.go', 12, 5, 14, 1)`))
+
+	// _lsp_refs: find-references results
+	must(db.Exec(`INSERT INTO _lsp_refs VALUES ('source_file/function_declaration', 'file:///main_test.go', 10, 2, 10, 10)`))
+	must(db.Exec(`INSERT INTO _lsp_refs VALUES ('source_file/function_declaration', 'file:///handler.go', 25, 8, 25, 16)`))
+	must(db.Exec(`INSERT INTO _lsp_refs VALUES ('source_file/type_declaration', 'file:///config.go', 5, 10, 5, 16)`))
+
+	// node_refs: cross-references for callers/ virtual dir
+	must(db.Exec(`INSERT INTO node_refs VALUES ('Validate', 'source_file/function_declaration')`))
+	must(db.Exec(`INSERT INTO node_refs VALUES ('Helper', 'source_file/function_declaration_1')`))
+	must(db.Exec(`INSERT INTO node_refs VALUES ('Config', 'source_file/type_declaration')`))
+
+	fmt.Printf("Generated %s\n", outPath)
+}
+
+func must(_ sql.Result, err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+```
+
+- [ ] **Step 2: Generate the fixture**
+
+Run: `go run tools/gen-lsp-fixture/main.go testdata/lsp-fixture.db`
+Expected: `Generated testdata/lsp-fixture.db`
+
+Verify: `sqlite3 testdata/lsp-fixture.db ".tables"` should show: `_ast _lsp _lsp_defs _lsp_hover _lsp_refs _source node_refs nodes`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/gen-lsp-fixture/main.go testdata/lsp-fixture.db
+git commit -m "test: add LSP fixture DB for pre-baked ley-line integration"
+```
+
+______________________________________________________________________
+
+### Task 2: Add `_lsp_defs` query helper to serve_lsp.go
+
+Extend the LSP query layer to read `_lsp_defs` for definition lookups. This supplements the existing `DefsMap()` approach (which uses in-memory refs) with LSP-sourced definitions.
+
+**Files:**
+
+- Modify: `cmd/serve_lsp.go`
+
+- Test: `cmd/serve_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cmd/serve_test.go` after the existing `TestSQLiteGraphGoldenPath`:
+
+```go
+// TestLSPEnrichedDefinition verifies that find_definition returns LSP-sourced
+// definition locations from _lsp_defs when the pre-baked DB has them.
+func TestLSPEnrichedDefinition(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	dbPath := filepath.Join(repoRoot, "testdata", "lsp-fixture.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Skip("testdata/lsp-fixture.db not found — run: go run tools/gen-lsp-fixture/main.go")
+	}
+
+	schemaBytes := []byte(`{"table":"nodes","nodes":[{"name":"functions","selector":"(function_declaration name: (identifier) @name) @scope","files":[{"name":"source","template":"{{.source}}"}]}]}`)
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal(schemaBytes, &schema))
+
+	sg, err := graph.OpenSQLiteGraph(dbPath, &schema, machetmpl.Render)
+	require.NoError(t, err)
+	defer func() { _ = sg.Close() }()
+	require.NoError(t, sg.EagerScan())
+
+	// Query LSP definitions for Validate
+	handler := makeLSPDefinitionHandler(sg)
+	result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "unexpected error: %s", resultText(t, result))
+
+	text := resultText(t, result)
+	assert.Contains(t, text, "file:///main.go", "should contain definition URI")
+	assert.Contains(t, text, "Validate", "should contain symbol name")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestLSPEnrichedDefinition -v`
+Expected: FAIL — `makeLSPDefinitionHandler` undefined
+
+- [ ] **Step 3: Add `queryLSPDefs` helper and `makeLSPDefinitionHandler`**
+
+Add to `cmd/serve_lsp.go`:
+
+```go
+// queryLSPDefs returns definition locations from _lsp_defs for a symbol.
+// The symbol is matched against node_id suffix (e.g., "Validate" matches
+// "source_file/function_declaration" if the node's _ast has that identifier).
+func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
+	// Check if _lsp_defs table exists
+	var tableExists int
+	rows, err := qg.QueryRefs(`SELECT count(*) FROM sqlite_master WHERE type='table' AND name='_lsp_defs'`)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		_ = rows.Scan(&tableExists)
+	}
+	_ = rows.Close()
+	if tableExists == 0 {
+		return nil, nil
+	}
+
+	// Join _lsp_defs with nodes to match by symbol name.
+	// The identifier node's record column contains the symbol text.
+	query := `SELECT d.node_id, d.def_uri, d.def_start_line, d.def_start_col, d.def_end_line, d.def_end_col
+		FROM _lsp_defs d
+		JOIN nodes n ON n.parent_id = d.node_id AND n.record = ?
+		JOIN _ast a ON a.node_id = n.id AND a.node_kind = 'identifier'`
+	rows, err = qg.QueryRefs(query, symbol)
+	if err != nil {
+		// Fallback: suffix match on node_id
+		rows, err = qg.QueryRefs(
+			`SELECT node_id, def_uri, def_start_line, def_start_col, def_end_line, def_end_col
+			 FROM _lsp_defs WHERE node_id LIKE ?`,
+			"%"+escapeLikeMeta(symbol)+"%",
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var results []lspDefLocation
+	for rows.Next() {
+		var r lspDefLocation
+		if err := rows.Scan(&r.NodeID, &r.URI, &r.StartLine, &r.StartCol, &r.EndLine, &r.EndCol); err != nil {
+			continue
+		}
+		results = append(results, r)
+	}
+	_ = rows.Close()
+	return results, nil
+}
+
+type lspDefLocation struct {
+	NodeID    string `json:"node_id"`
+	URI       string `json:"uri"`
+	StartLine int    `json:"start_line"`
+	StartCol  int    `json:"start_col"`
+	EndLine   int    `json:"end_line"`
+	EndCol    int    `json:"end_col"`
+}
+
+// queryLSPRefs returns reference locations from _lsp_refs for a symbol.
+func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
+	var tableExists int
+	rows, err := qg.QueryRefs(`SELECT count(*) FROM sqlite_master WHERE type='table' AND name='_lsp_refs'`)
+	if err != nil {
+		return nil, err
+	}
+	if rows.Next() {
+		_ = rows.Scan(&tableExists)
+	}
+	_ = rows.Close()
+	if tableExists == 0 {
+		return nil, nil
+	}
+
+	query := `SELECT d.node_id, d.ref_uri, d.ref_start_line, d.ref_start_col, d.ref_end_line, d.ref_end_col
+		FROM _lsp_refs d
+		JOIN nodes n ON n.parent_id = d.node_id AND n.record = ?
+		JOIN _ast a ON a.node_id = n.id AND a.node_kind = 'identifier'`
+	rows, err = qg.QueryRefs(query, symbol)
+	if err != nil {
+		rows, err = qg.QueryRefs(
+			`SELECT node_id, ref_uri, ref_start_line, ref_start_col, ref_end_line, ref_end_col
+			 FROM _lsp_refs WHERE node_id LIKE ?`,
+			"%"+escapeLikeMeta(symbol)+"%",
+		)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var results []lspRefLocation
+	for rows.Next() {
+		var r lspRefLocation
+		if err := rows.Scan(&r.NodeID, &r.URI, &r.StartLine, &r.StartCol, &r.EndLine, &r.EndCol); err != nil {
+			continue
+		}
+		results = append(results, r)
+	}
+	_ = rows.Close()
+	return results, nil
+}
+
+type lspRefLocation struct {
+	NodeID    string `json:"node_id"`
+	URI       string `json:"uri"`
+	StartLine int    `json:"start_line"`
+	StartCol  int    `json:"start_col"`
+	EndLine   int    `json:"end_line"`
+	EndCol    int    `json:"end_col"`
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestLSPEnrichedDefinition -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/serve_lsp.go cmd/serve_test.go
+git commit -m "feat: queryLSPDefs/queryLSPRefs — read ley-line LSP tables from pre-baked DBs"
+```
+
+______________________________________________________________________
+
+### Task 3: Wire LSP fallback into `find_definition`
+
+Extend the existing `makeFindDefinitionHandler` to fall back to `_lsp_defs` when the in-memory `DefsMap()` has no match.
+
+**Files:**
+
+- Modify: `cmd/serve_handlers.go:742-800`
+
+- Test: `cmd/serve_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `cmd/serve_test.go`:
+
+```go
+// TestFindDefinition_LSPFallback verifies that find_definition uses _lsp_defs
+// as a fallback when DefsMap() has no match (pre-baked DB path).
+func TestFindDefinition_LSPFallback(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	dbPath := filepath.Join(repoRoot, "testdata", "lsp-fixture.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Skip("testdata/lsp-fixture.db not found")
+	}
+
+	schemaBytes := []byte(`{"table":"nodes","nodes":[{"name":"functions","selector":"(function_declaration name: (identifier) @name) @scope","files":[{"name":"source","template":"{{.source}}"}]}]}`)
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal(schemaBytes, &schema))
+
+	sg, err := graph.OpenSQLiteGraph(dbPath, &schema, machetmpl.Render)
+	require.NoError(t, err)
+	defer func() { _ = sg.Close() }()
+	require.NoError(t, sg.EagerScan())
+
+	handler := makeFindDefinitionHandler(sg)
+	result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "unexpected error: %s", resultText(t, result))
+
+	text := resultText(t, result)
+	// Should contain LSP definition location
+	assert.Contains(t, text, "file:///main.go", "should have LSP def URI")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestFindDefinition_LSPFallback -v`
+Expected: FAIL — `find_definition` returns "no definition found" because `DefsMap()` is empty for SQLiteGraph without ingestion.
+
+- [ ] **Step 3: Add LSP fallback to `makeFindDefinitionHandler`**
+
+In `cmd/serve_handlers.go`, after the existing "no exact definition" block (~line 786), add the LSP fallback:
+
+```go
+			// Before returning "no definition found", try LSP-enriched defs
+			if qg, ok := g.(refsQuerier); ok {
+				lspDefs, err := queryLSPDefs(qg, symbol)
+				if err == nil && len(lspDefs) > 0 {
+					type lspDefResult struct {
+						Symbol      string           `json:"symbol"`
+						Source      string           `json:"source"`
+						Definitions []lspDefLocation `json:"definitions"`
+					}
+					data, _ := json.MarshalIndent(lspDefResult{
+						Symbol:      symbol,
+						Source:      "lsp",
+						Definitions: lspDefs,
+					}, "", "  ")
+					return mcp.NewToolResultText(string(data)), nil
+				}
+			}
+```
+
+Insert this right before the final `return mcp.NewToolResultText(fmt.Sprintf("no definition found for %q", symbol)), nil` at line ~787.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestFindDefinition_LSPFallback -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: All existing tests still pass — the LSP fallback only triggers when DefsMap() misses.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/serve_handlers.go cmd/serve_test.go
+git commit -m "feat: find_definition falls back to _lsp_defs from ley-line pre-baked DBs"
+```
+
+______________________________________________________________________
+
+### Task 4: Wire LSP refs into `find_callers` supplement
+
+Extend `find_callers` to include `_lsp_refs` locations alongside existing cross-reference results.
+
+**Files:**
+
+- Modify: `cmd/serve_handlers.go` (find_callers handler area)
+
+- Test: `cmd/serve_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+// TestFindCallers_LSPRefs verifies that find_callers includes _lsp_refs
+// locations from ley-line pre-baked DBs.
+func TestFindCallers_LSPRefs(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	dbPath := filepath.Join(repoRoot, "testdata", "lsp-fixture.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Skip("testdata/lsp-fixture.db not found")
+	}
+
+	schemaBytes := []byte(`{"table":"nodes","nodes":[{"name":"functions","selector":"(function_declaration name: (identifier) @name) @scope","files":[{"name":"source","template":"{{.source}}"}]}]}`)
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal(schemaBytes, &schema))
+
+	sg, err := graph.OpenSQLiteGraph(dbPath, &schema, machetmpl.Render)
+	require.NoError(t, err)
+	defer func() { _ = sg.Close() }()
+	require.NoError(t, sg.EagerScan())
+
+	handler := makeFindCallersHandler(sg)
+	result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "unexpected error: %s", resultText(t, result))
+
+	text := resultText(t, result)
+	// Validate has 2 LSP refs: main_test.go and handler.go
+	assert.Contains(t, text, "main_test.go", "should have LSP ref from main_test.go")
+	assert.Contains(t, text, "handler.go", "should have LSP ref from handler.go")
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `task test -- -run TestFindCallers_LSPRefs -v`
+Expected: FAIL — `find_callers` doesn't check `_lsp_refs` yet.
+
+- [ ] **Step 3: Add LSP refs supplement to find_callers handler**
+
+In `cmd/serve_handlers.go`, find the `makeFindCallersHandler` function. After the existing callers lookup, add:
+
+```go
+		// Supplement with LSP references if available
+		if qg, ok := g.(refsQuerier); ok {
+			lspRefs, err := queryLSPRefs(qg, symbol)
+			if err == nil && len(lspRefs) > 0 {
+				for _, ref := range lspRefs {
+					callerEntries = append(callerEntries, callerEntry{
+						Path:   ref.URI,
+						Source: "lsp",
+						Line:   ref.StartLine,
+					})
+				}
+			}
+		}
+```
+
+The exact integration point depends on the current `makeFindCallersHandler` structure — read it and insert after the graph-based callers are collected, before the JSON response is assembled.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `task test -- -run TestFindCallers_LSPRefs -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite**
+
+Run: `task test`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cmd/serve_handlers.go cmd/serve_test.go
+git commit -m "feat: find_callers supplements with _lsp_refs from ley-line pre-baked DBs"
+```
+
+______________________________________________________________________
+
+### Task 5: End-to-end integration test
+
+Full pipeline test: fixture DB → SQLiteGraph + ASTWalker → all LSP-enriched MCP tools.
+
+**Files:**
+
+- Modify: `cmd/serve_test.go`
+
+- [ ] **Step 1: Write the integration test**
+
+```go
+// TestLSPPrebakedEndToEnd exercises the complete pre-baked ley-line pipeline:
+// fixture DB (nodes + _ast + _source + _lsp* tables) → SQLiteGraph →
+// ASTWalker → all LSP-enriched MCP tools. No runtime daemon needed.
+func TestLSPPrebakedEndToEnd(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Dir(filepath.Dir(thisFile))
+
+	dbPath := filepath.Join(repoRoot, "testdata", "lsp-fixture.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Skip("testdata/lsp-fixture.db not found")
+	}
+
+	schemaBytes := []byte(`{"table":"nodes","nodes":[{"name":"functions","selector":"(function_declaration name: (identifier) @name) @scope","files":[{"name":"source","template":"{{.source}}"}]}]}`)
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal(schemaBytes, &schema))
+
+	sg, err := graph.OpenSQLiteGraph(dbPath, &schema, machetmpl.Render)
+	require.NoError(t, err)
+	defer func() { _ = sg.Close() }()
+	require.NoError(t, sg.EagerScan())
+
+	t.Run("get_type_info", func(t *testing.T) {
+		handler := makeGetTypeInfoHandler(sg)
+		result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+		require.NoError(t, err)
+		require.False(t, result.IsError, resultText(t, result))
+		assert.Contains(t, resultText(t, result), "func Validate(x int) error")
+	})
+
+	t.Run("get_diagnostics", func(t *testing.T) {
+		handler := makeGetDiagnosticsHandler(sg)
+		result, err := handler(context.Background(), makeRequest(map[string]any{}))
+		require.NoError(t, err)
+		// No diagnostics in fixture — should return clean
+		require.False(t, result.IsError, resultText(t, result))
+	})
+
+	t.Run("find_definition_lsp", func(t *testing.T) {
+		handler := makeFindDefinitionHandler(sg)
+		result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+		require.NoError(t, err)
+		require.False(t, result.IsError, resultText(t, result))
+		assert.Contains(t, resultText(t, result), "file:///main.go")
+	})
+
+	t.Run("find_callers_lsp", func(t *testing.T) {
+		handler := makeFindCallersHandler(sg)
+		result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Validate"}))
+		require.NoError(t, err)
+		require.False(t, result.IsError, resultText(t, result))
+		text := resultText(t, result)
+		assert.Contains(t, text, "main_test.go")
+		assert.Contains(t, text, "handler.go")
+	})
+
+	t.Run("get_overview", func(t *testing.T) {
+		handler := makeGetOverviewHandler(sg)
+		result, err := handler(context.Background(), makeRequest(map[string]any{}))
+		require.NoError(t, err)
+		require.False(t, result.IsError, resultText(t, result))
+		assert.NotEmpty(t, resultText(t, result))
+	})
+}
+```
+
+- [ ] **Step 2: Run to verify it passes**
+
+Run: `task test -- -run TestLSPPrebakedEndToEnd -v`
+Expected: All subtests PASS.
+
+- [ ] **Step 3: Run full suite**
+
+Run: `task test`
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/serve_test.go
+git commit -m "test: end-to-end LSP pre-baked pipeline — fixture DB → SQLiteGraph → MCP tools"
+```
+
+______________________________________________________________________
+
+### Task 6: Update bead and docs
+
+- [ ] **Step 1: Comment on bead with what was done**
+
+```bash
+rsry bead comment mache-6060ab "LSP pre-baked path implemented: mache reads _lsp_defs/_lsp_refs from ley-line DBs. find_definition falls back to LSP defs, find_callers supplements with LSP refs. E2E test with fixture DB."
+```
+
+- [ ] **Step 2: Update CLAUDE.md if needed**
+
+Add a bullet under Key Design Details:
+
+```
+- **LSP enrichment**: When a `.db` has `_lsp*` tables (produced by ley-line's `ll-open/lsp`), `find_definition` falls back to `_lsp_defs` and `find_callers` supplements with `_lsp_refs`. No runtime daemon needed — pre-baked at build time.
+```
+
+- [ ] **Step 3: Commit and close bead**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: document LSP enrichment from pre-baked ley-line DBs"
+rsry bead close mache-6060ab
+```

--- a/docs/superpowers/specs/2026-03-24-art-platform-release-infrastructure-design.md
+++ b/docs/superpowers/specs/2026-03-24-art-platform-release-infrastructure-design.md
@@ -1,0 +1,828 @@
+# ART Platform Release Infrastructure
+
+**Date**: 2026-03-24
+**Status**: Draft
+**Scope**: Cross-repo — affects `.github`, `rig`, `kiln`, `mache`, `ley-line`, `rosary`, `signet`
+
+## Problem
+
+The ART stack (mache, ley-line, rosary, signet) has fragmented release infrastructure:
+
+- Release workflows exist in individual repos but are copy-pasted, inconsistent, and partially broken
+- Merges to main cascade to kiln immediately with no release gate
+- No shared CI (testing, linting, pre-commit) — each repo reinvents it
+- GitHub repo settings (branch protection, secrets, dependabot) are manually configured per repo
+- Signet commit signing and artifact signing exist in code but are never activated
+- No trust chain from commit → build → artifact → distribution
+- Copilot PR reviews burn credits on external contributor PRs
+
+## Architecture
+
+Three layers, clean separation of concerns:
+
+```
+agentic-research/.github (public)     rig/tofu/modules/github (private)
+├── Reusable workflows                ├── Repo settings (TF)
+│   ├── go-ci.yml                     ├── Branch protection
+│   ├── rust-ci.yml                   ├── Secrets & variables
+│   ├── go-release.yml                ├── Dependabot config
+│   ├── rust-release.yml              ├── Copilot review rules
+│   ├── pre-commit.yml                └── Required status checks
+│   ├── signet-resign.yml
+│   └── signet-sign.yml               kiln (public)
+├── .pre-commit-config.yaml            ├── Downloads upstream artifacts
+└── README.md                          ├── Links Go + Rust backends
+                                       │   ├── mache + ley-line (staticlib)
+                                       │   └── signet + signet-sign (wasm)
+                                       ├── Packages all 4 tools
+                                       ├── Publishes to homebrew-tap
+                                       ├── Builds OCI images (apko/krust)
+                                       └── Signs artifacts (signet + cosign)
+```
+
+### Data Flow
+
+```
+repo tag (v*)
+  → shared workflow builds + tests
+  → GH Release (binaries + checksums)
+  → signet sign (artifact signatures)
+  → repository_dispatch to kiln
+      → kiln downloads artifacts
+      → kiln links Rust backends (where applicable)
+      → kiln publishes:
+          - Homebrew tap (Formula/mache.rb, Formula/signet.rb, etc.)
+          - OCI images (apko for Go, krust for Rust)
+          - cosign signatures (sigstore transparency log)
+      → signet-resign re-signs merge commit
+```
+
+## Component Design
+
+### 1. Reusable Workflows (`agentic-research/.github`)
+
+All workflows live in `.github/workflows/` in the org-level `.github` repo.
+Consuming repos call them with one-liner workflow files.
+
+#### `go-ci.yml` — Go CI (mache, signet)
+
+```yaml
+# Caller interface
+on:
+  workflow_call:
+    inputs:
+      go-version-file:
+        type: string
+        default: 'go.mod'  # reads toolchain directive, not a hardcoded version
+      cgo:
+        type: boolean
+        default: false
+      task-test-cmd:
+        type: string
+        default: 'task test'
+      task-lint-cmd:
+        type: string
+        default: 'task lint'
+      platforms:
+        type: string
+        default: '["ubuntu-latest", "macos-latest"]'
+```
+
+Steps:
+
+- Install Go + Task
+- If `cgo`: install platform FUSE deps (fuse-t on macOS, libfuse-dev on Linux)
+- `task fmt` → check no diff
+- `task vet`
+- `task lint` (golangci-lint)
+- `task test` (with `-race`)
+
+#### `rust-ci.yml` — Rust CI (ley-line, rosary)
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      rust-version:
+        type: string
+        default: 'stable'
+      features:
+        type: string
+        default: ''
+      platforms:
+        type: string
+        default: '["ubuntu-latest"]'
+      cargo-test-args:
+        type: string
+        default: ''
+```
+
+Steps:
+
+- Install Rust toolchain + Task
+- Platform deps (libfuse3-dev on Linux, capnp if needed)
+- `task fmt` (proxies to cargo fmt, consistent with Go path)
+- `task lint` (proxies to cargo clippy)
+- `task test`
+
+Note: All steps use `task` commands, never raw `cargo`. Repos must have a
+Taskfile.yml that wraps cargo commands with appropriate env/flags.
+
+#### `go-release.yml` — Go Release (mache, signet)
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        type: string
+        default: '["darwin-arm64", "linux-amd64", "linux-arm64"]'
+      cgo:
+        type: boolean
+        default: false
+      dispatch-to:
+        type: string
+        default: '[]'  # JSON array of "owner/repo" strings
+      binary-name:
+        type: string
+        required: true
+    secrets:
+      LEYLINE_PAT:
+        required: false
+      SIGNET_MASTER_KEY:
+        required: false
+```
+
+Steps:
+
+- Build matrix (per platform, maps to GHA runners: macos-latest, ubuntu-latest, ubuntu-24.04-arm)
+- CGO setup when `cgo: true`
+- `task release` (Taskfile wraps go build + ldflags + codesigning)
+- Collect artifacts + SHA256 checksums
+- If `SIGNET_MASTER_KEY` is set: download signet binary, `signet sign checksums-sha256.txt`
+- Create GH Release with all artifacts + `.sig` files
+- `repository_dispatch` to each repo in `dispatch-to`
+
+Note: All build steps use `task` commands, never raw `go build`. The Taskfile
+handles CGO flags, ldflags version injection, and macOS codesigning.
+
+#### `rust-release.yml` — Rust Release (ley-line, rosary)
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      platforms:
+        type: string
+        default: '["darwin-arm64", "linux-amd64", "linux-arm64"]'
+      staticlib:
+        type: boolean
+        default: false
+      cbindgen-header:
+        type: boolean
+        default: false
+      wasm:
+        type: boolean
+        default: false
+      crate:
+        type: string
+        required: true
+      features:
+        type: string
+        default: ''
+      dispatch-to:
+        type: string
+        default: '[]'
+    secrets:
+      SIGNET_MASTER_KEY:
+        required: false
+```
+
+Steps:
+
+- Cargo build matrix (per platform, `cargo-zigbuild` for cross-compile)
+- If `staticlib`: produce `.a` + optional `.h` (cbindgen)
+- If `wasm`: build for `wasm32-unknown-unknown`
+- Collect artifacts + SHA256 checksums
+- If `SIGNET_MASTER_KEY`: `signet sign checksums-sha256.txt`
+- Create GH Release
+- `repository_dispatch` to downstream
+
+#### `pre-commit.yml` — Shared Pre-commit
+
+```yaml
+on:
+  workflow_call:
+    inputs:
+      config-source:
+        type: string
+        default: 'remote'  # 'remote' uses .github repo config, 'local' uses repo's own
+```
+
+Steps:
+
+- Checkout
+- If `remote`: fetch `.pre-commit-config.yaml` from `agentic-research/.github`
+- `pre-commit run --all-files`
+
+The shared `.pre-commit-config.yaml` in `.github` includes:
+
+- gofumpt (Go repos, gated with `types: [go]` so it skips Rust repos)
+- rustfmt (Rust repos, gated with `types: [rust]` so it skips Go repos)
+- File hygiene (trailing whitespace, large files, merge conflicts)
+- Markdown formatting (mdformat)
+- YAML/JSON validation
+- gitleaks (secret detection)
+
+Language-specific hooks use pre-commit's `types:` or `types_or:` filtering so
+the shared config works in any repo without errors — Go hooks skip in Rust repos
+and vice versa. Repos that need additional hooks beyond the shared set can use
+`config-source: local` with a local `.pre-commit-config.yaml` that imports
+the shared config via `default_install_hook_types`.
+
+#### `signet-resign.yml` — Post-Merge Commit Re-signing
+
+```yaml
+on:
+  workflow_call:
+    secrets:
+      SIGNET_MASTER_KEY:
+        required: true
+```
+
+Steps:
+
+- Guard: `if: ${{ vars.SIGNET_RESIGN_ENABLED == 'true' }}`
+- Build signet from source (or download from GH Release)
+- `signet authority start` with master key from secret
+- Exchange GHA OIDC token for Ed25519 bridge cert
+- Configure `git config gpg.x509.program signet-git`
+- Amend HEAD commit with signet signature (preserve author/committer)
+- `git push --force-with-lease` using a GitHub App token or PAT (not GITHUB_TOKEN)
+
+Note: GITHUB_TOKEN cannot force-push to protected branches even with
+`enforce_admins: false`. The resign workflow requires a token with branch
+protection bypass rights. TF wires this as a repo secret (`RESIGN_TOKEN`)
+generated from a GitHub App installation. GITHUB_TOKEN's inability to
+retrigger workflows still provides loop prevention — the App token push
+will trigger workflows but the `SIGNET_RESIGN_ENABLED` guard + concurrency
+lock prevent infinite loops.
+
+#### `copilot-review.yml` — Gated Copilot PR Review
+
+```yaml
+on:
+  workflow_call:
+    # No inputs — uses github.event context
+```
+
+Steps:
+
+- Check `github.event.pull_request.author_association`
+- If `OWNER`, `MEMBER`, or `COLLABORATOR`: request Copilot review
+- If `FIRST_TIMER`, `CONTRIBUTOR`, `NONE`: skip (don't burn credits)
+
+### 2. Consuming Repo Workflow Files
+
+Each repo has minimal workflow files that call the shared ones.
+
+**Example: `mache/.github/workflows/ci.yml`**
+
+```yaml
+name: CI
+on:
+  push:
+    branches: [main]
+    paths-ignore: ['docs/**', '*.md', 'LICENSE']
+  pull_request:
+    paths-ignore: ['docs/**', '*.md', 'LICENSE']
+
+jobs:
+  ci:
+    uses: agentic-research/.github/.github/workflows/go-ci.yml@main
+    with:
+      cgo: true
+      task-test-cmd: 'task test'
+  pre-commit:
+    uses: agentic-research/.github/.github/workflows/pre-commit.yml@main
+  copilot:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: agentic-research/.github/.github/workflows/copilot-review.yml@main
+```
+
+**Example: `mache/.github/workflows/release.yml`**
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    uses: agentic-research/.github/.github/workflows/go-release.yml@main
+    with:
+      binary-name: mache
+      cgo: true
+      dispatch-to: '["agentic-research/kiln"]'
+    secrets: inherit
+  resign:
+    needs: release
+    uses: agentic-research/.github/.github/workflows/signet-resign.yml@main
+    secrets: inherit
+```
+
+**Example: `ley-line/.github/workflows/release.yml`**
+
+```yaml
+name: Release
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  release:
+    uses: agentic-research/.github/.github/workflows/rust-release.yml@main
+    with:
+      crate: leyline-cli
+      features: 'lsp,embed'
+      staticlib: true
+      cbindgen-header: true
+      wasm: false
+      dispatch-to: '["agentic-research/kiln"]'  # kiln only — kiln pulls latest mache
+    secrets: inherit
+```
+
+### 3. Kiln — Distribution Hub
+
+Kiln receives `repository_dispatch` events from all four repos and produces
+publishable artifacts.
+
+#### Dispatch Matrix
+
+| Source Event      | Kiln Action                                                        |
+| ----------------- | ------------------------------------------------------------------ |
+| `mache-release`   | Download mache + ley-line → link with `-tags leyline` → package    |
+| `leyline-release` | Download ley-line + latest mache → rebuild linked binary → package |
+| `signet-release`  | Download signet + signet-sign → link WASM backend → package        |
+| `rosary-release`  | Download rosary binary → package                                   |
+
+#### Build Outputs Per Tool
+
+| Tool     | Homebrew            | OCI (apko)              | OCI (krust)       | Signed          |
+| -------- | ------------------- | ----------------------- | ----------------- | --------------- |
+| mache    | `Formula/mache.rb`  | Yes (Go + LL staticlib) | —                 | signet + cosign |
+| signet   | `Formula/signet.rb` | Yes (Go + WASM)         | —                 | signet + cosign |
+| ley-line | —                   | —                       | Yes (Rust static) | signet + cosign |
+| rosary   | —                   | —                       | Yes (Rust static) | signet + cosign |
+
+#### Homebrew Tap (`agentic-research/homebrew-tap`)
+
+- `Formula/mache.rb` — installs two binaries: `mache` + `leyline` (kiln-built)
+- `Formula/signet.rb` — signet with signet-sign WASM backend (kiln-built)
+- Updated automatically by kiln's release workflow
+- `brew install agentic-research/tap/mache`
+- `brew install agentic-research/tap/signet`
+
+**Batteries-included model for mache + ley-line:**
+
+- `mache` works fully without ley-line — code intelligence, FUSE/NFS, MCP, callers/callees, refs
+- `leyline` binary ships alongside but is inert until explicitly activated (`leyline daemon`)
+- When running, mache auto-discovers leyline via UDS socket → enables semantic search + embeddings
+- No auto-start, no background process, no surprise closed-source activity
+- `brew info mache` documents leyline as an optional closed-source companion
+- Users who want mache-only: `go install` from source (fully open, no LL)
+
+Rosary and ley-line are server-side / developer tools — no standalone brew formula needed.
+Ley-line ships as a companion binary inside the mache formula, not as its own formula.
+
+#### OCI Images
+
+- **Go tools** (mache, signet): melange APK → apko distroless image
+- **Rust tools** (rosary, ley-line): krust (cargo-zigbuild → static musl → distroless OCI)
+- All images: multi-arch (amd64 + arm64), signed with cosign
+
+#### Version Reporting
+
+`mache --version`:
+
+```
+mache v0.8.0 (go1.25, darwin/arm64)
+```
+
+`mache version` or `mache --version --verbose`:
+
+```
+mache v0.8.0
+  ley-line: v0.2.0 (enabled, socket)
+  build:   kiln v1.2.3
+  commit:  abc1234
+
+# Kiln injects ley-line version via ldflags at link time:
+# -X cmd.LeylineVersion=${LEYLINE_TAG}
+# extracted from the downloaded ley-line artifact filename or a VERSION file
+  date:    2026-03-24T12:00:00Z
+  signed:  signet ed25519 (sha256:deadbeef...)
+```
+
+### 4. Terraform GitHub Module (`rig/tofu/modules/github/`)
+
+#### Provider
+
+```hcl
+terraform {
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "agentic-research"
+  token = var.github_token
+}
+```
+
+#### Repository Configuration
+
+```hcl
+variable "repositories" {
+  type = map(object({
+    visibility             = string           # "public" or "private"
+    description            = string
+    language               = string           # "go" or "rust"
+    has_issues             = optional(bool, true)
+    delete_branch_on_merge = optional(bool, true)
+    allow_squash_merge     = optional(bool, true)
+    allow_merge_commit     = optional(bool, false)
+    allow_rebase_merge     = optional(bool, false)
+
+    # CI configuration
+    signet_resign          = optional(bool, false)
+    dependabot             = optional(bool, true)
+    copilot_review         = optional(bool, true)
+
+    # Secrets (sensitive, from tfvars)
+    secrets                = optional(map(string), {})
+
+    # Variables
+    variables              = optional(map(string), {})
+
+    # Branch protection
+    branch_protection = optional(object({
+      required_checks = optional(list(string), ["ci", "pre-commit"])
+      require_review  = optional(bool, true)
+      enforce_admins  = optional(bool, false)
+    }), {})
+  }))
+}
+```
+
+#### Resources Per Repo
+
+```hcl
+resource "github_repository" "repo" {
+  for_each = var.repositories
+
+  name                   = each.key
+  visibility             = each.value.visibility
+  description            = each.value.description
+  has_issues             = each.value.has_issues
+  delete_branch_on_merge = each.value.delete_branch_on_merge
+  allow_squash_merge     = each.value.allow_squash_merge
+  allow_merge_commit     = each.value.allow_merge_commit
+  allow_rebase_merge     = each.value.allow_rebase_merge
+}
+
+resource "github_branch_protection" "main" {
+  for_each = var.repositories
+
+  repository_id = github_repository.repo[each.key].node_id
+  pattern       = "main"
+
+  required_status_checks {
+    strict   = true
+    contexts = each.value.branch_protection.required_checks
+  }
+
+  required_pull_request_reviews {
+    required_approving_review_count = each.value.branch_protection.require_review ? 1 : 0
+  }
+
+  enforce_admins = each.value.branch_protection.enforce_admins
+}
+
+resource "github_actions_secret" "secrets" {
+  for_each = merge([
+    for repo_name, repo in var.repositories : {
+      for secret_name, secret_value in repo.secrets :
+      "${repo_name}/${secret_name}" => {
+        repository  = repo_name
+        secret_name = secret_name
+        value       = secret_value
+      }
+    }
+  ]...)
+
+  repository      = each.value.repository
+  secret_name     = each.value.secret_name
+  encrypted_value = each.value.value  # pre-encrypted with repo public key
+}
+
+# Note: SIGNET_MASTER_KEY is the root of trust. Do NOT use plaintext_value —
+# that stores the secret in TF state. Instead, pre-encrypt with the repo's
+# public key (gh api /repos/{owner}/{repo}/actions/secrets/public-key)
+# or use a secrets manager reference. The tfvars should contain the
+# encrypted form, not the raw key material.
+#
+# Bootstrap: `signet authority setup-resign` can set the secret directly
+# via `gh secret set` for initial setup, then TF imports it.
+
+resource "github_actions_variable" "variables" {
+  for_each = merge([
+    for repo_name, repo in var.repositories : {
+      for var_name, var_value in repo.variables :
+      "${repo_name}/${var_name}" => {
+        repository = repo_name
+        var_name   = var_name
+        value      = var_value
+      }
+    }
+  ]...)
+
+  repository    = each.value.repository
+  variable_name = each.value.var_name
+  value         = each.value.value
+}
+
+resource "github_repository_dependabot_security_updates" "dependabot" {
+  for_each = {
+    for name, repo in var.repositories : name => repo if repo.dependabot
+  }
+
+  repository = github_repository.repo[each.key].name
+  enabled    = true
+}
+```
+
+#### Repo Definitions (`repos.tf`)
+
+```hcl
+module "github" {
+  source = "./modules/github"
+
+  repositories = {
+    mache = {
+      visibility  = "public"
+      language    = "go"
+      description = "Structural code intelligence — FUSE, NFS, and MCP"
+      signet_resign = true
+      secrets = {
+        SIGNET_MASTER_KEY = var.signet_master_key
+        LEYLINE_PAT       = var.leyline_pat
+      }
+      variables = {
+        SIGNET_RESIGN_ENABLED = "true"
+      }
+      branch_protection = {
+        required_checks = ["ci", "pre-commit"]
+      }
+    }
+
+    "ley-line" = {
+      visibility  = "private"
+      language    = "rust"
+      description = "Content-addressed storage and vector embeddings"
+      signet_resign = true
+      secrets = {
+        SIGNET_MASTER_KEY = var.signet_master_key
+      }
+      variables = {
+        SIGNET_RESIGN_ENABLED = "true"
+      }
+    }
+
+    signet = {
+      visibility  = "public"
+      language    = "go"
+      description = "Ephemeral certificate identity and signing"
+      signet_resign = true
+      secrets = {
+        SIGNET_MASTER_KEY = var.signet_master_key
+      }
+      variables = {
+        SIGNET_RESIGN_ENABLED = "true"
+      }
+    }
+
+    rosary = {
+      visibility  = "public"
+      language    = "rust"
+      description = "Autonomous work orchestrator"
+      signet_resign = true
+      secrets = {
+        SIGNET_MASTER_KEY = var.signet_master_key
+        LEYLINE_PAT       = var.leyline_pat
+      }
+      variables = {
+        SIGNET_RESIGN_ENABLED = "true"
+      }
+    }
+
+    kiln = {
+      visibility  = "public"
+      language    = "go"
+      description = "ART distribution hub — build, link, package, publish"
+      signet_resign = true
+      secrets = {
+        SIGNET_MASTER_KEY = var.signet_master_key
+        LEYLINE_PAT       = var.leyline_pat
+      }
+      variables = {
+        SIGNET_RESIGN_ENABLED = "true"
+      }
+    }
+  }
+}
+```
+
+### 5. Signet Trust Chain
+
+#### Signing Architecture
+
+```
+ML-DSA-44 master key (PQ root, stored in GH secret + OS keyring)
+  │
+  ├── Issues Ed25519 bridge certs (ephemeral, 5-min, OIDC-bound)
+  │     └── Signs git commits (GitHub-compatible Ed25519)
+  │
+  └── Signs artifacts directly (Ed25519 CMS today, PQ authority future)
+        ├── checksums-sha256.txt.sig
+        ├── individual binary .sig files
+        └── cosign keyless (OCI images, sigstore transparency log)
+```
+
+#### Current State (go-cms, local-only)
+
+- `signet sign <file>` uses go-cms (in-house, unaudited, OpenSSL-interop tested)
+- Ed25519 signatures via Go stdlib `crypto/ed25519`
+- CMS/PKCS#7 envelope construction is custom ASN.1
+- Works in CI today — pure Go binary, zero runtime deps
+
+#### Cloud Path (signet-sign, Rust/WASM)
+
+- `signet-sign` Rust crate uses audited RustCrypto `cms` crate
+- Compiled to WASM for CF Workers (auth.rosary.bot)
+- go-cms is NOT used in the cloud — only signet-sign
+- Kiln-built signet bundles signet-sign WASM for audited crypto locally
+
+#### PQ Authority (Future Milestone)
+
+**Goal**: ML-DSA-44 root authority issues Ed25519 bridge certs.
+
+```
+ML-DSA-44 master key (quantum-safe)
+  │
+  └── X.509 cert issuance (ML-DSA signature on Ed25519 leaf cert)
+        │
+        └── Ed25519 bridge cert signs commits (GitHub-compatible)
+```
+
+**Why**: GitHub requires Ed25519 for commit verification. A PQ root means:
+
+- Quantum computer can't forge new bridge certs (CA signature is ML-DSA)
+- Ephemeral 5-minute bridge certs limit exposure window
+- OIDC binding ties cert to specific GHA run
+
+**Blockers**:
+
+- Go `crypto/x509.CreateCertificate` does not support ML-DSA as issuer algorithm
+- Must use signet-sign (Rust) for cert issuance — RustCrypto `x509-cert` + `ml-dsa`
+- Authority server needs Rust/WASM backend for cert issuance path (same as cloud)
+
+**Implementation path**:
+
+1. signet-sign crate adds `issue_bridge_cert(master_key_mldsa, leaf_pubkey_ed25519)` FFI
+1. Signet authority calls signet-sign via WASM for cert issuance when master key is ML-DSA
+1. Bridge cert carries Ed25519 subject key, ML-DSA issuer signature
+1. `signet-git` signs commits with Ed25519 bridge cert (unchanged)
+1. Verifiers check Ed25519 commit signature + ML-DSA cert chain
+
+**Result**: Full post-quantum provenance for commit signing without breaking GitHub compatibility.
+
+### 6. Copilot PR Review Gating
+
+Managed via the shared `copilot-review.yml` workflow.
+
+```yaml
+# Gating logic
+- name: Guard — only runs on pull_request events
+  if: ${{ github.event_name != 'pull_request' }}
+  run: |
+    echo "::notice::Skipping Copilot review — not a pull_request event"
+    exit 0
+
+- name: Check author association
+  id: check
+  run: |
+    ASSOC="${{ github.event.pull_request.author_association }}"
+    if [[ "$ASSOC" == "OWNER" || "$ASSOC" == "MEMBER" || "$ASSOC" == "COLLABORATOR" ]]; then
+      echo "eligible=true" >> "$GITHUB_OUTPUT"
+    else
+      echo "eligible=false" >> "$GITHUB_OUTPUT"
+    fi
+
+- name: Request Copilot review
+  if: steps.check.outputs.eligible == 'true'
+  uses: actions/github-script@v7
+  with:
+    script: |
+      await github.rest.pulls.requestReviewers({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        pull_number: context.issue.number,
+        reviewers: ['copilot']
+      });
+```
+
+TF ensures all repos call this workflow via required status checks.
+
+## Phasing
+
+### Phase 1: Foundation
+
+**Goal**: Shared CI + TF repo management + basic release pipeline.
+
+1. Create reusable workflows in `agentic-research/.github`:
+   - `go-ci.yml`, `rust-ci.yml`, `pre-commit.yml`, `copilot-review.yml`
+1. Create `rig/tofu/modules/github/` with repo definitions
+1. `tofu apply` — wires branch protection, secrets, variables, dependabot across all repos
+1. Migrate mache + signet CI to shared `go-ci.yml`
+1. Migrate ley-line + rosary CI to shared `rust-ci.yml`
+1. Validate pre-commit works cross-language
+
+### Phase 2: Release Pipeline
+
+**Goal**: Tag-driven releases with artifact signing.
+
+**Bootstrap order** (signet must ship first so other releases can use it for signing):
+
+1. Create `go-release.yml` and `rust-release.yml` in `.github`
+1. **Bootstrap signet**: tag signet v0.3.0 using shared `go-release.yml` WITHOUT signing
+   (signet can't sign its own first release — chicken-and-egg)
+1. Wire `signet sign` into release workflows (Ed25519 CMS artifact signatures)
+   — now that signet has a GH Release, other workflows can download the binary
+1. Re-tag signet v0.3.1 WITH self-signing (signet signs its own release using v0.3.0)
+1. Migrate mache, ley-line, rosary release workflows to shared versions with signing
+1. Update kiln to receive dispatches from all four repos
+1. Add `Formula/signet.rb` to homebrew-tap
+1. Add krust builds for rosary + ley-line OCI images
+
+### Phase 3: Trust Chain
+
+**Goal**: Full signing from commit to distribution.
+
+1. Activate `signet-resign` across all repos (TF sets `SIGNET_RESIGN_ENABLED=true`)
+1. Create shared `signet-resign.yml` reusable workflow
+1. Wire cosign + signet KMS for OCI image signing in kiln
+1. Kiln-built signet bundles signet-sign WASM (audited crypto replaces go-cms)
+1. Kiln-built mache bundles ley-line (already works)
+
+### Phase 4: PQ Authority
+
+**Goal**: Post-quantum root of trust.
+
+1. Add `issue_bridge_cert` FFI to signet-sign Rust crate
+1. ML-DSA-44 master key support in signet authority (via WASM backend)
+1. PQ root issues Ed25519 bridge certs for commit signing
+1. Rotate all repos to PQ master keys (TF updates `SIGNET_MASTER_KEY` secrets)
+1. Document verification chain for external consumers
+
+## Testing Strategy
+
+- Shared workflows are tested via a **canary repo** (`agentic-research/ci-canary`) — a minimal repo that calls all shared workflows and validates they pass
+- TF module uses `tofu plan` in CI (no apply) to validate config changes
+- Kiln's existing smoke test (`task test`) validates the linked binary works
+- Signet's existing integration tests (`test_integration.sh`) validate signing end-to-end
+
+## Dependencies
+
+| Dependency                                                                        | Used By                 | Notes                                   |
+| --------------------------------------------------------------------------------- | ----------------------- | --------------------------------------- |
+| [krust](https://github.com/imjasonh/krust)                                        | kiln (Rust OCI)         | ko for Rust, cargo-zigbuild static musl |
+| [apko](https://github.com/chainguard-dev/apko)                                    | kiln (Go OCI)           | Distroless image assembly               |
+| [melange](https://github.com/chainguard-dev/melange)                              | kiln (APK packaging)    | Already in use                          |
+| [cosign](https://github.com/sigstore/cosign)                                      | kiln (OCI signing)      | Already in use, signet as optional KMS  |
+| [GitHub TF provider](https://registry.terraform.io/providers/integrations/github) | rig                     | `integrations/github ~> 6.0`            |
+| signet-sign                                                                       | signet (audited crypto) | RustCrypto cms crate, WASM target       |
+| go-cms                                                                            | signet (local signing)  | In-house, unaudited, Ed25519 only       |
+
+## Open Questions
+
+1. **Homebrew service**: Should `brew services start mache` work for the HTTP MCP server? Kiln already has entrypoint logic for this.
+1. **Canary repo**: Create `agentic-research/ci-canary` or use `.github` itself as the canary?
+1. **TF state**: Add GitHub module state to existing R2 backend in rig, or separate state file?
+1. **Dependabot config file**: Push `dependabot.yml` via TF (`github_repository_file`) or keep it manual?
+1. **Pre-commit remote config**: Does the `ci.config` remote reference work reliably, or should each repo vendor a thin config that imports from `.github`?


### PR DESCRIPTION
## Summary
14 untracked files were cluttering `git status`. Triaged into two groups:

**Gitignored (10 files — runtime / generated / scratch):**
- `/gen-lsp-fixture` (locally-built Mach-O binary)
- `/dolt-server.{lock,log,pid,port,activity}`, `/dolt/` (bd's root-level dolt server state)
- `/diagram.mermaid`, `/diagram-*.mermaid` (`get_diagram` MCP tool outputs)
- `/resume.txt`, `/mache-distrib-resume.txt` (session-resume scratch notes)

All anchored to repo root with leading `/` so they don't match deeper paths.

**Committed (3 files — substantive design docs):**
- `docs/superpowers/plans/2026-03-24-unified-language-registry.md` (720 lines)
- `docs/superpowers/plans/2026-03-30-lsp-enrichment-from-leyline-db.md` (723 lines)
- `docs/superpowers/specs/2026-03-24-art-platform-release-infrastructure-design.md` (828 lines)

The directory already tracks 4 sibling docs from 2026-03-22 — these 3 (03-24/03-30) have the same shape and look like design history that drifted into untracked state.

## Test plan
- [x] `git status` is now empty after merging
- [x] No code changes