### PR TITLE
feat(build): expose --schema flag for explicit topology

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -104,5 +104,12 @@ var buildCmd = &cobra.Command{
 }
 
 func init() {
+	// schemaPath is shared with rootCmd (mount path) and other subcommands.
+	// `mache build` needs its own flag binding because rootCmd's --schema
+	// lives on Flags(), not PersistentFlags(), so it doesn't propagate to
+	// children. Without this, users can't pass an explicit schema to build
+	// and have to rely on FCA inference — which doesn't yet produce a
+	// methods/ root for Go (mache-5d1o).
+	buildCmd.Flags().StringVarP(&schemaPath, "schema", "s", "", "Path to topology schema (defaults to FCA inference)")
 	rootCmd.AddCommand(buildCmd)
 }

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -54,6 +54,23 @@ func TestBuild_ProducesDB(t *testing.T) {
 	assert.Greater(t, info.Size(), int64(0), "output DB should be non-empty")
 }
 
+// TestBuild_SchemaFlagRegistered guards the --schema flag binding.
+// rootCmd's --schema lives on Flags() (not PersistentFlags), so it
+// doesn't propagate to children. buildCmd needs its own binding to
+// the same package-level schemaPath variable so users can pass
+// --schema on the CLI without falling through to FCA inference.
+func TestBuild_SchemaFlagRegistered(t *testing.T) {
+	flag := buildCmd.Flags().Lookup("schema")
+	require.NotNil(t, flag, "buildCmd must register a --schema flag")
+	assert.Equal(t, "s", flag.Shorthand, "shorthand must match the rootCmd convention")
+	// Setting through the flag should mutate schemaPath, since both
+	// flags bind to the same variable.
+	saved := schemaPath
+	defer func() { schemaPath = saved }()
+	require.NoError(t, buildCmd.Flags().Set("schema", "/tmp/test-schema.json"))
+	assert.Equal(t, "/tmp/test-schema.json", schemaPath)
+}
+
 func TestBuild_NonexistentSource(t *testing.T) {
 	tmpDir := t.TempDir()
 	outDB := filepath.Join(tmpDir, "out.db")


### PR DESCRIPTION
## Summary
`mache build` reads `schemaPath` to load an explicit topology, but the `--schema` flag lived on `rootCmd.Flags()` (not `PersistentFlags`), so it never reached `buildCmd`. Users couldn't pass `--schema` on the CLI; the only path to a non-inferred schema was the legacy `mount` flow.

This PR binds `--schema` (with `-s` shorthand) on `buildCmd.Flags()` to the same package-level `schemaPath` variable. `RunE` already reads it.

## Why it matters
Dogfooding mache against itself surfaced a class of `dead_code` false positives (`mache-5d1o`): the FCA-inferred schema doesn't produce a `methods/` root for Go, so functions only called from receiver methods look dead. With `--schema examples/go-schema.json`, methods are projected and the false positives go away.

## Local verification
```bash
mache build --schema examples/go-schema.json . /tmp/m.db
sqlite3 /tmp/m.db "SELECT id FROM nodes WHERE id LIKE '%method%' LIMIT 3"
# api/methods
# cmd/methods
# internal/graph/methods
```

## Test plan
- [x] New `TestBuild_SchemaFlagRegistered` — `Flags().Lookup("schema")` returns non-nil; `Flags().Set("schema", ...)` mutates `schemaPath`
- [x] Existing `TestBuild_ProducesDB` and `TestBuild_NonexistentSource` still pass (they manipulate `schemaPath` directly, unaffected by the new binding)
- [x] gofumpt + go vet + golangci-lint clean

Partial fix for `mache-5d1o`. Remaining work: make FCA inference produce `methods/` so users don't need `--schema` explicitly.