### PR TITLE
fix: bump FCA sample size for AST inference (1000 → 100k)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -41,8 +41,20 @@ var buildCmd = &cobra.Command{
 			}
 			schema = loaded
 		} else {
-			// No schema — infer via FCA from source tree
-			inf := &lattice.Inferrer{Config: lattice.DefaultInferConfig()}
+			// No schema — infer via FCA from source tree.
+			//
+			// AST records are dense: a single Go file produces hundreds
+			// of named-node records (function/method/var/expression/...).
+			// The default SampleSize of 1000 is sized for sparse JSON
+			// records — for AST it under-samples low-frequency node
+			// kinds. With ~32 files × ~1300 records ≈ 40k records, only
+			// ~2 method_declaration records would land in the reservoir
+			// and the closure-based detection of methods/ silently fails
+			// (mache-5d1o). Bump to 100k so AST inference sees enough
+			// of every kind. Memory is still bounded by maxFiles below.
+			cfg := lattice.DefaultInferConfig()
+			cfg.SampleSize = 100_000
+			inf := &lattice.Inferrer{Config: cfg}
 			log.Println("Inferring schema...")
 
 			// Walk source and parse multiple .go files. Single-file


### PR DESCRIPTION
## Summary
PR #233 wired multi-file AST accumulation but kept the default `SampleSize=1000`. AST records are dense — a single Go file flattens to ~1300 named-node records — so 32 files yield ~40K records. With reservoir sampling at size 1000, only ~2 `method_declaration` records land in the reservoir, and the closure-based detection in `ProjectAST` silently fails to project the `methods/` root.

## Fix
Build now uses `SampleSize=100_000` for the FCA-inference path so every AST node kind has enough representation. Memory is still bounded by the `maxFiles` cap on the source walk.

## Verification
Dogfood against mache itself:

| | Before | After |
| --- | --- | --- |
| Schema roots produced | `_project_files`, `functions` | `_project_files`, `functions`, `methods` |
| `methods/Bar`, `methods/Unmount`, etc. | ❌ silently dropped | ✅ projected |
| `node_refs[token=cleanPath]` | 0 | 5 |

This is the missing half of `mache-5d1o`: PR #233 added the multi-root accumulator, but the sample size still gated visibility for projects above ~3 files.

## Test plan
- [x] All existing `cmd/` tests pass.
- [x] Manual dogfood: `mache build` against `mache` produces `methods/` again.
- [x] `task lint` clean (commit hooks).

Closes the remaining half of `mache-5d1o`.