### PR TITLE
fix: duplicate_definitions skip-list adds vtab / billy / http.Handler

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -376,13 +376,27 @@ var smellRegistry = []SmellRule{
 				-- substr(token, instr(token, '.') + 1) strips the
 				-- 'pkg.' prefix; instr returns 0 when there's no
 				-- dot, so substr(token, 1) returns the full token.
+				-- Skip standard-library and common-external-interface
+				-- contracts. Duplicates of these aren't 'duplication'
+				-- in the architectural sense — they're each type's
+				-- implementation of a shared protocol. Mirror the
+				-- dead_code skip list (PRs #234, #239) so both rules
+				-- treat the same names consistently.
 				WHERE substr(token, instr(token, '.') + 1) NOT IN (
 					'main','init',
 					'String','Error','Format','Scan','GoString',
 					'Read','Write','Close','Open','Seek','ReadAt','WriteAt','ReadFrom','WriteTo',
 					'Len','Less','Swap',
 					'MarshalJSON','UnmarshalJSON','MarshalText','UnmarshalText','MarshalBinary','UnmarshalBinary',
-					'Marshal','Unmarshal','Reset','Clone','Copy','Equal','Hash','Validate'
+					'Marshal','Unmarshal','Reset','Clone','Copy','Equal','Hash','Validate',
+					-- vtab.Module (modernc.org/sqlite/vtab)
+					'BestIndex','Column','Connect','Create','Destroy','Disconnect',
+					'Eof','Filter','Rowid','Next',
+					-- billy.Filesystem (go-git)
+					'Chroot','Readlink','Sys','TempFile','MkdirAll','Symlink',
+					'Lstat','Stat','ReadDir','Capabilities','Root',
+					-- net/http
+					'ServeHTTP'
 				)
 				-- Exclude imports/ (refs TO external packages, not
 				-- defs) and non-callable categories (short names

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1946,6 +1946,66 @@ func TestFindSmells_DuplicateDefinitionsSkipsNonCallableCategories(t *testing.T)
 	)
 }
 
+// TestFindSmells_DuplicateDefinitionsSkipsExternalInterfaceMethods
+// asserts that vtab.Module / billy.Filesystem / http.Handler
+// methods aren't flagged. These are interface contracts shared
+// across multiple types; same-named methods aren't 'duplicates'
+// in the architectural sense — they're each type's implementation.
+// Mirrors the dead_code skip extended in PR #239.
+func TestFindSmells_DuplicateDefinitionsSkipsExternalInterfaceMethods(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- Two types each implementing vtab.Module's BestIndex —
+		-- legitimate Go interface implementations, not duplicates.
+		INSERT INTO node_defs VALUES
+		  ('BestIndex', 'pkg/methods/A.BestIndex'),
+		  ('BestIndex', 'pkg/methods/B.BestIndex');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/A.BestIndex', 'pkg/methods', 'A.BestIndex', 1, 0, 'a.go', ''),
+		  ('pkg/methods/B.BestIndex', 'pkg/methods', 'B.BestIndex', 1, 0, 'b.go', '');
+
+		-- Same for billy.Filesystem TempFile.
+		INSERT INTO node_defs VALUES
+		  ('TempFile', 'pkg/methods/X.TempFile'),
+		  ('TempFile', 'pkg/methods/Y.TempFile');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/X.TempFile', 'pkg/methods', 'X.TempFile', 1, 0, 'x.go', ''),
+		  ('pkg/methods/Y.TempFile', 'pkg/methods', 'Y.TempFile', 1, 0, 'y.go', '');
+
+		-- Real cross-package duplicate of a non-interface name.
+		INSERT INTO node_defs VALUES
+		  ('Helper', 'pkg/a/functions/Helper'),
+		  ('Helper', 'pkg/b/functions/Helper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/a/functions/Helper', 'pkg/a/functions', 'Helper', 1, 0, 'a/h.go', ''),
+		  ('pkg/b/functions/Helper', 'pkg/b/functions', 'Helper', 1, 0, 'b/h.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "duplicate_definitions"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.ElementsMatch(t,
+		[]string{"pkg/a/functions/Helper", "pkg/b/functions/Helper"},
+		gotIDs,
+		"only the real Helper duplicate is flagged; interface-implementation namesakes are skipped",
+	)
+}
+
 // TestFindSmells_DuplicateDefinitionsSkipsQualifiedInit asserts that
 // the skip list strips package qualifiers before comparing against
 // the leaf-token list. mache build emits both bare ('init') and


### PR DESCRIPTION
## Summary
PR #239 extended `dead_code`'s skip list with `vtab.Module` (BestIndex, Column, Connect, ...), `billy.Filesystem` (Chroot, Readlink, TempFile, ...), and `net/http` (ServeHTTP). Same-named implementations across multiple types are interface-contract noise — they're not "duplicates" in the architectural sense.

`duplicate_definitions` had a more limited skip list (just stdlib io/sort/encoding contracts). Mirror the dead_code extension so both rules treat the same names consistently. Without this, every package that implements one of those interfaces shows up as a "duplicate" in the advisory comment.

## Verification — `mache.db` dogfood

| | Before | After |
| --- | ---: | ---: |
| go-schema `duplicate_definitions` | 292 | 278 |
| FCA path `duplicate_definitions` | 7 | 7 (unchanged — FCA produces bare names that already collide with the prior skip list) |

## Test plan
- [x] `TestFindSmells_DuplicateDefinitionsSkipsExternalInterfaceMethods` (new) — vtab + billy + a real cross-package `Helper` duplicate. Asserts only the helper is flagged.
- [x] All existing `TestFindSmells_DuplicateDefinitions*` tests pass.
- [x] `task lint` clean.

Both rules now share the same canonical interface-contract skip-list shape, easier to keep in sync going forward.