### PR TITLE
fix: dead_code skips generated-code files

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -78,7 +78,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "dead_code",
-		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). source_id falls back to a child's source_file when the construct dir itself doesn't carry one (the schema engine sets source_file on leaf nodes — `source`, `ast.json`, `doc` — but not on the wrapping construct dir). False positives still expected for exported API consumed outside the indexed scope.",
+		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). source_id falls back to a child's source_file when the construct dir itself doesn't carry one (the schema engine sets source_file on leaf nodes — `source`, `ast.json`, `doc` — but not on the wrapping construct dir). Generated code files (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) are excluded because they intentionally export wide APIs the consumer picks from. False positives still expected for exported API consumed outside the indexed scope.",
 		Requires:    []string{"node_defs", "node_refs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -139,6 +139,17 @@ var smellRegistry = []SmellRule{
 			  -- rule. They aren't — they're how the code references
 			  -- external packages. Skip them.
 			  AND n.id NOT LIKE '%%/imports/%%'
+			  -- Generated code (capnp / protobuf / *_generated.go /
+			  -- *.gen.go) intentionally exports wide APIs that the
+			  -- consumer picks from — most exported methods aren't
+			  -- internally called. Flagging them buries real findings
+			  -- under noise (256/305 of mache's pre-filter findings
+			  -- came from a single capnp.go file). Skip-list by file
+			  -- suffix on the resolved source_id.
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.capnp.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.pb.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%_generated.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.gen.go'
 			%s
 			ORDER BY source_id, n.id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -381,6 +381,68 @@ func TestFindSmells_DeadCodeSkipsImports(t *testing.T) {
 	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs)
 }
 
+// TestFindSmells_DeadCodeSkipsGeneratedFiles asserts that constructs
+// in generated-code files (capnp, protobuf, _generated.go, .gen.go)
+// don't surface in dead_code. Generated code intentionally exports
+// wide APIs the consumer picks from, so most methods are statically
+// "dead" — flagging them buries real findings under noise (256/305
+// of mache's pre-filter findings came from one capnp.go file).
+func TestFindSmells_DeadCodeSkipsGeneratedFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Defs in generated files — must be skipped.
+		INSERT INTO node_defs VALUES
+		  ('CapnpFn',     'methods/CapnpFn'),
+		  ('PbFn',        'methods/PbFn'),
+		  ('GenFn',       'methods/GenFn'),
+		  ('DotGenFn',    'methods/DotGenFn');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('methods/CapnpFn',         'methods',           'CapnpFn',  1, 0, '',                     ''),
+		  ('methods/CapnpFn/source',  'methods/CapnpFn',   'source',   0, 0, 'a/b/foo.capnp.go',     ''),
+		  ('methods/PbFn',            'methods',           'PbFn',     1, 0, '',                     ''),
+		  ('methods/PbFn/source',     'methods/PbFn',      'source',   0, 0, 'a/b/foo.pb.go',        ''),
+		  ('methods/GenFn',           'methods',           'GenFn',    1, 0, '',                     ''),
+		  ('methods/GenFn/source',    'methods/GenFn',     'source',   0, 0, 'a/b/foo_generated.go', ''),
+		  ('methods/DotGenFn',        'methods',           'DotGenFn', 1, 0, '',                     ''),
+		  ('methods/DotGenFn/source', 'methods/DotGenFn',  'source',   0, 0, 'a/b/foo.gen.go',       '');
+
+		-- Real dead function in normal source file — control: must
+		-- still be flagged.
+		INSERT INTO node_defs VALUES ('Orphan', 'functions/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/Orphan',        'functions',         'Orphan',   1, 0, '',                     ''),
+		  ('functions/Orphan/source', 'functions/Orphan',  'source',   0, 0, 'pkg/x.go',             '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+		assert.NotContains(t, f.SourceID, ".capnp.go", "capnp generated files must be skipped")
+		assert.NotContains(t, f.SourceID, ".pb.go", "protobuf generated files must be skipped")
+		assert.NotContains(t, f.SourceID, "_generated.go", "_generated.go suffix must be skipped")
+		assert.NotContains(t, f.SourceID, ".gen.go", ".gen.go suffix must be skipped")
+	}
+	assert.Equal(t, []string{"functions/Orphan"}, gotIDs,
+		"only the non-generated dead function is flagged")
+}
+
 // TestFindSmells_DeadCodeSourceFileFallsBackToChildren asserts that
 // when the construct dir itself has source_file = ” (the schema
 // engine attaches Origin/source_file to leaf children — source,


### PR DESCRIPTION
## Summary
84% of `dead_code` findings on `mache.db` (256/305) came from a single generated file: `internal/leyline/schema/daemon.capnp.go`. Generated code intentionally exports wide APIs the consumer picks from, so flagging it as dead buries real findings under noise.

## Fix
Skip findings whose resolved `source_id` ends in:

| Suffix | Source |
| --- | --- |
| `*.capnp.go` | Cap'n Proto |
| `*.pb.go` | Protobuf |
| `*_generated.go` | common `generated` suffix |
| `*.gen.go` | common `gen` suffix |

## Verification
| | Before | After |
| --- | ---: | ---: |
| dead_code findings on `mache.db` | 305 | 49 |
| daemon.capnp.go contribution | 256 | 0 |

The remaining 49 are all in real source files where the FP rate is much lower and noise-to-signal matches what a human reviewer would expect.

## Test plan
- [x] `TestFindSmells_DeadCodeSkipsGeneratedFiles` (new) — four flavors of generated suffix + a real-file control. Asserts only the real file is flagged.
- [x] All existing `TestFindSmells_*` tests pass.
- [x] `task lint` clean.