### PR TITLE
chore(ci): find-smells comment uses repo-relative paths

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -130,7 +130,14 @@ jobs:
                 echo ""
                 echo "| Source | Node | Metric |"
                 echo "| --- | --- | ---: |"
-                jq -r '.findings | .[:20] | .[] | "| \(.source_id // "") | \(.node_id // "") | \(.metric // 0) |"' "/tmp/${rule}.json"
+                # Strip the runner workspace prefix from source_id so
+                # the comment shows repo-relative paths (cmd/serve.go)
+                # instead of /home/runner/work/mache/mache/cmd/serve.go.
+                # GITHUB_WORKSPACE is the canonical absolute path of
+                # the checked-out repo on the runner.
+                jq -r --arg ws "$GITHUB_WORKSPACE/" \
+                  '.findings | .[:20] | .[] | "| \((.source_id // "") | sub($ws; "")) | \(.node_id // "") | \(.metric // 0) |"' \
+                  "/tmp/${rule}.json"
                 if [ "$count" -gt 20 ]; then
                   echo ""
                   echo "_(showing top 20 of ${count})_"


### PR DESCRIPTION
## Summary
Findings in the find-smells advisory comment used to render with the full runner-workspace path:

```
| /home/runner/work/mache/mache/cmd/serve.go | cmd/functions/runServe | 51 |
```

Strip the `GITHUB_WORKSPACE` prefix so the table shows clean repo-relative paths:

```
| cmd/serve.go | cmd/functions/runServe | 51 |
```

`GITHUB_WORKSPACE` is the canonical absolute path of the checked-out repo on the runner; jq's `sub()` removes it (with trailing slash) from `source_id` before rendering.

No behavior change — same data, more readable.

## Test plan
- [x] jq filter verified locally on a sample with the workspace prefix.
- [x] YAML structure preserved (`yq` parses).