### PR TITLE
feat(graph): MultiRepoGraph foundation (mache-iegm step 1)

### DIFF
--- a/internal/graph/multi_repo.go
+++ b/internal/graph/multi_repo.go
@@ -1,0 +1,258 @@
+package graph
+
+import (
+	"errors"
+	"io/fs"
+	"sort"
+	"strings"
+)
+
+// MultiRepoGraph composes multiple Graph backends and exposes them as
+// a single graph with each repo as a top-level virtual directory.
+//
+// Node IDs are namespaced: "repo-name/path/inside/repo". The virtual
+// root ("") returns the list of registered repo names as children.
+//
+// Federated queries — GetCallers and GetCallees walk every registered
+// repo and merge results. Each result's ID is rewritten to include
+// the repo prefix so callers can distinguish which repo a hit came
+// from. This implements the cheapest of the three federation
+// strategies sketched in mache-iegm and the Ref pointer kind from
+// ADR-0011 (docs/adr/0011-pointer-abstraction.md).
+//
+// MultiRepoGraph does not own its child Graphs — closing or
+// invalidating MultiRepoGraph does not propagate to children. The
+// caller manages backend lifecycles. Per-repo Invalidate is routed
+// through the namespaced ID so a write-back on one repo doesn't
+// disturb others.
+type MultiRepoGraph struct {
+	repos map[string]Graph
+	names []string // sorted for deterministic root listings
+}
+
+// NewMultiRepoGraph builds a MultiRepoGraph from a name → backend map.
+// Repo names must not contain '/'; that's the namespace separator.
+func NewMultiRepoGraph(repos map[string]Graph) *MultiRepoGraph {
+	names := make([]string, 0, len(repos))
+	for n := range repos {
+		if strings.Contains(n, "/") {
+			panic("MultiRepoGraph: repo name must not contain '/': " + n)
+		}
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return &MultiRepoGraph{
+		repos: repos,
+		names: names,
+	}
+}
+
+// splitRepoID splits "repo/inner/path" into ("repo", "inner/path").
+// "" maps to ("", "") meaning the virtual root.
+// "repo" maps to ("repo", "") meaning the repo's root inside its backend.
+func splitRepoID(id string) (repo, inner string) {
+	id = strings.TrimPrefix(id, "/")
+	if id == "" {
+		return "", ""
+	}
+	if before, after, ok := strings.Cut(id, "/"); ok {
+		return before, after
+	}
+	return id, ""
+}
+
+func (m *MultiRepoGraph) wrapID(repo, inner string) string {
+	if inner == "" {
+		return repo
+	}
+	return repo + "/" + inner
+}
+
+// GetNode returns the node at id. The virtual root synthesizes a
+// directory whose children are the registered repo names. Otherwise
+// the call is dispatched to repo's backend with the inner path.
+func (m *MultiRepoGraph) GetNode(id string) (*Node, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		children := make([]string, len(m.names))
+		copy(children, m.names)
+		return &Node{
+			ID:       "",
+			Mode:     fs.ModeDir | 0o555,
+			Children: children,
+		}, nil
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	n, err := g.GetNode(inner)
+	if err != nil {
+		return nil, err
+	}
+	// Shallow-copy + rewrite children IDs so consumers can navigate
+	// back into MultiRepoGraph without dropping the repo prefix.
+	out := *n
+	out.ID = m.wrapID(repo, n.ID)
+	if len(n.Children) > 0 {
+		wrapped := make([]string, len(n.Children))
+		for i, c := range n.Children {
+			wrapped[i] = m.wrapID(repo, c)
+		}
+		out.Children = wrapped
+	}
+	return &out, nil
+}
+
+// ListChildren returns the children of id. Same routing as GetNode.
+func (m *MultiRepoGraph) ListChildren(id string) ([]string, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		out := make([]string, len(m.names))
+		copy(out, m.names)
+		return out, nil
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	children, err := g.ListChildren(inner)
+	if err != nil {
+		return nil, err
+	}
+	wrapped := make([]string, len(children))
+	for i, c := range children {
+		wrapped[i] = m.wrapID(repo, c)
+	}
+	return wrapped, nil
+}
+
+// ListChildStats returns stat snapshots. Same routing as ListChildren.
+func (m *MultiRepoGraph) ListChildStats(id string) ([]NodeStat, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		out := make([]NodeStat, len(m.names))
+		for i, name := range m.names {
+			out[i] = NodeStat{
+				ID:    name,
+				IsDir: true,
+			}
+		}
+		return out, nil
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	stats, err := g.ListChildStats(inner)
+	if err != nil {
+		return nil, err
+	}
+	for i := range stats {
+		stats[i].ID = m.wrapID(repo, stats[i].ID)
+	}
+	return stats, nil
+}
+
+// ReadContent dispatches to the repo holding id.
+func (m *MultiRepoGraph) ReadContent(id string, buf []byte, offset int64) (int, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		return 0, ErrNotFound
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return 0, ErrNotFound
+	}
+	return g.ReadContent(inner, buf, offset)
+}
+
+// GetCallers walks every registered repo and merges results. Each
+// returned node's ID is rewritten to include the repo prefix so
+// callers can distinguish which repo a hit came from.
+//
+// Errors on individual repos are tolerated — the merged result is
+// returned even if some repos failed. The first error is surfaced
+// only when no callers were found anywhere.
+func (m *MultiRepoGraph) GetCallers(token string) ([]*Node, error) {
+	var out []*Node
+	var firstErr error
+	for _, name := range m.names {
+		callers, err := m.repos[name].GetCallers(token)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		for _, c := range callers {
+			wrapped := *c
+			wrapped.ID = m.wrapID(name, c.ID)
+			out = append(out, &wrapped)
+		}
+	}
+	if len(out) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	return out, nil
+}
+
+// GetCallees dispatches to the repo holding id. Cross-repo callees
+// (where the called function lives in a different repo) are not
+// resolved by this step — that requires an inter-repo defs index,
+// filed as future work in mache-iegm.
+func (m *MultiRepoGraph) GetCallees(id string) ([]*Node, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		return nil, ErrNotFound
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	callees, err := g.GetCallees(inner)
+	if err != nil {
+		return nil, err
+	}
+	// Rewrite IDs back into the multi-repo namespace.
+	for i, c := range callees {
+		wrapped := *c
+		wrapped.ID = m.wrapID(repo, c.ID)
+		callees[i] = &wrapped
+	}
+	return callees, nil
+}
+
+// Invalidate routes to the repo holding id. The virtual root and
+// unknown repos are no-ops.
+func (m *MultiRepoGraph) Invalidate(id string) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		return
+	}
+	if g, ok := m.repos[repo]; ok {
+		g.Invalidate(inner)
+	}
+}
+
+// Act dispatches to the repo holding id. The virtual root rejects
+// all actions — there's nothing to act on at the registry level.
+func (m *MultiRepoGraph) Act(id, action, payload string) (*ActionResult, error) {
+	repo, inner := splitRepoID(id)
+	if repo == "" {
+		return nil, errors.New("MultiRepoGraph: cannot Act on virtual root")
+	}
+	g, ok := m.repos[repo]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	return g.Act(inner, action, payload)
+}
+
+// Repos returns the registered repo names in deterministic order.
+// Useful for diagnostics and listing.
+func (m *MultiRepoGraph) Repos() []string {
+	out := make([]string, len(m.names))
+	copy(out, m.names)
+	return out
+}

--- a/internal/graph/multi_repo_test.go
+++ b/internal/graph/multi_repo_test.go
@@ -1,0 +1,174 @@
+package graph
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildAuthRepo seeds an "auth" repo with one function (Validate) and
+// a caller of itself. Used by the cross-repo tests.
+func buildAuthRepo(t *testing.T) *MemoryStore {
+	t.Helper()
+	store := NewMemoryStore()
+	store.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	store.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	store.AddNode(&Node{
+		ID:   "functions/Validate/source",
+		Mode: 0,
+		Data: []byte("func Validate() {}"),
+	})
+	require.NoError(t, store.AddRef("Validate", "functions/Validate/source"))
+	return store
+}
+
+// buildBillingRepo seeds a "billing" repo that ALSO calls Validate
+// (cross-repo reference: billing/Charge calls auth/Validate). Used to
+// verify GetCallers federation aggregates across repos.
+func buildBillingRepo(t *testing.T) *MemoryStore {
+	t.Helper()
+	store := NewMemoryStore()
+	store.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	store.AddNode(&Node{
+		ID:       "functions/Charge",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Charge/source"},
+	})
+	store.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	require.NoError(t, store.AddRef("Validate", "functions/Charge/source"))
+	require.NoError(t, store.AddRef("Charge", "functions/Charge/source"))
+	return store
+}
+
+// TestMultiRepoGraph_VirtualRootListsRepos asserts the synthesized
+// root returns the registered repo names as children.
+func TestMultiRepoGraph_VirtualRootListsRepos(t *testing.T) {
+	m := NewMultiRepoGraph(map[string]Graph{
+		"auth":    buildAuthRepo(t),
+		"billing": buildBillingRepo(t),
+	})
+
+	root, err := m.GetNode("")
+	require.NoError(t, err)
+	assert.True(t, root.Mode.IsDir(), "virtual root must be a directory")
+	assert.Equal(t, []string{"auth", "billing"}, root.Children, "deterministic alphabetical order")
+
+	children, err := m.ListChildren("")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"auth", "billing"}, children)
+
+	stats, err := m.ListChildStats("")
+	require.NoError(t, err)
+	require.Len(t, stats, 2)
+	for _, s := range stats {
+		assert.True(t, s.IsDir, "repo top-level entries are directories")
+	}
+}
+
+// TestMultiRepoGraph_GetNodeRoutesByPrefix asserts that "repo/path"
+// IDs route to the right backend and the returned IDs are rewritten
+// to keep the prefix.
+func TestMultiRepoGraph_GetNodeRoutesByPrefix(t *testing.T) {
+	auth := buildAuthRepo(t)
+	billing := buildBillingRepo(t)
+	m := NewMultiRepoGraph(map[string]Graph{"auth": auth, "billing": billing})
+
+	// Node inside auth.
+	n, err := m.GetNode("auth/functions/Validate/source")
+	require.NoError(t, err)
+	assert.Equal(t, "auth/functions/Validate/source", n.ID, "ID must keep the repo prefix")
+	assert.Equal(t, []byte("func Validate() {}"), n.Data)
+
+	// Directory inside billing — children are rewritten with prefix.
+	n, err = m.GetNode("billing/functions/Charge")
+	require.NoError(t, err)
+	require.Len(t, n.Children, 1)
+	assert.Equal(t, "billing/functions/Charge/source", n.Children[0],
+		"children must carry the repo prefix so callers can navigate back")
+}
+
+// TestMultiRepoGraph_UnknownRepoReturnsNotFound asserts that a path
+// pointing at a repo that wasn't registered surfaces ErrNotFound
+// rather than a generic error or a routing-table panic.
+func TestMultiRepoGraph_UnknownRepoReturnsNotFound(t *testing.T) {
+	m := NewMultiRepoGraph(map[string]Graph{"auth": buildAuthRepo(t)})
+
+	_, err := m.GetNode("nonexistent/foo/bar")
+	assert.ErrorIs(t, err, ErrNotFound)
+
+	_, err = m.ListChildren("nonexistent")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+// TestMultiRepoGraph_GetCallersFederates is the headline cross-repo
+// behavior: a token defined in one repo and referenced from multiple
+// repos returns callers from every repo, with IDs prefixed.
+func TestMultiRepoGraph_GetCallersFederates(t *testing.T) {
+	auth := buildAuthRepo(t)
+	billing := buildBillingRepo(t)
+	m := NewMultiRepoGraph(map[string]Graph{"auth": auth, "billing": billing})
+
+	callers, err := m.GetCallers("Validate")
+	require.NoError(t, err)
+	require.Len(t, callers, 2, "auth references Validate (self-ref test fixture); billing/Charge calls Validate")
+
+	gotIDs := make([]string, len(callers))
+	for i, c := range callers {
+		gotIDs[i] = c.ID
+	}
+	assert.ElementsMatch(t,
+		[]string{
+			"auth/functions/Validate/source",
+			"billing/functions/Charge/source",
+		},
+		gotIDs,
+		"callers must carry repo prefix so callers can route back",
+	)
+}
+
+// TestMultiRepoGraph_GetCallersNoMatchAnywhere asserts an unknown
+// token returns no callers and no error (consistent with single-repo
+// MemoryStore.GetCallers).
+func TestMultiRepoGraph_GetCallersNoMatchAnywhere(t *testing.T) {
+	m := NewMultiRepoGraph(map[string]Graph{
+		"auth":    buildAuthRepo(t),
+		"billing": buildBillingRepo(t),
+	})
+
+	callers, err := m.GetCallers("DefinitelyNotAToken")
+	require.NoError(t, err)
+	assert.Empty(t, callers)
+}
+
+// TestMultiRepoGraph_ReposListsRegisteredNames asserts the helper
+// surface returns the same deterministic ordering as the virtual
+// root's children.
+func TestMultiRepoGraph_ReposListsRegisteredNames(t *testing.T) {
+	m := NewMultiRepoGraph(map[string]Graph{
+		"zebra":  NewMemoryStore(),
+		"apple":  NewMemoryStore(),
+		"middle": NewMemoryStore(),
+	})
+
+	assert.Equal(t, []string{"apple", "middle", "zebra"}, m.Repos(),
+		"Repos() must return alphabetically-sorted names matching virtual-root children")
+}
+
+// TestMultiRepoGraph_RepoNameWithSlashPanics guards the namespace
+// invariant: repo names cannot contain '/' because that's the
+// separator. Caught at construction so misuse is loud.
+func TestMultiRepoGraph_RepoNameWithSlashPanics(t *testing.T) {
+	assert.Panics(t, func() {
+		NewMultiRepoGraph(map[string]Graph{"bad/name": NewMemoryStore()})
+	})
+}


### PR DESCRIPTION
## Summary
First PR of the cross-repo refs implementation tracked by `mache-iegm`. Adds `MultiRepoGraph` — composes multiple `Graph` backends, exposes them as a single graph with each repo as a top-level virtual directory. Federated `GetCallers` walks every registered repo and merges results.

This implements the **Ref pointer kind** from [ADR-0011](docs/adr/0011-pointer-abstraction.md) — the first concrete step on that ADR, taken because cross-repo refs is the use case that motivated the framing.

## What's in this PR
- `internal/graph/multi_repo.go` — `MultiRepoGraph` struct + Graph-interface implementation
- `internal/graph/multi_repo_test.go` — 7 tests covering virtual-root listing, ID routing, federation, error paths, namespace invariants
- Node IDs are namespaced: `repo-name/path/inside/repo`
- Virtual root (`""`) synthesizes a directory whose children are the registered repo names

## What's NOT in this PR (filed as future steps in mache-iegm)
- `--repo NAME=PATH` flag in `cmd/serve.go`
- `find_callers` / `find_definition` MCP handler `repo:` prefix syntax
- Cross-repo callees resolution (needs an inter-repo defs index)
- SQLiteGraph + HotSwap composition

These all build on this foundation. Step 1 is intentionally a pure data-structure PR with no MCP-surface or CLI changes.

## Caller flow

```go
m := NewMultiRepoGraph(map[string]Graph{
    "auth":    authStore,
    "billing": billingStore,
})

m.GetNode("")                            // -> children=[auth, billing]
m.GetNode("auth/functions/Validate")     // -> routes to auth, ID kept
m.GetCallers("Validate")                 // -> federates across both
                                         //    returns nodes from both
                                         //    repos, IDs prefixed
```

## Test plan
- [x] `go test -run TestMultiRepoGraph ./internal/graph/` — 7/7 pass
- [x] `go test ./internal/graph/` — full graph package green (no regressions)
- [x] gofumpt + go vet + golangci-lint clean

Tracks `mache-iegm`. This is step 1 of the multi-PR implementation outlined there.