### PR TITLE
docs: split README into top-level overview + GETTING-STARTED.md

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -1,0 +1,175 @@
+# Getting started with mache
+
+This guide walks you from install to a working MCP server in under five minutes, then through the things you'll likely want next: filesystem mount, write-back, schema inference, troubleshooting.
+
+For the architectural picture, see [ARCHITECTURE.md](docs/ARCHITECTURE.md). For where the project is going, see [ROADMAP.md](docs/ROADMAP.md).
+
+## Install
+
+Build from source. Requires [Go 1.23+](https://go.dev/dl/) and [Task](https://taskfile.dev/installation/):
+
+```bash
+git clone https://github.com/agentic-research/mache.git
+cd mache
+task build
+task install   # copies the binary to ~/.local/bin
+```
+
+**Platform notes:**
+
+- **macOS** — `brew install go-task` for Task.
+- **Linux** — [install Task](https://taskfile.dev/installation/). NFS mount requires `nfs-common` (`apt-get install nfs-common`).
+
+To check the install:
+
+```bash
+mache version
+```
+
+## First run — MCP server
+
+The simplest way to use mache is as an MCP server pointed at a codebase or `.db` file:
+
+```bash
+mache serve .
+# starts on localhost:7532, auto-infers a schema, ready for clients
+```
+
+**Connect from Claude Code (HTTP, recommended — one server shared across sessions):**
+
+```bash
+claude mcp add --transport http mache http://localhost:7532/mcp
+```
+
+**Connect from Claude Code (stdio — subprocess per session, useful when the host manages lifecycle):**
+
+`.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "mache": {
+      "command": "mache",
+      "args": ["serve", "--stdio", "."]
+    }
+  }
+}
+```
+
+**Connect from Claude Desktop:**
+
+```json
+{
+  "mcpServers": {
+    "mache": {
+      "command": "/path/to/mache",
+      "args": ["serve", "--stdio", "/path/to/code"]
+    }
+  }
+}
+```
+
+Once connected, the agent can call `list_directory`, `read_file`, `find_callers`, `find_callees`, `find_definition`, `search`, `get_communities`, `get_overview`, `get_impact`, `get_architecture`, `get_diagram`, `write_file`, and `find_smells`. With [ley-line-open](https://github.com/agentic-research/ley-line-open) installed, three more tools become available: `semantic_search`, `get_type_info`, `get_diagnostics`.
+
+See the [MCP Server section in ARCHITECTURE.md](docs/ARCHITECTURE.md#core-abstractions) for the full tool inventory and the [Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open) section for which tools require an LLO-built `.db`.
+
+## Mount as a filesystem (optional)
+
+Beyond MCP, the graph can be exposed as a mounted directory tree — useful for `ls`, `cat`, shell scripts, or tools that work with files:
+
+```bash
+mache --infer -d ./src --writable /tmp/mache-src
+```
+
+Layout:
+
+```
+/tmp/mache-src/
+  functions/
+    HandleRequest/
+      source        # the function body
+      context       # imports, types visible to this scope
+      callers/      # who calls this function
+      callees/      # what this function calls
+    ValidateToken/
+      source
+  types/
+    Config/
+      source        # type Config struct { ... }
+  _project_files/
+    README.md
+    go.mod
+```
+
+Navigate by function name, not file path. `callers/` and `callees/` are virtual directories that appear only when references exist.
+
+**Other mount examples:**
+
+```bash
+# Agent mode — generates PROMPT.txt for LLMs
+mache --agent -d ~/my-project
+
+# Mount a SQLite database directly (zero-copy, no ingestion)
+mache --schema examples/nvd-schema.json --data results.db /tmp/nvd
+
+# Hot-reload schema while mounted
+mache --control /tmp/control.sock --infer -d ./src /tmp/mount
+```
+
+NFS is the only mount backend (FUSE was removed in v0.7.0; for FUSE today, use [ley-line-open's `leyline serve`](https://github.com/agentic-research/ley-line-open)).
+
+## Write-back
+
+With `--writable`, edits to `source` files go through a pipeline before touching the actual source on disk:
+
+1. **Validate** — tree-sitter checks syntax
+1. **Format** — gofumpt for Go, hclwrite for HCL/Terraform
+1. **Splice** — atomic byte-range replacement in the source file
+1. **Update** — node content updated in-place, no re-ingest
+
+If validation fails, the write is saved as a draft. The node path stays stable; errors surface via `_diagnostics/`.
+
+For the full pipeline design, see [ADR-0009: AST-Aware Write Pipeline](docs/adr/0009-ast-aware-write-pipeline.md).
+
+## Schema inference
+
+Mache auto-infers a topology from your source if you don't provide a schema (`--infer` is the default for source mounts). The inference pipeline:
+
+1. **FCA** (Formal Concept Analysis) — reservoir-samples records, builds a concept lattice, projects to a `Topology`
+1. **Greedy entropy** — information-theoretic field scoring picks identifier columns, temporal shards, leaf files
+1. Schema-driven projection mounts the result
+
+To inspect the inferred schema after mount:
+
+```bash
+cat /tmp/mache-src/_schema.json
+```
+
+Or pass an explicit schema if the inferred one isn't right:
+
+```bash
+mache serve --schema examples/go-schema.json -d ./src
+```
+
+See [ADR-0005](docs/adr/0005-fca-schema-inference.md) and [ADR-0008](docs/adr/0008-greedy-entropy-schema-inference.md) for the inference design.
+
+## Troubleshooting
+
+**`get_diagnostics` returns "no \_lsp table in database"** — the LSP-enrichment tools require an [ley-line-open](https://github.com/agentic-research/ley-line-open)-built `.db`. Either pre-enrich with `ll-open enrich-lsp`, pass a `file` param to trigger live enrichment (requires the ley-line daemon), or skip those three tools — the other 13 work without LLO. See [Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
+
+**`find_smells` rule "requires SQL tables [\_ast]" error** — same root cause. The four `_ast`-based smell rules (`magic_int_in_comparison`, `cyclomatic_complexity`, `long_function`, `long_file`) need an LLO-built `.db`. The other five rules (`dead_code`, `untested_function`, `duplicate_definitions`, `god_file`, `fan_out_skew`) run on standalone mache.
+
+**Mount stuck or `umount` complains "device busy"** — see `mache unmount <mountpoint>` and the open-bead ergonomics in `mache-fsi`. macOS sometimes needs `diskutil unmount force`.
+
+**NFS mount fails on Linux with "no such device"** — install `nfs-common` (`apt-get install nfs-common`).
+
+**Build error about CGO** — mache's standalone path uses CGO tree-sitter; either install `gcc` / `clang` or use the LLO-paired path (no CGO required for that).
+
+## Where to next
+
+- [ARCHITECTURE.md](docs/ARCHITECTURE.md) — graph backends, write pipeline, virtual directories, ley-line-open interplay
+- [ROADMAP.md](docs/ROADMAP.md) — what's stable, what's next, what's long-term
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to send a PR
+- [docs/adr/](docs/adr/) — Architectural Decision Records
+- [docs/PRIOR_ART.md](docs/PRIOR_ART.md) — what mache builds on
+- [docs/competitive-landscape-2026.md](docs/competitive-landscape-2026.md) — comparison with other tools in the space

--- a/README.md
+++ b/README.md
@@ -10,167 +10,29 @@ Point it at a codebase. It parses the code, discovers the structure, and lets yo
 
 ## Quick start
 
-### Install
-
-Build from source (requires [Go 1.23+](https://go.dev/dl/) and [Task](https://taskfile.dev/installation/)):
-
 ```bash
 git clone https://github.com/agentic-research/mache.git
-cd mache
-task build
-task install   # copies to ~/.local/bin
-```
-
-**macOS:** `brew install go-task` for Task.
-**Linux:** [Install Task](https://taskfile.dev/installation/). NFS mount requires `nfs-common` (`apt-get install nfs-common`).
-
-### Use with Claude Code
-
-Start the server, then register it:
-
-```bash
-mache serve .                    # starts on localhost:7532
+cd mache && task build && task install
+mache serve .
 claude mcp add --transport http mache http://localhost:7532/mcp
 ```
 
-Mache auto-infers the schema from your codebase. One server shared across all sessions.
+That's the 30-second path. For the full first-run flow — install on Linux/macOS, Claude Desktop / stdio configs, mount as filesystem, write-back, schema inference, troubleshooting — see [GETTING-STARTED.md](GETTING-STARTED.md).
 
-## MCP tools
+## What it gives an agent
 
-13 tools work out of the box. 3 optional tools provide LSP type info and semantic search when [ley-line-open](https://github.com/agentic-research/ley-line-open) enrichment is available — without it, they return a message explaining how to enable them. `find_smells` partially degrades on tree-sitter-only mounts (rules that need `_ast` tables require an LLO-built `.db`); see [Architecture](docs/ARCHITECTURE.md#interplay-with-ley-line-open) for details.
+Sixteen MCP tools wrap the projected graph. Thirteen work standalone; three (`semantic_search`, `get_type_info`, `get_diagnostics`) require [ley-line-open](https://github.com/agentic-research/ley-line-open) enrichment. `find_smells` covers nine structural code-smell rules (`dead_code`, `cyclomatic_complexity`, `god_file`, `fan_out_skew`, `untested_function`, …); four of those require an LLO-built `.db`.
 
-| Tool               | What it does                                                                                                        |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `get_overview`     | Top-level structure, node counts, entry points                                                                      |
-| `list_directory`   | Browse the graph by path                                                                                            |
-| `read_file`        | Read source content (supports batch reads)                                                                          |
-| `find_definition`  | Jump to where a symbol is defined                                                                                   |
-| `find_callers`     | Who calls this?                                                                                                     |
-| `find_callees`     | What does this call?                                                                                                |
-| `search`           | Pattern match across symbols                                                                                        |
-| `get_communities`  | Find clusters of tightly-coupled code                                                                               |
-| `get_impact`       | Blast radius of changing a symbol                                                                                   |
-| `get_architecture` | Entry points, abstractions, dependency layers                                                                       |
-| `get_diagram`      | Mermaid diagram of system structure                                                                                 |
-| `write_file`       | Edit through the splice pipeline: validate, format, splice                                                          |
-| `find_smells`      | Run structural code-smell rules (cyclomatic, dead code, fan-out skew, duplicate defs, etc.) — `_ast` rules need LLO |
-| `semantic_search`  | Natural-language search via embeddings *(optional — ley-line)*                                                      |
-| `get_type_info`    | LSP type info and hover data *(optional — ley-line)*                                                                |
-| `get_diagnostics`  | LSP errors and warnings *(optional — ley-line)*                                                                     |
+For the full tool inventory and capability matrix (which tools need which tables), see [ARCHITECTURE.md § MCP Server](docs/ARCHITECTURE.md#core-abstractions) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
 
 ## How it works
 
 1. **Parse** — tree-sitter parses source into AST nodes (28 languages)
-1. **Infer** — schema inference (FCA) discovers the natural groupings (`functions/`, `types/`, `classes/`)
+1. **Infer** — schema inference (FCA + greedy entropy) discovers the natural groupings (`functions/`, `types/`, `classes/`)
 1. **Link** — cross-reference extraction builds a call graph from identifiers and imports
 1. **Project** — the graph is exposed as MCP tools (primary) or a mounted filesystem (optional)
 
-## Mount as a filesystem (optional)
-
-The graph can also be browsed as a mounted directory tree — useful for `ls`, `cat`, shell scripts, or tools that work with files:
-
-```bash
-mache --infer -d ./src --writable /tmp/mache-src
-```
-
-```
-/tmp/mache-src/
-  functions/
-    HandleRequest/
-      source        # the function body
-      context       # imports, types visible to this scope
-      callers/      # who calls this function
-      callees/      # what this function calls
-    ValidateToken/
-      source
-  types/
-    Config/
-      source        # type Config struct { ... }
-  _project_files/
-    README.md
-    go.mod
-```
-
-Navigate by function name, not file path. `callers/` and `callees/` are virtual directories that appear only when references exist.
-
-<details>
-<summary>More mount examples</summary>
-
-```bash
-# Mount with agent mode (generates PROMPT.txt for LLMs)
-mache --agent -d ~/my-project
-
-# Mount a SQLite database (zero-copy)
-mache --schema examples/nvd-schema.json --data results.db /tmp/nvd
-```
-
-</details>
-
-<details>
-<summary>Write-back</summary>
-
-With `--writable`, edits to `source` files go through a pipeline before touching your actual source:
-
-1. **Validate** — tree-sitter checks syntax
-1. **Format** — gofumpt (Go), hclwrite (HCL)
-1. **Splice** — atomic byte-range replacement in the source file
-1. **Update** — node content updated in-place, no re-ingest
-
-If the syntax is wrong, the write is saved as a draft. The node path stays stable. Errors show up in `_diagnostics/`.
-
-</details>
-
-## MCP server options
-
-```bash
-# HTTP (recommended) — one server, multiple clients
-mache serve .
-mache serve --http localhost:9000 -s examples/nvd-schema.json results.db
-
-# stdio — for tools that manage the subprocess lifecycle
-mache serve --stdio .
-```
-
-<details>
-<summary>Claude Code setup (detailed)</summary>
-
-**HTTP (recommended)** — register once, shared across sessions:
-
-```bash
-mache serve /path/to/data &
-claude mcp add --transport http mache http://localhost:7532/mcp
-```
-
-**stdio** — `.mcp.json` (spawns a subprocess per session):
-
-```json
-{
-  "mcpServers": {
-    "mache": {
-      "command": "mache",
-      "args": ["serve", "--stdio", "."]
-    }
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>Claude Desktop setup</summary>
-
-```json
-{
-  "mcpServers": {
-    "mache": {
-      "command": "/path/to/mache",
-      "args": ["serve", "--stdio", "/path/to/code"]
-    }
-  }
-}
-```
-
-</details>
+The graph is the same on either path; MCP and the filesystem are two ways to talk to it.
 
 ## Status
 
@@ -179,6 +41,7 @@ claude mcp add --transport http mache http://localhost:7532/mcp
 | Tree-sitter parsing (28 langs)          | Stable                                                                        |
 | MCP server (16 tools, stdio + HTTP)     | Stable                                                                        |
 | Cross-references (callers/callees)      | Stable                                                                        |
+| `find_smells` (9 structural rules)      | Stable                                                                        |
 | NFS mount + write-back                  | Stable                                                                        |
 | Schema inference (FCA)                  | Beta                                                                          |
 | Community detection (Louvain)           | Beta                                                                          |
@@ -207,16 +70,20 @@ Operating systems never formalized this mapping. Mache does:
 - Schema defines topology — the formal specification of how source nodes map to filesystem nodes
 - The filesystem exposes traversal primitives: `cd` traverses an edge, `ls` enumerates children, `cat` reads node data
 
+[ADR-0011](docs/adr/0011-pointer-abstraction.md) takes this further: every navigable thing in mache (path, token, SHA, range, record, ref) is a Pointer; the graph is a network of pointers; mache resolves them on demand.
+
 See [Architecture](docs/ARCHITECTURE.md) for the full picture.
 
 </details>
 
 ## Docs
 
-- [Architecture](docs/ARCHITECTURE.md)
-- [Prior Art & Landscape](docs/PRIOR_ART.md)
-- [Example Schemas](examples/README.md)
-- [ADRs](docs/adr/)
+- [Getting started](GETTING-STARTED.md) — install + first run
+- [Architecture](docs/ARCHITECTURE.md) — graph backends, write pipeline, virtual directories, LLO interplay
+- [Roadmap](docs/ROADMAP.md) — what's landed, near-term, long-term
+- [ADRs](docs/adr/) — Architectural Decision Records
+- [Prior art & landscape](docs/PRIOR_ART.md) — what mache builds on, how it compares
+- [Example schemas](examples/README.md) — NVD, KEV, Go source, MCP registry
 - [Contributing](CONTRIBUTING.md)
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,16 @@
 # Mache Architecture
 
+This document is the architectural reference. If you're getting started for the first time, read [GETTING-STARTED.md](../GETTING-STARTED.md) first — it covers install, first-run, and common workflows.
+
+If you're looking for:
+
+- **Where things go** — see [Core Abstractions](#core-abstractions) and [Key File Reference](#key-file-reference)
+- **Why mache works without LLO and what changes when you have it** — see [Interplay with ley-line-open](#interplay-with-ley-line-open)
+- **The write pipeline** — see [Write Pipeline](#write-pipeline)
+- **Virtual directories (`callers/`, `callees/`, `_diagnostics/`, `.query/`)** — see [Virtual Directories](#virtual-directories)
+- **Past decisions** — see [Architectural Decision Records (ADRs)](#architectural-decision-records-adrs)
+- **Where things are going** — see [ROADMAP.md](ROADMAP.md)
+
 ## High-Level Design
 
 ```mermaid
@@ -245,3 +256,5 @@ cat /functions/HandleRequest/callees/functions_ValidateToken_source
 | [0007: Git Object Graph as FS Projection](adr/0007-git-object-graph-as-fs-projection.md) | Proposed   | Git objects as first-class data source                                       |
 | [0008: Greedy Entropy Schema Inference](adr/0008-greedy-entropy-schema-inference.md)     | Accepted   | Information-theoretic field scoring for schema inference                     |
 | [0009: AST-Aware Write Pipeline](adr/0009-ast-aware-write-pipeline.md)                   | Accepted   | Validate → format → splice → surgical update (no re-ingest)                  |
+| [0010: Hosted Mache Architecture](adr/0010-hosted-mache-architecture.md)                 | Proposed   | Hosted-mode design (cluster, R2, BYO storage)                                |
+| [0011: Pointer Abstraction](adr/0011-pointer-abstraction.md)                             | Proposed   | Path/token/SHA/range/record/ref/trace/embedding all unified as Pointer       |


### PR DESCRIPTION
## Summary
The README had grown to 224 lines covering install, first-run, mount, write-back, schema inference, Claude setups (HTTP/stdio/Desktop), and philosophy. New readers had to scroll past everything to find the 30-second path.

This PR splits it:

- **README.md** (224 → 91 lines, **60% reduction**): top-level overview + 30-second quick start, status table, kept "why this exists" + graph isomorphism as collapsibles, links to other docs.
- **GETTING-STARTED.md** (new, 175 lines): focused first-run flow — install → MCP server → Claude setups → mount as filesystem → write-back → schema inference → troubleshooting.
- **ARCHITECTURE.md**: new "where to enter" header at the top pointing at the relevant section by question (e.g., "If you're looking for the write pipeline → §Write Pipeline"). ADR table updated with 0010 and the newly-shipped 0011.

## Cross-link structure

```
README.md
  ├─ Quick start (30s) → GETTING-STARTED.md (full first-run flow)
  ├─ "What it gives an agent" → ARCHITECTURE.md § Interplay with LLO
  ├─ Status table (kept inline)
  ├─ Why-this-exists (collapsible, kept inline)
  └─ Graph isomorphism (collapsible) → ADR-0011

GETTING-STARTED.md
  └─ "Where to next" → ARCHITECTURE.md, ROADMAP.md, ADRs, etc.

ARCHITECTURE.md
  └─ Top header points at GETTING-STARTED.md for first-time readers
```

## Test plan
- [x] No code changes
- [x] All internal links resolve (manually verified)
- [x] Pre-commit hooks pass (markdownlint applied its `1.` ordered-list normalization)

Stacked behind PR #209 (ADR-0011) but doesn't depend on it textually — references ADR-0011 in one collapsible only.