### PR TITLE
feat: find_callers surfaces mount prefix on CompositeGraph (mache-iegm step 3)

### DIFF
--- a/cmd/serve_find_callers_mount_test.go
+++ b/cmd/serve_find_callers_mount_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io/fs"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// scopedCallerRow mirrors the JSON shape the handler produces when
+// any result carries a mount prefix.
+type scopedCallerRow struct {
+	Path  string `json:"path"`
+	Mount string `json:"mount,omitempty"`
+}
+
+// twoMountStores builds two MemoryStores each with one caller of the
+// shared token "Validate" — one in "auth", one in "billing". Mirrors
+// the cross-repo refs use case mache-iegm tracks.
+func twoMountStores(t *testing.T) (*graph.MemoryStore, *graph.MemoryStore) {
+	t.Helper()
+	auth := graph.NewMemoryStore()
+	auth.AddRoot(&graph.Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&graph.Node{ID: "functions/AuthCaller", Mode: fs.ModeDir})
+	auth.AddNode(&graph.Node{ID: "functions/AuthCaller/source", Mode: 0, Data: []byte("func AuthCaller() { Validate() }")})
+	require.NoError(t, auth.AddRef("Validate", "functions/AuthCaller/source"))
+
+	billing := graph.NewMemoryStore()
+	billing.AddRoot(&graph.Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&graph.Node{ID: "functions/Charge", Mode: fs.ModeDir})
+	billing.AddNode(&graph.Node{ID: "functions/Charge/source", Mode: 0, Data: []byte("func Charge() { Validate() }")})
+	require.NoError(t, billing.AddRef("Validate", "functions/Charge/source"))
+	return auth, billing
+}
+
+// TestFindCallers_AnnotatesMountOnComposite asserts that when the
+// active graph is a CompositeGraph and callers come from multiple
+// mounts, the response surfaces the mount prefix per result rather
+// than burying it in the path string.
+func TestFindCallers_AnnotatesMountOnComposite(t *testing.T) {
+	auth, billing := twoMountStores(t)
+	cg := graph.NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	handler := makeFindCallersHandler(cg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"token": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Callers []scopedCallerRow `json:"callers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Callers, 2)
+
+	byMount := make(map[string]string, len(resp.Callers))
+	for _, c := range resp.Callers {
+		byMount[c.Mount] = c.Path
+	}
+	require.Contains(t, byMount, "auth", "expected at least one caller from auth mount")
+	require.Contains(t, byMount, "billing", "expected at least one caller from billing mount")
+	assert.Equal(t, "auth/functions/AuthCaller/source", byMount["auth"])
+	assert.Equal(t, "billing/functions/Charge/source", byMount["billing"])
+}
+
+// TestFindCallers_NonCompositeKeepsLegacyShape ensures a non-composite
+// graph still returns the historical []string response — agents that
+// hardcode the old shape don't break.
+func TestFindCallers_NonCompositeKeepsLegacyShape(t *testing.T) {
+	auth, _ := twoMountStores(t)
+	handler := makeFindCallersHandler(auth)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"token": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	// Legacy shape: bare []string.
+	var paths []string
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &paths))
+	assert.Equal(t, []string{"functions/AuthCaller/source"}, paths)
+}
+
+// TestFindCallers_CompositeNoCallersKeepsLegacyShape covers the path
+// where the composite is in play but the token has no callers — the
+// handler falls through to the existing "[]" empty-array response.
+func TestFindCallers_CompositeNoCallersKeepsLegacyShape(t *testing.T) {
+	auth, billing := twoMountStores(t)
+	cg := graph.NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	handler := makeFindCallersHandler(cg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"token": "NeverReferenced"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	assert.Equal(t, "[]", resultText(t, res),
+		"empty-result path keeps the bare-array response (backward-compat)")
+}
+
+// TestCompositeGraph_MountPrefixOf is the unit test for the public
+// accessor added in this PR. Empty / virtual-root / unknown-prefix
+// inputs all return "" so handlers can distinguish "this id is
+// composite-routed" from "this id was never under any mount."
+func TestCompositeGraph_MountPrefixOf(t *testing.T) {
+	cg := graph.NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", graph.NewMemoryStore()))
+
+	cases := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"empty_id", "", ""},
+		{"unknown_prefix", "billing/foo", ""},
+		{"known_prefix_root", "auth", "auth"},
+		{"known_prefix_path", "auth/functions/Foo", "auth"},
+		{"leading_slash_stripped", "/auth/functions/Foo", "auth"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, cg.MountPrefixOf(tc.id))
+		})
+	}
+}

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -442,6 +442,36 @@ func makeFindCallersHandler(g graph.Graph) server.ToolHandlerFunc {
 			paths = append(paths, c.ID)
 		}
 
+		// Cross-repo annotation: when running on a CompositeGraph
+		// (mache serve --mount NAME=PATH), each caller ID is prefixed
+		// with its mount name. Surface that explicitly so agents
+		// don't have to parse node IDs themselves.
+		if cg, ok := g.(*graph.CompositeGraph); ok && len(paths) > 0 {
+			type scopedCaller struct {
+				Path  string `json:"path"`
+				Mount string `json:"mount,omitempty"`
+			}
+			scoped := make([]scopedCaller, 0, len(paths))
+			anyMounted := false
+			for _, p := range paths {
+				m := cg.MountPrefixOf(p)
+				if m != "" {
+					anyMounted = true
+				}
+				scoped = append(scoped, scopedCaller{Path: p, Mount: m})
+			}
+			// Only switch to the annotated shape when at least one
+			// result actually carries a mount prefix — single-mount
+			// or non-composite paths keep the simpler legacy shape.
+			if anyMounted {
+				type callersResult struct {
+					Callers []scopedCaller `json:"callers"`
+				}
+				data, _ := json.MarshalIndent(callersResult{Callers: scoped}, "", "  ")
+				return mcp.NewToolResultText(string(data)), nil
+			}
+		}
+
 		// Supplement with LSP references if available
 		if qg, ok := g.(refsQuerier); ok {
 			lspRefs, lspErr := queryLSPRefs(qg, token)

--- a/internal/graph/composite.go
+++ b/internal/graph/composite.go
@@ -74,6 +74,19 @@ func (c *CompositeGraph) resolve(id string) (string, string, Graph) {
 	return prefix, subPath, g
 }
 
+// MountPrefixOf returns the mount-name prefix that would route id to
+// a mounted sub-graph, or "" if id doesn't resolve to any mount (the
+// virtual root or an unknown prefix).
+//
+// MCP handlers use this to annotate cross-repo results with their
+// mount of origin without having to parse node IDs themselves.
+func (c *CompositeGraph) MountPrefixOf(id string) string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	prefix, _, _ := c.resolve(id)
+	return prefix
+}
+
 // GetNode implements Graph.
 func (c *CompositeGraph) GetNode(id string) (*Node, error) {
 	c.mu.RLock()


### PR DESCRIPTION
## Summary
`find_callers` now annotates results with their mount of origin when running on a `CompositeGraph` (i.e., `mache serve --mount NAME=PATH ...` from PR #215).

**Before:**
```json
["auth/functions/Validate/source", "billing/functions/Charge/source"]
```

**After:**
```json
{
  "callers": [
    {"path": "auth/functions/Validate/source", "mount": "auth"},
    {"path": "billing/functions/Charge/source", "mount": "billing"}
  ]
}
```

## Two pieces
1. **`(*graph.CompositeGraph).MountPrefixOf(id) string`** — public accessor wrapping the existing private `resolve()`. Returns `""` for virtual root / unknown prefix / empty input.
2. **`find_callers` handler** — type-asserts `*graph.CompositeGraph` and switches to the annotated shape **only when at least one result carries a mount prefix**. Non-composite graphs and empty results keep the legacy `[]string` shape. Agents that hardcoded the old shape don't break.

## Future shapes that could ride on the same accessor (not in this PR)
- `find_callees`: mount of resolved callee
- `find_definition`: mount where the def lives
- `search`: mount per match
- `get_impact`: mount per blast-radius hop

## Test plan
- [x] `TestFindCallers_AnnotatesMountOnComposite` — two-mount composite, asserts both mount labels appear with their correct paths
- [x] `TestFindCallers_NonCompositeKeepsLegacyShape` — single MemoryStore returns bare `[]string`
- [x] `TestFindCallers_CompositeNoCallersKeepsLegacyShape` — composite + zero callers returns `"[]"`
- [x] `TestCompositeGraph_MountPrefixOf` — 5 sub-cases (empty, unknown, known root, known path, leading slash)
- [x] Full `cmd/` + `internal/graph/` suites green

Closes step 3 of `mache-iegm`. Two steps remain: cross-repo callees resolution (inter-repo defs index) and `ARCHITECTURE.md` + `GETTING-STARTED.md` documentation update.