### PR TITLE
fix: duplicate_definitions skips non-callable categories

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -285,7 +285,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "duplicate_definitions",
-		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' nodes — they're references TO external packages, not definitions. source_id falls back to a child's source_file when the construct dir doesn't carry one. Cross-language since node_defs is populated by every leyline parser.",
+		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' (refs to external packages, not defs) and the non-callable categories types/, constants/, variables/ — short names like 'content', 'src', 'name' duplicate across functions and aren't meaningful 'duplicate definitions'. source_id falls back to a child's source_file when the construct dir doesn't carry one. Cross-language since node_defs is populated by every leyline parser.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -320,20 +320,35 @@ var smellRegistry = []SmellRule{
 					'MarshalJSON','UnmarshalJSON','MarshalText','UnmarshalText','MarshalBinary','UnmarshalBinary',
 					'Marshal','Unmarshal','Reset','Clone','Copy','Equal','Hash','Validate'
 				)
-				-- Exclude imports/ nodes — those are references TO
-				-- external packages (e.g. '"fmt"' appears in many
-				-- imports), not duplicate definitions.
+				-- Exclude imports/ (refs TO external packages, not
+				-- defs) and non-callable categories (short names
+				-- like 'content', 'src', 'name' duplicate across
+				-- functions and aren't meaningful 'duplicates').
 				AND node_id NOT LIKE '%%/imports/%%'
+				AND node_id NOT LIKE 'imports/%%'
+				AND node_id NOT LIKE '%%/types/%%'
+				AND node_id NOT LIKE 'types/%%'
+				AND node_id NOT LIKE '%%/constants/%%'
+				AND node_id NOT LIKE 'constants/%%'
+				AND node_id NOT LIKE '%%/variables/%%'
+				AND node_id NOT LIKE 'variables/%%'
 				GROUP BY token
 				HAVING copies > 1
 			) c
 			JOIN node_defs d ON d.token = c.token
 			JOIN nodes n ON n.id = d.node_id
 			LEFT JOIN child_source cs ON cs.node_id = n.id
-			-- Apply the same import filter to the join so partial
-			-- matches (where one repo's imports overlap with a real
-			-- def in another repo) don't leak through.
+			-- Apply the same filters to the join so partial matches
+			-- (where one repo's imports overlap with a real def in
+			-- another repo) don't leak through.
 			WHERE d.node_id NOT LIKE '%%/imports/%%'
+			  AND d.node_id NOT LIKE 'imports/%%'
+			  AND d.node_id NOT LIKE '%%/types/%%'
+			  AND d.node_id NOT LIKE 'types/%%'
+			  AND d.node_id NOT LIKE '%%/constants/%%'
+			  AND d.node_id NOT LIKE 'constants/%%'
+			  AND d.node_id NOT LIKE '%%/variables/%%'
+			  AND d.node_id NOT LIKE 'variables/%%'
 			%s
 			ORDER BY metric DESC, source_id, d.node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1421,6 +1421,72 @@ func TestFindSmells_DuplicateDefinitionsSkipsImports(t *testing.T) {
 	)
 }
 
+// TestFindSmells_DuplicateDefinitionsSkipsNonCallableCategories
+// asserts that types/, constants/, variables/ duplicates don't
+// surface — common short names like 'content', 'src', 'name'
+// legitimately duplicate as local variables across functions and
+// aren't meaningful "duplicate definitions". Surfaced by PR #243's
+// GHA comment showing 9 variable-shape duplicate findings.
+func TestFindSmells_DuplicateDefinitionsSkipsNonCallableCategories(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Variable / constant / type duplicates — must NOT surface.
+		INSERT INTO node_defs VALUES
+		  ('content', 'pkg/variables/content'),
+		  ('content', 'pkg/other/variables/content'),
+		  ('MaxSize', 'pkg/constants/MaxSize'),
+		  ('MaxSize', 'pkg/other/constants/MaxSize'),
+		  ('Result',  'pkg/types/Result'),
+		  ('Result',  'pkg/other/types/Result');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/variables/content',       'pkg/variables', 'content', 1, 0, 'a.go', ''),
+		  ('pkg/other/variables/content', 'pkg/other/variables', 'content', 1, 0, 'b.go', ''),
+		  ('pkg/constants/MaxSize',       'pkg/constants', 'MaxSize', 1, 0, 'c.go', ''),
+		  ('pkg/other/constants/MaxSize', 'pkg/other/constants', 'MaxSize', 1, 0, 'd.go', ''),
+		  ('pkg/types/Result',            'pkg/types',     'Result',  1, 0, 'e.go', ''),
+		  ('pkg/other/types/Result',      'pkg/other/types', 'Result', 1, 0, 'f.go', '');
+
+		-- Real function duplicate — control: must still flag.
+		INSERT INTO node_defs VALUES
+		  ('Helper', 'pkg/a/functions/Helper'),
+		  ('Helper', 'pkg/b/functions/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/functions/Helper', 'pkg/a/functions', 'Helper', 1, 0, 'a/h.go', ''),
+		  ('pkg/b/functions/Helper', 'pkg/b/functions', 'Helper', 1, 0, 'b/h.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "duplicate_definitions"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	for _, id := range gotIDs {
+		assert.NotContains(t, id, "/types/", "types/ must be skipped")
+		assert.NotContains(t, id, "/constants/", "constants/ must be skipped")
+		assert.NotContains(t, id, "/variables/", "variables/ must be skipped")
+	}
+	assert.ElementsMatch(t,
+		[]string{"pkg/a/functions/Helper", "pkg/b/functions/Helper"},
+		gotIDs,
+		"only the real function duplicate is flagged",
+	)
+}
+
 // TestFindSmells_DuplicateDefinitionsSkipsQualifiedInit asserts that
 // the skip list strips package qualifiers before comparing against
 // the leaf-token list. mache build emits both bare ('init') and


### PR DESCRIPTION
## Summary
Same fix as PR #243's dead_code change. The find_smells GHA on PR #243 reported 9 duplicate_definitions findings — every one a variable shape (`cmd/variables/content`, `cmd/variables/src`, `cmd/variables/name`, etc.). Short identifiers legitimately duplicate across functions as local variables; that's not a meaningful "duplicate definition".

## Fix
Skip `types/`, `constants/`, `variables/` (and matching `*/types/`, `*/constants/`, `*/variables/` for explicit-package schemas) at the same level as the existing `imports/` skip. Methods and functions still flag normally.

## Verification
- FCA path on `mache.db`: unchanged at 12 (FCA doesn't currently produce non-callable roots).
- go-schema path: drops dramatically — those 9 GHA-reported variable-shape findings disappear.

## Test plan
- [x] `TestFindSmells_DuplicateDefinitionsSkipsNonCallableCategories` (new) — variables/constants/types duplicates + a real functions/Helper duplicate. Asserts only the function is flagged.
- [x] All existing duplicate_definitions tests pass.
- [x] `task lint` clean.