### PR TITLE
test: add find_callers benchmarks

### DIFF
--- a/cmd/serve_find_callers_bench_test.go
+++ b/cmd/serve_find_callers_bench_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// buildFindCallersBenchGraph seeds a MemoryStore where one popular
+// token (`hot`) has nFanout distinct callers and a single rare token
+// (`cold`) has one caller. Lets the benchmark measure both common and
+// long-tail lookups.
+func buildFindCallersBenchGraph(b *testing.B, nFanout int) *graph.MemoryStore {
+	b.Helper()
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{ID: "pkg", Mode: fs.ModeDir})
+
+	for i := range nFanout {
+		callerID := fmt.Sprintf("pkg/Caller%05d/source", i)
+		// AddRef expects (token, nodeID).
+		if err := store.AddRef("hot", callerID); err != nil {
+			b.Fatal(err)
+		}
+		store.AddNode(&graph.Node{ID: callerID})
+	}
+	if err := store.AddRef("cold", "pkg/Other/source"); err != nil {
+		b.Fatal(err)
+	}
+	store.AddNode(&graph.Node{ID: "pkg/Other/source"})
+	return store
+}
+
+// BenchmarkFindCallers_HotToken measures the agent's most common path:
+// look up a token that's referenced from many callers. Covers the
+// graph.GetCallers + JSON-marshal pipeline. The LSP-supplement branch
+// is exercised lazily — MemoryStore implements refsQuerier but its
+// node_refs table doesn't contain the token, so the LSP query returns
+// empty and the handler falls through to the no-LSP shape.
+func BenchmarkFindCallers_HotToken(b *testing.B) {
+	for _, n := range []int{1, 50, 500, 5000} {
+		b.Run(fmt.Sprintf("fanout=%d", n), func(b *testing.B) {
+			store := buildFindCallersBenchGraph(b, n)
+			handler := makeFindCallersHandler(store)
+			req := makeRequest(map[string]any{"token": "hot"})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindCallers_RareToken measures the long-tail case (single
+// caller). Useful as a baseline floor — agents browsing find_callers
+// across many symbols hit this shape constantly.
+func BenchmarkFindCallers_RareToken(b *testing.B) {
+	store := buildFindCallersBenchGraph(b, 100)
+	handler := makeFindCallersHandler(store)
+	req := makeRequest(map[string]any{"token": "cold"})
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_, err := handler(context.Background(), req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkFindCallers_MissingToken measures the empty-result path —
+// hit when an agent asks about a token that isn't referenced anywhere.
+// Should be cheap; this benchmark guards against an accidental
+// regression that scans the full refs map.
+func BenchmarkFindCallers_MissingToken(b *testing.B) {
+	store := buildFindCallersBenchGraph(b, 1000)
+	handler := makeFindCallersHandler(store)
+	req := makeRequest(map[string]any{"token": "neverReferenced"})
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_, err := handler(context.Background(), req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Three new benchmarks for `find_callers`: HotToken (fanout 1/50/500/5000), RareToken, MissingToken
- Same harness pattern as the find_smells benchmarks (PR #200)
- Continues mache-9b4d8a (broader MCP-tool-latency benchmarks task)

## Why
`find_callers` is the agent's most common path after `list_directory`/`read_file`. No existing benchmark caught regressions on the GetCallers + JSON-marshal pipeline. The MissingToken path specifically guards against an accidental full-refs-map scan (cheap today, would regress invisibly).

## Local measurements (M3 Max)

| Bench                                | Time    | Bytes/op | Allocs/op |
| ------------------------------------ | ------- | -------- | --------- |
| `HotToken/fanout=1`                  | 12 µs   | 2.3 KB   | 10        |
| `HotToken/fanout=50`                 | 12 µs   | 9.5 KB   | 14        |
| `HotToken/fanout=500`                | 76 µs   | 91 KB    | 28        |
| `HotToken/fanout=5000`               | 825 µs  | 1 MB     | 57        |
| `RareToken` (1 caller)               | 5.5 µs  | 2.5 KB   | 13        |
| `MissingToken` (empty result)        | 4.8 µs  | 128 B    | 3         |

Linear with fanout — expected; the cost is JSON-marshalling caller paths. Cold paths are negligible.

## Test plan
- [x] `go test -bench BenchmarkFindCallers -benchtime=2x ./cmd/` runs cleanly
- [x] `go vet` + `golangci-lint run` clean
- [x] No production-code changes