### PR TITLE
fix: pin tree-sitter workers to OS threads (mache-2y9w mitigation)

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -431,6 +431,17 @@ func (e *Engine) ingestTreeSitterParallel(rootPath string) error {
 	var workerWg sync.WaitGroup
 	for range numWorkers {
 		workerWg.Go(func() {
+			// Pin to one OS thread for the lifetime of the worker.
+			// tree-sitter's CGO bridge is sensitive to goroutine
+			// migration mid-call: when the Go runtime preempts and
+			// resumes a goroutine on a different OS thread while
+			// CGO is in flight, we've seen sporadic SIGSEGVs in
+			// internal/ingest tests on ubuntu-latest (mache-2y9w).
+			// LockOSThread isolates each parser/cursor pair to a
+			// stable thread; UnlockOSThread on exit lets the runtime
+			// reclaim the thread when the worker goroutine ends.
+			runtime.LockOSThread()
+			defer runtime.UnlockOSThread()
 			parser := sitter.NewParser()
 			for job := range jobs {
 				result := parsedTreeSitterFile{job: job}


### PR DESCRIPTION
## Summary
CI tests in `internal/ingest` occasionally crash with `SIGSEGV` during CGO execution on `ubuntu-latest` (3 hits today, ~1-in-5 PR rate per `mache-2y9w`). Traces point at `SitterWalker.ExtractCalls` / `QueryCursor.NextMatch` — CGO entry points where the Go runtime can preempt and resume the goroutine on a different OS thread mid-call. tree-sitter's C state isn't designed for that kind of migration.

## Mitigation
Pin the worker goroutines to a stable OS thread:

```go
workerWg.Go(func() {
    runtime.LockOSThread()
    defer runtime.UnlockOSThread()
    parser := sitter.NewParser()
    for job := range jobs { ... }
})
```

The lock applies across the worker's entire lifetime — every parse, every `ExtractContext` / `ExtractGoImports` call — so each parser-cursor pair stays on one thread for all of its operations. `defer runtime.UnlockOSThread()` lets the runtime reclaim the thread when the worker exits.

## Scope
- **This is a mitigation, not a permanent fix.** The full fix is `mache-37ae8b` (CGO removal). If the SIGSEGV reappears with this locking in place, the cause is more fundamental (e.g. Query sharing across goroutines) and we'd need different work.
- Only the tree-sitter parallel path is locked. The JSON-walker path (`ingestSQLiteStreaming`) is pure Go.

## Test plan
- [x] `go test ./internal/ingest/ ./cmd/` — passes (128s).
- [x] `task lint` — clean.
- [x] Local repro of the flake hasn't been pinned down (the bead notes 1-in-4-to-5 frequency); the next dozen CI runs across the merge train will tell us if the rate drops.

Refs `mache-2y9w`.