### PR TITLE
fix: drop assignment / short-var-decl patterns from Go ref query

### DIFF
--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -21,13 +21,10 @@ func init() {
 
 	// Register Go ref query (used by ExtractCalls, the bare-token
 	// path that populates node_refs). Mirrors defaultCallQuery for
-	// call_expression but adds three function-value patterns so
-	// dead_code stops flagging functions that are referenced as
-	// values rather than called (mache-02r9):
+	// call_expression and adds the keyed_element pattern so
+	// dead_code stops flagging cobra RunE callbacks (mache-02r9):
 	//
-	//   &cobra.Command{ RunE: runServe }        — keyed_element value
-	//   factories["go"] = goFactory             — assignment_statement RHS
-	//   shortDecl := someFn                     — short_var_declaration RHS
+	//   &cobra.Command{ RunE: runServe }   — keyed_element value
 	//
 	// We capture the IDENTIFIER inside the SECOND literal_element of
 	// a keyed_element (the value), not the first (the field name).
@@ -35,19 +32,26 @@ func init() {
 	// shapes anyway, but this query is precise so node_refs stays
 	// signal-rich.
 	//
-	// Patterns fire on whatever scope ExtractCalls is given. Function-
-	// body scopes catch nested cobra literals; file-level scopes need
-	// the separate ExtractFileLevelFnValueRefs pass — see engine.go.
+	// Earlier iterations of this query also matched
+	// assignment_statement and short_var_declaration RHS identifiers
+	// to catch 'factories[k] = goFactory' and 'h := someFn' shapes
+	// — but those over-collected (every 'filtered := findings[:0]'
+	// in normal Go code added 'findings' to node_refs as a
+	// 'callee'), inflating fan_out_skew and add scoring noise to
+	// every other rule. Drop those two patterns; the remaining
+	// keyed_element shape captures the highest-value cobra/init
+	// case without the over-capture.
+	//
+	// Patterns fire on whatever scope ExtractCalls is given.
+	// Function-body scopes catch nested cobra literals; file-level
+	// cases (top-level var declarations) still need a separate pass
+	// — known follow-up under mache-02r9.
 	RegisterRefQuery("go", `
 		(call_expression function: (identifier) @call)
 		(call_expression function: (selector_expression field: (field_identifier) @call))
 		(keyed_element
 			(literal_element)
 			(literal_element (identifier) @call))
-		(assignment_statement
-			right: (expression_list (identifier) @call))
-		(short_var_declaration
-			right: (expression_list (identifier) @call))
 	`)
 
 	// ASTWalker context kinds — top-level node kinds whose source bytes

--- a/internal/ingest/sitter_walker_test.go
+++ b/internal/ingest/sitter_walker_test.go
@@ -490,12 +490,17 @@ func bar() {}
 	assert.Contains(t, calls, "bar")
 }
 
-// TestExtractCalls_GoFunctionValueRefs guards the keyed_element /
-// assignment / short_var_declaration patterns added to the Go ref
-// query for mache-02r9. dead_code used to flag every cobra RunE
-// callback and init-time factory because static call extraction
-// only saw call_expression. Now identifiers used as values get
-// captured too.
+// TestExtractCalls_GoFunctionValueRefs guards the keyed_element
+// pattern in the Go ref query (mache-02r9). dead_code used to flag
+// every cobra RunE callback because static call extraction only saw
+// call_expression. The keyed_element capture lets the value
+// identifier (the function reference) land in node_refs.
+//
+// Earlier versions of this query also matched assignment_statement
+// and short_var_declaration RHS identifiers, but those over-collected
+// every variable read on the RHS of normal assignments — see
+// TestExtractCalls_AssignmentRHSDoesNotPolluteRefs below for the
+// regression guard.
 func TestExtractCalls_GoFunctionValueRefs(t *testing.T) {
 	w := NewSitterWalker()
 	code := []byte(`package main
@@ -503,9 +508,6 @@ func TestExtractCalls_GoFunctionValueRefs(t *testing.T) {
 import "github.com/spf13/cobra"
 
 func runServe() error    { return nil }
-func runInit() error     { return nil }
-func goFactory()         {}
-func someHelper()        {}
 
 func setup() {
 	// keyed_element value (cobra RunE pattern, mache-02r9 case 1).
@@ -513,15 +515,6 @@ func setup() {
 		Use:  "x",
 		RunE: runServe,
 	}
-
-	// assignment_statement RHS (init-registry pattern, case 2).
-	factories := map[string]func(){}
-	factories["go"] = goFactory
-
-	// short_var_declaration RHS (function-value variable, case 3).
-	helper := someHelper
-	_ = helper
-	_ = factories
 }
 `)
 	lang := golang.GetLanguage()
@@ -533,8 +526,6 @@ func setup() {
 	calls, err := w.ExtractCalls(tree.RootNode(), code, lang, "go")
 	require.NoError(t, err)
 	assert.Contains(t, calls, "runServe", "keyed_element value identifier captured")
-	assert.Contains(t, calls, "goFactory", "assignment_statement RHS identifier captured")
-	assert.Contains(t, calls, "someHelper", "short_var_declaration RHS identifier captured")
 
 	// "RunE" is the keyed_element FIELD NAME — must NOT be captured
 	// (we want the value identifier, not the field name).
@@ -542,6 +533,45 @@ func setup() {
 		"struct field name must not leak into refs — only the value identifier should")
 	assert.NotContains(t, calls, "Use",
 		"struct field name must not leak into refs")
+}
+
+// TestExtractCalls_AssignmentRHSDoesNotPolluteRefs guards against
+// over-broad capture: variable reads on the RHS of `=` or `:=` must
+// NOT be added to node_refs. An earlier iteration of the Go ref
+// query matched assignment_statement / short_var_declaration RHS
+// identifiers (intended for `factories[k] = goFactory` shapes), but
+// those captured every `filtered := findings[:0]` too, polluting
+// fan_out_skew with non-callee identifiers.
+func TestExtractCalls_AssignmentRHSDoesNotPolluteRefs(t *testing.T) {
+	w := NewSitterWalker()
+	code := []byte(`package p
+
+func handler(input []int, threshold int) []int {
+	filtered := input[:0]
+	for _, v := range input {
+		if v > threshold {
+			filtered = append(filtered, v)
+		}
+	}
+	return filtered
+}
+`)
+	lang := golang.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	calls, err := w.ExtractCalls(tree.RootNode(), code, lang, "go")
+	require.NoError(t, err)
+	// `append` is a real call_expression and SHOULD be captured.
+	assert.Contains(t, calls, "append")
+	// `input`, `filtered`, `threshold`, `v` are local variables read
+	// in expression positions — NOT calls. They must not appear.
+	for _, varName := range []string{"input", "filtered", "threshold", "v"} {
+		assert.NotContains(t, calls, varName,
+			"local variable %q must not appear in node_refs", varName)
+	}
 }
 
 func TestRefQueryRegistry_PythonUsesRegistered(t *testing.T) {


### PR DESCRIPTION
## Summary
PR #236 added three function-value capture patterns to the Go ref query: `keyed_element`, `assignment_statement` RHS, and `short_var_declaration` RHS. The first is precise (cobra `RunE`) but the latter two over-collect — every `filtered := findings[:0]` adds `findings` to `node_refs` as a "callee", inflating `fan_out_skew` and polluting every rule that joins against `node_refs`.

## Fix
Drop the two over-broad patterns. The `keyed_element` capture alone covers the highest-value cobra/init-registry case. Top-level cobra var declarations remain a known limitation under `mache-02r9` — fixing those needs a separate file-root extraction pass, not broader expression-position capture.

## Verification — dogfood on `mache.db`

| Rule | Before | After |
| --- | ---: | ---: |
| `fan_out_skew` | 42 | 36 |
| `makeFindSmellsHandler` distinct callees | 18 | 17 (drops local `findings`) |
| `dead_code` | 37 | 37 (unchanged) |
| `untested_function` | 30 | 30 (unchanged) |
| `duplicate_definitions` | 7 | 7 (unchanged) |

## Test plan
- [x] `TestExtractCalls_AssignmentRHSDoesNotPolluteRefs` (new) — local variables in assignment / range / short-var-decl RHS positions must NOT land in `node_refs`. `append()` (a real call) must.
- [x] `TestExtractCalls_GoFunctionValueRefs` updated to keep the keyed_element assertion only.
- [x] All existing tests pass.
- [x] `task lint` clean.

Refs `mache-02r9` (file-level cobra top-level still pending).