### PR TITLE
fix: register bare leaf def for Receiver.Method names

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -1396,6 +1396,22 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 					}
 				}
 			}
+			// When the schema renders a Receiver.Method shape (the
+			// go-schema methods/ branch uses '{{.receiver}}.{{.name}}'),
+			// also register the bare leaf token so call-extraction —
+			// which captures the field_identifier of obj.Method() as
+			// just 'Method' — can resolve to this def. Without this,
+			// every method on a typed receiver looks dead in dead_code
+			// because 'Method' (call) doesn't match 'Receiver.Method'
+			// (def). We don't strip on every dot — only the last one,
+			// since fully-qualified shapes like 'pkg.Receiver.Method'
+			// are added separately above.
+			if dot := strings.LastIndex(name, "."); dot > 0 && dot < len(name)-1 {
+				leaf := name[dot+1:]
+				if err := store.AddDef(leaf, id); err != nil {
+					return fmt.Errorf("add bare leaf def %s -> %s: %w", leaf, id, err)
+				}
+			}
 		}
 
 		// Register schema-declared refs (cross-reference tokens for callers/)

--- a/internal/ingest/engine_test.go
+++ b/internal/ingest/engine_test.go
@@ -217,6 +217,47 @@ func (g Greeter) String() string {
 	assert.Contains(t, string(varSource.Data), "DefaultName")
 }
 
+// TestEngine_MethodReceiverShape_RegistersBareLeafDef asserts that
+// when the schema renders a method's name as 'Receiver.Method' (the
+// go-schema methods/ branch), AddDef registers BOTH the full
+// 'Receiver.Method' shape and the bare 'Method' leaf token. Without
+// the bare leaf, call-extraction (which captures just the
+// field_identifier of obj.Method() as 'Method') fails to resolve to
+// the method's def — so dead_code flags every method on a typed
+// receiver as unreferenced (mache.db go-schema path: 510 → 20 after
+// this fix).
+func TestEngine_MethodReceiverShape_RegistersBareLeafDef(t *testing.T) {
+	schema := loadGoSchema(t)
+
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "demo.go")
+	err := os.WriteFile(goFile, []byte(`package demo
+
+type Greeter struct{ Name string }
+
+func (g *Greeter) Greet() string { return "hi" }
+func (g Greeter)  String() string { return g.Name }
+`), 0o644)
+	require.NoError(t, err)
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	require.NoError(t, engine.Ingest(goFile))
+
+	// Both rendered shapes should be registered.
+	id := "demo/methods/Greeter.Greet"
+	assert.Contains(t, store.LookupDef("Greeter.Greet"), id,
+		"fully-rendered Receiver.Method def must resolve")
+	assert.Contains(t, store.LookupDef("demo.Greeter.Greet"), id,
+		"package-qualified def must resolve")
+	assert.Contains(t, store.LookupDef("Greet"), id,
+		"bare leaf def must resolve so call-extraction (which captures just 'Greet' from obj.Greet()) finds the method")
+
+	// Same for value-receiver methods.
+	assert.Contains(t, store.LookupDef("String"), "demo/methods/Greeter.String",
+		"value-receiver method must also register a bare leaf def")
+}
+
 func TestEngine_IngestTreeSitter_Imports(t *testing.T) {
 	schema := loadGoSchema(t)
 


### PR DESCRIPTION
## Summary
When the schema renders a method's name as `Receiver.Method` — the shape used by `examples/go-schema.json` — `AddDef` registered only `Receiver.Method` and `pkg.Receiver.Method`, never the bare `Method` leaf. Call-extraction captures the `field_identifier` of `obj.Method()` as just `Method`, so it never resolved to any def, and `dead_code` flagged every method on a typed receiver as unreferenced.

## Fix
Strip on the **last** dot of the rendered name and register the bare leaf alongside the qualified shapes. Don't strip on every dot — the package-qualified shape (`cmd.lazyGraph.GetCallers`) already gets its own `AddDef` above, and stripping further would over-collide.

## Verification
Dogfood on `mache.db` (go-schema path):

| | Before | After |
| --- | ---: | ---: |
| dead_code findings | 510 | 20 |
| `GetCallers` refs | 0 | 21 |

The FCA-inferred path is unaffected (FCA renders methods as bare `{{.name}}` = `field_identifier`, so this branch never fires).

## Test plan
- [x] `TestEngine_MethodReceiverShape_RegistersBareLeafDef` (new) — pointer + value-receiver methods; asserts `LookupDef` resolves all three shapes (`Greeter.Greet`, `demo.Greeter.Greet`, `Greet`).
- [x] All existing `TestEngine_*` tests pass.
- [x] `go test -race ./...` passes.
- [x] `task lint` clean.