### PR TITLE
fix: untested_function restricted to functions/ category

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -170,7 +170,7 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "untested_function",
 		Languages:   []string{"go"},
-		Description: "Exported Go functions with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Excludes Test*/Benchmark*/Example* (they ARE tests) and main/init (entry points). The rule's heuristic is Go-specific — running it against a Python or Rust .db will produce mostly noise.",
+		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -190,6 +190,13 @@ var smellRegistry = []SmellRule{
 			  AND d.token NOT LIKE 'Example%%'
 			  AND d.token NOT IN ('main','init','String','Error')
 			  AND t.token IS NULL
+			  -- Restrict to constructs in a 'functions/' category dir.
+			  -- 'functions/Foo' (auto-inferred flat shape) and
+			  -- 'pkg/functions/Foo' (explicit go-schema package shape)
+			  -- both match. Skips methods/, types/, constants/,
+			  -- variables/, imports/ — those don't follow the
+			  -- TestFoo naming convention.
+			  AND (d.node_id LIKE 'functions/%%' OR d.node_id LIKE '%%/functions/%%')
 			%s
 			ORDER BY COALESCE(n.source_file, ''), d.token
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -610,26 +610,40 @@ func TestFindSmells_UntestedFunction(t *testing.T) {
 		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
 
 		-- Covered: TestFooBar exists, so FooBar is OK.
-		INSERT INTO node_defs VALUES ('FooBar', 'pkg/funcs/FooBar');
-		INSERT INTO node_defs VALUES ('TestFooBar', 'pkg/funcs/TestFooBar');
+		-- Paths use 'functions/' category dir — the rule restricts to
+		-- that segment to skip methods/, types/, constants/, etc.
+		INSERT INTO node_defs VALUES ('FooBar', 'pkg/functions/FooBar');
+		INSERT INTO node_defs VALUES ('TestFooBar', 'pkg/functions/TestFooBar');
 		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
-		  ('pkg/funcs/FooBar',     'pkg/funcs', 'FooBar',     1, 0, 'foo.go',     ''),
-		  ('pkg/funcs/TestFooBar', 'pkg/funcs', 'TestFooBar', 1, 0, 'foo_test.go', '');
+		  ('pkg/functions/FooBar',     'pkg/functions', 'FooBar',     1, 0, 'foo.go',     ''),
+		  ('pkg/functions/TestFooBar', 'pkg/functions', 'TestFooBar', 1, 0, 'foo_test.go', '');
 
 		-- Uncovered: no TestOrphan anywhere.
-		INSERT INTO node_defs VALUES ('Orphan', 'pkg/funcs/Orphan');
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/functions/Orphan');
 		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
-		  ('pkg/funcs/Orphan', 'pkg/funcs', 'Orphan', 1, 0, 'orphan.go', '');
+		  ('pkg/functions/Orphan', 'pkg/functions', 'Orphan', 1, 0, 'orphan.go', '');
 
 		-- Skip list: capitalized but excluded.
-		INSERT INTO node_defs VALUES ('String', 'pkg/funcs/String');
+		INSERT INTO node_defs VALUES ('String', 'pkg/functions/String');
 		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
-		  ('pkg/funcs/String', 'pkg/funcs', 'String', 1, 0, 'stringer.go', '');
+		  ('pkg/functions/String', 'pkg/functions', 'String', 1, 0, 'stringer.go', '');
 
 		-- Unexported (lowercase): must NOT be flagged.
-		INSERT INTO node_defs VALUES ('helper', 'pkg/funcs/helper');
+		INSERT INTO node_defs VALUES ('helper', 'pkg/functions/helper');
 		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
-		  ('pkg/funcs/helper', 'pkg/funcs', 'helper', 1, 0, 'helpers.go', '');
+		  ('pkg/functions/helper', 'pkg/functions', 'helper', 1, 0, 'helpers.go', '');
+
+		-- A method (uppercase, no Test counterpart) — must NOT be
+		-- flagged because methods/ is outside the rule's scope.
+		INSERT INTO node_defs VALUES ('Receiver.Method', 'pkg/methods/Receiver.Method');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/Receiver.Method', 'pkg/methods', 'Receiver.Method', 1, 0, 'receiver.go', '');
+
+		-- A type (uppercase, no Test counterpart) — must NOT be
+		-- flagged for the same reason.
+		INSERT INTO node_defs VALUES ('Config', 'pkg/types/Config');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/types/Config', 'pkg/types', 'Config', 1, 0, 'config.go', '');
 	`)
 	require.NoError(t, err)
 
@@ -645,8 +659,8 @@ func TestFindSmells_UntestedFunction(t *testing.T) {
 		Findings []smellFinding `json:"findings"`
 	}
 	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
-	require.Equal(t, 1, resp.Total, "only Orphan is uncovered + exported + not on skip list")
-	assert.Equal(t, "pkg/funcs/Orphan", resp.Findings[0].NodeID)
+	require.Equal(t, 1, resp.Total, "only Orphan is uncovered + exported + not on skip list + in functions/")
+	assert.Equal(t, "pkg/functions/Orphan", resp.Findings[0].NodeID)
 	assert.Equal(t, "orphan.go", resp.Findings[0].SourceID)
 }
 


### PR DESCRIPTION
## Summary
Dogfooding mache against itself with `--schema` (PR #226) showed `untested_function` flagging 1250 nodes — most were methods, types, constants, variables, imports. The rule's `Test<Foo>` heuristic only makes sense for **standalone functions**:

- methods are tested via type-level tests (`Test<Type>`), not `TestReceiver.Method`
- types don't have direct test functions
- constants/variables don't follow `Test<Name>` at all
- `imports/<path>` are external references, not defs to test

Restrict to `functions/` category dir:
```sql
AND (d.node_id LIKE 'functions/%'           -- inferred flat shape
     OR d.node_id LIKE '%/functions/%')     -- explicit per-package shape
```

Both shapes covered.

## Verified on mache.db
| Before | After |
| ---: | ---: |
| 1250 findings | 227 |

Zero non-`/functions/` paths in the output.

## Test plan
- [x] `TestFindSmells_UntestedFunction` rewritten to use `pkg/functions/...` paths matching the new scope, plus two negative cases (a `Receiver.Method` in `pkg/methods/` and a `Config` in `pkg/types/`) that must not be flagged.
- [x] gofumpt + go vet + golangci-lint clean

Closes `mache-k5aq`.