### PR TITLE
fix: defensive nil-tree check in parallel tree-sitter ingest

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -465,9 +465,18 @@ func (e *Engine) ingestTreeSitterParallel(rootPath string) error {
 
 				parser.SetLanguage(job.lang)
 				tree, err := parser.ParseCtx(context.Background(), nil, result.content)
-				if err != nil {
+				switch {
+				case err != nil:
 					result.parseErr = err
-				} else {
+				case tree == nil:
+					// ParseCtx is documented to return (nil, nil) for
+					// non-error empty inputs. Treat as a no-op parse so
+					// downstream tree.RootNode() can't nil-deref under
+					// the parallel worker (which would surface as a
+					// SIGSEGV in CGO via the tree-sitter call stack —
+					// the same class of failure as mache-2y9w).
+					result.parseErr = fmt.Errorf("tree-sitter returned nil tree")
+				default:
 					result.tree = tree
 					// Extract context (imports, globals) — CPU-bound query execution.
 					if ctxBytes, err := e.sitterWalker.ExtractContext(


### PR DESCRIPTION
## Summary
`parser.ParseCtx(ctx, nil, content)` is documented to return `(nil, nil)` for empty or non-parseable input — no error, but also no tree. The previous code took `err == nil` as proof of a non-nil tree and called `tree.RootNode()` unconditionally. A nil tree from a worker goroutine would nil-deref through CGO and surface as a `SIGSEGV` — the same class of crash as `mache-2y9w`.

## Fix
Convert the nil-error check to a 3-arm switch:

```go
switch {
case err != nil:        // existing error path
    result.parseErr = err
case tree == nil:       // NEW — synthesize error so result collection sees it
    result.parseErr = fmt.Errorf("tree-sitter returned nil tree")
default:                // proceed with non-nil tree
    result.tree = tree
    ...
}
```

The synthetic `"tree-sitter returned nil tree"` error keeps the result-collection loop's existing handling — it'll log the failure and skip the file, just as it does for any parse error.

## Test plan
- [x] `go test -race -count=1 ./internal/ingest/ ./cmd/` passes (~76s).
- [x] `task lint` clean.
- [x] Behavior under nil-tree from ParseCtx now graceful (no nil-deref); previously it would have crashed the worker.

Defense in depth for `mache-2y9w` (alongside PR #257's `LockOSThread`). Whether this code path is actually hit in production parses is unclear, but the cost of guarding against it is one extra branch on a hot path that's already CGO-bound.