### PR TITLE
fix(ci): find-smells uses literal substring match for changed-files filter

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -73,10 +73,14 @@ jobs:
             | jq -R -s -c 'split("\n") | map(select(length > 0))' \
             > /tmp/changed.json
           cat /tmp/changed.json
-          # Make a regex alternation for source_file matching:
-          # /tmp/changed-pattern.txt → "auth/main.go|billing/charge.go"
-          jq -r '. | join("|")' /tmp/changed.json > /tmp/changed-pattern.txt
-          if [ -z "$(cat /tmp/changed-pattern.txt)" ]; then
+          # Set skip=true when the changed-files array is empty.
+          # Filtering against this list happens in the next step via
+          # literal substring `contains()` (not regex), so we don't
+          # need to pre-compute a regex pattern here. Going through
+          # regex alternation would silently mis-match because '.'
+          # in '.go' is a regex metacharacter; literal `contains()`
+          # avoids that class of bug.
+          if [ "$(jq 'length' /tmp/changed.json)" = "0" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -86,17 +90,22 @@ jobs:
         if: steps.changed.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          PATTERN=$(cat /tmp/changed-pattern.txt)
           # Run the five rules that don't need _ast (work on the
           # standalone CGO ingestion path's node_defs / node_refs /
           # nodes tables). The four _ast-only rules
           # (magic_int_in_comparison, cyclomatic_complexity,
           # long_function, long_file) need an LLO-built .db.
+          #
+          # Filter findings by literal substring match against the
+          # changed-files list. We use `contains` rather than `test`
+          # because `.` in '.go' is a regex metacharacter — `test`
+          # against 'cmd/serve.go' would silently match
+          # 'cmd/serveXgo' too. `contains` is literal substring.
           for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
             /tmp/mache find-smells --db /tmp/repo.db --rule "$rule" \
               --format json --limit 1000 \
-              | jq --arg pat "$PATTERN" \
-                  '.findings = (.findings | map(select(.source_id | test($pat))))' \
+              | jq --slurpfile changed /tmp/changed.json \
+                  '.findings = (.findings | map(. as $f | select($changed[0] | any(. as $c | $f.source_id | contains($c)))))' \
               > "/tmp/${rule}.json"
             echo "=== $rule ==="
             jq '.findings | length' "/tmp/${rule}.json"


### PR DESCRIPTION
## Summary
The previous filter built a regex alternation from the changed filenames and called jq's `test()`. That silently mis-matches when filenames contain regex metacharacters — most importantly `.` in `.go`. The pattern `cmd/serve.go` would match `cmd/serveXgo` too. In a clean repo no such doppelganger exists, but it's a fragile foundation for a CI gate, especially when filenames could contain `+`, `(`, `?`, etc.

## Fix
Switch to literal substring matching via jq's `contains()` against the slurped changed-files array. A finding's `source_id` is kept iff **any** changed-file string appears as a substring.

```jq
.findings = (.findings | map(. as $f |
  select($changed[0] | any(. as $c | $f.source_id | contains($c)))
))
```

## Side effects
- Drop `/tmp/changed-pattern.txt` — no longer needed since the run-rules step uses the JSON array directly.
- Skip detection now reads the JSON array's length instead of the (former) pattern file's emptiness.

## Verification
| Changed file | Source path | Match (regex/old) | Match (substring/new) |
| --- | --- | :---: | :---: |
| `cmd/serve.go` | `/path/cmd/serve.go` | ✓ | ✓ |
| `cmd/serve.go` | `/path/cmd/serveXgo` | ✓ (bug) | ✗ |
| `foo+bar.go` | `/path/foo+bar.go` | ? (depends on regex) | ✓ |
| `foo+bar.go` | `/path/foobar.go` | ✓ (bug) | ✗ |

Tested with the jq filter directly.

## Test plan
- [x] No code change.
- [x] Workflow YAML valid (`yq` parses).
- [x] jq filter works correctly on sample inputs (above table).