### PR TITLE
fix: fan_out_skew skips Test*/Benchmark*/Example*/Fuzz* prefixes

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -260,7 +260,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "fan_out_skew",
-		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
+		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* — tests are expected to call many things, no signal there. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
 		Requires:    []string{"node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -281,9 +281,20 @@ var smellRegistry = []SmellRule{
 			       f.n AS metric
 			FROM fanout f
 			JOIN nodes n ON n.id = f.caller_id
+			-- Construct directory is the parent of the source node.
+			-- Match against ctor.name so the test-prefix filter checks
+			-- the construct name directly, not arbitrary substrings of
+			-- the path. ctor will be NULL for top-level callers (rare);
+			-- the LEFT JOIN keeps those rows so the test-prefix filter
+			-- only excludes when we positively identify a test name.
+			LEFT JOIN nodes ctor ON ctor.id = n.parent_id
 			CROSS JOIN proj p
 			WHERE f.n >= 5
 			  AND CAST(f.n AS REAL) > 3.0 * p.mu
+			  AND COALESCE(ctor.name, '') NOT LIKE 'Test%%'
+			  AND COALESCE(ctor.name, '') NOT LIKE 'Benchmark%%'
+			  AND COALESCE(ctor.name, '') NOT LIKE 'Example%%'
+			  AND COALESCE(ctor.name, '') NOT LIKE 'Fuzz%%'
 			%s
 			ORDER BY metric DESC, source_id, node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -790,6 +790,76 @@ func TestFindSmells_FanOutSkew(t *testing.T) {
 	assert.Equal(t, int64(12), resp.Findings[0].Metric, "fan-out count is reported as metric")
 }
 
+// TestFindSmells_FanOutSkewSkipsTestPrefixes asserts that a Test-
+// prefixed construct with high fan-out is NOT flagged. Mirrors how
+// mache writes data: caller_id is a source-file node whose parent
+// is the construct directory, and ctor.name carries the function
+// name. The new skip-list joins through that parent.
+//
+// Surfaced by dogfooding: mache's own test runners
+// (TestArena_AllTools etc) topped fan_out_skew with 48 callees —
+// tests are *expected* to call many things; no signal there.
+func TestFindSmells_FanOutSkewSkipsTestPrefixes(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Construct hierarchy: parent dir → source-file node.
+		-- caller_id in node_refs is the source-file id (matches mache's
+		-- production write shape), and the parent dir's name is what
+		-- the skip-list checks.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions',                        '',          'functions',          1, 0, '',                        ''),
+		  ('functions/TestRunner',             'functions', 'TestRunner',         1, 0, 'runner_test.go',          ''),
+		  ('functions/TestRunner/source',      'functions/TestRunner', 'source',  0, 0, 'runner_test.go',          ''),
+		  ('functions/Dispatcher',             'functions', 'Dispatcher',         1, 0, 'dispatcher.go',           ''),
+		  ('functions/Dispatcher/source',      'functions/Dispatcher', 'source',  0, 0, 'dispatcher.go',           '');
+
+		-- TestRunner has 12 distinct callees — would normally trip
+		-- fan_out_skew. The new skip-list excludes it on the 'Test'
+		-- prefix of the parent ctor.name.
+		INSERT INTO node_refs VALUES
+		  ('A','functions/TestRunner/source'),('B','functions/TestRunner/source'),('C','functions/TestRunner/source'),
+		  ('D','functions/TestRunner/source'),('E','functions/TestRunner/source'),('F','functions/TestRunner/source'),
+		  ('G','functions/TestRunner/source'),('H','functions/TestRunner/source'),('I','functions/TestRunner/source'),
+		  ('J','functions/TestRunner/source'),('K','functions/TestRunner/source'),('L','functions/TestRunner/source');
+
+		-- Dispatcher also has 12 distinct callees — should be flagged.
+		-- (Production code, not test.)
+		INSERT INTO node_refs VALUES
+		  ('M','functions/Dispatcher/source'),('N','functions/Dispatcher/source'),('O','functions/Dispatcher/source'),
+		  ('P','functions/Dispatcher/source'),('Q','functions/Dispatcher/source'),('R','functions/Dispatcher/source'),
+		  ('S','functions/Dispatcher/source'),('T','functions/Dispatcher/source'),('U','functions/Dispatcher/source'),
+		  ('V','functions/Dispatcher/source'),('W','functions/Dispatcher/source'),('X','functions/Dispatcher/source');
+
+		-- Six tiny callers to dilute the project mean below 3× threshold.
+		INSERT INTO node_refs VALUES
+		  ('z1','functions/n1'),('z2','functions/n2'),('z3','functions/n3'),
+		  ('z4','functions/n4'),('z5','functions/n5'),('z6','functions/n6');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "fan_out_skew"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Dispatcher/source"}, gotIDs,
+		"Dispatcher (production code) is flagged; TestRunner (test) is skipped via parent ctor.name LIKE 'Test%'")
+}
+
 // TestFindSmells_DuplicateDefinitions seeds three groups: a duplicated
 // helper (two defs, two source files — flagged twice), an interface
 // method on the skip list (two defs — excluded), and a unique symbol


### PR DESCRIPTION
## Summary
Third dogfood-driven `find_smells` fix today. Top `fan_out_skew` findings against `mache.db` were all test orchestrators (TestArena_AllTools 48, TestSQLiteGraphGoldenPath 32, TestHotSwap* 24/22, etc) — tests are *expected* to call many things; no signal there.

Same skip-list semantic as `dead_code` (#208, #224) and `untested_function`: identify the construct via parent_id → `ctor` row, filter on `ctor.name` not starting with Test/Benchmark/Example/Fuzz.

## Implementation
```sql
LEFT JOIN nodes ctor ON ctor.id = n.parent_id
...
WHERE COALESCE(ctor.name, '') NOT LIKE 'Test%'
  AND COALESCE(ctor.name, '') NOT LIKE 'Benchmark%'
  AND COALESCE(ctor.name, '') NOT LIKE 'Example%'
  AND COALESCE(ctor.name, '') NOT LIKE 'Fuzz%'
```

LEFT JOIN keeps top-level callers (where `ctor` doesn't exist in `nodes`) — the COALESCE-to-empty-string ensures the LIKE filter only excludes positively-identified test names.

## Verified against mache.db
| Before | After |
| ---: | ---: |
| 18 findings | 13 findings |

5 dropped — all Test*-prefixed. Remaining are real god-functions (`runServe`, `mountNFS`, `buildServeGraph`, `makeGetArchitectureHandler`, etc) or non-Test orchestrators (`RunGraphSuiteWithOpts`).

## Test plan
- [x] New `TestFindSmells_FanOutSkewSkipsTestPrefixes` — production-shape data with TestRunner (skipped) and Dispatcher (flagged)
- [x] Existing `TestFindSmells_FanOutSkew` still passes (backward compat)
- [x] gofumpt + go vet + golangci-lint clean