### PR TITLE
fix: file-level Go query captures function-value arguments

### DIFF
--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -87,6 +87,8 @@ func init() {
 			(literal_element (identifier) @call))
 		(call_expression function: (identifier) @call)
 		(call_expression function: (selector_expression field: (field_identifier) @call))
+		(call_expression
+			arguments: (argument_list (identifier) @call))
 	`)
 
 	// ASTWalker context kinds — top-level node kinds whose source bytes

--- a/internal/ingest/sitter_walker_test.go
+++ b/internal/ingest/sitter_walker_test.go
@@ -605,6 +605,40 @@ var initCmd = &cobra.Command{
 		"call_expression inside a top-level func_literal value must be captured")
 }
 
+// TestExtractFileLevelRefs_GoFunctionValueAsArgument asserts the
+// argument-list capture. Test runners that take a factory function
+// as a parameter (e.g. RunGraphSuite(t, hotSwapFactory)) pass a bare
+// identifier — captured as part of the file-level argument_list
+// pattern, which lands the factory in node_refs under the sentinel
+// caller_id and prevents dead_code from flagging it.
+func TestExtractFileLevelRefs_GoFunctionValueAsArgument(t *testing.T) {
+	w := NewSitterWalker()
+	code := []byte(`package graph
+
+import "testing"
+
+func hotSwapFactory(t *testing.T) Graph { return nil }
+
+type Graph interface{}
+
+func RunGraphSuite(t *testing.T, factory func(*testing.T) Graph) {}
+
+func TestHotSwap_GraphSuite(t *testing.T) {
+	RunGraphSuite(t, hotSwapFactory)
+}
+`)
+	lang := golang.GetLanguage()
+	parser := sitter.NewParser()
+	parser.SetLanguage(lang)
+	tree, err := parser.ParseCtx(context.Background(), nil, code)
+	require.NoError(t, err)
+
+	refs, err := w.ExtractFileLevelRefs(tree.RootNode(), code, lang, "go")
+	require.NoError(t, err)
+	assert.Contains(t, refs, "hotSwapFactory",
+		"function-value passed as a call argument must be captured")
+}
+
 // TestExtractFileLevelRefs_NoQueryReturnsNil asserts that languages
 // without a registered file-level query get nil-no-error from
 // ExtractFileLevelRefs (caller treats that as 'skip').


### PR DESCRIPTION
## Summary
After PR #271, `mache.db` dogfood still flagged `hotSwapFactory`, `sqliteGraphFactory`, `stubRender`, `writableGraphFactory`, `stubRenderer` — factories passed as **arguments** to test runners:

```go
RunGraphSuite(t, hotSwapFactory)
```

Per-scope `ExtractCalls` captures the call_expression's function (`RunGraphSuite`) but not its arguments. The function-value passed by name never landed in `node_refs`, so `dead_code` flagged each factory as unreferenced.

## Fix
Add a fourth pattern to the Go file-level query:

```
(call_expression
    arguments: (argument_list (identifier) @call))
```

Captures any identifier passed as a top-level argument. Most identifier arguments are local variables that don't share names with defined functions and don't affect `dead_code`'s alive set. The few that do (`Foo` passed as `Foo`) become alive — exactly what we want.

Captures land under the sentinel caller_id from PR #270, so `fan_out_skew` / `find_callers` stay clean.

## Verification

| | After #271 | This PR |
| --- | ---: | ---: |
| `dead_code` on `mache.db` | 20 | **14** |
| `hotSwapFactory` refs | 0 | 1 (sentinel) |
| `sqliteGraphFactory` refs | 0 | 1 |
| `stubRender` refs | 0 | 2 |
| `fan_out_skew` | 36 | 36 (unchanged) |

**Cumulative session totals on `dead_code`**: 306 → 14 (-95%).

The remaining 14 are predominantly the "public API consumed outside the indexed scope" class explicitly documented in the rule's description (`validate.File`, `validate.FileErrors`, `mount.NFS`, etc.) plus a handful of build-tag-gated functions (`registerFormat`).

## Test plan
- [x] `TestExtractFileLevelRefs_GoFunctionValueAsArgument` (new) — `RunGraphSuite(t, hotSwapFactory)` shape; asserts `hotSwapFactory` is captured.
- [x] All existing `TestExtractFileLevelRefs_*` tests pass.
- [x] `go test ./internal/ingest/ ./internal/graph/ ./cmd/` passes (~50s).
- [x] `task lint` clean.

Closes the function-value-argument shape of `mache-02r9`.