### PR TITLE
feat(serve): --mount NAME=PATH for cross-repo graphs (mache-iegm step 2)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -46,6 +46,7 @@ var (
 	servePath    string
 	serveRepo    string
 	serveControl string
+	serveMounts  []string
 )
 
 func init() {
@@ -55,6 +56,8 @@ func init() {
 	serveCmd.Flags().StringVar(&servePath, "path", "", "Base directory for project detection (defaults to current working directory)")
 	serveCmd.Flags().StringVar(&serveRepo, "repo", "", "Git repo URL to clone and serve (ephemeral: cleaned up on exit)")
 	serveCmd.Flags().StringVar(&serveControl, "control", "", "Path to ley-line control block (reads from arena, enables hot-swap)")
+	serveCmd.Flags().StringArrayVar(&serveMounts, "mount", nil,
+		"Mount a graph at NAME=PATH; repeatable. Each PATH is loaded via the same path-or-.db resolution as the positional source. NAME becomes a top-level virtual directory. Cross-repo find_callers federates across all mounts. Composes with --schema (applied to every mount).")
 	rootCmd.AddCommand(serveCmd)
 }
 
@@ -437,6 +440,55 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func
 		_ = store.Close()
 		resolver.Close()
 	}, nil
+}
+
+// buildMaybeMultiGraph dispatches between single-source and composite
+// (multi-mount) construction. With no --mount flags, it's a thin
+// pass-through to buildServeGraph. With one or more --mount NAME=PATH
+// flags, it builds a CompositeGraph by calling buildServeGraph for
+// each mount path and Mount-ing the result under NAME.
+//
+// When --mount is set, the positional dataSource is rejected — the
+// caller must choose between a single source and a composite.
+//
+// Cleanup runs in reverse-mount order so child graphs are torn down
+// before any shared resources they depend on.
+func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph, func(), error) {
+	if len(serveMounts) == 0 {
+		return buildServeGraph(dataSource, schema)
+	}
+	if dataSource != "" {
+		return nil, func() {}, fmt.Errorf("cannot use both a positional source (%q) and --mount; use one or the other", dataSource)
+	}
+
+	composite := graph.NewCompositeGraph()
+	var cleanups []func()
+	runAll := func() {
+		// Reverse order so later mounts close before earlier ones.
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+
+	for _, spec := range serveMounts {
+		name, path, ok := strings.Cut(spec, "=")
+		if !ok || name == "" || path == "" {
+			runAll()
+			return nil, func() {}, fmt.Errorf("invalid --mount spec %q (expected NAME=PATH)", spec)
+		}
+		g, cleanup, err := buildServeGraph(path, schema)
+		if err != nil {
+			runAll()
+			return nil, func() {}, fmt.Errorf("mount %s=%s: %w", name, path, err)
+		}
+		cleanups = append(cleanups, cleanup)
+		if err := composite.Mount(name, g); err != nil {
+			runAll()
+			return nil, func() {}, fmt.Errorf("mount %q: %w", name, err)
+		}
+		log.Printf("mounted %s -> %s", name, path)
+	}
+	return composite, runAll, nil
 }
 
 // openDBGraph opens a .db file as a SQLiteGraph after materializing virtual

--- a/cmd/serve_mount_test.go
+++ b/cmd/serve_mount_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// withServeMounts swaps the package-level serveMounts flag for the
+// duration of the test and restores it on cleanup. Cobra binds the
+// flag globally so direct mutation is the practical seam.
+func withServeMounts(t *testing.T, mounts []string) {
+	t.Helper()
+	saved := serveMounts
+	serveMounts = mounts
+	t.Cleanup(func() { serveMounts = saved })
+}
+
+// writeSourceDir lays down a tiny Go source tree mache can ingest
+// without going through ley-line — single file under the given dir
+// with a known function name.
+func writeSourceDir(t *testing.T, fnName string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "main.go")
+	src := "package main\n\nfunc " + fnName + "() {}\n"
+	require.NoError(t, os.WriteFile(path, []byte(src), 0o600))
+	return dir
+}
+
+// TestBuildMaybeMultiGraph_NoMountsFallsThroughToSingleSource asserts
+// the wrapper is a pass-through when no --mount flags are present.
+// Behavior must be byte-identical to calling buildServeGraph directly.
+func TestBuildMaybeMultiGraph_NoMountsFallsThroughToSingleSource(t *testing.T) {
+	withServeMounts(t, nil)
+	dir := writeSourceDir(t, "Foo")
+
+	// Disable auto-leyline so the test exercises the in-process
+	// MemoryStore path deterministically.
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+
+	g, cleanup, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, g)
+
+	// We don't assert graph contents here — that would require a
+	// non-empty topology and exercise the schema/ingest pipeline,
+	// which has its own coverage. The point of this test is to
+	// verify the dispatch path: no --mount → buildServeGraph fires
+	// → returns a Graph + cleanup with no error.
+	_, isComposite := g.(*graph.CompositeGraph)
+	assert.False(t, isComposite, "no --mount must not wrap in CompositeGraph")
+}
+
+// TestBuildMaybeMultiGraph_MountsBuildComposite asserts that with
+// two --mount flags, the result is a CompositeGraph whose virtual
+// root lists both mount names.
+func TestBuildMaybeMultiGraph_MountsBuildComposite(t *testing.T) {
+	authDir := writeSourceDir(t, "Validate")
+	billingDir := writeSourceDir(t, "Charge")
+	withServeMounts(t, []string{
+		"auth=" + authDir,
+		"billing=" + billingDir,
+	})
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+
+	g, cleanup, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+
+	root, err := g.GetNode("")
+	require.NoError(t, err)
+	assert.True(t, root.Mode.IsDir(), "composite root is a directory")
+
+	// CompositeGraph populates the root's children via ListChildren,
+	// not GetNode (intentional; keeps GetNode cheap and Mount/Unmount
+	// from invalidating cached Node objects).
+	children, err := g.ListChildren("")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"auth", "billing"}, children,
+		"composite root must list both mount names via ListChildren")
+}
+
+// TestBuildMaybeMultiGraph_PositionalSourceWithMountErrors guards the
+// "choose one" rule — if the user passes both a positional source
+// and --mount, fail loudly rather than silently picking one.
+func TestBuildMaybeMultiGraph_PositionalSourceWithMountErrors(t *testing.T) {
+	dir := writeSourceDir(t, "Foo")
+	withServeMounts(t, []string{"x=" + dir})
+
+	_, _, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot use both")
+}
+
+// TestBuildMaybeMultiGraph_InvalidSpecErrors checks that --mount
+// values without an '=' separator (or with empty NAME/PATH) produce
+// a clear error and don't leak the partial composite.
+func TestBuildMaybeMultiGraph_InvalidSpecErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		spec string
+	}{
+		{"no_equals", "noequalshere"},
+		{"empty_name", "=/some/path"},
+		{"empty_path", "name="},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withServeMounts(t, []string{tc.spec})
+			_, _, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "invalid --mount spec")
+		})
+	}
+}

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -449,7 +449,7 @@ func (lg *lazyGraph) init() {
 			}
 		}
 
-		g, cleanup, err := buildServeGraph(dataSource, schema)
+		g, cleanup, err := buildMaybeMultiGraph(dataSource, schema)
 		if err != nil {
 			lg.err = err
 			return


### PR DESCRIPTION
## Summary
Wire `CompositeGraph` (the existing primitive — see PR #214 for why we're not building a new one) into `mache serve` via a new repeatable `--mount NAME=PATH` flag. Each mount runs through `buildServeGraph` for its path resolution; results compose under one CompositeGraph; `find_callers` federates across mounts.

## Examples

```bash
# Cross-repo: auth-svc + billing-svc, find callers across both
mache serve --mount auth=./auth-svc --mount billing=./billing-svc

# Mix sources: core library + a pre-baked test-fixture .db
mache serve --mount core=./core-lib --mount tests=./fixtures.db
```

`mache serve ./single-repo` (no `--mount`) is unchanged — `buildMaybeMultiGraph` is a thin pass-through to `buildServeGraph`.

## Validation
- `--mount` and a positional source are mutually exclusive (clear error if both)
- Each spec must be `NAME=PATH` with non-empty `NAME` and `PATH`
- `CompositeGraph.Mount` already rejects duplicate names
- Cleanup runs in reverse-mount order

## What's NOT in this PR (future steps of mache-iegm)
- **Step 3**: `find_callers` response annotation — today the mount prefix is in the node ID but agents have to parse it; would be cleaner to surface explicitly
- **Step 4**: Cross-repo callees resolution (inter-repo defs index)
- **Step 5**: `ARCHITECTURE.md` + `GETTING-STARTED.md` documentation update

## Test plan
- [x] `go test -run TestBuildMaybeMultiGraph ./cmd/` — 6 tests, all pass
  - no-mount pass-through (verified result is not `*CompositeGraph`)
  - two-mount composite (root lists both names via `ListChildren`)
  - positional+mount conflict
  - invalid spec shapes (no `=`, empty NAME, empty PATH)
- [x] `mache serve --help` shows the new flag
- [x] gofumpt + go vet + golangci-lint clean

Continues `mache-iegm`.