### PR TITLE
fix(ci): notify-kiln is continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [test, lint]
     runs-on: ubuntu-latest
+    # Best-effort cross-repo dispatch. The OIDC exchange against
+    # octo-sts depends on a trust policy in the kiln repo; if that
+    # trust isn't established yet, the step fails and we don't
+    # want to mark the whole CI run as failed (the test + lint jobs
+    # are the gate). Continue-on-error keeps the run green when
+    # this is the only failing job.
+    continue-on-error: true
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
Every push to main shows as "failed" on the CI workflow because the cross-repo `notify-kiln` job fails its OIDC handshake — the trust policy in `agentic-research/kiln` isn't yet established. `test` + `lint` always pass; the run is functionally green.

## Fix
Mark `notify-kiln` `continue-on-error: true` so the run reflects the **gate** (`test` + `lint`) rather than the opportunistic kiln-rebuild trigger.

## Why this is safe
- The job is gated on `push` to `main` only; PRs aren't affected.
- The dispatch is opportunistic — kiln rebuilds independently via its own scheduled scans, so a missed dispatch is at most a small staleness window, not a correctness issue.
- When the trust policy lands in kiln, this job will start succeeding without further changes here.

## Verification
- [x] YAML structure preserved (`yq` parses).
- [x] Other jobs unaffected.