### PR TITLE
fix: tag FCA-inferred schema with its source language

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,6 +54,17 @@ var buildCmd = &cobra.Command{
 			// of every kind. Memory is still bounded by maxFiles below.
 			cfg := lattice.DefaultInferConfig()
 			cfg.SampleSize = 100_000
+			// Tag the inferred schema with its source language. Without
+			// this, every node has Language='' which makes the engine's
+			// filterNodesByLanguage match the selector against every
+			// language — e.g. JS function_declarations match the
+			// inferred-from-Go selector and produce orphan construct
+			// dirs (no source/ast.json/doc children because the JS
+			// match shape doesn't render the Go templates cleanly).
+			// We currently bootstrap inference from Go files only;
+			// when other-language bootstraps land, this should pick
+			// up the actual language being sampled.
+			cfg.Language = "go"
 			inf := &lattice.Inferrer{Config: cfg}
 			log.Println("Inferring schema...")
 


### PR DESCRIPTION
## Summary
PR #259 surfaced a downstream side-effect of the FCA inference path: `mache build` (no `--schema`) infers a Go schema from `.go` files, but leaves `Language=""` on the resulting topology. When the engine's `filterNodesByLanguage` sees `Language=""`, it matches the selector against **every** language. JS `function_declaration` nodes match the inferred Go `(function_declaration name: (identifier) @name) @scope` pattern; `processNode` persists the construct dir but the file-children loop fails to render the Go-shaped templates against the JS match, leaving an orphan dir.

## Fix
Set `cfg.Language = "go"` before `InferFromTreeSitterRoots`. The inferred `Topology` now has `Language="go"` on every node, so the engine only applies it to `.go` files. JS function declarations stop generating orphan dirs.

When a future iteration adds non-Go bootstrap support (Python / Rust / TS files in the walk), this should derive from the actual language being sampled. Today the walk only opens `.go` files (line 79 of `cmd/build.go`), so `"go"` is correct.

## Verification
| | Before | After |
| --- | ---: | ---: |
| `processUser` orphan in `mache.db` | ✓ exists | ✗ gone |
| `dead_code` count | 36 | 36 (unchanged — already filtered by #259) |

The `dead_code` count is unchanged because PR #259's SQL-side filter already drops orphans. This PR closes the **engine-level** half: orphan dirs aren't created in the first place.

## Defense in depth
PR #259's SQL filter stays — any future code path that produces orphan dirs (e.g. malformed user-provided schemas) won't pollute `dead_code` findings.

## Test plan
- [x] `go test ./cmd/ ./internal/ingest/ ./internal/lattice/` passes (~120s).
- [x] `task lint` clean.
- [x] Manual: `mache build` against the full mache repo no longer produces `functions/processUser` (which used to leak from the JS test fixture).