### PR TITLE
fix: dead_code skips Test*/Benchmark*/Example*/Fuzz* prefixes

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -78,7 +78,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "dead_code",
-		Description: "Symbols defined in node_defs that have no entries in node_refs — nothing in the indexed graph references them. False positives expected for entry points (main, init), interface methods invoked dynamically (String, Error), and exported API consumed outside the indexed scope. The skip list at the top of the rule excludes the most common offenders; tune by editing the rule.",
+		Description: "Symbols defined in node_defs that have no entries in node_refs — nothing in the indexed graph references them. False positives expected for entry points (main, init), interface methods invoked dynamically (String, Error), and exported API consumed outside the indexed scope. Test*/Benchmark*/Example* are skip-listed because Go's testing framework invokes them via reflection (no static refs). The skip list at the top of the rule excludes the most common offenders; tune by editing the rule.",
 		Requires:    []string{"node_defs", "node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -94,6 +94,15 @@ var smellRegistry = []SmellRule{
 			LEFT JOIN node_refs refs ON refs.token = defs.token
 			WHERE refs.token IS NULL
 			  AND defs.token NOT IN ('main','init','String','Error','Read','Write','Close','Len','Less','Swap','MarshalJSON','UnmarshalJSON','Format','Scan')
+			  -- Skip-list testing-framework prefixes after stripping any 'pkg.'
+			  -- qualifier — mache writers emit either bare 'TestFoo' or
+			  -- qualified 'pkg.TestFoo'. instr(token, '.') is 0 when there's
+			  -- no dot, and substr(token, 1) is the full token, so this
+			  -- handles both shapes.
+			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Test%%'
+			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Benchmark%%'
+			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Example%%'
+			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Fuzz%%'
 			%s
 			ORDER BY COALESCE(n.source_file, ''), defs.node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -334,6 +334,61 @@ func TestFindSmells_DeadCode(t *testing.T) {
 		"source_id comes from the construct dir's source_file column")
 }
 
+// TestFindSmells_DeadCodeSkipsTestingFrameworkPrefixes asserts that
+// Test*, Benchmark*, Example*, Fuzz* defs with no static refs are NOT
+// flagged. Go's testing framework invokes them via reflection, so they
+// never appear in node_refs. The skip list pattern is borrowed from
+// untested_function. Surfaced by dogfooding find_smells against mache
+// itself.
+func TestFindSmells_DeadCodeSkipsTestingFrameworkPrefixes(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Real dead code (control: the rule must still flag this).
+		INSERT INTO node_defs VALUES ('OrphanFunc', 'pkg/OrphanFunc');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/OrphanFunc', 'pkg', 'OrphanFunc', 1, 0, 'orphan.go', '');
+
+		-- Each of the 4 testing-framework prefixes — none have refs.
+		-- Mix bare and 'pkg.'-qualified tokens to exercise the
+		-- substr/instr leaf-extraction in the skip clause.
+		INSERT INTO node_defs VALUES
+		  ('TestSomething',          'pkg/TestSomething'),
+		  ('cmd.TestQualified',      'pkg/TestQualified'),
+		  ('BenchmarkSomething',     'pkg/BenchmarkSomething'),
+		  ('cmd.BenchmarkQualified', 'pkg/BenchmarkQualified'),
+		  ('ExampleSomething',       'pkg/ExampleSomething'),
+		  ('FuzzSomething',          'pkg/FuzzSomething');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/TestSomething',      'pkg', 'TestSomething',      1, 0, 'a_test.go',     ''),
+		  ('pkg/TestQualified',      'pkg', 'TestQualified',      1, 0, 'q_test.go',     ''),
+		  ('pkg/BenchmarkSomething', 'pkg', 'BenchmarkSomething', 1, 0, 'b_test.go',     ''),
+		  ('pkg/BenchmarkQualified', 'pkg', 'BenchmarkQualified', 1, 0, 'q_test.go',     ''),
+		  ('pkg/ExampleSomething',   'pkg', 'ExampleSomething',   1, 0, 'example_test.go', ''),
+		  ('pkg/FuzzSomething',      'pkg', 'FuzzSomething',      1, 0, 'fuzz_test.go',  '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "dead_code",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only OrphanFunc should be flagged; testing-framework prefixes are skipped")
+	assert.Equal(t, "pkg/OrphanFunc", resp.Findings[0].NodeID)
+}
+
 // TestFindSmells_DeadCodeSourceIDFilter exercises the per-rule
 // ScopeColumn — for dead_code that's `COALESCE(n.source_file, ”)`,
 // not the magic-int rule's `lit.source_id`.


### PR DESCRIPTION
## Summary
- Skip-list testing-framework prefixes (`Test`, `Benchmark`, `Example`, `Fuzz`) in `dead_code`'s WHERE clause
- Handles both bare (`TestFoo`) and qualified (`pkg.TestFoo`) token shapes via `substr(token, instr(token, '.') + 1)`

## Why
Found by dogfooding the new `mache find-smells` CLI (PR #205) against mache's own `.db`: `dead_code` reported **26 testing-framework symbols as dead** even though Go's testing runtime invokes them reflectively — they never appear in `node_refs` by design. `untested_function` already skip-listed these prefixes; `dead_code` now matches.

## SQL note
Mache emits two token shapes for testing-framework defs:
- `TestFoo` (bare)
- `cmd.TestFoo` (package-qualified)

Bare `LIKE 'Test%'` only catches the first. Using `substr(token, instr(token, '.') + 1)` extracts the leaf:
- No dot → `instr` returns 0 → `substr(token, 1)` is the full token → bare `TestFoo` matched
- One dot → `instr` returns the offset → `substr(token, offset+1)` is everything after the dot → `cmd.TestFoo` → `TestFoo` matched

Same clause catches both.

## Verification
Re-ran against `mache.db`: **26 false positives → 1** (the remaining 1 is `FilterTestRefs`, a real function whose name happens to contain "Test" in the middle — not a false positive of this rule).

## Test plan
- [x] New `TestFindSmells_DeadCodeSkipsTestingFrameworkPrefixes` — seeds bare + qualified Test/Benchmark/Example/Fuzz tokens with no refs, asserts none are flagged; control `OrphanFunc` still flagged
- [x] All existing `TestFindSmells*` pass (20 tests)
- [x] gofumpt + go vet + golangci-lint via pre-commit