### PR TITLE
fix(ci): find_smells GHA includes god_file (5 standalone rules, not 4)

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -80,9 +80,12 @@ jobs:
         run: |
           set -euo pipefail
           PATTERN=$(cat /tmp/changed-pattern.txt)
-          # Run the four rules that don't need _ast (the rules that
-          # work on the standalone CGO ingestion path).
-          for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+          # Run the five rules that don't need _ast (work on the
+          # standalone CGO ingestion path's node_defs / node_refs /
+          # nodes tables). The four _ast-only rules
+          # (magic_int_in_comparison, cyclomatic_complexity,
+          # long_function, long_file) need an LLO-built .db.
+          for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
             /tmp/mache find-smells --db /tmp/repo.db --rule "$rule" \
               --format json --limit 1000 \
               | jq --arg pat "$PATTERN" \
@@ -99,10 +102,10 @@ jobs:
           {
             echo "## find_smells (advisory)"
             echo ""
-            echo "Scoped to files changed in this PR. Rules below run on the standalone (no-LLO) cross-ref tables; \`_ast\` rules (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison, god_file) are not exercised here."
+            echo "Scoped to files changed in this PR. Rules below run on the standalone (no-LLO) cross-ref tables; \`_ast\` rules (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison) are not exercised here."
             echo ""
             total=0
-            for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+            for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
               count=$(jq '.findings | length' "/tmp/${rule}.json")
               total=$((total + count))
               if [ "$count" -gt 0 ]; then

--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -57,12 +57,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Diff base...head, keep only Go source files. The list
-          # gates the comment; if nothing Go changed, the workflow's
-          # paths filter would have skipped us already, so we can
-          # assume non-empty here.
+          # Diff base...head, keep only Go source files. The
+          # workflow's paths filter triggers on `.go` AND on its own
+          # `.yml`, so this PR may have zero Go files changed (e.g.
+          # this very PR only edits the workflow). `grep -E '\.go$'`
+          # with `set -e -o pipefail` would fail the step in that
+          # case — append `|| true` so an empty match short-circuits
+          # cleanly to skip=true rather than error.
           git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
-            | grep -E '\.go$' \
+            | { grep -E '\.go$' || true; } \
             | jq -R -s -c 'split("\n") | map(select(length > 0))' \
             > /tmp/changed.json
           cat /tmp/changed.json


### PR DESCRIPTION
## Summary
`god_file` is a standalone rule (`Requires: node_defs, nodes`, added in PR #205) — but the find-smells GHA workflow still iterated only the original four rules, AND its preamble miscategorised `god_file` as `_ast`-only.

## Fix
- **`Run find_smells rules` step**: loop now iterates 5 rules — `god_file` joins `dead_code`, `untested_function`, `duplicate_definitions`, `fan_out_skew`.
- **`Render comment` step**: loop adds `god_file` too, so its findings actually surface in the comment table.
- **Comment preamble**: drops `god_file` from the `_ast`-only list.

The four genuinely `_ast`-required rules are `magic_int_in_comparison`, `cyclomatic_complexity`, `long_function`, and `long_file` (matches the post-#252 `ROADMAP` / `ARCHITECTURE` wording).

## Test plan
- [x] YAML structure preserved (verified with `yq`).
- [x] No code change; behavior change is "find_smells GHA now reports `god_file` findings on changed files".