### PR TITLE
fix: dead_code receiver-strip in SQL; revert bare-leaf def at ingest

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -85,10 +85,29 @@ var smellRegistry = []SmellRule{
 			-- A construct is "alive" if ANY of its token aliases appears
 			-- in node_refs. We flag a construct as dead only when every
 			-- one of its tokens is unreferenced.
+			--
+			-- The JOIN also matches when ref.token equals the LEAF of
+			-- def.token after the FIRST '.' — this handles methods
+			-- rendered as 'Receiver.Method' (the go-schema methods
+			-- branch). Call-extraction captures obj.Method() as just
+			-- 'Method', so without the strip every method on a typed
+			-- receiver would look dead. We strip on the first dot only
+			-- (not the last) because that's the receiver boundary in
+			-- 'Receiver.Method'; the package-qualified shape
+			-- 'pkg.Receiver.Method' is also registered as the bare
+			-- rendered alias 'Receiver.Method', whose first-dot strip
+			-- gives 'Method' as expected. Doing it as a JOIN predicate
+			-- rather than registering bare-leaf aliases at ingest time
+			-- avoids inflating duplicate_definitions (every interface
+			-- method like 'AddDef' or 'Read' would show up N copies,
+			-- one per implementing type, even though the implementations
+			-- are conceptually distinct).
 			WITH alive AS (
 				SELECT DISTINCT d.node_id
 				FROM node_defs d
-				JOIN node_refs r ON r.token = d.token
+				JOIN node_refs r
+				  ON r.token = d.token
+				  OR (instr(d.token, '.') > 0 AND r.token = substr(d.token, instr(d.token, '.') + 1))
 			),
 			-- Skip-listed: any token of a construct matches a skip rule.
 			-- ANY-MATCH is the right semantic — a function with both

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -574,6 +574,65 @@ func TestFindSmells_DeadCodeSkipsGeneratedFiles(t *testing.T) {
 		"only the non-generated dead function is flagged")
 }
 
+// TestFindSmells_DeadCodeStripsReceiverPrefixForLeafMatch asserts
+// that a method defined as 'Receiver.Method' is treated as alive
+// when call-extraction captures the bare 'Method' field_identifier.
+// Without the leaf-strip in the alive CTE, every method on a typed
+// receiver under the go-schema methods/ branch looked dead because
+// the call token never matched 'Receiver.Method' verbatim.
+//
+// Surfaced by dogfooding: mache.db's go-schema path had 510 dead_code
+// findings, 494 of them methods/. After this fix: 32.
+func TestFindSmells_DeadCodeStripsReceiverPrefixForLeafMatch(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Method defined under the Receiver.Method shape (go-schema
+		-- methods/ branch). The corresponding call site captures
+		-- only the field_identifier — bare 'Greet'.
+		INSERT INTO node_defs VALUES
+		  ('Greeter.Greet',     'pkg/methods/Greeter.Greet'),
+		  ('demo.Greeter.Greet','pkg/methods/Greeter.Greet');
+		INSERT INTO node_refs VALUES ('Greet', 'pkg/functions/CallSite/source');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/Greeter.Greet',         'pkg/methods', 'Greeter.Greet', 1, 0, '',         ''),
+		  ('pkg/methods/Greeter.Greet/source',  'pkg/methods/Greeter.Greet','source',0, 0, 'g.go',     ''),
+		  ('pkg/functions/CallSite',            'pkg/functions','CallSite',1, 0, '',                 ''),
+		  ('pkg/functions/CallSite/source',     'pkg/functions/CallSite','source', 0, 0, 'c.go',    '');
+
+		-- Truly dead method (no call to bare leaf, no call to
+		-- Receiver.Method) — control: must still be flagged.
+		INSERT INTO node_defs VALUES
+		  ('Greeter.Sing',      'pkg/methods/Greeter.Sing');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/Greeter.Sing',         'pkg/methods', 'Greeter.Sing', 1, 0, '',         ''),
+		  ('pkg/methods/Greeter.Sing/source',  'pkg/methods/Greeter.Sing','source',0, 0, 's.go',    '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"pkg/methods/Greeter.Sing"}, gotIDs,
+		"Greeter.Greet is alive (Greet ref matches the leaf-strip); only Greeter.Sing remains dead")
+}
+
 // TestFindSmells_DeadCodeSourceFileFallsBackToChildren asserts that
 // when the construct dir itself has source_file = ” (the schema
 // engine attaches Origin/source_file to leaf children — source,


### PR DESCRIPTION
## Summary
PR #245 registered a bare leaf def for `Receiver.Method`-shaped names so `dead_code`'s `alive` CTE could match calls like `obj.Method()` (which capture as just `Method`). It worked, but it inflated `duplicate_definitions`: every interface method (`AddDef`, `Read`, `Close`, …) implemented by N types showed up as N copies even though those are conceptually distinct implementations.

## Fix
Move the leaf-handling into the SQL where it belongs. The `alive` CTE's JOIN now ALSO matches when `ref.token` equals the substring of `def.token` after the first `.`:

```sql
ON r.token = d.token
OR (instr(d.token,'.') > 0 AND r.token = substr(d.token, instr(d.token,'.')+1))
```

- For `'Greeter.Greet'` → strip yields `'Greet'` — matches a bare `Greet` call.
- For `'demo.Greeter.Greet'` → strip yields `'Receiver.Method'`, which doesn't match a bare call. That's fine: the rendered alias `'Greeter.Greet'` (already registered) covers the leaf path.

## Verification — `mache.db` go-schema dogfood

| | Before #245 | With #245 (bare leaf) | This PR |
| --- | ---: | ---: | ---: |
| dead_code findings | 510 | 20 | 32 |
| duplicate_definitions findings | 9 | ~9·N (interface-noise) | 10 |

So we capture 96% of #245's dead_code reduction without the duplicate_definitions inflation.

## Test plan
- [x] `TestFindSmells_DeadCodeStripsReceiverPrefixForLeafMatch` (new) — `Greeter.Greet` aliveness via bare `Greet` call; `Greeter.Sing` (no callers) remains dead. Asserts the leaf-strip fires and is correctly bounded.
- [x] All existing `TestFindSmells_DeadCode*` tests still pass.
- [x] `task lint` clean.

Reverts the `AddDef` change from PR #245; keeps its conceptual goal.