### PR TITLE
chore: unknown-rule error lists the available rules

### DIFF
--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -84,7 +84,10 @@ This tool is observability, not a gate. It never exits non-zero on findings.`,
 			}
 		}
 		if rule == nil {
-			return cliExit(3, fmt.Errorf("unknown rule %q — run with no --rule for the registry listing", findSmellsRule))
+			return cliExit(3, fmt.Errorf(
+				"unknown rule %q — available: %s — run with no --rule for full descriptions",
+				findSmellsRule, strings.Join(allRuleIDs(), ", "),
+			))
 		}
 
 		// Pre-flight required tables, same shape as the MCP handler.

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -592,7 +592,10 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 			}
 		}
 		if rule == nil {
-			return mcp.NewToolResultError(fmt.Sprintf("unknown rule %q. Call this tool with no rule for the registry listing.", ruleID)), nil
+			return mcp.NewToolResultError(fmt.Sprintf(
+				"unknown rule %q — available: %s. Call this tool with no rule for full descriptions.",
+				ruleID, strings.Join(allRuleIDs(), ", "),
+			)), nil
 		}
 
 		// Need a *sql.DB to run the rule. Today we hand-shake via the
@@ -648,6 +651,18 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 		}
 		return mcp.NewToolResultText(jsonOrPanic(resp)), nil
 	}
+}
+
+// allRuleIDs returns the registered rule IDs in alphabetical order.
+// Used by the unknown-rule error message so agents/users see what
+// they could have typed without having to call the registry first.
+func allRuleIDs() []string {
+	ids := make([]string, 0, len(smellRegistry))
+	for _, r := range smellRegistry {
+		ids = append(ids, r.ID)
+	}
+	sort.Strings(ids)
+	return ids
 }
 
 // rulesListing produces the JSON returned when find_smells is called


### PR DESCRIPTION
## Summary
Both find_smells code paths (MCP handler in `cmd/serve_find_smells.go` and CLI in `cmd/find_smells_cli.go`) returned a generic `run with no --rule for the registry listing` on a typo'd rule name. The user has to re-run a separate command to learn the available IDs.

Inline the list:

> unknown rule `"fakeo"` — available: `cyclomatic_complexity`, `dead_code`, `duplicate_definitions`, `fan_out_skew`, `god_file`, `long_file`, `long_function`, `magic_int_in_comparison`, `untested_function` — run with no --rule for full descriptions

A new `allRuleIDs()` helper centralises the alphabetical listing (used by both the MCP handler and the CLI). The "full descriptions" pointer is preserved for the discovery flow.

No behavior change beyond the error message.

## Test plan
- [x] `go test ./cmd/` passes.
- [x] `task lint` clean.
- [x] Manual: `mache find-smells --db ... --rule fake_rule` shows the new message.