### PR TITLE
docs: cross-repo serve via --mount (mache-iegm step 5)

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -73,6 +73,29 @@ Once connected, the agent can call `list_directory`, `read_file`, `find_callers`
 
 See the [MCP Server section in ARCHITECTURE.md](docs/ARCHITECTURE.md#core-abstractions) for the full tool inventory and the [Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open) section for which tools require an LLO-built `.db`.
 
+## Cross-repo serve (`--mount`)
+
+To span multiple codebases from one MCP endpoint, use repeatable `--mount NAME=PATH` flags:
+
+```bash
+mache serve --mount auth=./auth-svc --mount billing=./billing-svc
+```
+
+Each mount becomes a top-level virtual directory. `find_callers Validate` walks both repos and returns results annotated with their mount of origin:
+
+```json
+{
+  "callers": [
+    {"path": "auth/functions/AuthCaller/source", "mount": "auth"},
+    {"path": "billing/functions/Charge/source",  "mount": "billing"}
+  ]
+}
+```
+
+Mounts compose any source `mache serve` accepts — directories, `.db` files, or a mix. `--mount` and a positional source are mutually exclusive (use one or the other).
+
+See [ARCHITECTURE.md § Cross-repo serve](docs/ARCHITECTURE.md#cross-repo-serve---mount) for the design and what's not yet wired (cross-repo `find_callees` resolution lands separately under `mache-iegm`).
+
 ## Mount as a filesystem (optional)
 
 Beyond MCP, the graph can be exposed as a mounted directory tree — useful for `ls`, `cat`, shell scripts, or tools that work with files:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The graph is the same on either path; MCP and the filesystem are two ways to tal
 | --------------------------------------- | ----------------------------------------------------------------------------- |
 | Tree-sitter parsing (28 langs)          | Stable                                                                        |
 | MCP server (16 tools, stdio + HTTP)     | Stable                                                                        |
+| Cross-repo serve (`--mount NAME=PATH`)  | Stable (find_callers federates; find_callees stays per-mount for now)         |
 | Cross-references (callers/callees)      | Stable                                                                        |
 | `find_smells` (9 structural rules)      | Stable                                                                        |
 | NFS mount + write-back                  | Stable                                                                        |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -158,6 +158,39 @@ Key types:
 
 If validation fails, the write is saved as a **draft** — the node path remains stable, and the error is available via `_diagnostics/ast-errors`. The agent can read its broken code and fix it without losing the file path.
 
+## Cross-repo serve (`--mount`)
+
+`mache serve` accepts repeatable `--mount NAME=PATH` flags to compose multiple per-source graphs into a single `CompositeGraph`. Use it when you want one MCP endpoint to span several codebases — e.g., `auth-svc` and `billing-svc`, or a core library plus its tests, or a mix of source repos and pre-baked `.db` files.
+
+```bash
+mache serve --mount auth=./auth-svc --mount billing=./billing-svc
+```
+
+Under the composite:
+
+- **Each mount becomes a top-level virtual directory.** `list_directory ""` returns `[auth, billing]`. Per-mount paths are namespaced as `mount-name/path/inside/repo`.
+- **`find_callers` federates across mounts.** Calling `find_callers Validate` walks every registered mount and merges the results. The response shape switches to objects carrying an explicit `mount` field so agents don't have to parse node IDs:
+  ```json
+  {
+    "callers": [
+      {"path": "auth/functions/AuthCaller/source", "mount": "auth"},
+      {"path": "billing/functions/Charge/source",  "mount": "billing"}
+    ]
+  }
+  ```
+- **`get_node` / `read_file` / `find_callees` route by prefix.** A path with no recognized mount prefix returns `ErrNotFound`.
+- **Single-source serves are unchanged.** Without `--mount`, the response shape and behavior are byte-identical to before.
+
+`CompositeGraph` is the existing internal primitive that powers this — `internal/graph/composite.go`. It supports dynamic `Mount`/`Unmount`, has a recursion guard against mounted graphs that delegate back, and uses a stable `mountTime` so NFS/FUSE attribute caches don't churn on every readdir.
+
+This is the first concrete implementation of the **`Ref` pointer kind** from [ADR-0011](adr/0011-pointer-abstraction.md): a name-scoped pointer that resolves through a registry of named graphs.
+
+**What's not yet wired (tracked in `mache-iegm`):**
+
+- Cross-repo `find_callees` resolution — when a function in mount A calls a function defined in mount B, the callee resolver doesn't yet walk into B's defs index. Today each mount resolves callees within itself.
+- `find_definition` mount annotation — same shape as `find_callers` annotation but on the def lookup; currently emits the legacy single-string response.
+- `search` and `get_impact` mount annotation — same idea, lower priority.
+
 ## Virtual Directories
 
 ### `_schema.json`


### PR DESCRIPTION
## Summary
Documents the cross-repo serve feature shipped in PRs #215 (`--mount` flag) and #216 (find_callers mount annotation).

## Changes
- **ARCHITECTURE.md** — new "Cross-repo serve (`--mount`)" section between Write Pipeline and Virtual Directories. Covers usage, namespaced node IDs, find_callers federation + annotated response shape, per-prefix routing, backward compat, the CompositeGraph primitive, ADR-0011 framing as the first `Ref` pointer implementation, and what's not yet wired.
- **GETTING-STARTED.md** — brief Cross-repo serve subsection with a ready-to-paste example and the annotated find_callers JSON.
- **README.md** — Status table gains a Cross-repo serve row showing stable with the find_callees caveat.

## Test plan
- [x] No code changes
- [x] All cross-references resolve
- [x] Pre-commit hooks pass

Closes step 5 of `mache-iegm`. Step 4 remains — cross-repo callees resolution needs an inter-repo defs index, substantial PR-shape, will land separately.