### PR TITLE
fix: FCA inference covers methods/ for Go projects

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -45,7 +45,18 @@ var buildCmd = &cobra.Command{
 			inf := &lattice.Inferrer{Config: lattice.DefaultInferConfig()}
 			log.Println("Inferring schema...")
 
-			// Walk source to find the first .go file for bootstrap inference
+			// Walk source and parse multiple .go files. Single-file
+			// inference misses node types absent from that file —
+			// e.g. parsing a file with only function_declarations
+			// yields no methods/, even when the project has receiver
+			// methods (mache-5d1o). Cap at maxFiles to keep inference
+			// fast on large repos; FCA only needs enough samples to
+			// surface the closures, not exhaustive coverage.
+			const maxFiles = 32
+			parser := sitter.NewParser()
+			parser.SetLanguage(lang.ForName("go").Grammar())
+			var roots []*sitter.Node
+			var trees []*sitter.Tree // keep alive for root lifetime
 			if walkErr := filepath.WalkDir(source, func(path string, d os.DirEntry, err error) error {
 				if err != nil {
 					return err
@@ -59,29 +70,34 @@ var buildCmd = &cobra.Command{
 				content, readErr := os.ReadFile(path)
 				if readErr != nil {
 					log.Printf("schema inference: read %s: %v", path, readErr)
-					return nil // try next file
+					return nil
 				}
-				parser := sitter.NewParser()
-				parser.SetLanguage(lang.ForName("go").Grammar())
 				tree, parseErr := parser.ParseCtx(context.Background(), nil, content)
 				if parseErr != nil {
 					log.Printf("schema inference: parse %s: %v", path, parseErr)
-					return nil // try next file
+					return nil
 				}
 				if tree != nil {
-					var inferErr error
-					schema, inferErr = inf.InferFromTreeSitter(tree.RootNode())
-					if inferErr != nil {
-						log.Printf("schema inference: infer from %s: %v", path, inferErr)
-					}
+					roots = append(roots, tree.RootNode())
+					trees = append(trees, tree)
 				}
-				if schema != nil {
-					return filepath.SkipDir // Stop after first success
+				if len(roots) >= maxFiles {
+					return filepath.SkipDir
 				}
 				return nil
 			}); walkErr != nil && walkErr != filepath.SkipDir {
 				return fmt.Errorf("walk source: %w", walkErr)
 			}
+
+			if len(roots) > 0 {
+				inferred, inferErr := inf.InferFromTreeSitterRoots(roots...)
+				if inferErr != nil {
+					log.Printf("schema inference: %v", inferErr)
+				} else {
+					schema = inferred
+				}
+			}
+			_ = trees // hold trees alive until inference returns
 
 			if schema == nil {
 				schema = &api.Topology{Version: "v1alpha1"}

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"database/sql"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 // ---------------------------------------------------------------------------
@@ -52,6 +54,59 @@ func TestBuild_ProducesDB(t *testing.T) {
 	info, err := os.Stat(outDB)
 	require.NoError(t, err)
 	assert.Greater(t, info.Size(), int64(0), "output DB should be non-empty")
+}
+
+// TestBuild_FCAInferenceCoversMethods guards the multi-file FCA
+// inference. The previous bootstrap parsed the first .go file only
+// and stopped — when that file held only function_declarations the
+// inferred schema was missing the 'methods' grouping, which silently
+// dropped every method_declaration at ingest. As a knock-on, dead_code
+// flagged any function only called by a method (mache-5d1o).
+//
+// Layout: two files where the FIRST one walked alphabetically has
+// no methods. Without multi-file accumulation the schema would lack
+// methods/, so the method's call to standaloneFunc would not appear
+// in node_refs.
+func TestBuild_FCAInferenceCoversMethods(t *testing.T) {
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+
+	// a.go has only standalone funcs — single-file inference would
+	// produce 'functions/' with no 'methods/'.
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "a.go"),
+		[]byte("package p\n\nfunc standaloneFunc() {}\n"), 0o644))
+
+	// b.go has methods that call standaloneFunc. Without methods/
+	// in the schema, the call is silently dropped from node_refs.
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "b.go"),
+		[]byte("package p\n\ntype T struct{}\n\nfunc (T) MethodCallsStandalone() { standaloneFunc() }\n"),
+		0o644))
+
+	outDB := filepath.Join(tmpDir, "out.db")
+
+	// Empty schemaPath forces the FCA-inference branch.
+	oldSchemaPath := schemaPath
+	schemaPath = ""
+	defer func() { schemaPath = oldSchemaPath }()
+
+	require.NoError(t, buildCmd.RunE(buildCmd, []string{srcDir, outDB}))
+
+	db, err := sql.Open("sqlite", outDB)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var methodCount int
+	require.NoError(t, db.QueryRow(
+		`SELECT count(*) FROM nodes WHERE id LIKE 'methods/%' AND id NOT LIKE '%/source' AND id NOT LIKE '%/ast.json' AND id NOT LIKE '%/doc'`,
+	).Scan(&methodCount))
+	assert.GreaterOrEqual(t, methodCount, 1, "FCA inference must produce a methods/ root when any file has receiver methods")
+
+	var refCount int
+	require.NoError(t, db.QueryRow(
+		`SELECT count(*) FROM node_refs WHERE token = 'standaloneFunc'`,
+	).Scan(&refCount))
+	assert.GreaterOrEqual(t, refCount, 1, "method's call to standaloneFunc must appear in node_refs (dead_code FP fix)")
 }
 
 // TestBuild_SchemaPathRelative guards the resolveSchema call site.

--- a/internal/lattice/context.go
+++ b/internal/lattice/context.go
@@ -126,8 +126,15 @@ func DecideScaling(stats map[string]*FieldStats, totalRecords int) []Attribute {
 
 		fs := stats[field]
 		switch {
-		case field == "type":
-			// Always scale "type" field for AST inference
+		case field == "type" || strings.HasPrefix(field, "field_") && strings.HasSuffix(field, "_type"):
+			// Always scale "type" and AST field shape attributes
+			// (e.g. field_name_type, field_body_type) — these are
+			// low-cardinality discriminators that ProjectAST relies
+			// on to generate correct tree-sitter selectors. Without
+			// this, small samples that don't pass the enum-ratio
+			// gate produce schemas using the wrong AST node type
+			// (e.g. method_declaration name: (identifier) instead of
+			// (field_identifier), which silently matches nothing).
 			sortedVals := sortedKeys(fs.Values)
 			for _, val := range sortedVals {
 				attrs = append(attrs, Attribute{

--- a/internal/lattice/infer.go
+++ b/internal/lattice/infer.go
@@ -104,7 +104,23 @@ func (inf *Inferrer) InferFromRecords(records []any) (*api.Topology, error) {
 // JSONPath selectors which are incompatible with tree-sitter ingestion.
 // ProjectAST generates proper S-expression selectors for tree-sitter queries.
 func (inf *Inferrer) InferFromTreeSitter(root *sitter.Node) (*api.Topology, error) {
-	records := ingest.FlattenAST(root)
+	return inf.InferFromTreeSitterRoots(root)
+}
+
+// InferFromTreeSitterRoots infers a topology by accumulating records from
+// multiple AST roots before running FCA. Single-file inference can miss
+// node types absent from that file (e.g., a file with only top-level
+// functions yields no methods/, even though the rest of the project has
+// receiver methods). Callers that have access to several parsed files
+// should pass them all so the inferred schema covers the project.
+func (inf *Inferrer) InferFromTreeSitterRoots(roots ...*sitter.Node) (*api.Topology, error) {
+	var records []any
+	for _, root := range roots {
+		if root == nil {
+			continue
+		}
+		records = append(records, ingest.FlattenAST(root)...)
+	}
 
 	// Force FCA method for AST data — greedy generates JSONPath selectors
 	// that fail when the engine tries to use them as tree-sitter queries.


### PR DESCRIPTION
## Summary
Two compounding bugs caused `mache build` (FCA-inference path) to silently drop all `method_declaration` nodes for Go projects, which made `dead_code` flag any function only called by methods (`mache-5d1o`).

1. **Single-file bootstrap.** `cmd/build.go` parsed only the first `.go` file walked, then stopped. If that file had no receiver methods (common — e.g. `main.go`), the inferred schema lacked the `methods/` root entirely.

2. **Field-shape attributes not value-scaled.** Even with multi-file records, `internal/lattice/context.go`'s `DecideScaling` only value-scaled `"type"`; all other AST shape attributes (`field_name_type`, `field_body_type`, etc.) only got `Presence` attributes unless the enum-ratio gate happened to pass. `ProjectAST` then defaulted `nameType` to `"identifier"` — wrong for `method_declaration` whose name field is a `(field_identifier)`. The generated selector never matched real method nodes at ingest.

## Changes
- `cmd/build.go` accumulates up to 32 `.go` files via the new `lattice.InferFromTreeSitterRoots` helper.
- `internal/lattice/context.go` `DecideScaling` always value-scales `field_*_type` attributes (low-cardinality discriminators that `ProjectAST` relies on).
- `internal/lattice/infer.go` adds `InferFromTreeSitterRoots(...roots)` for multi-root accumulation; `InferFromTreeSitter` still works for single-root callers.

## Verification
On `mache` itself, `mache build` now produces:

| Before fix | After fix |
| ---: | ---: |
| 0 methods | 404 methods |
| 0 callers of `cleanPath` | 5 callers of `cleanPath` |

(Knock-on: `find_smells dead_code` no longer flags functions only called by methods.)

## Test plan
- [x] `TestBuild_FCAInferenceCoversMethods` (new, `cmd/cli_test.go`) — two-file project where the first file walked has no methods; asserts `methods/` root exists and method's call to `standaloneFunc` appears in `node_refs`.
- [x] Full `task test` (with `-race`) — passes.
- [x] `task lint` — clean.
- [x] Manual: `mache build` against `mache` itself produces 404 methods.

Closes mache-5d1o (the FCA half — the `build --schema` half landed in #232).