### PR TITLE
fix: dead_code skips non-callable categories (types/constants/variables)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -78,7 +78,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "dead_code",
-		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). source_id falls back to a child's source_file when the construct dir itself doesn't carry one (the schema engine sets source_file on leaf nodes — `source`, `ast.json`, `doc` — but not on the wrapping construct dir). Generated code files (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) are excluded because they intentionally export wide APIs the consumer picks from. False positives still expected for exported API consumed outside the indexed scope.",
+		Description: "Constructs whose tokens (any alias — bare 'Foo' or qualified 'pkg.Foo') have NO entries in node_refs. Aggregated per construct, not per token: a function with three token aliases where any one is referenced is treated as live. Skip list rejects entry points (main, init), interface methods invoked dynamically (String, Error, Read, Write, ...), and the testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (the runtime invokes those reflectively). Restricted to call-target-shaped categories ('functions/', 'methods/'): types, constants, variables, and imports are referenced as identifiers rather than called, so node_refs (call-extraction-only) doesn't reflect their use; flagging them is pure noise. source_id falls back to a child's source_file when the construct dir itself doesn't carry one (the schema engine sets source_file on leaf nodes — `source`, `ast.json`, `doc` — but not on the wrapping construct dir). Generated code files (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) are excluded because they intentionally export wide APIs the consumer picks from. False positives still expected for exported API consumed outside the indexed scope.",
 		Requires:    []string{"node_defs", "node_refs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -159,13 +159,20 @@ var smellRegistry = []SmellRule{
 			WHERE n.id IN (SELECT DISTINCT node_id FROM node_defs)
 			  AND n.id NOT IN (SELECT node_id FROM alive)
 			  AND n.id NOT IN (SELECT node_id FROM skipped)
-			  -- Imports are external references, not defs. Their
-			  -- "tokens" (e.g. '"fmt"') never appear in node_refs
-			  -- because node_refs tracks function calls, not import
-			  -- paths, so every imports/ node looks dead by this
-			  -- rule. They aren't — they're how the code references
-			  -- external packages. Skip them.
+			  -- Skip non-callable categories. node_refs is populated
+			  -- by call-extraction (call_expression / selector field,
+			  -- plus a handful of function-value patterns for Go) —
+			  -- types/constants/variables/imports are referenced by
+			  -- identifier in non-call contexts and never make it
+			  -- into the table, so flagging them is pure noise.
 			  AND n.id NOT LIKE '%%/imports/%%'
+			  AND n.id NOT LIKE 'imports/%%'
+			  AND n.id NOT LIKE '%%/types/%%'
+			  AND n.id NOT LIKE 'types/%%'
+			  AND n.id NOT LIKE '%%/constants/%%'
+			  AND n.id NOT LIKE 'constants/%%'
+			  AND n.id NOT LIKE '%%/variables/%%'
+			  AND n.id NOT LIKE 'variables/%%'
 			  -- Generated code (capnp / protobuf / *_generated.go /
 			  -- *.gen.go) intentionally exports wide APIs that the
 			  -- consumer picks from — most exported methods aren't

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -381,6 +381,62 @@ func TestFindSmells_DeadCodeSkipsImports(t *testing.T) {
 	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs)
 }
 
+// TestFindSmells_DeadCodeSkipsNonCallableCategories asserts that
+// types/, constants/, and variables/ category nodes don't surface
+// in dead_code. node_refs is populated by call-extraction only;
+// identifiers used in type / const / variable position never land
+// there, so flagging them is pure noise. Surfaced by the explicit
+// go-schema path (PR #240's GHA comment showed dozens of FPs like
+// 'cmd/types/SmellRule', 'cmd/constants/padding').
+func TestFindSmells_DeadCodeSkipsNonCallableCategories(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Non-callable categories — none of these belong in dead_code.
+		INSERT INTO node_defs VALUES
+		  ('SomeType',  'pkg/types/SomeType'),
+		  ('MaxSize',   'pkg/constants/MaxSize'),
+		  ('globalCfg', 'pkg/variables/globalCfg');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/types/SomeType',         'pkg/types',     'SomeType',  1, 0, 'a.go', ''),
+		  ('pkg/constants/MaxSize',      'pkg/constants', 'MaxSize',   1, 0, 'b.go', ''),
+		  ('pkg/variables/globalCfg',    'pkg/variables', 'globalCfg', 1, 0, 'c.go', '');
+
+		-- Real dead function — control: must still be flagged.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/functions/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/Orphan', 'pkg/functions', 'Orphan', 1, 0, 'orphan.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	for _, id := range gotIDs {
+		assert.NotContains(t, id, "/types/", "types/ nodes must not appear")
+		assert.NotContains(t, id, "/constants/", "constants/ nodes must not appear")
+		assert.NotContains(t, id, "/variables/", "variables/ nodes must not appear")
+	}
+	assert.Equal(t, []string{"pkg/functions/Orphan"}, gotIDs,
+		"only the real dead function in functions/ is flagged")
+}
+
 // TestFindSmells_DeadCodeSkipsExternalInterfaceMethods asserts that
 // methods implementing common external-interface contracts (SQLite
 // vtab, billy.Filesystem, net/http handlers) don't surface in


### PR DESCRIPTION
## Summary
The find_smells GHA comment on PR #242 surfaced this clearly: the explicit `examples/go-schema.json` path produces `cmd/types/SmellRule`, `cmd/constants/padding`, `cmd/variables/smellRegistry` etc., all of which dead_code flagged because their tokens never appear in `node_refs`.

But that's by construction. `node_refs` is populated by call-extraction (`call_expression` / selector field, plus a few function-value patterns). Identifiers in type / const / variable position never land there, so flagging them is pure noise — there's no signal to extract.

## Fix
Skip `types/`, `constants/`, `variables/` (and matching `*/types/`, `*/constants/`, `*/variables/` for explicit-package schemas) at the same level as the existing `imports/` skip. Mirrors what `untested_function` already does (restricted to `functions/`).

## Verification
- FCA-inferred path on `mache.db`: 37 findings — unchanged (FCA doesn't currently produce types/constants/variables roots).
- go-schema path on `mache.db`: noise-rule findings drop to 0; remaining 510 are all `methods/` or `functions/` (those are a separate receiver-name resolution issue tracked elsewhere).

## Test plan
- [x] `TestFindSmells_DeadCodeSkipsNonCallableCategories` (new) — types + constants + variables + a real-functions/ control. Asserts only the function is flagged.
- [x] All existing dead_code tests pass.
- [x] `task lint` clean.