### PR TITLE
fix: dead_code skips imports/ nodes

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -117,6 +117,13 @@ var smellRegistry = []SmellRule{
 			WHERE n.id IN (SELECT DISTINCT node_id FROM node_defs)
 			  AND n.id NOT IN (SELECT node_id FROM alive)
 			  AND n.id NOT IN (SELECT node_id FROM skipped)
+			  -- Imports are external references, not defs. Their
+			  -- "tokens" (e.g. '"fmt"') never appear in node_refs
+			  -- because node_refs tracks function calls, not import
+			  -- paths, so every imports/ node looks dead by this
+			  -- rule. They aren't — they're how the code references
+			  -- external packages. Skip them.
+			  AND n.id NOT LIKE '%%/imports/%%'
 			%s
 			ORDER BY COALESCE(n.source_file, ''), n.id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -334,6 +334,53 @@ func TestFindSmells_DeadCode(t *testing.T) {
 		"source_id comes from the construct dir's source_file column")
 }
 
+// TestFindSmells_DeadCodeSkipsImports asserts that imports/ nodes
+// don't surface in dead_code, mirroring the same skip in
+// duplicate_definitions (#227). Imports are references TO external
+// packages; their "tokens" never appear in node_refs because
+// node_refs tracks function calls, not import paths.
+func TestFindSmells_DeadCodeSkipsImports(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Import token — has no entry in node_refs. The OLD rule would
+		-- flag this as dead; the new filter must skip /imports/.
+		INSERT INTO node_defs VALUES ('"fmt"', 'pkg/imports/"fmt"');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/imports/"fmt"', 'pkg/imports', '"fmt"', 1, 0, 'main.go', '');
+
+		-- Real dead function — control: must still be flagged.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/functions/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/Orphan', 'pkg/functions', 'Orphan', 1, 0, 'orphan.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	for _, id := range gotIDs {
+		assert.NotContains(t, id, "/imports/", "imports/ nodes must not appear in dead_code")
+	}
+	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs)
+}
+
 // TestFindSmells_DeadCodePerNodeAggregation asserts that dead_code
 // aggregates by node_id, not by token. A function with multiple
 // token aliases (bare + qualified) where ANY token is referenced


### PR DESCRIPTION
## Summary
Same imports-noise pattern as duplicate_definitions (#227). Imports are references, not definitions: their tokens (e.g. `"fmt"`) never appear in `node_refs` (which tracks function calls), so every `imports/` node looks dead. They aren't.

Filter `n.id NOT LIKE '%/imports/%'`.

## Verified on mache.db (with `--schema examples/go-schema.json`)
| Before | After |
| ---: | ---: |
| 2000 (limit hit) | 1881 |

Zero `imports/` paths in output.

## Why not also filter methods/types/variables/constants?
Each needs different remediation:
- methods/ — receiver-qualified call tracking missing in node_refs (`Receiver.Method` → just `Method`)
- types/ — package-qualified usage (`pkg.Type`) not always resolved
- variables/constants — same package-qualifier problem

None are unambiguous enough for a blanket skip. **imports is the only unambiguous noise class** — they're definitionally not refs.

## Test plan
- [x] New `TestFindSmells_DeadCodeSkipsImports` — `imports/"fmt"` has no refs but must NOT be flagged; control `pkg/functions/Orphan` IS flagged
- [x] All existing `TestFindSmells_DeadCode*` pass
- [x] gofumpt + go vet + golangci-lint clean