### PR TITLE
fix: file-level Go query captures call_expression (closure-body half of mache-02r9)

### DIFF
--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -55,28 +55,38 @@ func init() {
 	`)
 
 	// Register Go file-level ref query — runs once per FILE against
-	// the source_file root, catching identifiers in positions that
-	// per-scope ExtractCalls can't see. Specifically: function
-	// references in TOP-LEVEL var declarations like
+	// the source_file root, catching tokens in positions that the
+	// per-scope ExtractCalls can't see. Two cases (mache-02r9):
 	//
 	//   var serveCmd = &cobra.Command{ RunE: runServe }
+	//   ^^^ keyed_element value identifier at file root
+	//
+	//   var initCmd = &cobra.Command{
+	//       RunE: func(cmd *cobra.Command, args []string) error {
+	//           return cliExit(4, ...)   <-- call_expression inside
+	//       },                                  func_literal value
+	//   }
 	//
 	// The outer var_declaration is at the file root, NOT inside any
-	// function_declaration, so ExtractCalls — which only walks the
-	// matched scope (function body) — never sees runServe. Re-running
-	// the same keyed_element query at the file root catches those
-	// references (mache-02r9).
+	// function_declaration. Per-scope ExtractCalls (which walks
+	// function bodies) never sees either case.
 	//
-	// Why this is the same query, just at a different scope:
-	// in-function keyed_element captures are already in node_refs
-	// from per-scope ExtractCalls; the engine's merge step
-	// deduplicates per-token before insert, so a token captured in
-	// both scopes lands in node_refs exactly once per caller. The
-	// only NEW tokens this query adds are the file-level ones.
+	// Captures land in node_refs under a SENTINEL caller_id
+	// '_file_level:<path>' — see engine.go's worker phase. dead_code
+	// reads token presence so it's correct; fan_out_skew /
+	// GetCallers exclude the sentinel (PR #270) so per-construct
+	// aggregations stay clean.
+	//
+	// Per-scope-already-captured tokens (a Go function body's normal
+	// call_expressions) are duplicated into the sentinel row — they
+	// also exist as legitimate per-scope rows. Storage waste is
+	// bounded; correctness is unaffected.
 	RegisterFileLevelRefQuery("go", `
 		(keyed_element
 			(literal_element)
 			(literal_element (identifier) @call))
+		(call_expression function: (identifier) @call)
+		(call_expression function: (selector_expression field: (field_identifier) @call))
 	`)
 
 	// ASTWalker context kinds — top-level node kinds whose source bytes

--- a/internal/ingest/sitter_walker_test.go
+++ b/internal/ingest/sitter_walker_test.go
@@ -572,6 +572,39 @@ var serveCmd = &cobra.Command{
 		"struct field name (RunE) must not leak into refs — only the value identifier")
 }
 
+// TestExtractFileLevelRefs_GoCallsInsideTopLevelClosure asserts the
+// closure-body half of mache-02r9. The Go file-level query also
+// includes call_expression patterns so calls inside top-level
+// func_literal values (cobra RunE: func() { cliExit(...) }) are
+// captured. Per-scope ExtractCalls would never see them because
+// the func_literal lives outside any function_declaration.
+func TestExtractFileLevelRefs_GoCallsInsideTopLevelClosure(t *testing.T) {
+	w := NewSitterWalker()
+	code := []byte(`package cmd
+
+import "github.com/spf13/cobra"
+
+func cliExit(code int, err error) error { return err }
+
+var initCmd = &cobra.Command{
+	Use: "init",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return cliExit(4, nil)
+	},
+}
+`)
+	lang := golang.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	refs, err := w.ExtractFileLevelRefs(tree.RootNode(), code, lang, "go")
+	require.NoError(t, err)
+	assert.Contains(t, refs, "cliExit",
+		"call_expression inside a top-level func_literal value must be captured")
+}
+
 // TestExtractFileLevelRefs_NoQueryReturnsNil asserts that languages
 // without a registered file-level query get nil-no-error from
 // ExtractFileLevelRefs (caller treats that as 'skip').


### PR DESCRIPTION
## Summary
PR #269's keyed_element-only file-level query caught top-level `RunE: runServe` patterns. The remaining FP class was calls INSIDE top-level `func_literal`s — the cobra Command pattern that uses an inline closure:

```go
var initCmd = &cobra.Command{
    RunE: func(cmd *cobra.Command, args []string) error {
        return cliExit(4, ...)   // not captured
    },
}
```

The `func_literal` is a keyed_element value, but its **body** contains the `call_expression`s per-scope `ExtractCalls` couldn't see either (`func_literal` isn't a `function_declaration`).

## Fix
Add `call_expression` patterns to the Go file-level query. Tree-sitter's recursive descent matches `call_expression`s anywhere in the file root scope, including inside top-level `func_literal` bodies. Captures land under the sentinel `caller_id` from PR #270, so `fan_out_skew` and `find_callers` stay clean.

**Side-effect**: per-scope-already-captured calls (normal function bodies) are duplicated into the sentinel row. Storage is wasted but correctness is unaffected — `dead_code` only checks token presence.

## Verification — dogfood

| | Pre-#269 | After #269 | After #270 | This PR |
| --- | ---: | ---: | ---: | ---: |
| `dead_code` | 36 | 33 | 33 | **20** |
| `cliExit` refs | 0 | 0 | 0 | **1** (sentinel) |
| `runInit` refs | 0 | 0 | 0 | **1** (sentinel) |
| `fan_out_skew` | 36 | 79 | 36 | **36** |

Cumulative across the mache-02r9 work this session: **306 → 20 dead_code findings (-93%)**.

## Test plan
- [x] `TestExtractFileLevelRefs_GoCallsInsideTopLevelClosure` (new) — top-level cobra Command with `RunE: func() { cliExit(...) }`. Asserts `cliExit` lands in the file-level refs.
- [x] All existing `TestExtractFileLevelRefs_*` tests pass.
- [x] `go test ./internal/ingest/ ./internal/graph/ ./cmd/` passes (~50s).
- [x] `task lint` clean.

Closes the closure-body half of `mache-02r9`. Other small remaining FPs (e.g. `hotSwapFactory` passed as a function-value argument: `RunGraphSuite(t, hotSwapFactory)`) need yet another shape — left for a separate PR.