### PR TITLE
fix: file-level ref extraction for top-level Go fn-value patterns

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -107,14 +107,15 @@ type treeSitterJob struct {
 // parsedTreeSitterFile is the result of tree-sitter parsing (parallel or sequential).
 // Contains the pre-parsed AST and file content, ready for processTreeSitterResult.
 type parsedTreeSitterFile struct {
-	job      treeSitterJob
-	realPath string
-	content  []byte
-	tree     *sitter.Tree
-	context  []byte            // extracted imports/globals context
-	imports  map[string]string // structured imports: alias → path (Go only, nil for others)
-	parseErr error             // non-nil if tree-sitter parsing failed
-	readErr  error             // non-nil if file read failed
+	job           treeSitterJob
+	realPath      string
+	content       []byte
+	tree          *sitter.Tree
+	context       []byte            // extracted imports/globals context
+	imports       map[string]string // structured imports: alias → path (Go only, nil for others)
+	fileLevelRefs []string          // identifiers captured at the file root (Go: top-level cobra refs etc., mache-02r9)
+	parseErr      error             // non-nil if tree-sitter parsing failed
+	readErr       error             // non-nil if file read failed
 }
 
 // langForExt is a thin wrapper over the lang registry.
@@ -488,6 +489,15 @@ func (e *Engine) ingestTreeSitterParallel(rootPath string) error {
 					if job.langName == "go" {
 						result.imports = e.sitterWalker.ExtractGoImports(tree.RootNode(), result.content, job.lang)
 					}
+					// Extract file-level refs (identifiers in positions
+					// that per-scope ExtractCalls can't see, e.g. Go
+					// top-level cobra var declarations — mache-02r9).
+					// nil-OK for languages with no registered query.
+					if refs, err := e.sitterWalker.ExtractFileLevelRefs(
+						tree.RootNode(), result.content, job.lang, job.langName,
+					); err == nil {
+						result.fileLevelRefs = refs
+					}
 				}
 				parsed <- result
 			}
@@ -830,6 +840,13 @@ func (e *Engine) processTreeSitterResult(result *parsedTreeSitterFile) error {
 		if addrRefs, err := wt.ExtractAddressRefs(result.job.path, result.job.langName); err == nil {
 			fileAddrRefs = addrRefs
 		}
+	}
+	// Merge file-level fn-value refs (mache-02r9: Go top-level cobra
+	// callbacks etc.) into the same bag as fileAddrRefs. They share
+	// the same merge semantics — the dedup loop in processNode skips
+	// any token already captured at scope level.
+	if len(result.fileLevelRefs) > 0 {
+		fileAddrRefs = append(fileAddrRefs, result.fileLevelRefs...)
 	}
 
 	// 5. processNode for each applicable schema node.

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -54,6 +54,31 @@ func init() {
 			(literal_element (identifier) @call))
 	`)
 
+	// Register Go file-level ref query — runs once per FILE against
+	// the source_file root, catching identifiers in positions that
+	// per-scope ExtractCalls can't see. Specifically: function
+	// references in TOP-LEVEL var declarations like
+	//
+	//   var serveCmd = &cobra.Command{ RunE: runServe }
+	//
+	// The outer var_declaration is at the file root, NOT inside any
+	// function_declaration, so ExtractCalls — which only walks the
+	// matched scope (function body) — never sees runServe. Re-running
+	// the same keyed_element query at the file root catches those
+	// references (mache-02r9).
+	//
+	// Why this is the same query, just at a different scope:
+	// in-function keyed_element captures are already in node_refs
+	// from per-scope ExtractCalls; the engine's merge step
+	// deduplicates per-token before insert, so a token captured in
+	// both scopes lands in node_refs exactly once per caller. The
+	// only NEW tokens this query adds are the file-level ones.
+	RegisterFileLevelRefQuery("go", `
+		(keyed_element
+			(literal_element)
+			(literal_element (identifier) @call))
+	`)
+
 	// ASTWalker context kinds — top-level node kinds whose source bytes
 	// constitute the context blob. Mirrors the Go context query above.
 	RegisterASTContextKinds("go", []string{

--- a/internal/ingest/sitter_walker.go
+++ b/internal/ingest/sitter_walker.go
@@ -27,10 +27,28 @@ var contextQueryRegistry sync.Map // string (language name) -> string
 // both @call and @pkg for qualified call resolution (e.g., auth.Validate).
 var qualifiedCallQueryRegistry sync.Map // string (language name) -> string
 
+// fileLevelRefQueryRegistry stores per-language queries run against the
+// FILE root (not function bodies). The use case is patterns whose
+// captures live outside any function_declaration — Go's top-level
+// `var serveCmd = &cobra.Command{ RunE: runServe }` is the
+// motivating case (mache-02r9). Per-scope ExtractCalls would never
+// see runServe because the keyed_element is in a top-level
+// var_declaration, not a function body.
+var fileLevelRefQueryRegistry sync.Map // string (language name) -> string
+
 // RegisterRefQuery registers a reference extraction query for a specific language.
 // This should be called during initialization.
 func RegisterRefQuery(langName, query string) {
 	refQueryRegistry.Store(langName, query)
+}
+
+// RegisterFileLevelRefQuery registers a reference extraction query
+// that runs once per FILE (against the root node), not per function
+// scope. The captures supplement per-scope ExtractCalls — typical use:
+// matching identifiers used as struct field values in top-level
+// composite literals.
+func RegisterFileLevelRefQuery(langName, query string) {
+	fileLevelRefQueryRegistry.Store(langName, query)
 }
 
 // RegisterContextQuery registers a context extraction query for a specific language.
@@ -67,6 +85,8 @@ type SitterWalker struct {
 	// (selector, language) pair. Schema selectors are the same across all
 	// files of the same language, so caching avoids recompilation on every file.
 	schemaQueryCache sync.Map // schemaQueryKey -> *sitter.Query
+	// fileLevelRefQueryCache caches compiled file-level ref queries.
+	fileLevelRefQueryCache sync.Map // string (language name) -> *sitter.Query
 }
 
 func NewSitterWalker() *SitterWalker {
@@ -266,6 +286,77 @@ func (w *SitterWalker) Close() {
 		v.(*sitter.Query).Close()
 		return true
 	})
+	w.fileLevelRefQueryCache.Range(func(_, v any) bool {
+		v.(*sitter.Query).Close()
+		return true
+	})
+}
+
+// getFileLevelRefQuery returns a cached compiled query for file-level
+// ref extraction. Returns nil (no error) when no query is registered
+// for the language — caller treats nil as 'no file-level extraction
+// for this lang' and skips.
+func (w *SitterWalker) getFileLevelRefQuery(lang *sitter.Language, langName string) (*sitter.Query, error) {
+	if cached, ok := w.fileLevelRefQueryCache.Load(langName); ok {
+		return cached.(*sitter.Query), nil
+	}
+	val, ok := fileLevelRefQueryRegistry.Load(langName)
+	if !ok {
+		return nil, nil
+	}
+	q, err := sitter.NewQuery([]byte(val.(string)), lang)
+	if err != nil {
+		return nil, err
+	}
+	actual, loaded := w.fileLevelRefQueryCache.LoadOrStore(langName, q)
+	if loaded {
+		q.Close()
+		return actual.(*sitter.Query), nil
+	}
+	return q, nil
+}
+
+// ExtractFileLevelRefs runs the file-level ref query against the
+// FILE root and returns matched identifier text (deduped). Used to
+// catch identifiers in positions that per-scope ExtractCalls can't
+// see — e.g. function references in top-level cobra var declarations
+// (mache-02r9). Returns nil when no file-level query is registered
+// for the language.
+func (w *SitterWalker) ExtractFileLevelRefs(root *sitter.Node, source []byte, lang *sitter.Language, langName string) ([]string, error) {
+	q, err := w.getFileLevelRefQuery(lang, langName)
+	if err != nil {
+		return nil, fmt.Errorf("invalid file-level ref query: %w", err)
+	}
+	if q == nil {
+		return nil, nil
+	}
+	// Don't close q — owned by the cache.
+	qc := sitter.NewQueryCursor()
+	defer qc.Close()
+	qc.Exec(q, root)
+
+	seen := make(map[string]bool)
+	var refs []string
+	for {
+		m, ok := qc.NextMatch()
+		if !ok {
+			break
+		}
+		m = qc.FilterPredicates(m, source)
+		for _, c := range m.Captures {
+			start := c.Node.StartByte()
+			end := c.Node.EndByte()
+			if start < uint32(len(source)) && end <= uint32(len(source)) {
+				key := unsafe.String(&source[start], int(end-start))
+				if !seen[key] {
+					token := string(source[start:end])
+					seen[token] = true
+					refs = append(refs, token)
+				}
+			}
+		}
+	}
+	return refs, nil
 }
 
 // getContextQuery returns a cached compiled query for context extraction.

--- a/internal/ingest/sitter_walker_test.go
+++ b/internal/ingest/sitter_walker_test.go
@@ -535,6 +535,62 @@ func setup() {
 		"struct field name must not leak into refs")
 }
 
+// TestExtractFileLevelRefs_GoTopLevelCobraVar guards the file-level
+// ref extraction path (mache-02r9). Per-scope ExtractCalls only sees
+// call_expressions within a matched function body — top-level
+// `var serveCmd = &cobra.Command{ RunE: runServe }` is outside any
+// function_declaration, so runServe never lands in node_refs and
+// gets flagged as dead by find_smells.
+//
+// File-level extraction runs the same keyed_element query against
+// the source_file root, so the top-level keyed_element value
+// identifier is captured.
+func TestExtractFileLevelRefs_GoTopLevelCobraVar(t *testing.T) {
+	w := NewSitterWalker()
+	code := []byte(`package cmd
+
+import "github.com/spf13/cobra"
+
+func runServe() error { return nil }
+
+var serveCmd = &cobra.Command{
+	Use:  "serve",
+	RunE: runServe,
+}
+`)
+	lang := golang.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	refs, err := w.ExtractFileLevelRefs(tree.RootNode(), code, lang, "go")
+	require.NoError(t, err)
+	assert.Contains(t, refs, "runServe",
+		"top-level keyed_element value identifier must be captured by file-level extraction")
+	assert.NotContains(t, refs, "RunE",
+		"struct field name (RunE) must not leak into refs — only the value identifier")
+}
+
+// TestExtractFileLevelRefs_NoQueryReturnsNil asserts that languages
+// without a registered file-level query get nil-no-error from
+// ExtractFileLevelRefs (caller treats that as 'skip').
+func TestExtractFileLevelRefs_NoQueryReturnsNil(t *testing.T) {
+	w := NewSitterWalker()
+	code := []byte(`def main():
+    print("hi")
+`)
+	lang := python.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	refs, err := w.ExtractFileLevelRefs(tree.RootNode(), code, lang, "python")
+	require.NoError(t, err)
+	assert.Nil(t, refs, "no file-level query registered for python; should return nil cleanly")
+}
+
 // TestExtractCalls_AssignmentRHSDoesNotPolluteRefs guards against
 // over-broad capture: variable reads on the RHS of `=` or `:=` must
 // NOT be added to node_refs. An earlier iteration of the Go ref


### PR DESCRIPTION
## Summary
Per-scope `ExtractCalls` only sees `call_expression`s and `keyed_element`s within a matched function body. Top-level declarations like:

```go
var serveCmd = &cobra.Command{
    Use:  "serve",
    RunE: runServe,
}
```

are outside any `function_declaration`, so `runServe` never landed in `node_refs` and find_smells `dead_code` flagged every cobra `RunE` callback as unreferenced — the dominant remaining FP class on `mache-02r9`.

## Fix
Add a per-language registry for file-level ref queries, run once per FILE against the `source_file` root, and merge the captures into the same `fileAddrRefs` bag the engine already plumbs through `processNode`.

- **`SitterWalker.ExtractFileLevelRefs`** — nil-OK for languages with no registered query; existing langs unaffected.
- **`RegisterFileLevelRefQuery` + `fileLevelRefQueryCache`** — mirrors the existing call-query / context-query / qualified-call-query plumbing.
- **Go registers the same `keyed_element` pattern** it already uses per-scope, but at the FILE root.
- **engine.go worker** calls `ExtractFileLevelRefs` alongside `ExtractContext` / `ExtractGoImports`, stores into `parsedTreeSitterFile.fileLevelRefs`, and merges into `fileAddrRefs` for downstream processing.

## Verification
| | Before | After |
| --- | ---: | ---: |
| `dead_code` on `mache.db` | 36 | 33 |
| `runServe` ref count | 0 | 14 |

`runServe` was the canonical FP in the bead description — now correctly alive.

## Scope / out-of-scope
**Remaining FPs** like `cliExit`, `hotSwapFactory`: these are calls inside **anonymous function literals** (`cobra.Command{ RunE: func() { cliExit(...) } }`). Different shape — needs an extraction pass that walks function-literal bodies. Tracked separately under `mache-02r9`.

## Test plan
- [x] `TestExtractFileLevelRefs_GoTopLevelCobraVar` (new) — direct unit test of the new method.
- [x] `TestExtractFileLevelRefs_NoQueryReturnsNil` (new) — Python (no registered query) returns `nil`-no-error cleanly.
- [x] `go test -race -count=1 ./internal/ingest/ ./cmd/` passes (~75s).
- [x] `task lint` clean.