### PR TITLE
chore: apply modernize lint suggestions across the tree

### DIFF
--- a/cmd/serve_architecture.go
+++ b/cmd/serve_architecture.go
@@ -113,10 +113,7 @@ func makeGetArchitectureHandler(g graph.Graph) server.ToolHandlerFunc {
 			sort.Slice(counts, func(i, j int) bool {
 				return counts[i].count > counts[j].count
 			})
-			limit := 20
-			if len(counts) < limit {
-				limit = len(counts)
-			}
+			limit := min(len(counts), 20)
 			for _, tc := range counts[:limit] {
 				arch.MostReferenced = append(arch.MostReferenced, entryPoint{
 					Symbol: tc.token,
@@ -165,10 +162,7 @@ func makeGetArchitectureHandler(g graph.Graph) server.ToolHandlerFunc {
 			sort.Slice(syms, func(i, j int) bool {
 				return len(syms[i].ids) > len(syms[j].ids)
 			})
-			limit := 20
-			if len(syms) < limit {
-				limit = len(syms)
-			}
+			limit := min(len(syms), 20)
 			for _, sd := range syms[:limit] {
 				arch.KeyAbstractions = append(arch.KeyAbstractions, keyAbstraction{
 					Symbol: sd.symbol,

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -663,14 +663,8 @@ func populateSnippets(qg refsQuerier, findings []smellFinding) {
 			continue
 		}
 		const padding = 30
-		s := findings[i].StartByte - padding
-		if s < 0 {
-			s = 0
-		}
-		e := findings[i].EndByte + padding
-		if e > len(src) {
-			e = len(src)
-		}
+		s := max(findings[i].StartByte-padding, 0)
+		e := min(findings[i].EndByte+padding, len(src))
 		if s < e {
 			snippet := string(src[s:e])
 			snippet = strings.ReplaceAll(snippet, "\n", " ")

--- a/cmd/serve_hosted.go
+++ b/cmd/serve_hosted.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -83,12 +84,7 @@ func validateRepoURL(repoURL string) error {
 // isValidSchemaPreset returns true if the schema name is a known preset.
 // Prevents arbitrary file reads via ?schema=/etc/passwd.
 func isValidSchemaPreset(schema string) bool {
-	for _, name := range PresetNames() {
-		if schema == name {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(PresetNames(), schema)
 }
 
 // repoFromContext extracts the repo URL from context, if present.

--- a/cmd/serve_impact.go
+++ b/cmd/serve_impact.go
@@ -35,13 +35,7 @@ func makeGetImpactHandler(g graph.Graph) server.ToolHandlerFunc {
 		if symbol == "" {
 			return mcp.NewToolResultError("symbol is required"), nil
 		}
-		maxDepth := request.GetInt("depth", 2)
-		if maxDepth < 1 {
-			maxDepth = 1
-		}
-		if maxDepth > 5 {
-			maxDepth = 5
-		}
+		maxDepth := min(max(request.GetInt("depth", 2), 1), 5)
 		direction := request.GetString("direction", "both")
 		if direction != "callers" && direction != "callees" && direction != "both" {
 			return mcp.NewToolResultError("direction must be 'callers', 'callees', or 'both'"), nil

--- a/cmd/serve_listdir_bench_test.go
+++ b/cmd/serve_listdir_bench_test.go
@@ -21,12 +21,12 @@ func buildBenchGraph(b *testing.B, nChildren int) *graph.MemoryStore {
 	rootID := "pkg"
 	root := &graph.Node{ID: rootID, Mode: fs.ModeDir}
 	root.Children = make([]string, nChildren)
-	for i := 0; i < nChildren; i++ {
+	for i := range nChildren {
 		root.Children[i] = fmt.Sprintf("%s/child_%04d", rootID, i)
 	}
 	store.AddRoot(root)
 
-	for i := 0; i < nChildren; i++ {
+	for i := range nChildren {
 		dirID := fmt.Sprintf("%s/child_%04d", rootID, i)
 		store.AddNode(&graph.Node{
 			ID:       dirID,

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -267,8 +267,8 @@ func getGitHead(rootPath string) string {
 	}
 	head := strings.TrimSpace(string(data))
 
-	if strings.HasPrefix(head, "ref: ") {
-		ref := strings.TrimPrefix(head, "ref: ")
+	if after, ok := strings.CutPrefix(head, "ref: "); ok {
+		ref := after
 		refPath := filepath.Join(gitDir, filepath.FromSlash(ref))
 		if data2, err := os.ReadFile(refPath); err == nil {
 			// Loose ref found — use its content.

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -516,7 +516,7 @@ func TestSearch_RequiredPattern(t *testing.T) {
 func TestSearch_WithLimit(t *testing.T) {
 	store := graph.NewMemoryStore()
 	// Add many refs
-	for i := 0; i < 20; i++ {
+	for i := range 20 {
 		require.NoError(t, store.AddRef("Token", "path/"+string(rune('A'+i))))
 	}
 	require.NoError(t, store.InitRefsDB())

--- a/graph/cache_test.go
+++ b/graph/cache_test.go
@@ -249,7 +249,7 @@ func TestGraphCache_ConcurrentAccess(t *testing.T) {
 
 	var wg sync.WaitGroup
 	// Concurrent writers.
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
@@ -259,14 +259,12 @@ func TestGraphCache_ConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 	// Concurrent readers.
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			c.GetNode("root")
 			c.ListChildren("root")
 			c.RootIDs()
-		}()
+		})
 	}
 	wg.Wait()
 
@@ -402,7 +400,7 @@ func TestGraphCache_NoRaceOnGetNodeChildren(t *testing.T) {
 	go func() {
 		defer close(done)
 		close(ready)
-		for k := 0; k < 5000; k++ {
+		for range 5000 {
 			n, ok := c.GetNode("pkg")
 			if !ok {
 				continue
@@ -414,7 +412,7 @@ func TestGraphCache_NoRaceOnGetNodeChildren(t *testing.T) {
 	}()
 
 	<-ready
-	for i := 0; i < 50; i++ {
+	for i := range 50 {
 		id := fmt.Sprintf("pkg/f_%03d", i)
 		c.PutFile(id, []byte("v"))
 		c.AppendChild("pkg", id)

--- a/internal/graph/arena_writer.go
+++ b/internal/graph/arena_writer.go
@@ -203,10 +203,7 @@ func (f *ArenaFlusher) flushInternal() error {
 
 		// Write only changed pages within DB content
 		for off := int64(0); off < int64(len(dbBytes)); off += int64(pageSize) {
-			end := off + int64(pageSize)
-			if end > int64(len(dbBytes)) {
-				end = int64(len(dbBytes))
-			}
+			end := min(off+int64(pageSize), int64(len(dbBytes)))
 			if !bytes.Equal(dbBytes[off:end], oldBuf[off:end]) {
 				if _, err := af.WriteAt(dbBytes[off:end], inactiveOffset+off); err != nil {
 					return fmt.Errorf("write page at offset %d: %w", off, err)
@@ -218,10 +215,7 @@ func (f *ArenaFlusher) flushInternal() error {
 		// Allocate the zero page once and reuse for each write.
 		zeroPage := make([]byte, pageSize)
 		for off := int64(len(dbBytes)); off < bufferSize; off += int64(pageSize) {
-			end := off + int64(pageSize)
-			if end > bufferSize {
-				end = bufferSize
-			}
+			end := min(off+int64(pageSize), bufferSize)
 			if !isZeroPage(oldBuf[off:end]) {
 				if _, err := af.WriteAt(zeroPage[:end-off], inactiveOffset+off); err != nil {
 					return fmt.Errorf("zero-pad at offset %d: %w", off, err)

--- a/internal/graph/arena_writer_test.go
+++ b/internal/graph/arena_writer_test.go
@@ -127,7 +127,7 @@ func TestArenaFlusher_Coalesce(t *testing.T) {
 	flusher.Start(50 * time.Millisecond)
 
 	// Fire 10 rapid RequestFlush calls (should coalesce into ~1-2 flushes)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		flusher.RequestFlush()
 	}
 
@@ -171,7 +171,7 @@ func BenchmarkArenaFlush(b *testing.B) {
 			stmt, err := tx.Prepare("INSERT INTO t VALUES (?, ?)")
 			require.NoError(b, err)
 			payload := "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" // ~90 chars
-			for i := 0; i < rowCount; i++ {
+			for i := range rowCount {
 				_, err = stmt.Exec(i, payload)
 				require.NoError(b, err)
 			}

--- a/internal/graph/batch_test.go
+++ b/internal/graph/batch_test.go
@@ -106,7 +106,7 @@ func TestMemoryStore_AddFileChildren_Atomicity(t *testing.T) {
 		}
 	}
 
-	for cycle := 0; cycle < cycles; cycle++ {
+	for cycle := range cycles {
 		dirID := fmt.Sprintf("pkg/atomic_%d", cycle)
 		dir := &Node{ID: dirID, Mode: fs.ModeDir}
 		store.AddNode(dir)
@@ -174,7 +174,7 @@ func TestMemoryStore_AddFileChildren_NodeMapConsistency(t *testing.T) {
 
 	const cycles = 100
 
-	for cycle := 0; cycle < cycles; cycle++ {
+	for cycle := range cycles {
 		store := NewMemoryStore()
 		dirID := "pkg/cons"
 		dir := &Node{ID: dirID, Mode: fs.ModeDir}
@@ -254,7 +254,7 @@ func TestMemoryStore_AddFileChildren_NoRaceOnGetNodeChildren(t *testing.T) {
 	go func() {
 		defer close(done)
 		close(ready)
-		for k := 0; k < 5000; k++ {
+		for range 5000 {
 			n, err := store.GetNode("pkg/race")
 			if err != nil {
 				continue
@@ -367,7 +367,7 @@ func TestListChildStats_SnapshotConsistency(t *testing.T) {
 
 	// Reader: take snapshots repeatedly. Each snapshot must be all-10 or all-99.
 	// Never a mix — that would prove non-atomic reads.
-	for attempt := 0; attempt < 500; attempt++ {
+	for attempt := range 500 {
 		stats, err := store.ListChildStats("snap")
 		require.NoError(t, err)
 		require.Len(t, stats, N)
@@ -404,24 +404,20 @@ func TestListChildStats_RaceDetectorClean(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// Writer: continuously mutate node Data (changes ContentSize)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
+	wg.Go(func() {
+		for i := range 1000 {
 			store.AddNode(&Node{
 				ID: "race/a", Mode: 0o444,
 				Data: make([]byte, 10+i%50),
 			})
 		}
-	}()
+	})
 
 	// Reader: continuously read stats and access ALL fields.
 	// With []*Node, accessing n.ContentSize() after RLock release races.
 	// With []NodeStat, all fields are value copies — no race.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < 1000; i++ {
+	wg.Go(func() {
+		for range 1000 {
 			stats, err := store.ListChildStats("race")
 			if err != nil {
 				continue
@@ -435,7 +431,7 @@ func TestListChildStats_RaceDetectorClean(t *testing.T) {
 				_ = s.HasOrigin
 			}
 		}
-	}()
+	})
 
 	wg.Wait()
 	// If this test passes with -race, snapshot semantics are proven.

--- a/internal/graph/community.go
+++ b/internal/graph/community.go
@@ -67,7 +67,7 @@ func DetectCommunities(refs map[string][]string, minCommunitySize int) *Communit
 	improved := true
 	for improved {
 		improved = false
-		for node := 0; node < n; node++ {
+		for node := range n {
 			bestComm := community[node]
 			bestDelta := 0.0
 			ki := degree[node]
@@ -191,7 +191,7 @@ func buildProjection(refs map[string][]string) ([]map[int]float64, map[string]in
 		for i, n := range nodes {
 			indices[i] = nodeIndex[n]
 		}
-		for i := 0; i < len(indices); i++ {
+		for i := range indices {
 			for j := i + 1; j < len(indices); j++ {
 				a, b := indices[i], indices[j]
 				if a != b {
@@ -222,9 +222,9 @@ func computeModularity(adj []map[int]float64, community []int, degree []float64,
 		return 0
 	}
 	q := 0.0
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ki := degree[i]
-		for j := 0; j < n; j++ {
+		for j := range n {
 			if community[i] != community[j] {
 				continue
 			}
@@ -249,7 +249,7 @@ func ConnectedComponents(refs map[string][]string) [][]string {
 	visited := make([]bool, n)
 	var components [][]string
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if visited[i] {
 			continue
 		}

--- a/internal/graph/delete_file_nodes_perf_test.go
+++ b/internal/graph/delete_file_nodes_perf_test.go
@@ -42,10 +42,10 @@ func buildBenchStore(b *testing.B, nFiles, perFile int) (*MemoryStore, []string)
 	store.AddRoot(parent)
 
 	files := make([]string, 0, nFiles)
-	for f := 0; f < nFiles; f++ {
+	for f := range nFiles {
 		filePath := fmt.Sprintf("/src/file_%04d.go", f)
 		files = append(files, filePath)
-		for i := 0; i < perFile; i++ {
+		for i := range perFile {
 			id := fmt.Sprintf("%s/file%04d_node%03d", parentID, f, i)
 			parent.Children = append(parent.Children, id)
 			store.AddNode(&Node{
@@ -102,7 +102,7 @@ func readdFile(store *MemoryStore, filePath string, perFile int) {
 	parentClone.Children = append([]string(nil), parent.Children...)
 
 	idPrefix := fmt.Sprintf("pkg/%s_node", lastSegment(filePath))
-	for i := 0; i < perFile; i++ {
+	for i := range perFile {
 		id := fmt.Sprintf("%s%03d", idPrefix, i)
 		parentClone.Children = append(parentClone.Children, id)
 		store.AddNode(&Node{

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -197,10 +197,7 @@ func SliceContent(data, buf []byte, offset int64) int {
 	if offset < 0 || offset >= int64(len(data)) {
 		return 0
 	}
-	end := offset + int64(len(buf))
-	if end > int64(len(data)) {
-		end = int64(len(data))
-	}
+	end := min(offset+int64(len(buf)), int64(len(data)))
 	return copy(buf, data[offset:end])
 }
 
@@ -226,13 +223,7 @@ func (s *MemoryStore) SetCallExtractor(fn CallExtractor) {
 // Cache size scales with node count: 25% of nodes, floor 1024, ceiling 16384.
 func (s *MemoryStore) SetResolver(fn ContentResolverFunc) {
 	s.resolver = fn
-	size := len(s.nodes) / 4
-	if size < 1024 {
-		size = 1024
-	}
-	if size > 16384 {
-		size = 16384
-	}
+	size := min(max(len(s.nodes)/4, 1024), 16384)
 	s.cache = NewContentCache(size)
 }
 

--- a/internal/graph/hotswap_test.go
+++ b/internal/graph/hotswap_test.go
@@ -60,23 +60,19 @@ func TestHotSwapGraph_ConcurrentReadsDuringSwap(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 500 {
 				_, _ = h.GetNode("pkg/auth/source")
 				_, _ = h.ListChildren("pkg")
 				_, _ = h.ListChildStats("pkg")
 			}
-		}()
+		})
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for range 100 {
 			h.Swap(memoryStoreFactory(t))
 		}
-	}()
+	})
 
 	wg.Wait()
 }

--- a/internal/graph/quotient_test.go
+++ b/internal/graph/quotient_test.go
@@ -829,7 +829,7 @@ func TestMermaid_EdgeLabelsAreValidSyntax(t *testing.T) {
 	out := q.Mermaid("TD")
 
 	// Must not contain parentheses in edge labels (breaks mermaid parser).
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		if strings.Contains(line, "-->|") {
 			assert.NotContains(t, line, "(", "edge label must not contain '(' — breaks mermaid syntax")
 			assert.NotContains(t, line, ")", "edge label must not contain ')' — breaks mermaid syntax")

--- a/internal/graph/shared_test.go
+++ b/internal/graph/shared_test.go
@@ -247,36 +247,30 @@ func TestContentCache_ConcurrentReadWrite(t *testing.T) {
 
 	// Writers
 	for i := range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range 100 {
 				key := fmt.Sprintf("key_%d_%d", i, j)
 				c.Put(key, []byte(key))
 			}
-		}()
+		})
 	}
 
 	// Readers
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range 100 {
 				c.Get("key_0_0") // may or may not exist
 			}
-		}()
+		})
 	}
 
 	// Deleters
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range 50 {
 				c.Delete(fmt.Sprintf("key_0_%d", j))
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/internal/graph/sliceutil_test.go
+++ b/internal/graph/sliceutil_test.go
@@ -190,7 +190,7 @@ func TestFlushChildSlices_UnsortedInput(t *testing.T) {
 
 func TestMergeSortedDedup_Fuzz(t *testing.T) {
 	rng := rand.New(rand.NewSource(42))
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		a := randomSortedPaths(rng, rng.Intn(100))
 		b := randomSortedPaths(rng, rng.Intn(100))
 		merged := mergeSortedDedup(a, b)

--- a/internal/graph/sqlite_graph_test.go
+++ b/internal/graph/sqlite_graph_test.go
@@ -654,7 +654,7 @@ func BenchmarkScanRoot_Synthetic(b *testing.B) {
 	// Build a 10K record DB
 	const numRecords = 10000
 	records := make(map[string]string, numRecords)
-	for i := 0; i < numRecords; i++ {
+	for i := range numRecords {
 		id := fmt.Sprintf("CVE-2024-%04d", i)
 		records[id] = fmt.Sprintf(
 			`{"schema":"kev","identifier":"%s","item":{"cveID":"%s","vendorProject":"Vendor%d","product":"Product%d","shortDescription":"Desc %d"}}`,

--- a/internal/graph/writable_graph_test.go
+++ b/internal/graph/writable_graph_test.go
@@ -143,7 +143,7 @@ func TestWritableGraph_UpdateRecord_ConcurrentSerialised(t *testing.T) {
 	const b = "BBBBBBBBBBBBBBBB"
 
 	var wg sync.WaitGroup
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -923,12 +923,13 @@ func (w *ASTWalker) findChildByKindAST(db *sql.DB, parentID, kind, sourceID stri
 		// For ancestry=["parameter_list","parameter_declaration"], build:
 		//   LIKE 'parentID/%/%/%'         (3 segments: 2 ancestors + leaf)
 		//   NOT LIKE 'parentID/%/%/%/%'   (exclude deeper nodes)
-		depthPattern := parentID
+		var depthPattern strings.Builder
+		depthPattern.WriteString(parentID)
 		for range len(ancestry) + 1 {
-			depthPattern += "/%"
+			depthPattern.WriteString("/%")
 		}
 		query = baseCols + "n.id LIKE ? AND n.id NOT LIKE ? AND a.node_kind = ?"
-		args = []any{depthPattern, depthPattern + "/%", kind}
+		args = []any{depthPattern.String(), depthPattern.String() + "/%", kind}
 	}
 
 	if sourceID != "" {

--- a/internal/ingest/ast_walker_bench_test.go
+++ b/internal/ingest/ast_walker_bench_test.go
@@ -57,7 +57,7 @@ func seedManyCalls(b *testing.B, dir string, nCalls int) *sql.DB {
 			b.Fatalf("seed: %v\nquery=%s\nargs=%v", err, query, args)
 		}
 	}
-	for i := 0; i < nCalls; i++ {
+	for i := range nCalls {
 		callID := fmt.Sprintf("call_expression_%d", i)
 		if i%2 == 0 {
 			selID := callID + "/selector_expression"

--- a/internal/ingest/ast_walker_test.go
+++ b/internal/ingest/ast_walker_test.go
@@ -866,9 +866,7 @@ func TestASTWalker_RaceSelectWalker(t *testing.T) {
 	errs := make(chan error, goroutines)
 
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			w, err := SelectWalker(db)
 			if err != nil {
 				errs <- err
@@ -878,7 +876,7 @@ func TestASTWalker_RaceSelectWalker(t *testing.T) {
 			if _, ok := w.(*ASTWalker); !ok {
 				errs <- fmt.Errorf("expected ASTWalker, got %T", w)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -429,10 +429,8 @@ func (e *Engine) ingestTreeSitterParallel(rootPath string) error {
 
 	// Phase 1: Workers parse files in parallel (CPU-bound tree-sitter parsing).
 	var workerWg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
-		workerWg.Add(1)
-		go func() {
-			defer workerWg.Done()
+	for range numWorkers {
+		workerWg.Go(func() {
 			parser := sitter.NewParser()
 			for job := range jobs {
 				result := parsedTreeSitterFile{job: job}
@@ -473,7 +471,7 @@ func (e *Engine) ingestTreeSitterParallel(rootPath string) error {
 				}
 				parsed <- result
 			}
-		}()
+		})
 	}
 
 	// Walk directory and send jobs. Non-tree-sitter files (raw files) are
@@ -1050,15 +1048,13 @@ func (e *Engine) ingestSQLiteStreaming(dbPath string) error {
 	diagramCache := &e.diagramTmplCache
 
 	var workerWg sync.WaitGroup
-	for i := 0; i < numWorkers; i++ {
-		workerWg.Add(1)
-		go func() {
-			defer workerWg.Done()
+	for range numWorkers {
+		workerWg.Go(func() {
 			w := NewJsonWalker()
 			for job := range jobs {
 				results <- processRecord(e.Schema, w, dbPath, job, diagramFuncs, diagramCache)
 			}
-		}()
+		})
 	}
 
 	// Collector: apply nodes to store (single goroutine, no lock contention).
@@ -1066,9 +1062,7 @@ func (e *Engine) ingestSQLiteStreaming(dbPath string) error {
 	// and parent-child links.
 	var collectErr error
 	var collectWg sync.WaitGroup
-	collectWg.Add(1)
-	go func() {
-		defer collectWg.Done()
+	collectWg.Go(func() {
 		parentChildSeen := make(map[string]map[string]bool)
 		count := 0
 		for res := range results {
@@ -1115,7 +1109,7 @@ func (e *Engine) ingestSQLiteStreaming(dbPath string) error {
 			}
 		}
 		log.Printf("Processed %d records total.", count)
-	}()
+	})
 
 	// Reader: stream raw rows from SQLite (I/O bound, single goroutine)
 	readErr := StreamSQLiteRaw(dbPath, func(id, raw string) error {
@@ -1511,7 +1505,7 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 				if err == nil {
 					startLine := byteOffsetToLine(root.Source, extStart)
 					endLine := byteOffsetToLine(root.Source, extEnd)
-					node.Properties["location"] = []byte(fmt.Sprintf("%s:%d:%d", relPath, startLine, endLine))
+					node.Properties["location"] = fmt.Appendf(nil, "%s:%d:%d", relPath, startLine, endLine)
 				}
 			}
 		}

--- a/internal/ingest/gitignore.go
+++ b/internal/ingest/gitignore.go
@@ -194,8 +194,8 @@ func matchPattern(pattern, relPath string) bool {
 	}
 
 	// Also match each path component for directory patterns.
-	parts := strings.Split(relPath, "/")
-	for _, part := range parts {
+	parts := strings.SplitSeq(relPath, "/")
+	for part := range parts {
 		if ok, _ := filepath.Match(pattern, part); ok {
 			return true
 		}
@@ -243,7 +243,7 @@ func matchDoublestar(pattern, relPath string) bool {
 		rest := relPath[len(prefix)+1:]
 		// Try matching suffix at each depth
 		relParts := strings.Split(rest, "/")
-		for i := 0; i < len(relParts); i++ {
+		for i := range relParts {
 			sub := strings.Join(relParts[i:], "/")
 			if matchPattern(suffix, sub) {
 				return true

--- a/internal/ingest/parent_match.go
+++ b/internal/ingest/parent_match.go
@@ -1,5 +1,7 @@
 package ingest
 
+import "maps"
+
 import sitter "github.com/smacker/go-tree-sitter"
 
 // parentAwareMatch wraps a Match and injects a _parent key into Values()
@@ -25,9 +27,7 @@ func (m *parentAwareMatch) Values() map[string]any {
 	}
 	inner := m.inner.Values()
 	v := make(map[string]any, len(inner)+1)
-	for k, val := range inner {
-		v[k] = val
-	}
+	maps.Copy(v, inner)
 	v["_parent"] = m.parentValues
 	m.cached = v
 	return v

--- a/internal/ingest/sitter_flatten.go
+++ b/internal/ingest/sitter_flatten.go
@@ -35,7 +35,7 @@ func walkAST(n *sitter.Node, records *[]any, enrichFn func(*sitter.Node, map[str
 
 		// Inspect children to gather structural properties
 		count := int(n.ChildCount())
-		for i := 0; i < count; i++ {
+		for i := range count {
 			child := n.Child(i)
 			if child == nil {
 				continue
@@ -61,7 +61,7 @@ func walkAST(n *sitter.Node, records *[]any, enrichFn func(*sitter.Node, map[str
 
 	// Recurse
 	count := int(n.ChildCount())
-	for i := 0; i < count; i++ {
+	for i := range count {
 		walkAST(n.Child(i), records, enrichFn)
 	}
 }

--- a/internal/ingest/watcher.go
+++ b/internal/ingest/watcher.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -239,10 +240,8 @@ func (w *Watcher) shouldIgnorePath(path string) bool {
 	}
 
 	// Check for .git anywhere in path components.
-	for _, seg := range strings.Split(path, string(filepath.Separator)) {
-		if seg == ".git" {
-			return true
-		}
+	if slices.Contains(strings.Split(path, string(filepath.Separator)), ".git") {
+		return true
 	}
 
 	// Check gitignore rules (file patterns like *.log, directory patterns, etc.).

--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -249,10 +249,10 @@ func TestShouldIgnoreDir(t *testing.T) {
 
 func TestWatcher_VendorIgnored(t *testing.T) {
 	dir := t.TempDir()
-	var called int32
+	var called atomic.Int32
 
 	w, err := NewWatcher(dir, func(path string) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 	}, nil, WithDebounce(20*time.Millisecond))
 	require.NoError(t, err)
 	defer w.Stop()
@@ -265,7 +265,7 @@ func TestWatcher_VendorIgnored(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(vendorDir, "dep.go"), []byte("package dep"), 0o644))
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, int32(0), atomic.LoadInt32(&called), "vendor/ files should be ignored")
+	assert.Equal(t, int32(0), called.Load(), "vendor/ files should be ignored")
 }
 
 // TestWatcher_TargetIgnored is a regression test for the FD leak where the
@@ -274,10 +274,10 @@ func TestWatcher_VendorIgnored(t *testing.T) {
 // a Rust target/ tree with 11K+ subdirectories leaked thousands of FDs.
 func TestWatcher_TargetIgnored(t *testing.T) {
 	dir := t.TempDir()
-	var called int32
+	var called atomic.Int32
 
 	w, err := NewWatcher(dir, func(path string) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 	}, nil, WithDebounce(20*time.Millisecond))
 	require.NoError(t, err)
 	defer w.Stop()
@@ -305,7 +305,7 @@ func TestWatcher_TargetIgnored(t *testing.T) {
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, int32(0), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(0), called.Load(),
 		"files in target/, dist/, build/ should be ignored by watcher")
 }
 
@@ -320,9 +320,9 @@ func TestWatcher_GitignoreSkipsDirs(t *testing.T) {
 	gi := LoadGitignore(dir)
 	require.NotNil(t, gi)
 
-	var called int32
+	var called atomic.Int32
 	w, err := NewWatcher(dir, func(path string) {
-		atomic.AddInt32(&called, 1)
+		called.Add(1)
 	}, nil, WithDebounce(20*time.Millisecond), WithGitignore(gi))
 	require.NoError(t, err)
 	defer w.Stop()
@@ -336,13 +336,13 @@ func TestWatcher_GitignoreSkipsDirs(t *testing.T) {
 		[]byte("package gen"), 0o644))
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, int32(0), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(0), called.Load(),
 		"gitignored directories should not trigger watcher callbacks")
 
 	// Verify non-ignored files still trigger callbacks
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main"), 0o644))
 	time.Sleep(100 * time.Millisecond)
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&called),
+	assert.Equal(t, int32(1), called.Load(),
 		"non-ignored source files should still trigger callbacks")
 }

--- a/internal/lattice/context.go
+++ b/internal/lattice/context.go
@@ -340,17 +340,17 @@ func hasAttribute(rec any, attr Attribute) bool {
 		}
 		// Extract the expected suffix from attr.Name beyond the field
 		suffix := strings.TrimPrefix(attr.Name, attr.Field)
-		if strings.HasPrefix(suffix, ".year=") {
-			year := strings.TrimPrefix(suffix, ".year=")
+		if after, ok0 := strings.CutPrefix(suffix, ".year="); ok0 {
+			year := after
 			return len(s) >= 4 && s[:4] == year
 		}
-		if strings.HasPrefix(suffix, ".month=") {
-			month := strings.TrimPrefix(suffix, ".month=")
+		if after, ok0 := strings.CutPrefix(suffix, ".month="); ok0 {
+			month := after
 			return len(s) >= 7 && s[5:7] == month
 		}
 		// Enum: "field=value"
-		if strings.HasPrefix(suffix, "=") {
-			expected := strings.TrimPrefix(suffix, "=")
+		if after, ok0 := strings.CutPrefix(suffix, "="); ok0 {
+			expected := after
 			return s == expected
 		}
 		return false

--- a/internal/lattice/grammar_introspect_test.go
+++ b/internal/lattice/grammar_introspect_test.go
@@ -2,6 +2,7 @@ package lattice
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -208,17 +209,17 @@ func inspectNode(n *sitter.Node, depth int, t *testing.T) {
 		return
 	}
 
-	indent := ""
-	for i := 0; i < depth; i++ {
-		indent += "  "
+	var indent strings.Builder
+	for range depth {
+		indent.WriteString("  ")
 	}
 
 	if n.IsNamed() {
-		t.Logf("%s%s", indent, n.Type())
+		t.Logf("%s%s", indent.String(), n.Type())
 
 		// Show field names for children
 		count := int(n.ChildCount())
-		for i := 0; i < count; i++ {
+		for i := range count {
 			child := n.Child(i)
 			if child == nil {
 				continue
@@ -226,13 +227,13 @@ func inspectNode(n *sitter.Node, depth int, t *testing.T) {
 
 			fieldName := n.FieldNameForChild(i)
 			if fieldName != "" && child.IsNamed() {
-				t.Logf("%s  field '%s': %s", indent, fieldName, child.Type())
+				t.Logf("%s  field '%s': %s", indent.String(), fieldName, child.Type())
 			}
 		}
 
 		// Only recurse for block types to keep output manageable
 		if n.Type() == "block" || n.Type() == "config_file" || n.Type() == "body" {
-			for i := 0; i < count; i++ {
+			for i := range count {
 				inspectNode(n.Child(i), depth+1, t)
 			}
 		}

--- a/internal/lattice/greedy.go
+++ b/internal/lattice/greedy.go
@@ -371,14 +371,14 @@ func parseAttribute(attr string) (string, string) {
 		parts := strings.Split(attr, ":")
 		return parts[0], parts[1]
 	}
-	if strings.HasSuffix(attr, "_year") {
-		return strings.TrimSuffix(attr, "_year"), "year"
+	if before, ok := strings.CutSuffix(attr, "_year"); ok {
+		return before, "year"
 	}
-	if strings.HasSuffix(attr, "_month") {
-		return strings.TrimSuffix(attr, "_month"), "month"
+	if before, ok := strings.CutSuffix(attr, "_month"); ok {
+		return before, "month"
 	}
-	if strings.HasSuffix(attr, "_day") {
-		return strings.TrimSuffix(attr, "_day"), "day"
+	if before, ok := strings.CutSuffix(attr, "_day"); ok {
+		return before, "day"
 	}
 	return attr, ""
 }

--- a/internal/lattice/greedy_test.go
+++ b/internal/lattice/greedy_test.go
@@ -1,6 +1,7 @@
 package lattice
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,7 +98,7 @@ func TestIntegration(t *testing.T) {
 	// So with 2 records it returns leaf.
 
 	// Let's override for test or provide more records.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		records = append(records, map[string]any{"a": 1})
 		records = append(records, map[string]any{"b": 2})
 	}
@@ -116,14 +117,12 @@ func TestGreedyInference_WithHints(t *testing.T) {
 	}
 	// Duplicate records to exceed min threshold (10)
 	baseLen := len(records)
-	for i := 0; i < 3; i++ {
-		for j := 0; j < baseLen; j++ {
+	for range 3 {
+		for j := range baseLen {
 			// Deep copy map to avoid reference issues if modified (though strictly not needed here)
 			orig := records[j].(map[string]any)
 			dup := make(map[string]any)
-			for k, v := range orig {
-				dup[k] = v
-			}
+			maps.Copy(dup, orig)
 			records = append(records, dup)
 		}
 	}

--- a/internal/lattice/project_ast.go
+++ b/internal/lattice/project_ast.go
@@ -121,8 +121,8 @@ func ProjectAST(concepts []Concept, ctx *FormalContext, config ProjectConfig) *a
 			if attrName == "has_name" {
 				hasName = true
 			}
-			if strings.HasPrefix(attrName, "field_name_type=") {
-				nameType = strings.TrimPrefix(attrName, "field_name_type=")
+			if after, ok := strings.CutPrefix(attrName, "field_name_type="); ok {
+				nameType = after
 			}
 			if attrName == "has_body" {
 				hasBody = true

--- a/internal/lattice/project_test.go
+++ b/internal/lattice/project_test.go
@@ -146,7 +146,7 @@ func makeKEVRecords(n int) []any {
 	records := make([]any, n)
 	vendors := []string{"Acme", "BetaCorp", "GammaInc", "DeltaLLC", "EpsilonSys"}
 	products := []string{"Widget", "Gadget", "Sprocket", "Thingamajig", "Doohickey"}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		records[i] = map[string]any{
 			"schema":     "kev",
 			"identifier": fmt.Sprintf("CVE-2024-%04d", i+1),
@@ -168,7 +168,7 @@ func makeNVDRecords(n int) []any {
 	years := []string{"2023", "2024"}
 	months := []string{"01", "03", "06", "09", "11"}
 	statuses := []string{"Analyzed", "Modified", "Awaiting Analysis"}
-	for i := 0; i < n; i++ {
+	for i := range n {
 		y := years[i%len(years)]
 		m := months[i%len(months)]
 		records[i] = map[string]any{

--- a/internal/leyline/sheaf_test.go
+++ b/internal/leyline/sheaf_test.go
@@ -446,7 +446,7 @@ func TestBuildRestrictions_DeterministicOrder(t *testing.T) {
 
 	// Run multiple times to ensure ordering is stable.
 	var prev []restriction
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		r := buildRestrictions(cr, refs)
 		if prev != nil {
 			for j := range r {

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -72,7 +72,7 @@ func Lint(content []byte, langName string) ([]Diagnostic, error) {
 			// Simple check: iterate children of var_spec
 			hasValue := false
 			count := int(c.Node.ChildCount())
-			for i := 0; i < count; i++ {
+			for i := range count {
 				// In Go grammar, the value is usually an expression list?
 				// Field names: name, type, value
 				if c.Node.FieldNameForChild(i) == "value" {

--- a/internal/writeback/splice_test.go
+++ b/internal/writeback/splice_test.go
@@ -198,7 +198,7 @@ func TestSplice_DetectsConcurrentModification(t *testing.T) {
 		defer close(done)
 		// Wait for Splice to be in flight (best-effort), then mutate.
 		// We bump the mtime by writing fresh bytes to the file.
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			info, _ := os.Stat(path)
 			if info != nil && info.ModTime().After(initial) {
 				// Splice may have already finished one Stat; mutate now.

--- a/tools/fuzz-gen/main.go
+++ b/tools/fuzz-gen/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	fmt.Printf("🎯 Targeting %s in %s\n", *fuzzTarget, *targetFile)
 
-	for i := 0; i < maxAttempts; i++ {
+	for i := range maxAttempts {
 		fmt.Printf("Attempt %d/%d: ", i+1, maxAttempts)
 		mutated, desc := mutate(src, rng)
 		if bytes.Equal(mutated, src) {

--- a/tools/gen-lsp-fixture/main.go
+++ b/tools/gen-lsp-fixture/main.go
@@ -255,7 +255,7 @@ func Helper() string {
 	}
 
 	for _, n := range nodesData {
-		var parentID, record, sf interface{}
+		var parentID, record, sf any
 		if n.parentID != "" {
 			parentID = n.parentID
 		}
@@ -349,7 +349,7 @@ func Helper() string {
 	}
 
 	for _, l := range lspData {
-		var diag interface{}
+		var diag any
 		if l.diagnostics != "" {
 			diag = l.diagnostics
 		}

--- a/tools/mcp-fetch/main.go
+++ b/tools/mcp-fetch/main.go
@@ -178,9 +178,9 @@ func normalizeEntry(raw map[string]any) map[string]any {
 	fullName, _ := server["name"].(string)
 	namespace := fullName
 	shortName := fullName
-	if idx := strings.Index(fullName, "/"); idx >= 0 {
-		namespace = fullName[:idx]
-		shortName = fullName[idx+1:]
+	if before, after, ok := strings.Cut(fullName, "/"); ok {
+		namespace = before
+		shortName = after
 	}
 
 	item := map[string]any{


### PR DESCRIPTION
## Summary
Auto-fix sweep via `golangci-lint run --enable-only modernize --fix`, plus manual cleanup of three cases the tool couldn't combine into the same pass.

## Categories of change
| Old | New |
| --- | --- |
| `for i := 0; i < n; i++` | `for i := range n` |
| `wg.Add(1); go func() { defer wg.Done(); ... }()` | `wg.Go(func() { ... })` |
| `if x < N { x = N }` (similar for >) | `x = max/min(x, N)` |
| `strings.HasPrefix + TrimPrefix` | `strings.CutPrefix` |
| `for _, seg := range strings.Split(...)` | `slices.Contains` where applicable |
| repeated `s += suffix` | `strings.Builder` |
| `[]byte(fmt.Sprintf(...))` | `fmt.Appendf` |
| `atomic.AddInt32(&x, ...)` | `atomic.Int32` method form |
| map-copy `for k, v := range m { ... }` | `maps.Copy` |

41 files, +131 / -192 — net deletion. Pure semantic-preserving modernization.

## Test plan
- [x] `go test -race -count=1 ./...` — passes.
- [x] `task lint` — 0 issues.
- [x] No behavior changes; the diffs are all idiomatic-syntax updates that preserve types and control flow.