### PR TITLE
fix: dead_code aggregates per-node, not per-token

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -78,33 +78,47 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "dead_code",
-		Description: "Symbols defined in node_defs that have no entries in node_refs — nothing in the indexed graph references them. False positives expected for entry points (main, init), interface methods invoked dynamically (String, Error), and exported API consumed outside the indexed scope. Test*/Benchmark*/Example* are skip-listed because Go's testing framework invokes them via reflection (no static refs). The skip list at the top of the rule excludes the most common offenders; tune by editing the rule.",
+		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). False positives still expected for exported API consumed outside the indexed scope.",
 		Requires:    []string{"node_defs", "node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
+			-- A construct is "alive" if ANY of its token aliases appears
+			-- in node_refs. We flag a construct as dead only when every
+			-- one of its tokens is unreferenced.
+			WITH alive AS (
+				SELECT DISTINCT d.node_id
+				FROM node_defs d
+				JOIN node_refs r ON r.token = d.token
+			),
+			-- Skip-listed: any token of a construct matches a skip rule.
+			-- ANY-MATCH is the right semantic — a function with both
+			-- 'TestFoo' and 'pkg.TestFoo' should be skipped on the
+			-- testing-framework rule even if only one row triggers.
+			skipped AS (
+				SELECT DISTINCT node_id FROM node_defs
+				WHERE token IN ('main','init','String','Error','Read','Write','Close','Len','Less','Swap','MarshalJSON','UnmarshalJSON','Format','Scan')
+				   -- Strip any 'pkg.' qualifier when matching prefixes.
+				   -- instr returns 0 if there's no dot; substr(token, 1)
+				   -- is the full token, so bare and qualified shapes both
+				   -- get the same leaf check.
+				   OR substr(token, instr(token, '.') + 1) LIKE 'Test%%'
+				   OR substr(token, instr(token, '.') + 1) LIKE 'Benchmark%%'
+				   OR substr(token, instr(token, '.') + 1) LIKE 'Example%%'
+				   OR substr(token, instr(token, '.') + 1) LIKE 'Fuzz%%'
+			)
 			SELECT COALESCE(n.source_file, '') AS source_id,
-			       defs.node_id,
+			       n.id AS node_id,
 			       0  AS start_byte,
 			       0  AS end_byte,
 			       0  AS start_row,
 			       0  AS start_col,
 			       0  AS metric
-			FROM node_defs defs
-			JOIN nodes n ON n.id = defs.node_id
-			LEFT JOIN node_refs refs ON refs.token = defs.token
-			WHERE refs.token IS NULL
-			  AND defs.token NOT IN ('main','init','String','Error','Read','Write','Close','Len','Less','Swap','MarshalJSON','UnmarshalJSON','Format','Scan')
-			  -- Skip-list testing-framework prefixes after stripping any 'pkg.'
-			  -- qualifier — mache writers emit either bare 'TestFoo' or
-			  -- qualified 'pkg.TestFoo'. instr(token, '.') is 0 when there's
-			  -- no dot, and substr(token, 1) is the full token, so this
-			  -- handles both shapes.
-			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Test%%'
-			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Benchmark%%'
-			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Example%%'
-			  AND substr(defs.token, instr(defs.token, '.') + 1) NOT LIKE 'Fuzz%%'
+			FROM nodes n
+			WHERE n.id IN (SELECT DISTINCT node_id FROM node_defs)
+			  AND n.id NOT IN (SELECT node_id FROM alive)
+			  AND n.id NOT IN (SELECT node_id FROM skipped)
 			%s
-			ORDER BY COALESCE(n.source_file, ''), defs.node_id
+			ORDER BY COALESCE(n.source_file, ''), n.id
 		`,
 	},
 	{

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -334,6 +334,64 @@ func TestFindSmells_DeadCode(t *testing.T) {
 		"source_id comes from the construct dir's source_file column")
 }
 
+// TestFindSmells_DeadCodePerNodeAggregation asserts that dead_code
+// aggregates by node_id, not by token. A function with multiple
+// token aliases (bare + qualified) where ANY token is referenced
+// must NOT be flagged dead, and the response never contains
+// duplicate node_id entries.
+//
+// Surfaced by dogfooding mache against itself: 'functions/Unmount'
+// has three tokens (Unmount, mount.Unmount, nfsmount.Unmount); only
+// the bare 'Unmount' has refs, so the old per-token query flagged
+// the construct twice (once per qualified-but-unreferenced token).
+func TestFindSmells_DeadCodePerNodeAggregation(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Multi-token live construct: 3 aliases, only bare has refs.
+		-- Old per-token query flagged this twice (once per qualified
+		-- alias). New per-node query treats it as live (any-token-
+		-- referenced means live).
+		INSERT INTO node_defs VALUES
+		  ('Unmount',          'pkg/Unmount'),
+		  ('mount.Unmount',    'pkg/Unmount'),
+		  ('nfsmount.Unmount', 'pkg/Unmount');
+		INSERT INTO node_refs VALUES ('Unmount', 'pkg/Caller/source');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/Unmount', 'pkg', 'Unmount', 1, 0, 'unmount.go', '');
+
+		-- Truly dead: 2 token aliases, neither referenced.
+		INSERT INTO node_defs VALUES
+		  ('Orphan',     'pkg/Orphan'),
+		  ('pkg.Orphan', 'pkg/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/Orphan', 'pkg', 'Orphan', 1, 0, 'orphan.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"pkg/Orphan"}, gotIDs,
+		"only Orphan is flagged; Unmount has a referenced bare token; no duplicate node_ids")
+}
+
 // TestFindSmells_DeadCodeSkipsTestingFrameworkPrefixes asserts that
 // Test*, Benchmark*, Example*, Fuzz* defs with no static refs are NOT
 // flagged. Go's testing framework invokes them via reflection, so they


### PR DESCRIPTION
## Summary
Fix a real correctness bug in `dead_code`. Found by dogfooding mache against itself.

`functions/Unmount` has three token aliases — `Unmount`, `mount.Unmount`, `nfsmount.Unmount`. The bare `Unmount` has refs; the qualified ones don't. The old per-token query flagged the construct **twice** (once per qualified-but-unreferenced token) even though the function is clearly alive.

## Two issues, one fix
1. **Visible duplicates** — same `node_id` appearing N times in findings (N = unreferenced aliases).
2. **Correctness** — old query: "dead iff ANY token is unreferenced." Should be: "dead iff ALL tokens are unreferenced."

## SQL change
Two CTEs:
- `alive` — `node_id`s where any token has a ref
- `skipped` — `node_id`s where any token matches the skip list (entry points + testing-framework prefixes)

Main `SELECT` operates on `nodes`, filtered to those with defs that aren't in `alive` and aren't in `skipped`. One row per construct.

Skip-list semantics also flipped from per-token to per-node — a construct with both `TestFoo` and `pkg.TestFoo` is skipped when **either** matches the testing-prefix rule.

## Verified against `mache.db`
| Before | After |
| ---: | ---: |
| 200 findings (limit hit, with dups) | 176 unique constructs |

The 24 missing constructs were aliased-but-actually-live functions the old query incorrectly flagged.

## Test plan
- [x] New `TestFindSmells_DeadCodePerNodeAggregation` — seeds a multi-token live construct (`Unmount`, 3 aliases, only bare referenced) and a truly-dead construct (`Orphan`, 2 aliases, neither referenced). Asserts only `Orphan` is flagged and no duplicate `node_id`s in the response.
- [x] All existing `TestFindSmells_DeadCode*` pass
- [x] gofumpt + go vet + golangci-lint clean