### PR TITLE
feat: cross-mount callees resolution (mache-iegm step 4)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -462,6 +462,12 @@ func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph,
 	}
 
 	composite := graph.NewCompositeGraph()
+	// Wire a tree-sitter call extractor onto the composite so cross-mount
+	// callees resolve: when a function in mount A calls one defined in
+	// mount B, find_callees on A's function returns B's def via the
+	// federated DefsMap. Without this, callees only route per-mount.
+	composite.SetCallExtractor(newCallExtractor())
+
 	var cleanups []func()
 	runAll := func() {
 		// Reverse order so later mounts close before earlier ones.

--- a/internal/graph/composite.go
+++ b/internal/graph/composite.go
@@ -26,6 +26,14 @@ type CompositeGraph struct {
 	// callerDepth guards against infinite recursion in GetCallers/GetCallees
 	// when a mounted sub-graph delegates back to this CompositeGraph.
 	callerDepth atomic.Int32
+
+	// extractor enables cross-mount callees resolution. When set, GetCallees
+	// extracts calls from the routed source itself (in addition to running
+	// the sub-graph's local resolution) and looks each one up against the
+	// federated DefsMap. Tokens that resolve to a different mount produce
+	// extra results in the merged response. nil means cross-mount callees
+	// are off — sub-graphs still run their own GetCallees as before.
+	extractor CallExtractor
 }
 
 // NewCompositeGraph creates an empty composite graph.
@@ -285,7 +293,12 @@ func (c *CompositeGraph) GetCallers(token string) ([]*Node, error) {
 	return all, nil
 }
 
-// GetCallees implements Graph.
+// GetCallees implements Graph. Routes to the local mount for in-mount
+// resolution; if a cross-mount CallExtractor is configured (via
+// SetCallExtractor), additionally resolves each extracted call against
+// the federated DefsMap so callees living in OTHER mounts surface in
+// the response. Local results win on dedupe; cross-mount results
+// supplement.
 func (c *CompositeGraph) GetCallees(id string) ([]*Node, error) {
 	if c.callerDepth.Add(1) > maxCallerDepth {
 		c.callerDepth.Add(-1)
@@ -294,21 +307,131 @@ func (c *CompositeGraph) GetCallees(id string) ([]*Node, error) {
 	defer c.callerDepth.Add(-1)
 
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	prefix, subPath, g := c.resolve(id)
+	extractor := c.extractor
+	c.mu.RUnlock()
+
 	if g == nil {
 		return nil, ErrNotFound
 	}
+
+	// Phase 1: route to local mount and re-prefix the results.
 	nodes, err := g.GetCallees(subPath)
 	if err != nil {
 		return nil, err
 	}
-	res := make([]*Node, len(nodes))
-	for i, n := range nodes {
-		res[i] = c.reprefixNode(prefix, n)
+	res := make([]*Node, 0, len(nodes))
+	seen := make(map[string]bool, len(nodes))
+	for _, n := range nodes {
+		wrapped := c.reprefixNode(prefix, n)
+		res = append(res, wrapped)
+		seen[wrapped.ID] = true
+	}
+
+	// Phase 2: cross-mount resolution. Skip if no extractor was wired
+	// or if the local mount didn't expose the construct shape we need
+	// (no source child / no language hint).
+	if extractor != nil {
+		extra := c.crossMountCallees(g, id, subPath, extractor)
+		for _, n := range extra {
+			if seen[n.ID] {
+				continue
+			}
+			res = append(res, n)
+			seen[n.ID] = true
+		}
 	}
 	return res, nil
+}
+
+// crossMountCallees re-extracts calls from id's source content using
+// the composite's own extractor and resolves each against the
+// federated DefsMap. Returns nodes whose IDs are composite-namespaced
+// (mount/path/...). Errors are swallowed — cross-mount resolution is
+// a best-effort supplement, not a replacement for local resolution.
+func (c *CompositeGraph) crossMountCallees(local Graph, fullID, subPath string, extractor CallExtractor) []*Node {
+	// Find the construct node and its source child.
+	node, err := local.GetNode(subPath)
+	if err != nil || node == nil || !node.Mode.IsDir() {
+		return nil
+	}
+	var sourceID string
+	for _, childID := range node.Children {
+		base := childID
+		if i := strings.LastIndex(childID, "/"); i >= 0 {
+			base = childID[i+1:]
+		}
+		if base == "source" {
+			sourceID = childID
+			break
+		}
+	}
+	if sourceID == "" {
+		return nil
+	}
+
+	var langName string
+	if v, ok := node.Properties["lang"]; ok {
+		langName = string(v)
+	}
+	if langName == "" {
+		return nil
+	}
+
+	srcNode, err := local.GetNode(sourceID)
+	if err != nil || srcNode == nil {
+		return nil
+	}
+	buf := make([]byte, srcNode.ContentSize())
+	if _, err := local.ReadContent(sourceID, buf, 0); err != nil {
+		return nil
+	}
+
+	qcalls, err := extractor(buf, sourceID, langName)
+	if err != nil {
+		return nil
+	}
+
+	defs := c.DefsMap()
+	var results []*Node
+	seen := make(map[string]bool)
+	for _, qc := range qcalls {
+		// Resolution order matches MemoryStore: qualified first, then
+		// bare. No import-path fallback here — that's MemoryStore's
+		// per-language refinement, not the cross-mount contract.
+		keys := make([]string, 0, 2)
+		if qc.Qualifier != "" {
+			keys = append(keys, qc.Qualifier+"."+qc.Token)
+		}
+		keys = append(keys, qc.Token)
+
+		for _, key := range keys {
+			defIDs, ok := defs[key]
+			if !ok {
+				continue
+			}
+			for _, defID := range defIDs {
+				if defID == fullID || seen[defID] {
+					continue
+				}
+				results = append(results, &Node{ID: defID})
+				seen[defID] = true
+			}
+			break
+		}
+	}
+	return results
+}
+
+// SetCallExtractor wires a tree-sitter call extractor onto the
+// composite for cross-mount callees resolution. With nil or no
+// extractor set, GetCallees only consults the local mount's defs
+// index — sub-graphs that already have their own extractor still
+// resolve in-mount callees as before.
+func (c *CompositeGraph) SetCallExtractor(fn CallExtractor) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.extractor = fn
 }
 
 // Invalidate implements Graph.

--- a/internal/graph/composite_callees_test.go
+++ b/internal/graph/composite_callees_test.go
@@ -1,0 +1,167 @@
+package graph
+
+import (
+	"io/fs"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCallExtractor is a deterministic stand-in for tree-sitter that
+// returns a hard-coded call list regardless of input bytes. Lets the
+// cross-mount tests drive the resolution path without CGO.
+func fakeCallExtractor(calls []QualifiedCall) CallExtractor {
+	return func(_ []byte, _, _ string) ([]QualifiedCall, error) {
+		return calls, nil
+	}
+}
+
+// TestCompositeGraph_CrossMountCallees is the headline cross-repo
+// behavior: a function in mount A calls a function defined in mount
+// B, and find_callees on A's function returns the def from B
+// prefix-rewritten for the composite namespace.
+func TestCompositeGraph_CrossMountCallees(t *testing.T) {
+	// auth has a Charge() that calls Validate() (defined in billing).
+	auth := NewMemoryStore()
+	auth.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&Node{
+		ID:         "functions/Charge",
+		Mode:       fs.ModeDir,
+		Children:   []string{"functions/Charge/source"},
+		Properties: map[string][]byte{"lang": []byte("go")},
+	})
+	auth.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	require.NoError(t, auth.AddDef("Charge", "functions/Charge"))
+
+	// billing defines Validate.
+	billing := NewMemoryStore()
+	billing.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	billing.AddNode(&Node{ID: "functions/Validate/source", Mode: 0})
+	require.NoError(t, billing.AddDef("Validate", "functions/Validate"))
+
+	cg := NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	// Wire a deterministic extractor that returns the calls we
+	// expect tree-sitter to produce for Charge's source.
+	cg.SetCallExtractor(fakeCallExtractor([]QualifiedCall{
+		{Token: "Validate"},
+	}))
+
+	callees, err := cg.GetCallees("auth/functions/Charge")
+	require.NoError(t, err)
+
+	gotIDs := make([]string, len(callees))
+	for i, c := range callees {
+		gotIDs[i] = c.ID
+	}
+	assert.Contains(t, gotIDs, "billing/functions/Validate",
+		"cross-mount callee must be returned with composite-namespaced ID")
+}
+
+// TestCompositeGraph_CrossMountCalleesPrefersLocal asserts that when
+// the same token resolves in both the local mount and another, both
+// results appear (local AND cross-mount). The local mount's result
+// wins on dedupe order — no duplicate IDs in the merged response.
+func TestCompositeGraph_CrossMountCalleesDedupes(t *testing.T) {
+	// Both mounts define Validate; auth's Charge calls Validate.
+	auth := NewMemoryStore()
+	auth.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&Node{
+		ID:         "functions/Charge",
+		Mode:       fs.ModeDir,
+		Children:   []string{"functions/Charge/source"},
+		Properties: map[string][]byte{"lang": []byte("go")},
+	})
+	auth.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	auth.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	auth.AddNode(&Node{ID: "functions/Validate/source", Mode: 0})
+	require.NoError(t, auth.AddDef("Charge", "functions/Charge"))
+	require.NoError(t, auth.AddDef("Validate", "functions/Validate"))
+	auth.SetCallExtractor(fakeCallExtractor([]QualifiedCall{{Token: "Validate"}}))
+
+	billing := NewMemoryStore()
+	billing.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	billing.AddNode(&Node{ID: "functions/Validate/source", Mode: 0})
+	require.NoError(t, billing.AddDef("Validate", "functions/Validate"))
+
+	cg := NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+	cg.SetCallExtractor(fakeCallExtractor([]QualifiedCall{{Token: "Validate"}}))
+
+	callees, err := cg.GetCallees("auth/functions/Charge")
+	require.NoError(t, err)
+
+	gotIDs := make(map[string]int, len(callees))
+	for _, c := range callees {
+		gotIDs[c.ID]++
+	}
+	assert.Equal(t, 1, gotIDs["auth/functions/Validate"], "local mount's def appears exactly once")
+	assert.Equal(t, 1, gotIDs["billing/functions/Validate"], "cross-mount def appears exactly once")
+}
+
+// TestCompositeGraph_CrossMountCalleesNoExtractor proves the feature
+// is opt-in: without SetCallExtractor, GetCallees only consults the
+// local mount (the previously-shipped behavior).
+func TestCompositeGraph_CrossMountCalleesNoExtractor(t *testing.T) {
+	auth := NewMemoryStore()
+	auth.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&Node{
+		ID:         "functions/Charge",
+		Mode:       fs.ModeDir,
+		Children:   []string{"functions/Charge/source"},
+		Properties: map[string][]byte{"lang": []byte("go")},
+	})
+	auth.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	require.NoError(t, auth.AddDef("Charge", "functions/Charge"))
+
+	billing := NewMemoryStore()
+	billing.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&Node{
+		ID:   "functions/Validate",
+		Mode: fs.ModeDir,
+	})
+	require.NoError(t, billing.AddDef("Validate", "functions/Validate"))
+
+	cg := NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+	// Intentionally NOT calling cg.SetCallExtractor.
+
+	callees, err := cg.GetCallees("auth/functions/Charge")
+	require.NoError(t, err)
+
+	for _, c := range callees {
+		assert.NotEqual(t, "billing/functions/Validate", c.ID,
+			"without an extractor, the composite must not reach into other mounts")
+	}
+}


### PR DESCRIPTION
## Summary
Closes the last substantive piece of `mache-iegm`. `CompositeGraph.GetCallees` now resolves callees that live in **other** mounts, not just the local one. Built on the federated `DefsMap` shipped in PR #218.

**Before:** `auth/Charge` calls `Validate`. If `Validate` is in `billing`, the call doesn't resolve — `billing`'s defs are invisible to `auth`.

**After:** with `mache serve --mount auth=... --mount billing=...`, the call resolves to `billing/functions/Validate` and surfaces in the `find_callees` response (with the mount annotation from PR #218).

## Implementation
1. **`CompositeGraph` gains an extractor + setter** (opt-in). When nil, behavior is unchanged.
2. **`GetCallees` two-phase**:
   - Phase 1: route to local mount (existing behavior).
   - Phase 2: if the composite has an extractor and the construct exposes the `source` child shape, re-extract calls and resolve each against the federated `DefsMap()`.
3. **`cmd/serve.go`**: composite gets the standard `newCallExtractor()` automatically when `--mount` is used.

## Resolution order in the cross-mount phase
- Qualified key (`pkg.Token`) → bare `Token`.
- No import-path fallback — that's `MemoryStore`'s per-language refinement, not the cross-mount contract. Local mount's `GetCallees` already handles those nuances.

## Test plan
Three new tests in `internal/graph/composite_callees_test.go` using a deterministic `fakeCallExtractor` (no CGO):
- [x] `TestCompositeGraph_CrossMountCallees` — `auth/Charge` calls `Validate`, `Validate` defined in billing → response includes `billing/functions/Validate`
- [x] `TestCompositeGraph_CrossMountCalleesDedupes` — same token in both mounts → both surface, neither duplicated
- [x] `TestCompositeGraph_CrossMountCalleesNoExtractor` — feature is opt-in; without `SetCallExtractor`, the composite stays silent (backward-compat)
- [x] Full `cmd/` + `internal/graph/` suites green

**`mache-iegm` is now functionally complete.** Cross-repo refs work end-to-end via `mache serve --mount NAME=PATH ...`. Five steps shipped today (PRs #215, #216, #217, #218, #219... this one).