### PR TITLE
fix: untested_function accepts Test<Type>* for New<Type> constructors

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -256,7 +256,7 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "untested_function",
 		Languages:   []string{"go"},
-		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is skipped — generated APIs aren't expected to have project tests. source_id falls back to a child's source_file when the construct dir doesn't carry one. Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
+		Description: "Exported Go standalone functions (only constructs under a 'functions/' category) with no Test<Foo> counterpart anywhere in node_defs. Static proxy for test coverage — false positives expected for table-driven tests (one TestFoo covers multiple Foos), test helpers, and exported functions intentionally tested at integration boundaries. The check accepts two counterpart patterns: exact 'Test<Foo>' for a function named 'Foo', or any 'Test<Bar>...' (prefix) for a constructor named 'NewBar' — Go convention puts constructor coverage under TestBar / TestBar_<MethodName>, not TestNewBar. Methods, types, constants, variables, and imports are skipped: Go test names use Test<Func> not Test<Receiver>.<Method>, and types/constants don't follow the Test<Name> convention. Excludes Test*/Benchmark*/Example* tokens (they ARE tests) and main/init (entry points). Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is skipped — generated APIs aren't expected to have project tests. source_id falls back to a child's source_file when the construct dir doesn't carry one. Heuristic is Go-specific — running against a Python or Rust .db will produce mostly noise.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "COALESCE(NULLIF(n.source_file, ''), cs.source_file, '')",
 		Query: `
@@ -277,7 +277,19 @@ var smellRegistry = []SmellRule{
 			FROM node_defs d
 			JOIN nodes n ON n.id = d.node_id
 			LEFT JOIN child_source cs ON cs.node_id = n.id
-			LEFT JOIN node_defs t ON t.token = 'Test' || d.token
+			-- Accept either an exact 'Test<Foo>' counterpart (the
+			-- canonical Go test name for func Foo) OR — when the
+			-- function name starts with 'New' — any TestBar* prefix
+			-- match for the constructor's bare type name. NewMemoryStore
+			-- is overwhelmingly tested via TestMemoryStore_TracksMtimes
+			-- and friends, never via TestNewMemoryStore.
+			LEFT JOIN node_defs t
+			  ON t.token = 'Test' || d.token
+			  OR (
+			    substr(d.token, 1, 3) = 'New'
+			    AND length(d.token) > 3
+			    AND t.token LIKE 'Test' || substr(d.token, 4) || '%%'
+			  )
 			WHERE substr(d.token, 1, 1) GLOB '[A-Z]'
 			  AND d.token NOT LIKE 'Test%%'
 			  AND d.token NOT LIKE 'Benchmark%%'

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1318,6 +1318,75 @@ func TestFindSmells_FanOutSkewSkipsGeneratedFiles(t *testing.T) {
 		"Dispatcher (production) is flagged; CapnpStruct (generated) is skipped via source_file suffix")
 }
 
+// TestFindSmells_UntestedFunctionAcceptsTestTypePrefix asserts the
+// New<Type> → Test<Type>* alternate counterpart match. Go test code
+// for constructors typically lives under TestType_<Method> — not
+// under TestNewType — so flagging NewType as 'untested' when the
+// type IS tested is a noise FP.
+func TestFindSmells_UntestedFunctionAcceptsTestTypePrefix(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		-- Constructor with companion TestStore_Foo coverage — must NOT be flagged.
+		INSERT INTO node_defs VALUES
+		  ('NewStore',          'pkg/functions/NewStore'),
+		  ('TestStore_AddItem', 'pkg/functions/TestStore_AddItem');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/NewStore',                'pkg/functions', 'NewStore', 1, 0, '',                 ''),
+		  ('pkg/functions/NewStore/source',         'pkg/functions/NewStore', 'source', 0, 0, 's.go',         ''),
+		  ('pkg/functions/TestStore_AddItem',       'pkg/functions', 'TestStore_AddItem', 1, 0, '',         ''),
+		  ('pkg/functions/TestStore_AddItem/source','pkg/functions/TestStore_AddItem','source',0, 0, 's_t.go',     '');
+
+		-- Truly untested constructor — control: must still flag.
+		INSERT INTO node_defs VALUES ('NewOrphan', 'pkg/functions/NewOrphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/NewOrphan',        'pkg/functions',           'NewOrphan', 1, 0, '',          ''),
+		  ('pkg/functions/NewOrphan/source', 'pkg/functions/NewOrphan', 'source',    0, 0, 'o.go',     '');
+
+		-- Untested non-constructor — control: must still flag, since
+		-- the New-prefix lookup specifically requires 'New' prefix.
+		INSERT INTO node_defs VALUES ('Helper', 'pkg/functions/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/Helper',        'pkg/functions',         'Helper', 1, 0, '',         ''),
+		  ('pkg/functions/Helper/source', 'pkg/functions/Helper',  'source', 0, 0, 'h.go',    '');
+
+		-- Tested non-constructor (TestHelper exact match) — must NOT flag.
+		INSERT INTO node_defs VALUES
+		  ('Validate',     'pkg/functions/Validate'),
+		  ('TestValidate', 'pkg/functions/TestValidate');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/Validate',         'pkg/functions',           'Validate', 1, 0, '',          ''),
+		  ('pkg/functions/Validate/source',  'pkg/functions/Validate',  'source',   0, 0, 'v.go',    ''),
+		  ('pkg/functions/TestValidate',     'pkg/functions',           'TestValidate', 1, 0, '',     ''),
+		  ('pkg/functions/TestValidate/source','pkg/functions/TestValidate','source',0, 0, 'v_t.go',  '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "untested_function"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.ElementsMatch(t,
+		[]string{"pkg/functions/NewOrphan", "pkg/functions/Helper"},
+		gotIDs,
+		"NewStore is satisfied by TestStore_*; Validate is satisfied by exact TestValidate; only NewOrphan and Helper remain",
+	)
+}
+
 // TestFindSmells_UntestedFunctionSkipsGeneratedFiles asserts that
 // exported funcs in generated-code files don't get flagged for
 // missing TestFoo coverage — generated APIs aren't expected to have


### PR DESCRIPTION
## Summary
Go convention: a constructor `NewStore` is tested through its type's behavior under `TestStore_AddItem` / `TestStore_Empty` / `TestStore_Race` — almost never under `TestNewStore`. The previous heuristic was an exact `TestNewStore` match, so every constructor with normal table-driven coverage looked untested.

## Fix
Extend the LEFT JOIN to also accept `TestType*` (prefix) when the function starts with `New`:

```sql
LEFT JOIN node_defs t
  ON t.token = 'Test' || d.token
  OR (
    substr(d.token, 1, 3) = 'New'
    AND length(d.token) > 3
    AND t.token LIKE 'Test' || substr(d.token, 4) || '%'
  )
```

Both shapes still require the test to live in `node_defs` — a stray `TestStore` in some unrelated file doesn't trick us; the test has to actually be defined under `functions/`.

## Verification
| | Before | After |
| --- | ---: | ---: |
| untested_function on `mache.db` | 108 | 90 |

The remaining 90 are mostly real exported-API gaps (`Materialize`, `ExportSQLite`, `NewArenaFlusher`, `OpenOrCreate`) that don't have any `TestType*` coverage in the indexed scope.

## Test plan
- [x] `TestFindSmells_UntestedFunctionAcceptsTestTypePrefix` (new) — `NewStore` + `TestStore_AddItem` (constructor with companion test, must NOT flag) + `Validate` + exact `TestValidate` (must NOT flag) + `NewOrphan` and `Helper` controls (must flag).
- [x] All existing `untested_function` tests pass.
- [x] `task lint` clean.