### PR TITLE
chore(ci): find-smells comment links Source cells to PR head

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -113,6 +113,9 @@ jobs:
 
       - name: Render comment
         if: steps.changed.outputs.skip != 'true'
+        env:
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           {
@@ -130,13 +133,18 @@ jobs:
                 echo ""
                 echo "| Source | Node | Metric |"
                 echo "| --- | --- | ---: |"
-                # Strip the runner workspace prefix from source_id so
-                # the comment shows repo-relative paths (cmd/serve.go)
-                # instead of /home/runner/work/mache/mache/cmd/serve.go.
-                # GITHUB_WORKSPACE is the canonical absolute path of
-                # the checked-out repo on the runner.
+                # Render each finding row. Strip the runner workspace
+                # prefix from source_id (so paths are repo-relative)
+                # AND wrap the path in a Markdown link to the file at
+                # this PR's head SHA — readers can click straight to
+                # the offending file. GITHUB_WORKSPACE is the
+                # canonical absolute path of the checked-out repo on
+                # the runner.
                 jq -r --arg ws "$GITHUB_WORKSPACE/" \
-                  '.findings | .[:20] | .[] | "| \((.source_id // "") | sub($ws; "")) | \(.node_id // "") | \(.metric // 0) |"' \
+                       --arg base "https://github.com/${REPO}/blob/${HEAD_SHA}" \
+                  '.findings | .[:20] | .[] |
+                     ((.source_id // "") | sub($ws; "")) as $rel |
+                     "| [\($rel)](\($base)/\($rel)) | \(.node_id // "") | \(.metric // 0) |"' \
                   "/tmp/${rule}.json"
                 if [ "$count" -gt 20 ]; then
                   echo ""


### PR DESCRIPTION
## Summary
Each finding's Source cell is now a clickable Markdown link to the file at the PR's head SHA, so reviewers can click straight to the offending file rather than copy/paste the path.

```
Before: | cmd/serve.go | cmd/functions/runServe | 51 |
After:  | [cmd/serve.go](https://github.com/.../blob/<head_sha>/cmd/serve.go) | cmd/functions/runServe | 51 |
```

The link uses the **PR head's SHA** (not the branch ref) so it always points at the exact code the rule scanned — even if the branch is later updated.

## Changes
- New env vars `REPO` and `HEAD_SHA` on the Render step (sourced from `github.repository` and `github.event.pull_request.head.sha`).
- jq template wraps the relative path in `[label](url)` syntax.

## Test plan
- [x] jq filter verified locally on a sample finding (output: `| [cmd/serve.go](https://github.com/.../blob/abc123/cmd/serve.go) | ... | ... |`).
- [x] YAML structure preserved (`yq` parses).