### PR TITLE
fix: dedupe lspEnrichHint comment, link LSP errors to capability matrix

### DIFF
--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -17,16 +17,15 @@ import (
 // lspEnrichHint is the user-facing guidance shown when LSP data is missing
 // and ley-line daemon is not available. Single definition, used by both
 // get_type_info and get_diagnostics handlers.
-// lspEnrichHint is the user-facing guidance shown when LSP data is missing
-// and ley-line daemon is not available. Single definition, used by both
-// get_type_info and get_diagnostics handlers.
 const lspEnrichHint = "Pre-enrich your database with ll-open, or install ley-line for live enrichment.\n" +
-	"See: github.com/agentic-research/ley-line-open"
+	"See: github.com/agentic-research/ley-line-open\n" +
+	"Capability matrix: docs/ARCHITECTURE.md#interplay-with-ley-line-open"
 
 func lspTableMissing(table, feature string) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf("no %s table in database. To get %s, either:\n"+
 		"  1. Pre-enrich with: ll-open enrich-lsp (see github.com/agentic-research/ley-line-open)\n"+
-		"  2. Pass a 'file' param to trigger live enrichment (requires ley-line daemon)", table, feature))
+		"  2. Pass a 'file' param to trigger live enrichment (requires ley-line daemon)\n"+
+		"See docs/ARCHITECTURE.md#interplay-with-ley-line-open for which tools need which tables.", table, feature))
 }
 
 func lspEnrichFailed(feature string) *mcp.CallToolResult {


### PR DESCRIPTION
## Summary
Two small cleanups in `cmd/serve_lsp.go`:

1. **Dedup**: the godoc comment on `lspEnrichHint` was accidentally written twice — same 3 lines × 2.
2. **Better error pointers**: LSP error messages now also reference `docs/ARCHITECTURE.md#interplay-with-ley-line-open` (the capability matrix shipped in #197), so users who hit "no `_lsp` table" can see *which* tools need *which* tables, not just "install ley-line."

## Why
Found while triaging open GitHub issue #112 — an external user on v0.5.6 hit the unfriendly version of this error in March. Today's error already names the missing table and shows two enable paths; this PR adds the docs cross-link so users can see the full picture without searching.

## Test plan
- [x] `go test ./cmd/ -run "TestGetDiagnostics|TestGetTypeInfo"` passes
- [x] gofumpt + go vet + golangci-lint clean
- [x] Comment dedup is purely textual

Will follow up with a comment on issue #112 referencing this PR + the docs.