### PR TITLE
test: add read_file benchmarks (single + batch + missing-path)

### DIFF
--- a/cmd/serve_read_file_bench_test.go
+++ b/cmd/serve_read_file_bench_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// buildReadFileBenchGraph seeds a MemoryStore with files of varying
+// sizes addressed by stable IDs. Lets the benchmark exercise the
+// single-read path at small/medium/large content scales without
+// fighting through schema inference or template rendering.
+func buildReadFileBenchGraph(b *testing.B) *graph.MemoryStore {
+	b.Helper()
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{ID: "pkg", Mode: fs.ModeDir})
+
+	// Small (~100 B), medium (~10 KB), large (~1 MB). Spans the
+	// realistic content spectrum for source files / generated docs.
+	for _, sz := range []struct {
+		id   string
+		size int
+	}{
+		{"pkg/small/source", 100},
+		{"pkg/medium/source", 10_000},
+		{"pkg/large/source", 1_000_000},
+	} {
+		store.AddNode(&graph.Node{
+			ID:   sz.id,
+			Mode: 0,
+			Data: []byte(strings.Repeat("x", sz.size)),
+		})
+	}
+	return store
+}
+
+// BenchmarkReadFile_Single covers the most common path: agent reads
+// one file. Three scales (~100 B / ~10 KB / ~1 MB) capture the cost
+// of GetNode + content-marshal across the realistic content spectrum.
+func BenchmarkReadFile_Single(b *testing.B) {
+	store := buildReadFileBenchGraph(b)
+	handler := makeReadFileHandler(store)
+	for _, name := range []string{"small", "medium", "large"} {
+		b.Run(name, func(b *testing.B) {
+			req := makeRequest(map[string]any{"path": "pkg/" + name + "/source"})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkReadFile_MissingPath measures the cold-error path. Hit
+// when an agent asks for a path that doesn't exist (typo, race
+// against a delete). Should be cheap; this benchmark guards against
+// an accidental scan or expensive error-formatting regression.
+func BenchmarkReadFile_MissingPath(b *testing.B) {
+	store := buildReadFileBenchGraph(b)
+	handler := makeReadFileHandler(store)
+	req := makeRequest(map[string]any{"path": "pkg/does/not/exist"})
+	b.ResetTimer()
+	b.ReportAllocs()
+	for range b.N {
+		_, err := handler(context.Background(), req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkReadFile_Batch covers the batched path — agents often
+// fetch a fan-out of related files (e.g. all callers of a token).
+// Tests 1, 10, and 50 small-file batches against the per-file size
+// + total-size caps in makeReadFileHandler.
+func BenchmarkReadFile_Batch(b *testing.B) {
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{ID: "pkg", Mode: fs.ModeDir})
+	// Build 100 small files; benchmarks pick subsets via paths slice.
+	const total = 100
+	allPaths := make([]string, total)
+	for i := range total {
+		id := fmt.Sprintf("pkg/file_%03d/source", i)
+		store.AddNode(&graph.Node{
+			ID:   id,
+			Mode: 0,
+			Data: []byte(strings.Repeat("y", 200)),
+		})
+		allPaths[i] = id
+	}
+	handler := makeReadFileHandler(store)
+	for _, n := range []int{1, 10, 50} {
+		b.Run(fmt.Sprintf("batch=%d", n), func(b *testing.B) {
+			payload, err := json.Marshal(allPaths[:n])
+			if err != nil {
+				b.Fatal(err)
+			}
+			req := makeRequest(map[string]any{"paths": string(payload)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for range b.N {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Three new benchmarks for the `read_file` MCP handler — most-called tool after `list_directory` with no prior coverage:

- **`Single`** — small (~100B) / medium (~10KB) / large (~1MB) — `GetNode` + content-marshal cost across the realistic content spectrum
- **`MissingPath`** — cold-error path; guards against scan or expensive error-formatting regressions
- **`Batch`** — 1 / 10 / 50 small files; exercises the batch reader's per-file and total-size caps

## Local measurements (M3 Max)

| Bench                | Time    | Bytes/op  | Allocs/op |
| -------------------- | ------- | --------- | --------- |
| Single small (100 B) | 1.4 µs  | 376 B     | 6         |
| Single medium (10 KB)| 1.5 µs  | 20 KB     | 6         |
| Single large (1 MB)  | 199 µs  | 2 MB      | 6         |
| Missing path         | 44 µs   | 1.4 KB    | 9         |
| Batch=1              | 12 µs   | 3 KB      | 20        |
| Batch=10             | 28 µs   | 18 KB     | 58        |
| Batch=50             | 85 µs   | 96 KB     | 224       |

Linear scaling in both content size (single) and batch count, as expected. **One observation worth knowing:** MissingPath (44 µs) is slower than a successful small/medium read. The handler runs `prioritizeAndAdvise` on miss, which probes for a ley-line daemon. Not necessarily wrong, but visible now.

## Test plan
- [x] `go test -bench BenchmarkReadFile -benchtime=2x ./cmd/` runs cleanly
- [x] gofumpt + go vet + golangci-lint clean via pre-commit
- [x] No production-code changes

Continues `mache-9b4d8a` partial coverage. Prior: find_smells (PR #200), find_callers (PR #206). Remaining gaps: search, find_definition, ingestion throughput.