### PR TITLE
fix: file-level refs use sentinel caller_id (de-pollute fan_out_skew)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -501,8 +501,16 @@ var smellRegistry = []SmellRule{
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
 			WITH fanout AS (
+				-- Exclude the engine's file-level sentinel caller_ids
+				-- (prefix '_file_level:'). Those are synthetic node_ids
+				-- the engine uses to mark file-level fn-value refs
+				-- (mache-02r9) as alive without polluting per-construct
+				-- callee counts. Counting them here would attribute the
+				-- file-level refs to a 'caller' that isn't a real
+				-- construct, inflating fan_out_skew with virtual rows.
 				SELECT node_id AS caller_id, COUNT(DISTINCT token) AS n
 				FROM node_refs
+				WHERE node_id NOT LIKE '_file_level:%%'
 				GROUP BY node_id
 			),
 			proj AS (

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -250,7 +250,14 @@ func (r *NodesTableReader) renderFromRecord(filePath, recordID string) ([]byte, 
 
 // GetCallers returns nodes that reference the given token via node_refs table.
 func (r *NodesTableReader) GetCallers(token string) ([]*Node, error) {
-	rows, err := r.db.Query("SELECT node_id FROM node_refs WHERE token = ?", token)
+	// Skip the engine's file-level sentinel caller_ids (prefix
+	// '_file_level:') — they exist so dead_code's alive CTE can
+	// recognise top-level cobra RunE callbacks without polluting
+	// the caller view. They aren't real callers.
+	rows, err := r.db.Query(
+		"SELECT node_id FROM node_refs WHERE token = ? AND node_id NOT LIKE '_file_level:%'",
+		token,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("query node_refs: %w", err)
 	}

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -841,12 +841,24 @@ func (e *Engine) processTreeSitterResult(result *parsedTreeSitterFile) error {
 			fileAddrRefs = addrRefs
 		}
 	}
-	// Merge file-level fn-value refs (mache-02r9: Go top-level cobra
-	// callbacks etc.) into the same bag as fileAddrRefs. They share
-	// the same merge semantics — the dedup loop in processNode skips
-	// any token already captured at scope level.
+	// File-level refs (mache-02r9: top-level cobra RunE etc.) are
+	// emitted with a SENTINEL caller_id rather than merged into
+	// every construct's calls. Earlier iterations folded them into
+	// fileAddrRefs (per-construct merge), which inflated fan_out_skew
+	// — every function in a cobra-using file picked up the cobra
+	// callback as a 'callee' even though it doesn't actually call it.
+	//
+	// The sentinel form keeps the alive set correct for dead_code
+	// (token-only check) without polluting any rule that aggregates
+	// by caller. fan_out_skew explicitly skips sentinel rows.
+	const fileLevelSentinelPrefix = "_file_level:"
 	if len(result.fileLevelRefs) > 0 {
-		fileAddrRefs = append(fileAddrRefs, result.fileLevelRefs...)
+		sentinel := fileLevelSentinelPrefix + result.realPath
+		for _, token := range result.fileLevelRefs {
+			if err := bt.AddRef(token, sentinel); err != nil {
+				log.Printf("file-level ref %q: %v", token, err)
+			}
+		}
 	}
 
 	// 5. processNode for each applicable schema node.


### PR DESCRIPTION
## Problem
PR #269 added file-level ref extraction (top-level cobra `RunE` etc., `mache-02r9`), merging the captures into `fileAddrRefs`. That was wrong: `fileAddrRefs` propagates to **every** construct's calls in a file, so file-level fn-value refs got attributed to every function in cobra-using files. `fan_out_skew` on `mache.db` jumped 36 → 79 because `ingestTreeSitterParallel` and friends suddenly "called" `runServe`.

## Fix
Switch to a **sentinel** attribution. File-level refs are stored under `node_id = "_file_level:<absolute-path>"` instead of being merged into per-construct calls.

- **`dead_code`'s alive CTE** only checks token presence, so it stays correct (`runServe` still alive — the desired effect of #269).
- **`fan_out_skew`** adds `WHERE node_id NOT LIKE '_file_level:%'` to its `fanout` CTE.
- **`NodesTableReader.GetCallers`** (the `find_callers` MCP / NFS backend) adds the same `NOT LIKE` filter.
- **`untested_function` / `duplicate_definitions` / `god_file`** are unaffected — they aggregate by token or by file, not by caller_id.

## Verification — `mache.db` dogfood

| Rule | Pre-#269 | After #269 (broken) | This PR |
| --- | ---: | ---: | ---: |
| `dead_code` | 36 | 33 | **33** |
| `fan_out_skew` | 36 | 79 | **36** |
| `duplicate_definitions` | 7 | 7 | 7 |
| `untested_function` | 31 | 31 | 31 |
| `god_file` | 7 | 7 | 7 |

Closes the file-level half of `mache-02r9` cleanly. The closure-body case (calls inside `func_literal` values like `RunE: func() { cliExit(...) }`) remains as a separate follow-up.

## Test plan
- [x] `go test ./internal/ingest/ ./internal/graph/ ./cmd/` passes (~50s).
- [x] `task lint` clean.
- [x] Dogfood numbers verified above.