### PR TITLE
fix: duplicate_definitions skips imports/ nodes

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -196,7 +196,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "duplicate_definitions",
-		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Cross-language since node_defs is populated by every leyline parser.",
+		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' nodes — they're references TO external packages, not definitions. Cross-language since node_defs is populated by every leyline parser.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -218,11 +218,19 @@ var smellRegistry = []SmellRule{
 					'MarshalJSON','UnmarshalJSON','MarshalText','UnmarshalText','MarshalBinary','UnmarshalBinary',
 					'Marshal','Unmarshal','Reset','Clone','Copy','Equal','Hash','Validate'
 				)
+				-- Exclude imports/ nodes — those are references TO
+				-- external packages (e.g. '"fmt"' appears in many
+				-- imports), not duplicate definitions.
+				AND node_id NOT LIKE '%%/imports/%%'
 				GROUP BY token
 				HAVING copies > 1
 			) c
 			JOIN node_defs d ON d.token = c.token
 			JOIN nodes n ON n.id = d.node_id
+			-- Apply the same import filter to the join so partial
+			-- matches (where one repo's imports overlap with a real
+			-- def in another repo) don't leak through.
+			WHERE d.node_id NOT LIKE '%%/imports/%%'
 			%s
 			ORDER BY metric DESC, n.source_file, d.node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -911,6 +911,68 @@ func TestFindSmells_DuplicateDefinitions(t *testing.T) {
 	}
 }
 
+// TestFindSmells_DuplicateDefinitionsSkipsImports asserts that nodes
+// under '/imports/' don't surface as duplicate definitions, even
+// when the same import path appears across many packages. Imports
+// are external references, not definitions.
+//
+// Surfaced by dogfooding: 559 → 200 findings on mache.db after
+// excluding imports/.
+func TestFindSmells_DuplicateDefinitionsSkipsImports(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Same import path in three packages — these should NOT
+		-- surface as a duplicate-defs finding.
+		INSERT INTO node_defs VALUES
+		  ('"fmt"', 'pkg/a/imports/"fmt"'),
+		  ('"fmt"', 'pkg/b/imports/"fmt"'),
+		  ('"fmt"', 'pkg/c/imports/"fmt"');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/imports/"fmt"', 'pkg/a/imports', '"fmt"', 1, 0, 'a/main.go', ''),
+		  ('pkg/b/imports/"fmt"', 'pkg/b/imports', '"fmt"', 1, 0, 'b/main.go', ''),
+		  ('pkg/c/imports/"fmt"', 'pkg/c/imports', '"fmt"', 1, 0, 'c/main.go', '');
+
+		-- Real duplicate (functions with the same name in two
+		-- packages) — control: this should still be flagged.
+		INSERT INTO node_defs VALUES
+		  ('Helper', 'pkg/a/functions/Helper'),
+		  ('Helper', 'pkg/b/functions/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/functions/Helper', 'pkg/a/functions', 'Helper', 1, 0, 'a/helper.go', ''),
+		  ('pkg/b/functions/Helper', 'pkg/b/functions', 'Helper', 1, 0, 'b/helper.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "duplicate_definitions"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	for _, id := range gotIDs {
+		assert.NotContains(t, id, "/imports/",
+			"imports/ nodes must not appear in duplicate_definitions")
+	}
+	assert.ElementsMatch(t,
+		[]string{"pkg/a/functions/Helper", "pkg/b/functions/Helper"},
+		gotIDs,
+		"only the real Helper duplicate is flagged",
+	)
+}
+
 // TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
 func TestFindSmells_LongFile(t *testing.T) {
 	tg := seedSmellAST(t)


### PR DESCRIPTION
## Summary
Dogfooding mache against itself with the methods-aware schema (`--schema examples/go-schema.json` from PR #226) showed `duplicate_definitions` firing 559 times — the top ~270 were import paths like `cmd/imports/"fmt"`, `graph/imports/"testing"`. Imports are external references, not definitions.

Filter `node_id NOT LIKE '%/imports/%'` in both the inner `COUNT(*) GROUP BY` (so the count reflects only real defs) and the outer JOIN (so partial matches don't leak).

## Verified on mache.db
| Before | After |
| ---: | ---: |
| 559 findings | 200 (limit hit) |

Zero `imports/` paths in the output. Remaining findings are real:
- `api/types/Node` + `graph/types/Node` + `schema/types/Node` — `Node` defined in 3 packages, possibly worth consolidating
- `cmd/functions/tableExists` defined twice
- `cmd/functions/setupTestDB` defined twice

## Why not also filter variables/?
`variables/<name>` findings stay — the schema doesn't distinguish package-level vars from local vars, but the same-name pattern across packages (e.g., every package having an `err` package-level var) is at least debatable as a smell. Imports are unambiguously wrong; variables are arguably useful signal.

## Test plan
- [x] New `TestFindSmells_DuplicateDefinitionsSkipsImports` — three packages with the same import + a real duplicate function. Asserts only the real dup is flagged.
- [x] Existing `TestFindSmells_DuplicateDefinitions` still passes.
- [x] gofumpt + go vet + golangci-lint clean

Closes `mache-7n7n`.