### PR TITLE
fix: duplicate_definitions skips generated-code files

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -304,7 +304,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "duplicate_definitions",
-		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' (refs to external packages, not defs) and the non-callable categories types/, constants/, variables/ — short names like 'content', 'src', 'name' duplicate across functions and aren't meaningful 'duplicate definitions'. source_id falls back to a child's source_file when the construct dir doesn't carry one. Cross-language since node_defs is populated by every leyline parser.",
+		Description: "Symbols defined under more than one node_id in node_defs — same token, multiple definition sites. Common for genuinely-redundant helpers re-implemented per package; routine for Go interface methods like String/Error/Read/Write where one type per package is expected. The skip list excludes those interface contracts; tune by editing the rule. Metric is the duplicate count, sorted descending. Excludes 'imports/' (refs to external packages, not defs), non-callable categories types/, constants/, variables/ — short names like 'content', 'src', 'name' duplicate across functions and aren't meaningful 'duplicate definitions' — and generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) where wide method sets are produced by the generator and aren't 'duplication' in the architectural sense. source_id falls back to a child's source_file when the construct dir doesn't carry one. Cross-language since node_defs is populated by every leyline parser.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -368,6 +368,17 @@ var smellRegistry = []SmellRule{
 			  AND d.node_id NOT LIKE 'constants/%%'
 			  AND d.node_id NOT LIKE '%%/variables/%%'
 			  AND d.node_id NOT LIKE 'variables/%%'
+			  -- Generated code (capnp / protobuf / *_generated.go /
+			  -- *.gen.go) intentionally produces wide method sets
+			  -- (DecodeFromPtr, EncodeAsPtr, IsValid, Message, Segment,
+			  -- ToPtr) on every generated type — those aren't
+			  -- "duplicate definitions" in the architectural sense.
+			  -- Match by resolved source file (falling back to a
+			  -- child's source_file when the construct dir has none).
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.capnp.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.pb.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%_generated.go'
+			  AND COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') NOT LIKE '%%.gen.go'
 			%s
 			ORDER BY metric DESC, source_id, d.node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1480,6 +1480,69 @@ func TestFindSmells_DuplicateDefinitionsSkipsImports(t *testing.T) {
 	)
 }
 
+// TestFindSmells_DuplicateDefinitionsSkipsGeneratedFiles asserts
+// that capnp / protobuf / *_generated.go / *.gen.go method sets
+// don't surface in duplicate_definitions. Generated types share a
+// fixed method set (DecodeFromPtr, EncodeAsPtr, IsValid, Message,
+// Segment, ToPtr) — flagging that as 'duplication' buries real
+// findings under generator output.
+func TestFindSmells_DuplicateDefinitionsSkipsGeneratedFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Generated types sharing method 'IsValid' — must be skipped.
+		INSERT INTO node_defs VALUES
+		  ('TypeA.IsValid', 'pkg/methods/TypeA.IsValid'),
+		  ('TypeB.IsValid', 'pkg/methods/TypeB.IsValid'),
+		  ('IsValid',       'pkg/methods/TypeA.IsValid'),
+		  ('IsValid',       'pkg/methods/TypeB.IsValid');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/TypeA.IsValid',         'pkg/methods', 'TypeA.IsValid', 1, 0, '',                ''),
+		  ('pkg/methods/TypeA.IsValid/source',  'pkg/methods/TypeA.IsValid', 'source', 0, 0, 'a.capnp.go', ''),
+		  ('pkg/methods/TypeB.IsValid',         'pkg/methods', 'TypeB.IsValid', 1, 0, '',                ''),
+		  ('pkg/methods/TypeB.IsValid/source',  'pkg/methods/TypeB.IsValid', 'source', 0, 0, 'b.capnp.go', '');
+
+		-- Real duplicate as a control: a same-name method across
+		-- two PRODUCTION (non-generated) types — must still flag.
+		INSERT INTO node_defs VALUES
+		  ('Helper', 'pkg/a/functions/Helper'),
+		  ('Helper', 'pkg/b/functions/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/functions/Helper',        'pkg/a/functions', 'Helper', 1, 0, '',         ''),
+		  ('pkg/a/functions/Helper/source', 'pkg/a/functions/Helper', 'source', 0, 0, 'a.go',     ''),
+		  ('pkg/b/functions/Helper',        'pkg/b/functions', 'Helper', 1, 0, '',         ''),
+		  ('pkg/b/functions/Helper/source', 'pkg/b/functions/Helper', 'source', 0, 0, 'b.go',     '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "duplicate_definitions"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	for _, f := range resp.Findings {
+		assert.NotContains(t, f.SourceID, ".capnp.go", "capnp generated files must be skipped")
+	}
+	assert.ElementsMatch(t,
+		[]string{"pkg/a/functions/Helper", "pkg/b/functions/Helper"},
+		gotIDs,
+		"only the production-source duplicate is flagged",
+	)
+}
+
 // TestFindSmells_DuplicateDefinitionsSkipsNonCallableCategories
 // asserts that types/, constants/, variables/ duplicates don't
 // surface — common short names like 'content', 'src', 'name'


### PR DESCRIPTION
## Summary
go-schema dogfood on `mache.db`: 580 of `duplicate_definitions` findings were generated capnp method sets (`DecodeFromPtr`, `EncodeAsPtr`, `IsValid`, `Message`, `Segment`, `ToPtr` — six methods × ~96 generated types). That's not 'duplication' in the architectural sense — the generator produces a fixed method set on every type by design.

## Fix
Add the same suffix-based exclusion (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) that the other rules already use (PRs #238, #242).

## Verification
| | Before | After |
| --- | ---: | ---: |
| go-schema duplicate_definitions on `mache.db` | 580 | 292 |

The remaining 292 are real interface-implementation overlaps in production source (Graph backends, ASTWalker/SitterWalker, etc.) — those are legitimate observations, not noise.

## Test plan
- [x] `TestFindSmells_DuplicateDefinitionsSkipsGeneratedFiles` (new) — capnp method-set duplicates + a real `Helper` cross-package duplicate. Asserts only the real duplicate is flagged.
- [x] All existing duplicate_definitions tests pass.
- [x] `task lint` clean.