### PR TITLE
docs: update find_smells rule count (8 → 9) and standalone-OK list

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Mache works standalone, but pairs with [ley-line-open](https://github.com/agenti
 source dir → mache (Engine + SitterWalker + CGO tree-sitter) → MemoryStore → MCP / NFS
 ```
 
-Mache parses source itself via the `SitterWalker` (tree-sitter grammars linked via CGO). The ingestion writes a sidecar SQLite with `nodes`, `node_refs`, `node_defs`, `file_index` — enough to power `find_callers`, `find_callees`, `search`, `find_definition`, `get_communities`, `get_impact`, and the four `find_smells` rules that operate on `node_defs`/`node_refs` (`dead_code`, `untested_function`, `fan_out_skew`, `duplicate_definitions`). No `_ast`, `_source`, or `_lsp*` tables are produced — the AST lives in memory, not on disk.
+Mache parses source itself via the `SitterWalker` (tree-sitter grammars linked via CGO). The ingestion writes a sidecar SQLite with `nodes`, `node_refs`, `node_defs`, `file_index` — enough to power `find_callers`, `find_callees`, `search`, `find_definition`, `get_communities`, `get_impact`, and the five `find_smells` rules that operate on `node_defs`/`node_refs`/`nodes` (`dead_code`, `untested_function`, `fan_out_skew`, `duplicate_definitions`, `god_file`). No `_ast`, `_source`, or `_lsp*` tables are produced — the AST lives in memory, not on disk.
 
 ### LLO-paired (pure Go, pre-baked .db)
 
@@ -123,16 +123,16 @@ This is the path under [ADR-0006: Pure Go, MCP-First](adr/0006-pure-go-mcp-first
 
 ### Tool capability matrix
 
-| Tool                                                                                                  | Standalone (CGO) | LLO-paired (.db) | Notes                                                                |
-| ----------------------------------------------------------------------------------------------------- | ---------------- | ---------------- | -------------------------------------------------------------------- |
-| `list_directory`, `read_file`, `get_overview`, `get_diagram`                                          | ✓                | ✓                | Topology-only — works on any backend                                 |
-| `find_callers`, `find_callees`, `find_definition`, `search`                                           | ✓                | ✓                | `node_refs` / `node_defs` populated by both paths                    |
-| `get_communities`, `get_impact`, `get_architecture`                                                   | ✓                | ✓                | Derived from refs graph                                              |
-| `write_file`                                                                                          | ✓                | ✓                | Splice pipeline runs on either backend (validate → format → splice)  |
-| `find_smells` rules: `dead_code`, `untested_function`, `duplicate_definitions`, `fan_out_skew`        | ✓                | ✓                | Use `node_defs` / `node_refs` only                                   |
-| `find_smells` rules: `magic_int_in_comparison`, `cyclomatic_complexity`, `long_function`, `long_file` | ✗                | ✓                | Need `_ast` table — only LLO writes it                               |
-| `get_type_info`, `get_diagnostics`                                                                    | ✗                | ✓ (LSP-enriched) | Need `_lsp*` tables produced by ley-line's `lsp` crate at build time |
-| `semantic_search`                                                                                     | ✗                | ✓ (with daemon)  | Embeddings via the LLO daemon UDS proxy                              |
+| Tool                                                                                                       | Standalone (CGO) | LLO-paired (.db) | Notes                                                                |
+| ---------------------------------------------------------------------------------------------------------- | ---------------- | ---------------- | -------------------------------------------------------------------- |
+| `list_directory`, `read_file`, `get_overview`, `get_diagram`                                               | ✓                | ✓                | Topology-only — works on any backend                                 |
+| `find_callers`, `find_callees`, `find_definition`, `search`                                                | ✓                | ✓                | `node_refs` / `node_defs` populated by both paths                    |
+| `get_communities`, `get_impact`, `get_architecture`                                                        | ✓                | ✓                | Derived from refs graph                                              |
+| `write_file`                                                                                               | ✓                | ✓                | Splice pipeline runs on either backend (validate → format → splice)  |
+| `find_smells` rules: `dead_code`, `untested_function`, `duplicate_definitions`, `fan_out_skew`, `god_file` | ✓                | ✓                | Use `node_defs` / `node_refs` / `nodes` only                         |
+| `find_smells` rules: `magic_int_in_comparison`, `cyclomatic_complexity`, `long_function`, `long_file`      | ✗                | ✓                | Need `_ast` table — only LLO writes it                               |
+| `get_type_info`, `get_diagnostics`                                                                         | ✗                | ✓ (LSP-enriched) | Need `_lsp*` tables produced by ley-line's `lsp` crate at build time |
+| `semantic_search`                                                                                          | ✗                | ✓ (with daemon)  | Embeddings via the LLO daemon UDS proxy                              |
 
 When a tool falls into the second column without enrichment, the handler returns a friendly error message explaining how to enable it (typically: re-run `leyline parse` with the relevant flag).
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,7 +14,7 @@
 - Cross-reference indexing: `node_refs`/`node_defs` SQLite tables backed by tree-sitter (standalone) or LLO (`.db` path)
 - `callers/` and `callees/` virtual directories — self-gating, NFS-served as `graphFile`s
 - `.query/` Plan 9-style SQL query directory with symlink results
-- `find_smells` MCP tool: 8 structural rules (`magic_int_in_comparison`, `dead_code`, `cyclomatic_complexity`, `long_function`, `untested_function`, `duplicate_definitions`, `fan_out_skew`, `long_file`) with optional `min_metric` and `source_id` filters
+- `find_smells` MCP tool: 9 structural rules (`magic_int_in_comparison`, `dead_code`, `cyclomatic_complexity`, `long_function`, `untested_function`, `duplicate_definitions`, `god_file`, `fan_out_skew`, `long_file`) with optional `min_metric` and `source_id` filters; advisory PR comments via `.github/workflows/find-smells.yml`
 - FCA + greedy entropy schema inference: `--infer` auto-generates topology from data
 - Virtual `_schema.json` at mount root exposing the active topology
 - HotSwap graph with control block for live schema reload
@@ -23,7 +23,7 @@
 
 - Memory: ~2GB peak for 323K NVD records (1.6M graph nodes with string IDs) — addressable via [GenerationalGraph](https://github.com/agentic-research/mache) (mache-2f1287)
 - Write-back formatting is Go and HCL/Terraform only; other languages validate but don't auto-format
-- Standalone (CGO) path produces `node_defs`/`node_refs` but not `_ast` — 4 of 8 `find_smells` rules require an LLO-built `.db`
+- Standalone (CGO) path produces `node_defs`/`node_refs` but not `_ast` — 4 of 9 `find_smells` rules (`magic_int_in_comparison`, `cyclomatic_complexity`, `long_function`, `long_file`) require an LLO-built `.db`
 - bbolt-backed `ext/boltdb` projection is opt-in (not in default `go.work`); used by venturi/trivy-db workflows
 
 ## Near-term


### PR DESCRIPTION
## Summary
ROADMAP and ARCHITECTURE both predated `god_file` (added in PR #205) and the recent enhancement of standalone-path coverage (PR #251 added test-call detection to `untested_function`).

## Changes
- **ROADMAP**: 8 → 9 rules; explicit list of the 4 `_ast`-required rules in the standalone-limit note; mention the find_smells GHA wrapper.
- **ARCHITECTURE.md interplay matrix**: standalone-OK row now includes `god_file`. The narrative paragraph above the matrix bumps "four" to "five" standalone rules and corrects "`node_defs/node_refs` only" to "`node_defs/node_refs/nodes`" (`god_file` uses the `nodes` table).

No code change.

## Test plan
- [x] No tests / lint apply (docs only).
- [x] Manual: rule count verified by `grep '^\s*ID:\s*"' cmd/serve_find_smells.go | wc -l` → 9.