### PR TITLE
fix: dead_code skip-list adds vtab / billy / http.Handler methods

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -94,9 +94,36 @@ var smellRegistry = []SmellRule{
 			-- ANY-MATCH is the right semantic — a function with both
 			-- 'TestFoo' and 'pkg.TestFoo' should be skipped on the
 			-- testing-framework rule even if only one row triggers.
+			--
+			-- Token list includes:
+			--   • entry points: main, init
+			--   • io.Reader/Writer/Closer: Read, Write, Close
+			--   • fmt: String, Error, Format, Scan, GoString
+			--   • sort.Interface: Len, Less, Swap
+			--   • encoding: MarshalJSON, UnmarshalJSON
+			--   • SQLite virtual-table (modernc.org/sqlite/vtab):
+			--     BestIndex, Column, Connect, Create, Destroy,
+			--     Disconnect, Eof, Filter, Rowid, Open, Next
+			--   • billy.Filesystem (go-git): Chroot, Readlink, Sys,
+			--     TempFile, MkdirAll, Symlink, Lstat, Stat, ReadDir,
+			--     Capabilities, Root
+			--   • net/http: ServeHTTP
+			--
+			-- These are interface contracts invoked by external
+			-- runtimes / libraries; static call extraction can't see
+			-- the dispatch site, so the methods always look dead.
 			skipped AS (
 				SELECT DISTINCT node_id FROM node_defs
-				WHERE token IN ('main','init','String','Error','Read','Write','Close','Len','Less','Swap','MarshalJSON','UnmarshalJSON','Format','Scan')
+				WHERE token IN (
+					'main','init',
+					'String','Error','Read','Write','Close','Len','Less','Swap',
+					'MarshalJSON','UnmarshalJSON','Format','Scan','GoString',
+					'BestIndex','Column','Connect','Create','Destroy','Disconnect',
+					'Eof','Filter','Rowid','Open','Next',
+					'Chroot','Readlink','Sys','TempFile','MkdirAll','Symlink',
+					'Lstat','Stat','ReadDir','Capabilities','Root',
+					'ServeHTTP'
+				)
 				   -- Strip any 'pkg.' qualifier when matching prefixes.
 				   -- instr returns 0 if there's no dot; substr(token, 1)
 				   -- is the full token, so bare and qualified shapes both

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -381,6 +381,81 @@ func TestFindSmells_DeadCodeSkipsImports(t *testing.T) {
 	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs)
 }
 
+// TestFindSmells_DeadCodeSkipsExternalInterfaceMethods asserts that
+// methods implementing common external-interface contracts (SQLite
+// vtab, billy.Filesystem, net/http handlers) don't surface in
+// dead_code. These are dispatched by external runtimes / libraries
+// rather than via static call sites in the indexed scope.
+func TestFindSmells_DeadCodeSkipsExternalInterfaceMethods(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- vtab interface methods (SQLite virtual-table) — must skip.
+		INSERT INTO node_defs VALUES
+		  ('BestIndex',  'methods/BestIndex'),
+		  ('Filter',     'methods/Filter'),
+		  ('Eof',        'methods/Eof'),
+		  ('Rowid',      'methods/Rowid'),
+		  ('Connect',    'methods/Connect');
+		-- billy.Filesystem methods — must skip.
+		INSERT INTO node_defs VALUES
+		  ('Chroot',     'methods/Chroot'),
+		  ('Readlink',   'methods/Readlink'),
+		  ('TempFile',   'methods/TempFile');
+		-- net/http handler — must skip.
+		INSERT INTO node_defs VALUES
+		  ('ServeHTTP',  'methods/ServeHTTP');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('methods/BestIndex',         'methods', 'BestIndex',  1, 0, '',          ''),
+		  ('methods/BestIndex/source',  'methods/BestIndex',  'source', 0, 0, 'a.go', ''),
+		  ('methods/Filter',            'methods', 'Filter',     1, 0, '',          ''),
+		  ('methods/Filter/source',     'methods/Filter',     'source', 0, 0, 'a.go', ''),
+		  ('methods/Eof',               'methods', 'Eof',        1, 0, '',          ''),
+		  ('methods/Eof/source',        'methods/Eof',        'source', 0, 0, 'a.go', ''),
+		  ('methods/Rowid',             'methods', 'Rowid',      1, 0, '',          ''),
+		  ('methods/Rowid/source',      'methods/Rowid',      'source', 0, 0, 'a.go', ''),
+		  ('methods/Connect',           'methods', 'Connect',    1, 0, '',          ''),
+		  ('methods/Connect/source',    'methods/Connect',    'source', 0, 0, 'a.go', ''),
+		  ('methods/Chroot',            'methods', 'Chroot',     1, 0, '',          ''),
+		  ('methods/Chroot/source',     'methods/Chroot',     'source', 0, 0, 'b.go', ''),
+		  ('methods/Readlink',          'methods', 'Readlink',   1, 0, '',          ''),
+		  ('methods/Readlink/source',   'methods/Readlink',   'source', 0, 0, 'b.go', ''),
+		  ('methods/TempFile',          'methods', 'TempFile',   1, 0, '',          ''),
+		  ('methods/TempFile/source',   'methods/TempFile',   'source', 0, 0, 'b.go', ''),
+		  ('methods/ServeHTTP',         'methods', 'ServeHTTP',  1, 0, '',          ''),
+		  ('methods/ServeHTTP/source',  'methods/ServeHTTP',  'source', 0, 0, 'h.go', '');
+
+		-- Real dead helper as a control — must still be flagged.
+		INSERT INTO node_defs VALUES ('Orphan', 'functions/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/Orphan',        'functions',         'Orphan', 1, 0, '',          ''),
+		  ('functions/Orphan/source', 'functions/Orphan',  'source', 0, 0, 'orphan.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Orphan"}, gotIDs,
+		"only the non-interface-method dead function is flagged")
+}
+
 // TestFindSmells_DeadCodeSkipsGeneratedFiles asserts that constructs
 // in generated-code files (capnp, protobuf, _generated.go, .gen.go)
 // don't surface in dead_code. Generated code intentionally exports


### PR DESCRIPTION
## Summary
Static call extraction can't see dispatch sites for methods invoked by external runtimes — the SQLite driver invokes `vtab.Module` methods via reflection, `go-nfs` invokes `billy.Filesystem` methods through an interface, `net/http` invokes `ServeHTTP` via the `Handler` interface. So they always look dead when the indexed scope doesn't include the external library's call site.

## Fix
Extend the dead_code skip list with common interface contracts mache implements:

| Interface | Methods |
| --- | --- |
| `vtab.Module` (modernc.org/sqlite/vtab) | `BestIndex`, `Column`, `Connect`, `Create`, `Destroy`, `Disconnect`, `Eof`, `Filter`, `Rowid`, `Open`, `Next` |
| `billy.Filesystem` (go-git) | `Chroot`, `Readlink`, `Sys`, `TempFile`, `MkdirAll`, `Symlink`, `Lstat`, `Stat`, `ReadDir`, `Capabilities`, `Root` |
| `http.Handler` | `ServeHTTP` |

## Verification
| | Before | After |
| --- | ---: | ---: |
| dead_code findings on `mache.db` | 49 | 37 |

The remaining 37 are predominantly project-shape FPs (cobra `RunE` callbacks at file level, init-registry registrations) tracked separately on `mache-02r9` — those need file-level ref extraction, not skip-listing.

## Test plan
- [x] `TestFindSmells_DeadCodeSkipsExternalInterfaceMethods` (new) — vtab + billy + http.Handler implementations + a control real-dead helper. Asserts only the helper is flagged.
- [x] All existing `TestFindSmells_*` tests pass.
- [x] `task lint` clean.