### PR TITLE
fix: cap noisy sheaf-topology-push log to once-per-process

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"log"
 	"path/filepath"
 	"strings"
 
@@ -821,6 +820,12 @@ func makeGetCommunitiesHandler(g graph.Graph) server.ToolHandlerFunc {
 		result := graph.DetectCommunities(refs, minSize)
 
 		// Push topology to ley-line sheaf cache (fire-and-forget).
+		// Errors are best-effort: the daemon may be missing
+		// (DiscoverOrStart fails), unreachable (DialSocket fails),
+		// or running an older protocol that doesn't support
+		// sheaf_set_topology. None of those are actionable for the
+		// user mid-call; log only once per process to avoid the
+		// every-call spam during benchmarks and non-LLO setups.
 		go func() {
 			sockPath, err := leyline.DiscoverOrStart()
 			if err != nil {
@@ -833,7 +838,7 @@ func makeGetCommunitiesHandler(g graph.Graph) server.ToolHandlerFunc {
 			defer func() { _ = sock.Close() }()
 			sc := leyline.NewSheafClient(sock)
 			if pushErr := sc.PushTopology(result, refs); pushErr != nil {
-				log.Printf("sheaf topology push: %v", pushErr)
+				logSheafPushOnce(pushErr)
 			}
 		}()
 

--- a/cmd/sheaf_push_log.go
+++ b/cmd/sheaf_push_log.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"log"
+	"sync"
+)
+
+// sheafPushLogOnce caps the noisy "sheaf topology push" logs to one
+// per process. The fire-and-forget push runs on every
+// get_communities call; if the daemon doesn't support
+// sheaf_set_topology (older builds, non-LLO setups), every call
+// would log the error. Once is enough — the user knows the
+// daemon's capability state after the first attempt.
+var sheafPushLogOnce sync.Once
+
+// logSheafPushOnce logs the push error the first time it's called
+// in this process and silently swallows subsequent invocations.
+// Intended for the leyline sheaf-cache push goroutine in
+// makeGetCommunitiesHandler — every call would otherwise re-log
+// the same "unknown op" error from older daemons.
+func logSheafPushOnce(err error) {
+	sheafPushLogOnce.Do(func() {
+		log.Printf("sheaf topology push: %v (further occurrences silenced)", err)
+	})
+}


### PR DESCRIPTION
## Summary
The fire-and-forget goroutine in `makeGetCommunitiesHandler` pushes graph topology to the leyline daemon. When the daemon doesn't support `sheaf_set_topology` (older builds, non-LLO setups), every `get_communities` call logs:

```
sheaf topology push: sheaf_set_topology: unknown op: sheaf_set_topology
```

Visible in [PR #221's bench output](https://github.com/agentic-research/mache/pull/221) and any non-LLO setup. The error isn't actionable mid-call — daemon capability is fixed for the process lifetime, so logging once vs N times conveys the same signal.

## Fix
New helper `logSheafPushOnce` uses `sync.Once` to log on first occurrence only. The first log line notes that further occurrences are silenced so users know the truncation is intentional.

Also dropped the now-unused `log` import from `serve_handlers.go` — the only log call lived inside the goroutine that now routes through `logSheafPushOnce` in the new `cmd/sheaf_push_log.go`.

## Test plan
- [x] `go test ./cmd/` green
- [x] gofumpt + go vet + golangci-lint clean
- [x] No production-code path changed beyond log frequency