### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ tools/KNOWN_ISSUES.md
 # Session-resume scratch notes (per-clone, ad hoc)
 /resume.txt
 /mache-distrib-resume.txt
+
+# macOS Finder metadata
+.DS_Store


### PR DESCRIPTION
## Summary
The repo had an untracked `.DS_Store` under `experiments/`. Add the glob to `.gitignore` so macOS contributors don't accidentally commit them.

Cross-platform Finder metadata noise; never relevant to the code.

## Test plan
- [x] `git ls-files | grep DS_Store` returns nothing (none tracked).
- [x] After this change, the local untracked `experiments/.DS_Store` is correctly ignored by git.