### PR TITLE
fix: extend generated-code skip to fan_out_skew + untested_function

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -230,7 +230,7 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "untested_function",
 		Languages:   []string{"go"},
-		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). source_id falls back to a child's source_file when the construct dir doesn't carry one. Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
+		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is skipped — generated APIs aren't expected to have project tests. source_id falls back to a child's source_file when the construct dir doesn't carry one. Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -265,6 +265,13 @@ var smellRegistry = []SmellRule{
 			  -- variables/, imports/ — those don't follow the
 			  -- TestFoo naming convention.
 			  AND (d.node_id LIKE 'functions/%%' OR d.node_id LIKE '%%/functions/%%')
+			  -- Generated code (capnp / protobuf / *_generated.go /
+			  -- *.gen.go) isn't expected to have a TestFoo counterpart
+			  -- in the consumer's tests — skip it.
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.capnp.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.pb.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%_generated.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.gen.go'
 			%s
 			ORDER BY source_id, d.token
 		`,
@@ -357,7 +364,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "fan_out_skew",
-		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* — tests are expected to call many things, no signal there. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
+		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* — tests are expected to call many things, no signal there. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generated dispatchers naturally have wide fan-out. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
 		Requires:    []string{"node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -392,6 +399,13 @@ var smellRegistry = []SmellRule{
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Benchmark%%'
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Example%%'
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Fuzz%%'
+			  -- Generated dispatchers (capnp / protobuf / *_generated /
+			  -- *.gen) have intentionally wide fan-out; flagging them
+			  -- buries real findings under generated-code noise.
+			  AND COALESCE(n.source_file, '') NOT LIKE '%%.capnp.go'
+			  AND COALESCE(n.source_file, '') NOT LIKE '%%.pb.go'
+			  AND COALESCE(n.source_file, '') NOT LIKE '%%_generated.go'
+			  AND COALESCE(n.source_file, '') NOT LIKE '%%.gen.go'
 			%s
 			ORDER BY metric DESC, source_id, node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1144,6 +1144,114 @@ func TestFindSmells_FanOutSkewSkipsTestPrefixes(t *testing.T) {
 		"Dispatcher (production code) is flagged; TestRunner (test) is skipped via parent ctor.name LIKE 'Test%'")
 }
 
+// TestFindSmells_FanOutSkewSkipsGeneratedFiles asserts that a
+// generated-code dispatcher (capnp / pb / *_generated.go / *.gen.go)
+// with high fan-out is NOT flagged. Generated dispatchers naturally
+// touch many neighbors — flagging them buries real findings under
+// noise (capnp.go entries dominated mache's pre-filter top-N).
+func TestFindSmells_FanOutSkewSkipsGeneratedFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions',                       '',                       'functions', 1, 0, '',                ''),
+		  ('functions/CapnpStruct',           'functions',              'CapnpStruct',1, 0, '',                ''),
+		  ('functions/CapnpStruct/source',    'functions/CapnpStruct',  'source',    0, 0, 'foo.capnp.go',    ''),
+		  ('functions/Dispatcher',            'functions',              'Dispatcher',1, 0, '',                ''),
+		  ('functions/Dispatcher/source',     'functions/Dispatcher',   'source',    0, 0, 'dispatcher.go',   '');
+
+		-- Both have 12 distinct callees. CapnpStruct is in *.capnp.go
+		-- so must be skipped; Dispatcher (production) must be flagged.
+		INSERT INTO node_refs VALUES
+		  ('A','functions/CapnpStruct/source'),('B','functions/CapnpStruct/source'),('C','functions/CapnpStruct/source'),
+		  ('D','functions/CapnpStruct/source'),('E','functions/CapnpStruct/source'),('F','functions/CapnpStruct/source'),
+		  ('G','functions/CapnpStruct/source'),('H','functions/CapnpStruct/source'),('I','functions/CapnpStruct/source'),
+		  ('J','functions/CapnpStruct/source'),('K','functions/CapnpStruct/source'),('L','functions/CapnpStruct/source');
+
+		INSERT INTO node_refs VALUES
+		  ('M','functions/Dispatcher/source'),('N','functions/Dispatcher/source'),('O','functions/Dispatcher/source'),
+		  ('P','functions/Dispatcher/source'),('Q','functions/Dispatcher/source'),('R','functions/Dispatcher/source'),
+		  ('S','functions/Dispatcher/source'),('T','functions/Dispatcher/source'),('U','functions/Dispatcher/source'),
+		  ('V','functions/Dispatcher/source'),('W','functions/Dispatcher/source'),('X','functions/Dispatcher/source');
+
+		-- Tiny callers to bring project mean down so 12 trips the threshold.
+		INSERT INTO node_refs VALUES
+		  ('z1','functions/n1'),('z2','functions/n2'),('z3','functions/n3'),
+		  ('z4','functions/n4'),('z5','functions/n5'),('z6','functions/n6');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "fan_out_skew"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Dispatcher/source"}, gotIDs,
+		"Dispatcher (production) is flagged; CapnpStruct (generated) is skipped via source_file suffix")
+}
+
+// TestFindSmells_UntestedFunctionSkipsGeneratedFiles asserts that
+// exported funcs in generated-code files don't get flagged for
+// missing TestFoo coverage — generated APIs aren't expected to have
+// project-side tests.
+func TestFindSmells_UntestedFunctionSkipsGeneratedFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Exported funcs in generated files — must be skipped.
+		INSERT INTO node_defs VALUES
+		  ('NewMessage',  'functions/NewMessage'),
+		  ('NewBlob',     'functions/NewBlob');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/NewMessage',         'functions',           'NewMessage', 1, 0, '',              ''),
+		  ('functions/NewMessage/source',  'functions/NewMessage','source',     0, 0, 'm.capnp.go',    ''),
+		  ('functions/NewBlob',            'functions',           'NewBlob',    1, 0, '',              ''),
+		  ('functions/NewBlob/source',     'functions/NewBlob',   'source',     0, 0, 'b.pb.go',       '');
+
+		-- Real exported func in normal source — control: must be flagged
+		-- (no TestPublishFunction in node_defs).
+		INSERT INTO node_defs VALUES ('PublishFunction', 'functions/PublishFunction');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/PublishFunction',        'functions',                 'PublishFunction', 1, 0, '',         ''),
+		  ('functions/PublishFunction/source', 'functions/PublishFunction', 'source',          0, 0, 'pub.go',   '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "untested_function"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/PublishFunction"}, gotIDs,
+		"only the non-generated exported func without a TestFoo counterpart is flagged")
+}
+
 // TestFindSmells_DuplicateDefinitions seeds three groups: a duplicated
 // helper (two defs, two source files — flagged twice), an interface
 // method on the skip list (two defs — excluded), and a unique symbol


### PR DESCRIPTION
## Summary
PR #238 skipped generated code in `dead_code` only. The same noise still dominated `fan_out_skew` and `untested_function`:

- `fan_out_skew` ranked `daemon.capnp.go`'s `Struct` / `DecodeFromPtr` at the top — capnp dispatchers naturally touch many neighbors.
- `untested_function` flagged every `NewFoo` / `NewFoo_List` capnp constructor for missing a `TestNewFoo` counterpart that was never going to exist.

## Fix
Apply the same suffix-based exclusion (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) to both rules.

## Verification
| Rule | Before | After |
| --- | ---: | ---: |
| `fan_out_skew` | 32 | 22 |
| `untested_function` | 225 | 108 |

Production-source findings keep their place; only generated-code noise is dropped.

## Test plan
- [x] `TestFindSmells_FanOutSkewSkipsGeneratedFiles` (new) — capnp + production dispatcher with same fan-out; only production is flagged.
- [x] `TestFindSmells_UntestedFunctionSkipsGeneratedFiles` (new) — capnp constructor + protobuf constructor + a real exported func; only the real func is flagged.
- [x] All existing rule tests pass.
- [x] `task lint` clean.