### PR TITLE
fix: dead_code drops orphan construct dirs (no resolvable source_file)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -175,7 +175,16 @@ var smellRegistry = []SmellRule{
 			       0  AS metric
 			FROM nodes n
 			LEFT JOIN child_source cs ON cs.node_id = n.id
-			WHERE n.id IN (SELECT DISTINCT node_id FROM node_defs)
+			-- Drop orphan nodes (no resolvable source_file via either
+			-- the dir itself or any leaf child). These are construct
+			-- dirs that survived the engine's processNode but whose
+			-- file-children loop produced nothing — e.g. JS function
+			-- declarations matched against an FCA-inferred Go schema
+			-- where the {{.scope}} render path didn't yield writable
+			-- content. They have no source data and can't be navigated
+			-- to, so flagging them is pure noise.
+			WHERE COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') != ''
+			  AND n.id IN (SELECT DISTINCT node_id FROM node_defs)
 			  AND n.id NOT IN (SELECT node_id FROM alive)
 			  AND n.id NOT IN (SELECT node_id FROM skipped)
 			  -- Skip non-callable categories. node_refs is populated

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -581,6 +581,52 @@ func TestFindSmells_DeadCodeSkipsGeneratedFiles(t *testing.T) {
 		"only the non-generated dead function is flagged")
 }
 
+// TestFindSmells_DeadCodeSkipsOrphanNodes asserts that construct
+// dir nodes with no resolvable source_file (neither on the dir
+// itself nor on any leaf child) are dropped from dead_code. These
+// orphans appear when the engine's processNode persists the dir
+// but the file-children loop produces nothing — observed when an
+// FCA-inferred Go schema's `{{.scope}}` template runs against a
+// non-Go file (e.g. a JS function_declaration matched against the
+// inferred Go selector). Flagging the orphan is noise — there's no
+// source data to navigate to.
+func TestFindSmells_DeadCodeSkipsOrphanNodes(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- Orphan: defined, exists, but no leaf children with source_file.
+		INSERT INTO node_defs VALUES ('processUser', 'functions/processUser');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/processUser', 'functions', 'processUser', 1, 0, '', '');
+
+		-- Real dead function with leaf children — control: must flag.
+		INSERT INTO node_defs VALUES ('Orphan', 'functions/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/Orphan',        'functions',         'Orphan', 1, 0, '',         ''),
+		  ('functions/Orphan/source', 'functions/Orphan',  'source', 0, 0, 'o.go',     '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Orphan"}, gotIDs,
+		"only the dead function with leaf-resolvable source_file is flagged; orphan dropped")
+}
+
 // TestFindSmells_DeadCodeStripsReceiverPrefixForLeafMatch asserts
 // that a method defined as 'Receiver.Method' is treated as alive
 // when call-extraction captures the bare 'Method' field_identifier.


### PR DESCRIPTION
## Summary
`mache build` occasionally emits "orphan" construct dirs — `node_defs` + `nodes` rows but no leaf children carrying `source_file`. One slipped through on `mache.db`: `functions/processUser` from `tests/test_data/js/test.js`.

## Root cause
The FCA-inferred Go schema's selector `(function_declaration name: (identifier) @name) @scope` fires on JS `function_declaration` nodes too — `filterNodesByLanguage` matches all languages when `Language` is left empty (the FCA inference doesn't set it). `processNode` creates the construct dir at line 1389, then the file-children loop fails to render `{{.scope}}` for the JS match shape, so no `source` / `ast.json` / `doc` children get persisted. The dir survives without children.

The orphan can't be navigated to (no source data), so flagging it in `dead_code` is noise.

## Fix
Drop findings whose `source_file` resolution returns empty after the `child_source` fallback. The `processNode` side-effect remains — that's a separate engine issue worth its own PR — but the rule output is no longer polluted by it.

## Verification
| | Before | After |
| --- | ---: | ---: |
| `dead_code` on `mache.db` | 37 | 36 |

The one drop is `functions/processUser` (the JS-fixture orphan).

## Test plan
- [x] `TestFindSmells_DeadCodeSkipsOrphanNodes` (new) — orphan + a real-dead control. Asserts only the control is flagged.
- [x] All existing `dead_code` tests pass.
- [x] `task lint` clean.

The downstream engine bug (orphan dir creation) is tracked separately.