### PR TITLE
feat(ci): find_smells GHA — advisory PR comment

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           # Need the merge-base so we can list files changed in the PR.
           fetch-depth: 0
+          # LFS-tracked tree-sitter grammar fixtures are needed for
+          # `go build` to succeed (parser.c is otherwise an LFS pointer).
+          lfs: true
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:

--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -1,0 +1,152 @@
+name: find_smells
+
+# Advisory PR review using mache's own find_smells rule registry.
+# Builds the binary, indexes the PR head, runs the rules that work
+# on standalone (no LLO) — node_defs / node_refs only — and posts
+# a comment listing findings whose source_file was touched by this
+# PR. Never fails the build; the rules are heuristic and gating
+# would produce noise + frustration (mache-iegm / find_smells design).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      # Only run when Go source changes — docs / examples don't
+      # affect smell findings and would just spam the comment thread.
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/find-smells.yml'
+
+permissions:
+  # Required to post / edit the PR comment.
+  pull-requests: write
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Need the merge-base so we can list files changed in the PR.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Build mache
+        run: go build -o /tmp/mache ./
+
+      - name: Index repo
+        # The standalone (CGO) path produces nodes / node_defs /
+        # node_refs but not _ast. The four rules we run here only
+        # need the cross-ref tables, so we don't need an LLO-built
+        # .db.
+        run: /tmp/mache build --schema examples/go-schema.json . /tmp/repo.db
+
+      - name: List files changed in PR
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Diff base...head, keep only Go source files. The list
+          # gates the comment; if nothing Go changed, the workflow's
+          # paths filter would have skipped us already, so we can
+          # assume non-empty here.
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            | grep -E '\.go$' \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))' \
+            > /tmp/changed.json
+          cat /tmp/changed.json
+          # Make a regex alternation for source_file matching:
+          # /tmp/changed-pattern.txt → "auth/main.go|billing/charge.go"
+          jq -r '. | join("|")' /tmp/changed.json > /tmp/changed-pattern.txt
+          if [ -z "$(cat /tmp/changed-pattern.txt)" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run find_smells rules
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          PATTERN=$(cat /tmp/changed-pattern.txt)
+          # Run the four rules that don't need _ast (the rules that
+          # work on the standalone CGO ingestion path).
+          for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+            /tmp/mache find-smells --db /tmp/repo.db --rule "$rule" \
+              --format json --limit 1000 \
+              | jq --arg pat "$PATTERN" \
+                  '.findings = (.findings | map(select(.source_id | test($pat))))' \
+              > "/tmp/${rule}.json"
+            echo "=== $rule ==="
+            jq '.findings | length' "/tmp/${rule}.json"
+          done
+
+      - name: Render comment
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          {
+            echo "## find_smells (advisory)"
+            echo ""
+            echo "Scoped to files changed in this PR. Rules below run on the standalone (no-LLO) cross-ref tables; \`_ast\` rules (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison, god_file) are not exercised here."
+            echo ""
+            total=0
+            for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+              count=$(jq '.findings | length' "/tmp/${rule}.json")
+              total=$((total + count))
+              if [ "$count" -gt 0 ]; then
+                echo "<details>"
+                echo "<summary><b>${rule}</b> — ${count} finding(s) in changed files</summary>"
+                echo ""
+                echo "| Source | Node | Metric |"
+                echo "| --- | --- | ---: |"
+                jq -r '.findings | .[:20] | .[] | "| \(.source_id // "") | \(.node_id // "") | \(.metric // 0) |"' "/tmp/${rule}.json"
+                if [ "$count" -gt 20 ]; then
+                  echo ""
+                  echo "_(showing top 20 of ${count})_"
+                fi
+                echo ""
+                echo "</details>"
+                echo ""
+              fi
+            done
+            if [ "$total" -eq 0 ]; then
+              echo "No structural smells in changed files. ✓"
+            fi
+            echo ""
+            echo "_Rules: see [\`docs/ARCHITECTURE.md\`](../blob/main/docs/ARCHITECTURE.md#interplay-with-ley-line-open) for the full registry. Advisory only — these are heuristics, not gates._"
+          } > /tmp/comment.md
+          cat /tmp/comment.md
+
+      - name: Post / update PR comment
+        if: steps.changed.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Find an existing find_smells comment to edit. We tag the
+          # comment body with a hidden marker so subsequent runs of
+          # this workflow on the same PR update in place rather than
+          # accumulating one comment per push.
+          MARKER="<!-- find-smells-gha -->"
+          BODY="$MARKER"$'\n'"$(cat /tmp/comment.md)"
+          existing=$(gh api "repos/${REPO}/issues/${PR}/comments" \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\"))][0].id // empty")
+          if [ -n "$existing" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${existing}" \
+              -f body="$BODY"
+            echo "edited existing comment $existing"
+          else
+            gh pr comment "$PR" --body "$BODY"
+            echo "created new comment"
+          fi

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -27,8 +27,15 @@ var buildCmd = &cobra.Command{
 		// Load or infer schema. Falls back to FCA inference when no schema file is provided.
 		var schema *api.Topology
 		if schemaPath != "" {
-			// Explicit schema file — load it
-			loaded, err := resolveSchema(schemaPath, filepath.Dir(schemaPath))
+			// Explicit schema file — load it. resolveSchema joins
+			// schemaRef with configDir when schemaRef is relative,
+			// so passing filepath.Dir(schemaPath) double-prepends
+			// the directory ("examples" + "examples/go-schema.json"
+			// = "examples/examples/..."). The schemaPath flag is
+			// already relative-to-cwd or absolute by user intent;
+			// pass "." so resolveSchema only touches the path when
+			// it's preset-ref (no slash).
+			loaded, err := resolveSchema(schemaPath, ".")
 			if err != nil {
 				return fmt.Errorf("load schema: %w", err)
 			}

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -54,6 +54,51 @@ func TestBuild_ProducesDB(t *testing.T) {
 	assert.Greater(t, info.Size(), int64(0), "output DB should be non-empty")
 }
 
+// TestBuild_SchemaPathRelative guards the resolveSchema call site.
+// Passing 'examples/go-schema.json' on the CLI used to double-prepend
+// the directory ('examples/examples/go-schema.json'). Build now passes
+// '.' as the configDir so resolveSchema treats the schemaRef as
+// already cwd-relative.
+//
+// We use a tempdir-relative schema file rather than the real
+// examples/go-schema.json so the test isn't tied to that file's
+// content (it'd break if the schema's JSON shape evolved).
+func TestBuild_SchemaPathRelative(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"),
+		[]byte("package main\n\nfunc main() {}\n"), 0o644))
+
+	// Lay down a minimal schema in a 'schemas/' subdir so the path
+	// has a non-trivial directory component (mirrors the real
+	// 'examples/go-schema.json' shape that triggered the bug).
+	schemasDir := filepath.Join(tmpDir, "schemas")
+	require.NoError(t, os.MkdirAll(schemasDir, 0o755))
+	schemaFile := filepath.Join(schemasDir, "minimal.json")
+	require.NoError(t, os.WriteFile(schemaFile,
+		[]byte(`{"version": "v1alpha1"}`), 0o644))
+
+	// Run from tmpDir so the schema path is relative — that's the
+	// failure mode (absolute paths don't trigger the double-prepend).
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(oldWD) }()
+
+	oldSchemaPath := schemaPath
+	schemaPath = "schemas/minimal.json"
+	defer func() { schemaPath = oldSchemaPath }()
+
+	outDB := filepath.Join(tmpDir, "out.db")
+	err = buildCmd.RunE(buildCmd, []string{srcDir, outDB})
+	require.NoError(t, err, "build with relative --schema must not double-prepend the dir")
+
+	info, err := os.Stat(outDB)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+}
+
 // TestBuild_SchemaFlagRegistered guards the --schema flag binding.
 // rootCmd's --schema lives on Flags() (not PersistentFlags), so it
 // doesn't propagate to children. buildCmd needs its own binding to


### PR DESCRIPTION
## Summary
Closes `mache-0yy4` (filed when the CLI shipped in PR #205). Runs on every Go-touching PR; builds mache, indexes the PR head, runs the 4 rules that work on standalone (no-LLO) cross-ref tables — `dead_code`, `untested_function`, `duplicate_definitions`, `fan_out_skew` — and posts a markdown comment listing findings whose `source_file` was changed in the PR.

## Design choices
- **Advisory only** — never fails the build. Rules are heuristic; gating produces noise.
- **Scoped to changed files** — full-repo findings would spam; agents care about what THIS PR did.
- **Edits in place** — HTML-comment marker (`<!-- find-smells-gha -->`) finds existing comments on `synchronize`; updates instead of accumulating.
- **Skips `_ast` rules** — those need an LLO-built `.db` (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison, god_file). Add a `leyline parse` step later when LLO is bundled in runner images.

## Security
Untrusted-shaped inputs (`BASE_SHA`, `HEAD_SHA`, PR number, REPO) are passed via `env:` bindings, not inlined into `run:`. Prevents expansion-injection via branch names / PR titles.

Pinned action versions match the existing `ci.yml` (`actions/checkout@de0fac2e`, `actions/setup-go@4a360112`).

## Tipping-point flag
With the CLI (`mache-hupl`, PR #205) and now this GHA shipped, `find_smells` is clearly product-shaped. Natural moment to consider the `ext/machelint` extraction tracked in `mache-3f8w`.

## Test plan
- [x] Workflow yaml is valid (no parse errors)
- [x] Untrusted inputs routed via env, not inline shell expansion
- [ ] First-real-run will be this PR's own GHA invocation — if it works, the comment will appear here