### PR TITLE
fix: god_file resolves source_file via children + skips generated code

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -57,12 +57,15 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Diff base...head, keep only Go source files. The list
-          # gates the comment; if nothing Go changed, the workflow's
-          # paths filter would have skipped us already, so we can
-          # assume non-empty here.
+          # Diff base...head, keep only Go source files. The
+          # workflow's paths filter triggers on `.go` AND on its own
+          # `.yml`, so this PR may have zero Go files changed (e.g.
+          # this very PR only edits the workflow). `grep -E '\.go$'`
+          # with `set -e -o pipefail` would fail the step in that
+          # case — append `|| true` so an empty match short-circuits
+          # cleanly to skip=true rather than error.
           git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
-            | grep -E '\.go$' \
+            | { grep -E '\.go$' || true; } \
             | jq -R -s -c 'split("\n") | map(select(length > 0))' \
             > /tmp/changed.json
           cat /tmp/changed.json
@@ -80,9 +83,12 @@ jobs:
         run: |
           set -euo pipefail
           PATTERN=$(cat /tmp/changed-pattern.txt)
-          # Run the four rules that don't need _ast (the rules that
-          # work on the standalone CGO ingestion path).
-          for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+          # Run the five rules that don't need _ast (work on the
+          # standalone CGO ingestion path's node_defs / node_refs /
+          # nodes tables). The four _ast-only rules
+          # (magic_int_in_comparison, cyclomatic_complexity,
+          # long_function, long_file) need an LLO-built .db.
+          for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
             /tmp/mache find-smells --db /tmp/repo.db --rule "$rule" \
               --format json --limit 1000 \
               | jq --arg pat "$PATTERN" \
@@ -99,10 +105,10 @@ jobs:
           {
             echo "## find_smells (advisory)"
             echo ""
-            echo "Scoped to files changed in this PR. Rules below run on the standalone (no-LLO) cross-ref tables; \`_ast\` rules (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison, god_file) are not exercised here."
+            echo "Scoped to files changed in this PR. Rules below run on the standalone (no-LLO) cross-ref tables; \`_ast\` rules (cyclomatic_complexity, long_function, long_file, magic_int_in_comparison) are not exercised here."
             echo ""
             total=0
-            for rule in dead_code untested_function duplicate_definitions fan_out_skew; do
+            for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
               count=$(jq '.findings | length' "/tmp/${rule}.json")
               total=$((total + count))
               if [ "$count" -gt 0 ]; then

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -421,16 +421,31 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "god_file",
-		Description: "Source files whose distinct-definition count is at least 10 AND more than 3× the project mean — a fuzzy 'god file' detector that surfaces sprawl relative to the codebase's own distribution rather than a hard line-count cutoff. Metric is the def count, sorted descending. Cross-language since node_defs is populated by every backend. Pairs with long_file (line-count via _ast) for a 'lots of code' vs 'lots of API' split.",
+		Description: "Source files whose distinct-definition count is at least 10 AND more than 3× the project mean — a fuzzy 'god file' detector that surfaces sprawl relative to the codebase's own distribution rather than a hard line-count cutoff. Metric is the def count, sorted descending. Cross-language since node_defs is populated by every backend. source_file is resolved via the construct dir's child leaves (the schema engine attaches Origin to source / ast.json / doc, not the wrapping dir), so this works on FCA-inferred mounts too. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generators produce wide method sets by design, not by sprawl. Pairs with long_file (line-count via _ast) for a 'lots of code' vs 'lots of API' split.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "pf.file",
 		Query: `
-			WITH per_file AS (
-				SELECT n.source_file AS file, COUNT(DISTINCT d.token) AS n
+			-- Resolve source_file via leaf children when the dir
+			-- itself has none. The schema engine attaches Origin
+			-- (and thus source_file) to leaf rendered files (source,
+			-- ast.json, doc) but not to the wrapping construct dir.
+			-- Without this fallback per_file groups by '' (empty)
+			-- and produces zero rows on the FCA-inferred path.
+			WITH child_source AS (
+				SELECT parent_id AS node_id,
+				       MIN(source_file) AS source_file
+				FROM nodes
+				WHERE source_file IS NOT NULL AND source_file != ''
+				GROUP BY parent_id
+			),
+			per_file AS (
+				SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file) AS file,
+				       COUNT(DISTINCT d.token) AS n
 				FROM node_defs d
 				JOIN nodes n ON n.id = d.node_id
-				WHERE COALESCE(n.source_file, '') != ''
-				GROUP BY n.source_file
+				LEFT JOIN child_source cs ON cs.node_id = n.id
+				WHERE COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') != ''
+				GROUP BY COALESCE(NULLIF(n.source_file, ''), cs.source_file)
 			),
 			proj AS (
 				SELECT AVG(n) AS mu FROM per_file
@@ -446,6 +461,12 @@ var smellRegistry = []SmellRule{
 			CROSS JOIN proj p
 			WHERE pf.n >= 10
 			  AND CAST(pf.n AS REAL) > 3.0 * p.mu
+			  -- Skip generated code: capnp / protobuf / *_generated /
+			  -- *.gen produce wide method sets by design, not sprawl.
+			  AND pf.file NOT LIKE '%%.capnp.go'
+			  AND pf.file NOT LIKE '%%.pb.go'
+			  AND pf.file NOT LIKE '%%_generated.go'
+			  AND pf.file NOT LIKE '%%.gen.go'
 			%s
 			ORDER BY metric DESC, source_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1139,6 +1139,138 @@ func TestFindSmells_GodFile(t *testing.T) {
 	assert.Equal(t, int64(15), resp.Findings[0].Metric, "def count is the metric")
 }
 
+// TestFindSmells_GodFileFallsBackToChildSource asserts that god_file
+// resolves source_file via the construct dir's child leaves when
+// the dir itself has none — the FCA-inferred shape used by `mache
+// build` without --schema. Before this fix, per_file's GROUP BY
+// found zero rows on the FCA path because the dir's source_file
+// is ”, so god_file silently returned no findings on mache.db.
+func TestFindSmells_GodFileFallsBackToChildSource(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- 11 distinct defs all attributed (via leaf source_file) to
+		-- the same file. Project mean across the 5 normal files +
+		-- this one is (11 + 5) / 6 ≈ 2.7; 3× ≈ 8 — the god file
+		-- clears the 10-def floor and the 3× threshold.
+		INSERT INTO node_defs VALUES
+		  ('A','functions/A'),('B','functions/B'),('C','functions/C'),
+		  ('D','functions/D'),('E','functions/E'),('F','functions/F'),
+		  ('G','functions/G'),('H','functions/H'),('I','functions/I'),
+		  ('J','functions/J'),('K','functions/K');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/A','functions','A',1,0,'',''),
+		  ('functions/A/source','functions/A','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/B','functions','B',1,0,'',''),
+		  ('functions/B/source','functions/B','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/C','functions','C',1,0,'',''),
+		  ('functions/C/source','functions/C','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/D','functions','D',1,0,'',''),
+		  ('functions/D/source','functions/D','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/E','functions','E',1,0,'',''),
+		  ('functions/E/source','functions/E','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/F','functions','F',1,0,'',''),
+		  ('functions/F/source','functions/F','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/G','functions','G',1,0,'',''),
+		  ('functions/G/source','functions/G','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/H','functions','H',1,0,'',''),
+		  ('functions/H/source','functions/H','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/I','functions','I',1,0,'',''),
+		  ('functions/I/source','functions/I','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/J','functions','J',1,0,'',''),
+		  ('functions/J/source','functions/J','source',0,0,'pkg/god/sprawl.go',''),
+		  ('functions/K','functions','K',1,0,'',''),
+		  ('functions/K/source','functions/K','source',0,0,'pkg/god/sprawl.go','');
+
+		-- Five normal files (1 def each) to dilute the project mean.
+		INSERT INTO node_defs VALUES
+		  ('N1','functions/N1'),('N2','functions/N2'),('N3','functions/N3'),
+		  ('N4','functions/N4'),('N5','functions/N5');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/N1','functions','N1',1,0,'',''),
+		  ('functions/N1/source','functions/N1','source',0,0,'a.go',''),
+		  ('functions/N2','functions','N2',1,0,'',''),
+		  ('functions/N2/source','functions/N2','source',0,0,'b.go',''),
+		  ('functions/N3','functions','N3',1,0,'',''),
+		  ('functions/N3/source','functions/N3','source',0,0,'c.go',''),
+		  ('functions/N4','functions','N4',1,0,'',''),
+		  ('functions/N4/source','functions/N4','source',0,0,'d.go',''),
+		  ('functions/N5','functions','N5',1,0,'',''),
+		  ('functions/N5/source','functions/N5','source',0,0,'e.go','');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "god_file"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Findings, 1, "FCA-shape fixture: source_file is on the leaf, not the construct dir")
+	assert.Equal(t, "pkg/god/sprawl.go", resp.Findings[0].SourceID)
+	assert.Equal(t, int64(11), resp.Findings[0].Metric)
+}
+
+// TestFindSmells_GodFileSkipsGeneratedFiles asserts that *.capnp.go,
+// *.pb.go, *_generated.go, and *.gen.go aren't flagged even with
+// hundreds of definitions — generators produce wide method sets by
+// design, not architectural sprawl.
+func TestFindSmells_GodFileSkipsGeneratedFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- 12 defs in a generated file — would normally trigger
+		-- god_file, but must be skipped by the *.capnp.go suffix.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/A.x','pkg/methods','A.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/A.y','pkg/methods','A.y',1,0,'a.capnp.go',''),
+		  ('pkg/methods/B.x','pkg/methods','B.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/B.y','pkg/methods','B.y',1,0,'a.capnp.go',''),
+		  ('pkg/methods/C.x','pkg/methods','C.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/C.y','pkg/methods','C.y',1,0,'a.capnp.go',''),
+		  ('pkg/methods/D.x','pkg/methods','D.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/D.y','pkg/methods','D.y',1,0,'a.capnp.go',''),
+		  ('pkg/methods/E.x','pkg/methods','E.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/E.y','pkg/methods','E.y',1,0,'a.capnp.go',''),
+		  ('pkg/methods/F.x','pkg/methods','F.x',1,0,'a.capnp.go',''),
+		  ('pkg/methods/F.y','pkg/methods','F.y',1,0,'a.capnp.go','');
+		INSERT INTO node_defs VALUES
+		  ('A.x','pkg/methods/A.x'),('A.y','pkg/methods/A.y'),
+		  ('B.x','pkg/methods/B.x'),('B.y','pkg/methods/B.y'),
+		  ('C.x','pkg/methods/C.x'),('C.y','pkg/methods/C.y'),
+		  ('D.x','pkg/methods/D.x'),('D.y','pkg/methods/D.y'),
+		  ('E.x','pkg/methods/E.x'),('E.y','pkg/methods/E.y'),
+		  ('F.x','pkg/methods/F.x'),('F.y','pkg/methods/F.y');
+
+		-- A few normal files to populate the project mean.
+		INSERT INTO node_defs VALUES
+		  ('N1','functions/N1'),('N2','functions/N2'),('N3','functions/N3');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/N1','functions','N1',1,0,'a.go',''),
+		  ('functions/N2','functions','N2',1,0,'b.go',''),
+		  ('functions/N3','functions','N3',1,0,'c.go','');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "god_file"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.Empty(t, resp.Findings, "generated capnp.go file must be skipped despite high def count")
+}
+
 // TestFindSmells_FanOutSkew seeds a god-function and several normal
 // callers and asserts only the god-function is flagged. Mean fan-out
 // is (12 + 6×1) / 7 ≈ 2.57; 3×mean ≈ 7.7, well below the god's 12.


### PR DESCRIPTION
## Summary
Two fixes for `god_file` consistency with the rest of the rule registry:

### 1. Source-file fallback
The schema engine attaches `Origin` (and the persisted `source_file` column) to **leaf** rendered files (`source` / `ast.json` / `doc`) but not to the wrapping **construct dir**. `god_file`'s `per_file` CTE filtered `WHERE COALESCE(n.source_file, '') != ''` and so produced **zero** rows on the FCA-inferred path — the rule silently returned no findings on `mache.db`.

Apply the same `child_source` CTE that `dead_code`, `untested_function`, and `duplicate_definitions` already use (PR #235): resolve via any leaf child of the construct dir when the dir itself has no `source_file`.

### 2. Generated-code skip
capnp / protobuf / `*_generated.go` / `*.gen.go` files trip the threshold by design — generators produce wide method sets per type. Match what the other rules already skip (PRs #238, #242, #247).

## Verification
| | Before | After (with fallback) | After (with skip) |
| --- | ---: | ---: | ---: |
| `god_file` on `mache.db` | 0 | 8 (1 was capnp) | 7 |

Top remaining findings: `serve_test.go` (262 defs), `graphfs_test.go` (90), `config_test.go` (86), `serve_find_smells_test.go` (76), `engine.go` (74) — all real test/code sprawl candidates.

## Test plan
- [x] `TestFindSmells_GodFileFallsBackToChildSource` (new) — FCA-shape fixture with empty dir source_file, leaf children carrying `pkg/god/sprawl.go`. Asserts the god file is flagged via the leaf fallback.
- [x] `TestFindSmells_GodFileSkipsGeneratedFiles` (new) — `a.capnp.go` with 12 defs (would normally trigger) + a few production files. Asserts the generated file is skipped.
- [x] Existing `TestFindSmells_GodFile` still passes.
- [x] `task lint` clean.