### PR TITLE
perf: O(1) LookupDef for find_definition anchored-exact path

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -906,15 +906,35 @@ func makeFindDefinitionHandler(g graph.Graph) server.ToolHandlerFunc {
 		}
 		fuzzy := request.GetBool("fuzzy", false)
 
+		// 1. Anchored exact match — case-sensitive. Use LookupDef
+		// when the backend supports it: O(1) map lookup, no
+		// O(N) snapshot copy of the entire defs map. Falls back
+		// to DefsMap for backends that haven't implemented the
+		// optional lookup method.
+		if dl, ok := g.(defsLookuper); ok {
+			if dirIDs := dl.LookupDef(symbol); len(dirIDs) > 0 {
+				if r := findDefinitionResultScoped(g, symbol, dirIDs); r != nil {
+					return r, nil
+				}
+				return findDefinitionResult(symbol, dirIDs), nil
+			}
+		}
+
+		// Backends that ONLY expose DefsMap (older/composite shapes)
+		// or that didn't hit on the LookupDef path fall through to
+		// the snapshot for the case-insensitive + fuzzy paths below.
 		dp := g.(defsMapProvider)
 		defs := dp.DefsMap()
 
-		// 1. Anchored exact match — case-sensitive.
-		if dirIDs, ok := defs[symbol]; ok {
-			if r := findDefinitionResultScoped(g, symbol, dirIDs); r != nil {
-				return r, nil
+		// 1b. Anchored exact via the snapshot — only reached when
+		// the backend lacks a defsLookuper. Mirrors the old behavior.
+		if _, hasLookup := g.(defsLookuper); !hasLookup {
+			if dirIDs, ok := defs[symbol]; ok {
+				if r := findDefinitionResultScoped(g, symbol, dirIDs); r != nil {
+					return r, nil
+				}
+				return findDefinitionResult(symbol, dirIDs), nil
 			}
-			return findDefinitionResult(symbol, dirIDs), nil
 		}
 
 		// 2. Anchored exact match — case-insensitive.

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -614,6 +614,14 @@ type defsMapProvider interface {
 	DefsMap() map[string][]string
 }
 
+// defsLookuper is the cheaper alternative to defsMapProvider for the
+// common case of looking up exactly one symbol. Backends that
+// implement it avoid the O(N) snapshot copy of the full defs map
+// when the caller only needs one token's dir IDs.
+type defsLookuper interface {
+	LookupDef(token string) []string
+}
+
 // writeBacker is the subset of Graph backends that support surgical write-back
 // (validate → format → splice → update node).
 type writeBacker interface {

--- a/internal/graph/composite.go
+++ b/internal/graph/composite.go
@@ -102,6 +102,50 @@ type defsMapper interface {
 	DefsMap() map[string][]string
 }
 
+// LookupDef federates LookupDef across mounts: returns all dir IDs
+// across every mount that defines `token`, prefixed with the mount
+// name. Cheaper than DefsMap when only one token is wanted —
+// MemoryStore + SQLiteGraph both expose LookupDef as O(1).
+func (c *CompositeGraph) LookupDef(token string) []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	type lookuper interface{ LookupDef(string) []string }
+
+	var out []string
+	for prefix, g := range c.mounts {
+		dl, ok := g.(lookuper)
+		if !ok {
+			// Fall back to DefsMap snapshot for backends without
+			// a direct lookup method. Keeps this method total even
+			// when sub-graphs are heterogeneous.
+			dm, dmOK := g.(defsMapper)
+			if !dmOK {
+				continue
+			}
+			ids, ok := dm.DefsMap()[token]
+			if !ok {
+				continue
+			}
+			for _, id := range ids {
+				out = append(out, c.wrapDefID(prefix, id))
+			}
+			continue
+		}
+		for _, id := range dl.LookupDef(token) {
+			out = append(out, c.wrapDefID(prefix, id))
+		}
+	}
+	return out
+}
+
+// wrapDefID applies the mount-name prefix to a sub-graph's dir ID.
+func (c *CompositeGraph) wrapDefID(prefix, id string) string {
+	if id == "" {
+		return prefix
+	}
+	return prefix + "/" + id
+}
+
 // DefsMap aggregates token → dir IDs across every mount that
 // implements DefsMap(), prefixing each dir ID with its mount name.
 // Sub-graphs that don't expose a defs index are skipped.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -484,7 +484,10 @@ func (s *MemoryStore) RefsMap() map[string][]string {
 }
 
 // DefsMap returns a snapshot of the token→dirIDs definition map.
-// Used by find_definition to locate where symbols are defined.
+// Used by find_definition's case-insensitive and fuzzy paths and by
+// search role=definition — anywhere callers need to iterate. The
+// anchored-exact path in find_definition should use LookupDef
+// instead to avoid the O(N) snapshot copy.
 func (s *MemoryStore) DefsMap() map[string][]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -493,6 +496,22 @@ func (s *MemoryStore) DefsMap() map[string][]string {
 		cp[k] = append([]string(nil), v...)
 	}
 	return cp
+}
+
+// LookupDef returns the dir IDs that define `token` without
+// snapshotting the entire defs map. Returns nil for unknown tokens.
+// O(1) under the read lock; the returned slice is a copy so callers
+// can mutate it without races. Pair with DefsMap when the caller
+// needs to iterate (case-insensitive matching, fuzzy substring,
+// etc.); use this when one specific token's IDs are wanted.
+func (s *MemoryStore) LookupDef(token string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ids, ok := s.defs[token]
+	if !ok {
+		return nil
+	}
+	return append([]string(nil), ids...)
 }
 
 // DeleteFileNodes removes all nodes that originated from the given source file.

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -306,6 +306,19 @@ func (g *SQLiteGraph) DefsMap() map[string][]string {
 	return cp
 }
 
+// LookupDef returns the dir IDs that define `token` without
+// snapshotting the entire defs map. Returns nil for unknown tokens.
+// Mirrors MemoryStore.LookupDef; see that method's docstring.
+func (g *SQLiteGraph) LookupDef(token string) []string {
+	g.pendingMu.Lock()
+	defer g.pendingMu.Unlock()
+	ids, ok := g.defs[token]
+	if !ok {
+		return nil
+	}
+	return append([]string(nil), ids...)
+}
+
 func (g *SQLiteGraph) GetNode(id string) (*Node, error) {
 	if g.useNodesTable {
 		return g.ntr.GetNode(id)


### PR DESCRIPTION
## Summary
Bench from PR #220 showed `find_definition` AnchoredExact at 10K defs allocating O(N) per call: 405µs / 950 KB / 10K allocs. The lookup is O(1); the cost was `DefsMap()` returning a snapshot copy of the **entire** defs map every call.

Add `LookupDef(token) []string` to `MemoryStore`, `SQLiteGraph`, and `CompositeGraph`. Returns just one token's slice under a read lock. Bypasses the snapshot.

## Bench delta (M3 Max)

| defs | Before | After | Speedup |
| ---: | ---: | ---: | ---: |
| 100 | 13.6 µs / 9.6 KB / 113 allocs | **1.8 µs / 903 B / 9 allocs** | 7.5× |
| 1 000 | 63 µs / 117 KB / 1018 allocs | **1.6 µs / 876 B / 8 allocs** | 39× |
| 10 000 | 405 µs / 950 KB / 10K allocs | **1.4 µs / 876 B / 8 allocs** | 289× |

Time stays flat — true O(1) now. **1085× less memory and 1255× fewer allocs at 10K defs.**

## Implementation
- New `defsLookuper` interface paired with the existing `defsMapProvider`. `find_definition`'s anchored-exact path uses `LookupDef` when the backend supports it; case-insensitive + fuzzy still use `DefsMap` (they iterate). Backends without `LookupDef` fall through to the legacy snapshot — backward compatible.
- `CompositeGraph.LookupDef` federates: walks every mount, calls `LookupDef` when available, falls back to `DefsMap` per-mount otherwise.

## Test plan
- [x] All `TestFindDefinition*` pass (anchored exact + case-insensitive + fuzzy + cross-mount federation)
- [x] All `TestFindSmells*` pass (smell rules use DefsMap, not LookupDef — unaffected)
- [x] Bench numbers match commit message
- [x] gofumpt + go vet + golangci-lint clean

Closes `mache-23wg`.