### PR TITLE
fix(unmount): unmount-first ordering, tolerate missing sidecar

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -947,41 +947,61 @@ var unmountCmd = &cobra.Command{
 			mountPoint = filepath.Join(mountsDir, mountName)
 		}
 
-		// Load metadata
-		meta, err := loadMountMetadata(mountPoint)
-		if err != nil {
-			return fmt.Errorf("failed to load mount metadata: %w", err)
+		// Load metadata. The sidecar exists for agent-mode and serve-
+		// mode mounts; direct `mache <path>` and ley-line --control
+		// mounts have no sidecar. Don't fail when it's missing —
+		// unmount the kernel-side NFS first regardless, then clean up
+		// what we can (mache-fsi: 'No agent metadata' case).
+		meta, metaErr := loadMountMetadata(mountPoint)
+
+		isMCPServe := meta != nil && (meta.Type == "mcp-http" || meta.Type == "mcp-stdio")
+
+		// Step 1: kernel-side unmount FIRST (for NFS mounts only).
+		// SIGTERM-then-RemoveAll without an explicit umount races —
+		// if the daemon doesn't finish its own unmount before
+		// RemoveAll runs, we leave a stuck NFS mount that only
+		// `umount -f` can clear (mache-fsi: 'Race' + 'Orphaned mount'
+		// cases). Unmount is idempotent — repeating on an already-
+		// unmounted point logs a warning and we continue.
+		if !isMCPServe {
+			if err := nfsmount.Unmount(mountPoint); err != nil {
+				log.Printf("Note: nfsmount.Unmount(%s): %v (continuing)", mountPoint, err)
+			}
 		}
 
-		// Kill the process
-		if isProcessRunning(meta.PID) {
+		// Step 2: SIGTERM the owning process (only when we have its
+		// PID via the sidecar). For control / sidecar-less mounts
+		// the user is expected to stop the daemon separately.
+		if meta != nil && isProcessRunning(meta.PID) {
 			process, err := os.FindProcess(meta.PID)
-			if err != nil {
-				return fmt.Errorf("failed to find process %d: %w", meta.PID, err)
-			}
+			if err == nil {
+				log.Printf("Stopping mache process (PID %d)...", meta.PID)
+				_ = process.Signal(syscall.SIGTERM)
 
-			log.Printf("Stopping mache process (PID %d)...", meta.PID)
-			if err := process.Signal(syscall.SIGTERM); err != nil {
-				return fmt.Errorf("failed to send SIGTERM: %w", err)
-			}
+				// Wait briefly for graceful shutdown
+				time.Sleep(2 * time.Second)
 
-			// Wait briefly for graceful shutdown
-			time.Sleep(2 * time.Second)
-
-			if isProcessRunning(meta.PID) {
-				log.Printf("Process still running, sending SIGKILL...")
-				_ = process.Signal(syscall.SIGKILL)
+				if isProcessRunning(meta.PID) {
+					log.Printf("Process still running, sending SIGKILL...")
+					_ = process.Signal(syscall.SIGKILL)
+				}
+			} else {
+				log.Printf("Note: failed to find process %d: %v", meta.PID, err)
 			}
 		}
 
-		// Clean up mount directory and sidecar
+		// Step 3: clean up mount directory and sidecar.
 		log.Printf("Removing mount directory: %s", mountPoint)
 		if err := os.RemoveAll(mountPoint); err != nil {
 			return fmt.Errorf("failed to remove mount directory: %w", err)
 		}
 		_ = os.Remove(sidecarPath(mountPoint))
 
-		log.Println("Mount stopped successfully.")
+		if metaErr != nil {
+			log.Printf("Mount stopped (no sidecar metadata; resolved by direct unmount).")
+		} else {
+			log.Println("Mount stopped successfully.")
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
The previous `unmountCmd` flow had three failure modes documented in `mache-fsi`:

1. **Race** — SIGTERM-then-RemoveAll without an explicit umount left stuck NFS mounts when the daemon's signal handler hadn't finished unmounting before `RemoveAll` ran.
2. **Orphaned mount** — SIGKILL of a stuck process never reached the unmount syscall, leaving an unrecoverable kernel-side mount only `umount -f` could clear (#248 made that the last step inside `nfsmount.Unmount`).
3. **No agent metadata** — direct (non-agent) and ley-line `--control` mounts have no sidecar, so `loadMountMetadata` failed before any unmount could run; `mache unmount` was effectively a no-op for those mounts.

## Fix — re-order to "unmount → kill → cleanup"

| Step | Action | Conditions |
| --- | --- | --- |
| 1 | `nfsmount.Unmount(mountPoint)` | Always, regardless of sidecar. Skipped for serve-mode mounts (`Type == mcp-http` / `mcp-stdio`) where there's no kernel mount. |
| 2 | SIGTERM (then SIGKILL after 2s) | Only when we have a PID via sidecar. Sidecar-less paths are expected to stop the owning daemon separately. |
| 3 | `RemoveAll` mount dir + sidecar | Always. |

PR #248 already added `umount -f` as the last-resort fallback inside `nfsmount.Unmount`; this PR closes the remaining `mache-fsi` items by changing the **ORDER** (unmount → kill → cleanup) and by no longer aborting when the sidecar is absent.

## Test plan
- [x] All existing `cmd/` tests pass (118s).
- [x] `task lint` clean.
- [x] Manual reasoning: `nfsmount.Unmount` is idempotent (logs and continues if mount-point isn't actually mounted), so calling it on a sidecar-less directory is benign. The original failure paths (`fmt.Errorf` returns) are now `log.Printf` notes followed by `continue`.

Closes the remaining `mache-fsi` items.