### PR TITLE
chore(ci): opt CI workflows into FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ on:
 permissions:
   contents: read
 
+# arduino/setup-task hasn't shipped a Node 24 release yet
+# (https://github.com/arduino/setup-task/issues/1359). The runner
+# warns and will hard-fail in June 2026. Opt in to GitHub's forced
+# Node 24 shim until upstream releases v3.
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,11 @@ on:
 permissions:
   contents: read
 
+# Opt into Node 24 shim until arduino/setup-task ships a Node 24
+# release (https://github.com/arduino/setup-task/issues/1359).
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   integration:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.event.client_payload.tag || github.ref_name }}
+  # arduino/setup-task hasn't shipped Node 24 yet — opt into the
+  # forced shim (https://github.com/arduino/setup-task/issues/1359).
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
CI / Integration / Release runs print Node 20 deprecation annotations because `arduino/setup-task@v2` ships with Node 20 and hasn't released a Node 24 build yet ([upstream issue arduino/setup-task#1359](https://github.com/arduino/setup-task/issues/1359)).

GitHub's hard-fail date for Node 20 actions is September 16, 2026; the recommended interim is to opt into the forced Node 24 shim via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true`.

## Change
Set the env on the workflow level for `ci.yml`, `integration.yml`, and `release.yml` (`find-smells.yml` doesn't use `arduino/setup-task`, so it's untouched).

## Follow-up
Drop the env once `arduino/setup-task` ships v3 with Node 24.