### PR TITLE
fix: find_smells source_id falls back to child source_file

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -78,9 +78,9 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "dead_code",
-		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). False positives still expected for exported API consumed outside the indexed scope.",
+		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). source_id falls back to a child's source_file when the construct dir itself doesn't carry one (the schema engine sets source_file on leaf nodes — `source`, `ast.json`, `doc` — but not on the wrapping construct dir). False positives still expected for exported API consumed outside the indexed scope.",
 		Requires:    []string{"node_defs", "node_refs", "nodes"},
-		ScopeColumn: "COALESCE(n.source_file, '')",
+		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
 			-- A construct is "alive" if ANY of its token aliases appears
 			-- in node_refs. We flag a construct as dead only when every
@@ -105,8 +105,22 @@ var smellRegistry = []SmellRule{
 				   OR substr(token, instr(token, '.') + 1) LIKE 'Benchmark%%'
 				   OR substr(token, instr(token, '.') + 1) LIKE 'Example%%'
 				   OR substr(token, instr(token, '.') + 1) LIKE 'Fuzz%%'
+			),
+			-- Resolve source_file via children when the construct dir
+			-- itself has none. The schema engine attaches Origin (and
+			-- thus source_file) to the leaf rendered files (source,
+			-- ast.json, doc) but not to the wrapping construct dir.
+			-- Without this fallback every dead_code finding scopes to
+			-- '' (the empty string) and the find_smells GHA filters
+			-- nothing against the PR diff.
+			child_source AS (
+				SELECT parent_id AS node_id,
+				       MIN(source_file) AS source_file
+				FROM nodes
+				WHERE source_file IS NOT NULL AND source_file != ''
+				GROUP BY parent_id
 			)
-			SELECT COALESCE(n.source_file, '') AS source_id,
+			SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') AS source_id,
 			       n.id AS node_id,
 			       0  AS start_byte,
 			       0  AS end_byte,
@@ -114,6 +128,7 @@ var smellRegistry = []SmellRule{
 			       0  AS start_col,
 			       0  AS metric
 			FROM nodes n
+			LEFT JOIN child_source cs ON cs.node_id = n.id
 			WHERE n.id IN (SELECT DISTINCT node_id FROM node_defs)
 			  AND n.id NOT IN (SELECT node_id FROM alive)
 			  AND n.id NOT IN (SELECT node_id FROM skipped)
@@ -125,7 +140,7 @@ var smellRegistry = []SmellRule{
 			  -- external packages. Skip them.
 			  AND n.id NOT LIKE '%%/imports/%%'
 			%s
-			ORDER BY COALESCE(n.source_file, ''), n.id
+			ORDER BY source_id, n.id
 		`,
 	},
 	{
@@ -177,11 +192,18 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "untested_function",
 		Languages:   []string{"go"},
-		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
+		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). source_id falls back to a child's source_file when the construct dir doesn't carry one. Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
 		Requires:    []string{"node_defs", "nodes"},
-		ScopeColumn: "COALESCE(n.source_file, '')",
+		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
-			SELECT COALESCE(n.source_file, '') AS source_id,
+			WITH child_source AS (
+				SELECT parent_id AS node_id,
+				       MIN(source_file) AS source_file
+				FROM nodes
+				WHERE source_file IS NOT NULL AND source_file != ''
+				GROUP BY parent_id
+			)
+			SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') AS source_id,
 			       d.node_id,
 			       0 AS start_byte,
 			       0 AS end_byte,
@@ -190,6 +212,7 @@ var smellRegistry = []SmellRule{
 			       0 AS metric
 			FROM node_defs d
 			JOIN nodes n ON n.id = d.node_id
+			LEFT JOIN child_source cs ON cs.node_id = n.id
 			LEFT JOIN node_defs t ON t.token = 'Test' || d.token
 			WHERE substr(d.token, 1, 1) GLOB '[A-Z]'
 			  AND d.token NOT LIKE 'Test%%'
@@ -205,16 +228,23 @@ var smellRegistry = []SmellRule{
 			  -- TestFoo naming convention.
 			  AND (d.node_id LIKE 'functions/%%' OR d.node_id LIKE '%%/functions/%%')
 			%s
-			ORDER BY COALESCE(n.source_file, ''), d.token
+			ORDER BY source_id, d.token
 		`,
 	},
 	{
 		ID:          "duplicate_definitions",
-		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' nodes — they're references TO external packages, not definitions. Cross-language since node_defs is populated by every leyline parser.",
+		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' nodes — they're references TO external packages, not definitions. source_id falls back to a child's source_file when the construct dir doesn't carry one. Cross-language since node_defs is populated by every leyline parser.",
 		Requires:    []string{"node_defs", "nodes"},
-		ScopeColumn: "COALESCE(n.source_file, '')",
+		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
-			SELECT COALESCE(n.source_file, '') AS source_id,
+			WITH child_source AS (
+				SELECT parent_id AS node_id,
+				       MIN(source_file) AS source_file
+				FROM nodes
+				WHERE source_file IS NOT NULL AND source_file != ''
+				GROUP BY parent_id
+			)
+			SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') AS source_id,
 			       d.node_id,
 			       0 AS start_byte,
 			       0 AS end_byte,
@@ -247,12 +277,13 @@ var smellRegistry = []SmellRule{
 			) c
 			JOIN node_defs d ON d.token = c.token
 			JOIN nodes n ON n.id = d.node_id
+			LEFT JOIN child_source cs ON cs.node_id = n.id
 			-- Apply the same import filter to the join so partial
 			-- matches (where one repo's imports overlap with a real
 			-- def in another repo) don't leak through.
 			WHERE d.node_id NOT LIKE '%%/imports/%%'
 			%s
-			ORDER BY metric DESC, n.source_file, d.node_id
+			ORDER BY metric DESC, source_id, d.node_id
 		`,
 	},
 	{

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -381,6 +381,92 @@ func TestFindSmells_DeadCodeSkipsImports(t *testing.T) {
 	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs)
 }
 
+// TestFindSmells_DeadCodeSourceFileFallsBackToChildren asserts that
+// when the construct dir itself has source_file = ” (the schema
+// engine attaches Origin/source_file to leaf children — source,
+// ast.json, doc — but not the wrapping dir), the rule resolves the
+// source via any child with a non-empty source_file. Without this
+// the find_smells GHA workflow couldn't filter findings against the
+// PR diff (every finding scoped to ”).
+func TestFindSmells_DeadCodeSourceFileFallsBackToChildren(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO node_defs VALUES ('Orphan', 'functions/Orphan');
+
+		-- Dir node has source_file = '' (real-world FCA-inferred
+		-- schema). Leaf children carry the actual file path.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/Orphan',          'functions',          'Orphan',    1, 0, '',                ''),
+		  ('functions/Orphan/source',   'functions/Orphan',   'source',    0, 0, 'orphan.go',       ''),
+		  ('functions/Orphan/ast.json', 'functions/Orphan',   'ast.json',  0, 0, 'orphan.go',       ''),
+		  ('functions/Orphan/doc',      'functions/Orphan',   'doc',       0, 0, 'orphan.go',       '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Findings, 1)
+	assert.Equal(t, "functions/Orphan", resp.Findings[0].NodeID)
+	assert.Equal(t, "orphan.go", resp.Findings[0].SourceID,
+		"source_id falls back to a child's source_file when the construct dir itself has none")
+}
+
+// TestFindSmells_DeadCodeSourceFileScopeFilter asserts that the
+// child-fallback source_id is the column the source_id query param
+// scopes against — i.e. PR-diff filters in the GHA wrapper still
+// work after the fallback.
+func TestFindSmells_DeadCodeSourceFileScopeFilter(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Two dead constructs in two different files. Same shape:
+		-- dir source_file is empty, child source_file holds the path.
+		INSERT INTO node_defs VALUES
+		  ('OrphanA', 'functions/OrphanA'),
+		  ('OrphanB', 'functions/OrphanB');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/OrphanA',        'functions',         'OrphanA', 1, 0, '',          ''),
+		  ('functions/OrphanA/source', 'functions/OrphanA', 'source',  0, 0, 'a.go',      ''),
+		  ('functions/OrphanB',        'functions',         'OrphanB', 1, 0, '',          ''),
+		  ('functions/OrphanB/source', 'functions/OrphanB', 'source',  0, 0, 'b.go',      '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":      "dead_code",
+		"source_id": "a.go",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Findings, 1, "only the OrphanA in a.go matches the source_id filter")
+	assert.Equal(t, "functions/OrphanA", resp.Findings[0].NodeID)
+	assert.Equal(t, "a.go", resp.Findings[0].SourceID)
+}
+
 // TestFindSmells_DeadCodePerNodeAggregation asserts that dead_code
 // aggregates by node_id, not by token. A function with multiple
 // token aliases (bare + qualified) where ANY token is referenced


### PR DESCRIPTION
## Summary
Three find_smells rules — `dead_code`, `duplicate_definitions`, `untested_function` — query the construct directory node directly, but the schema engine attaches `Origin` (and the persisted `source_file` column) to the leaf nodes (`source`, `ast.json`, `doc`) — not the wrapping dir. Result: `source_id` came back empty for every finding. The find_smells GHA wrapper filters findings against the PR diff using `source_id`, so an empty value made the filter match nothing useful.

## Fix
Each affected rule now joins against a `child_source` CTE that resolves `source_file` from any non-empty leaf child:

```sql
WITH child_source AS (
    SELECT parent_id AS node_id,
           MIN(source_file) AS source_file
    FROM nodes
    WHERE source_file IS NOT NULL AND source_file != ''
    GROUP BY parent_id
)
SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') AS source_id, ...
```

`ScopeColumn` updated to the same `COALESCE` so the `source_id` query parameter still scopes correctly (i.e. the GHA wrapper's `--source-id` filter still works).

I also tried setting `Origin` on the construct dir at ingest time, but that broke incremental refresh: `DeleteFileNodes(filePath)` deletes by `source_file = filePath`, and assigning a single source_file to a multi-source construct dir would nuke shared dirs. SQL-side fallback is the contained fix.

## Verification
Dogfooded against `mache.db`:

| Rule | Before | After |
| --- | ---: | ---: |
| dead_code findings with non-empty source_id | 0 / 306 | 305 / 306 |
| duplicate_definitions | 0 / 12 | 12 / 12 |
| untested_function | 0 / 225 | 225 / 225 |

The 1 outlier in dead_code is a stale fixture node with no leaf children — no fallback target. Acceptable.

## Test plan
- [x] `TestFindSmells_DeadCodeSourceFileFallsBackToChildren` (new) — dir has empty source_file, leaf children have `orphan.go`. Asserts finding's `source_id` resolves to `orphan.go`.
- [x] `TestFindSmells_DeadCodeSourceFileScopeFilter` (new) — two dead funcs in two files; `source_id=a.go` filter must return only the one in `a.go`. Verifies `ScopeColumn` matches the SELECT projection.
- [x] All existing `TestFindSmells_*` tests pass.
- [x] `task lint` clean.