### PR TITLE
feat: mache find-smells CLI subcommand

### DIFF
--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -1,0 +1,223 @@
+package cmd
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	_ "modernc.org/sqlite"
+)
+
+// dbQuerier wraps a *sql.DB so it satisfies refsQuerier — the only
+// interface runSmellRule / missingTables / populateSnippets need.
+// Lets the CLI run rules against any SQLite db (mache-built or
+// LLO-built) without touching the graph stack.
+type dbQuerier struct{ db *sql.DB }
+
+func (q *dbQuerier) QueryRefs(query string, args ...any) (*sql.Rows, error) {
+	return q.db.Query(query, args...)
+}
+
+var (
+	findSmellsDBPath    string
+	findSmellsRule      string
+	findSmellsSourceID  string
+	findSmellsLimit     int
+	findSmellsMinMetric int64
+	findSmellsFormat    string
+)
+
+var findSmellsCmd = &cobra.Command{
+	Use:   "find-smells",
+	Short: "Run structural code-smell rules against a mache or leyline-built SQLite database",
+	Long: `Runs the same rule registry that powers the find_smells MCP tool, but as a
+CLI for non-MCP consumers (CI, scripts, GitHub Actions). With no --rule
+argument it lists registered rules; otherwise it executes the named rule.
+
+Output formats:
+  --format=json (default)  machine-readable, same shape as the MCP tool
+  --format=md              human-readable markdown summary
+
+Exit codes:
+  0  success — regardless of how many findings the rule produced
+  2  pre-flight failed (missing tables on the active backend)
+  3  unknown rule
+  4  database open / query error
+
+This tool is observability, not a gate. It never exits non-zero on findings.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Discovery mode: no rule -> dump the listing. No db required.
+		if findSmellsRule == "" {
+			return renderListing(cmd.OutOrStdout(), findSmellsFormat)
+		}
+
+		// Running a rule requires a db. SQLite would silently create
+		// missing files on Open, so existence-check first to give a
+		// clear error rather than running the rule against an empty
+		// auto-created file.
+		if findSmellsDBPath == "" {
+			return fmt.Errorf("--db PATH is required when --rule is set")
+		}
+		if _, err := os.Stat(findSmellsDBPath); err != nil {
+			return cliExit(4, fmt.Errorf("db file: %w", err))
+		}
+		db, err := sql.Open("sqlite", findSmellsDBPath)
+		if err != nil {
+			return cliExit(4, fmt.Errorf("open db: %w", err))
+		}
+		defer func() { _ = db.Close() }()
+		if err := db.Ping(); err != nil {
+			return cliExit(4, fmt.Errorf("ping db: %w", err))
+		}
+		qg := &dbQuerier{db: db}
+
+		var rule *SmellRule
+		for i := range smellRegistry {
+			if smellRegistry[i].ID == findSmellsRule {
+				rule = &smellRegistry[i]
+				break
+			}
+		}
+		if rule == nil {
+			return cliExit(3, fmt.Errorf("unknown rule %q — run with no --rule for the registry listing", findSmellsRule))
+		}
+
+		// Pre-flight required tables, same shape as the MCP handler.
+		if missing, err := missingTables(qg, rule.Requires); err != nil {
+			return cliExit(4, fmt.Errorf("pre-flight: %w", err))
+		} else if len(missing) > 0 {
+			return cliExit(2, fmt.Errorf(
+				"rule %q requires SQL tables [%s] which aren't present in %s — "+
+					"_ast / _source / _imports / _lsp* come from ley-line-open's `leyline parse`; "+
+					"node_defs / node_refs / nodes come from both standalone mache and LLO; "+
+					"see docs/ARCHITECTURE.md#interplay-with-ley-line-open for the full capability matrix",
+				findSmellsRule, strings.Join(missing, ", "), findSmellsDBPath,
+			))
+		}
+
+		findings, err := runSmellRule(qg, rule, findSmellsSourceID, findSmellsLimit)
+		if err != nil {
+			return cliExit(4, fmt.Errorf("rule %q: %w", findSmellsRule, err))
+		}
+
+		if findSmellsMinMetric > 0 {
+			filtered := findings[:0]
+			for _, f := range findings {
+				if f.Metric >= findSmellsMinMetric {
+					filtered = append(filtered, f)
+				}
+			}
+			findings = filtered
+		}
+		populateSnippets(qg, findings)
+
+		return renderFindings(cmd.OutOrStdout(), rule.ID, findings, findSmellsFormat)
+	},
+}
+
+// cliExit wraps an error with a specific exit code so callers can
+// distinguish pre-flight failures from real errors. Cobra's RunE only
+// supports a single err return, so we set the process exit code via
+// os.Exit at the call site.
+func cliExit(code int, err error) error {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(code)
+	return err // unreachable
+}
+
+func renderListing(w io.Writer, format string) error {
+	listing := rulesListing()
+	if format == "md" {
+		return renderListingMD(w, listing)
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(listing)
+}
+
+func renderListingMD(w io.Writer, listing any) error {
+	// rulesListing returns an anonymous struct; round-trip through JSON
+	// so we don't reach into its private shape from this package.
+	raw, err := json.Marshal(listing)
+	if err != nil {
+		return err
+	}
+	var parsed struct {
+		Help  string `json:"help"`
+		Rules []struct {
+			ID          string   `json:"id"`
+			Languages   []string `json:"languages,omitempty"`
+			Description string   `json:"description"`
+			Requires    []string `json:"requires,omitempty"`
+		} `json:"rules"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		return err
+	}
+	var sb strings.Builder
+	sb.WriteString("# find_smells rules\n\n")
+	sb.WriteString(parsed.Help)
+	sb.WriteString("\n\n")
+	for _, r := range parsed.Rules {
+		fmt.Fprintf(&sb, "## `%s`\n\n", r.ID)
+		if len(r.Languages) > 0 {
+			fmt.Fprintf(&sb, "**Languages:** %s\n\n", strings.Join(r.Languages, ", "))
+		}
+		if len(r.Requires) > 0 {
+			fmt.Fprintf(&sb, "**Requires tables:** %s\n\n", strings.Join(r.Requires, ", "))
+		}
+		sb.WriteString(r.Description)
+		sb.WriteString("\n\n")
+	}
+	_, err = io.WriteString(w, sb.String())
+	return err
+}
+
+func renderFindings(w io.Writer, ruleID string, findings []smellFinding, format string) error {
+	resp := struct {
+		Rule     string         `json:"rule"`
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}{Rule: ruleID, Total: len(findings), Findings: findings}
+
+	if format == "md" {
+		var sb strings.Builder
+		fmt.Fprintf(&sb, "# find_smells: `%s`\n\n", ruleID)
+		fmt.Fprintf(&sb, "**%d findings**\n\n", len(findings))
+		if len(findings) == 0 {
+			sb.WriteString("No findings on this run.\n")
+		} else {
+			sb.WriteString("| Source | Node | Line | Metric |\n")
+			sb.WriteString("| --- | --- | ---: | ---: |\n")
+			for _, f := range findings {
+				fmt.Fprintf(&sb, "| %s | %s | %d | %d |\n",
+					escapePipes(f.SourceID), escapePipes(f.NodeID), f.Line, f.Metric)
+			}
+		}
+		_, err := io.WriteString(w, sb.String())
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(resp)
+}
+
+func escapePipes(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}
+
+func init() {
+	findSmellsCmd.Flags().StringVar(&findSmellsDBPath, "db", "", "path to the SQLite database (mache-built or leyline-built) — required")
+	findSmellsCmd.Flags().StringVar(&findSmellsRule, "rule", "", "rule ID to run; omit to list available rules")
+	findSmellsCmd.Flags().StringVar(&findSmellsSourceID, "source-id", "", "scope rule to a single source file path")
+	findSmellsCmd.Flags().IntVar(&findSmellsLimit, "limit", 200, "cap result count")
+	findSmellsCmd.Flags().Int64Var(&findSmellsMinMetric, "min-metric", 0, "drop findings whose metric is below this threshold")
+	findSmellsCmd.Flags().StringVar(&findSmellsFormat, "format", "json", "output format: json or md")
+	rootCmd.AddCommand(findSmellsCmd)
+}

--- a/cmd/find_smells_cli_test.go
+++ b/cmd/find_smells_cli_test.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// writeSmellCLIFixture seeds a minimal nodes/node_defs/node_refs db
+// with one live + one dead symbol so dead_code returns the dead one.
+// Mirrors TestFindSmells_DeadCode but writes to a real file path so
+// the CLI can sql.Open it.
+func writeSmellCLIFixture(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "smells.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (id TEXT PRIMARY KEY, parent_id TEXT, name TEXT, kind INTEGER, mtime INTEGER, source_file TEXT, record TEXT);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/Live',   'pkg', 'Live',   1, 0, 'live.go',   ''),
+		  ('pkg/Caller', 'pkg', 'Caller', 1, 0, 'caller.go', ''),
+		  ('pkg/Dead',   'pkg', 'Dead',   1, 0, 'dead.go',   '');
+
+		INSERT INTO node_defs VALUES ('Live', 'pkg/Live'), ('Dead', 'pkg/Dead');
+		INSERT INTO node_refs VALUES ('Live', 'pkg/Caller');
+	`)
+	require.NoError(t, err)
+	return dbPath
+}
+
+// TestFindSmellsCLI_ListRulesNoDB asserts discovery mode works without
+// a --db flag and that requires/languages survive the JSON round-trip.
+func TestFindSmellsCLI_ListRulesNoDB(t *testing.T) {
+	saved := saveCLIFlags()
+	defer saved.restore()
+	findSmellsFormat = "json"
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	var resp struct {
+		Rules []struct {
+			ID       string   `json:"id"`
+			Requires []string `json:"requires"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	ids := make(map[string][]string, len(resp.Rules))
+	for _, r := range resp.Rules {
+		ids[r.ID] = r.Requires
+	}
+	assert.Contains(t, ids, "dead_code")
+	assert.Contains(t, ids["dead_code"], "node_refs")
+}
+
+// TestFindSmellsCLI_RunRuleAgainstFixture exercises the full CLI path:
+// open db, pre-flight, run rule, render JSON.
+func TestFindSmellsCLI_RunRuleAgainstFixture(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+
+	saved := saveCLIFlags()
+	defer saved.restore()
+	findSmellsRule = "dead_code"
+	findSmellsDBPath = dbPath
+	findSmellsFormat = "json"
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	var resp struct {
+		Rule     string         `json:"rule"`
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+	assert.Equal(t, "dead_code", resp.Rule)
+	require.Equal(t, 1, resp.Total, "only Dead has no ref")
+	assert.Equal(t, "pkg/Dead", resp.Findings[0].NodeID)
+}
+
+// TestFindSmellsCLI_MarkdownRender checks the human-readable format
+// renders a header and a table row for the finding.
+func TestFindSmellsCLI_MarkdownRender(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+
+	saved := saveCLIFlags()
+	defer saved.restore()
+	findSmellsRule = "dead_code"
+	findSmellsDBPath = dbPath
+	findSmellsFormat = "md"
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	out := buf.String()
+	assert.True(t, strings.HasPrefix(out, "# find_smells: `dead_code`"), "missing markdown header: %q", out[:80])
+	assert.Contains(t, out, "**1 findings**")
+	assert.Contains(t, out, "| pkg/Dead |")
+}
+
+// cliFlagSnapshot lets tests mutate the package-level flag vars without
+// leaking state across tests (cobra binds them globally).
+type cliFlagSnapshot struct {
+	rule, db, sourceID, format string
+	limit                      int
+	minMetric                  int64
+}
+
+func saveCLIFlags() cliFlagSnapshot {
+	return cliFlagSnapshot{
+		rule:      findSmellsRule,
+		db:        findSmellsDBPath,
+		sourceID:  findSmellsSourceID,
+		format:    findSmellsFormat,
+		limit:     findSmellsLimit,
+		minMetric: findSmellsMinMetric,
+	}
+}
+
+func (s cliFlagSnapshot) restore() {
+	findSmellsRule = s.rule
+	findSmellsDBPath = s.db
+	findSmellsSourceID = s.sourceID
+	findSmellsFormat = s.format
+	findSmellsLimit = s.limit
+	findSmellsMinMetric = s.minMetric
+}


### PR DESCRIPTION
## Summary
- New `mache find-smells` cobra subcommand that wraps the existing `find_smells` MCP rule registry
- `dbQuerier` adapter wraps `*sql.DB` so it satisfies the existing `refsQuerier` interface — same code path as the MCP handler
- Output formats: `json` (default, machine-readable) or `md` (human-readable markdown table)

## Why
Foundation for the GHA wrapper (`mache-0yy4`) and the eventual `ext/machelint` extraction (`mache-3f8w`). Non-MCP consumers (CI, scripts, GitHub Actions) need a CLI; today `find_smells` is MCP-only.

## Flags
| Flag | Default | Notes |
| --- | --- | --- |
| `--db PATH` | (required for rule mode) | mache-built or LLO-built `.db` |
| `--rule ID` | empty | omit to print registry listing |
| `--source-id PATH` | empty | scope to one source file |
| `--limit N` | 200 | cap result count |
| `--min-metric N` | 0 | drop findings below threshold |
| `--format json\|md` | json | output shape |

## Exit codes
| Code | Meaning |
| ---: | --- |
| 0 | success — regardless of how many findings |
| 2 | pre-flight failed (missing tables on backend) |
| 3 | unknown rule |
| 4 | db open/query error |

Never exits non-zero on findings — observability tool, not a gate.

## Test plan
- [x] `TestFindSmellsCLI_ListRulesNoDB` — discovery mode runs without `--db`, listing JSON includes `requires`
- [x] `TestFindSmellsCLI_RunRuleAgainstFixture` — full path: existence check, sql.Open, pre-flight, runSmellRule, JSON
- [x] `TestFindSmellsCLI_MarkdownRender` — `--format md` produces header + table with finding row
- [x] gofumpt + go vet + golangci-lint all clean
- [x] All `TestFindSmells*` (now 19 total) pass

Closes mache-hupl.