### PR TITLE
fix: untested_function skips Register* prefix (init-time registrations)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -326,6 +326,16 @@ var smellRegistry = []SmellRule{
 			  AND d.token NOT LIKE 'Benchmark%%'
 			  AND d.token NOT LIKE 'Example%%'
 			  AND d.token NOT LIKE 'Fuzz%%'
+			  -- Register* functions are by-convention init-time
+			  -- registration handlers (RegisterRefQuery,
+			  -- RegisterAddressRefQuery, etc.). They run via
+			  -- init() in every consumer of the package, so they
+			  -- ARE exercised in every test by virtue of importing
+			  -- the package — but the static call-graph view ties
+			  -- their callers to functions/init/source, which the
+			  -- tested_via_call CTE doesn't recognize as a test
+			  -- caller. Excluding the prefix avoids the FP.
+			  AND d.token NOT LIKE 'Register%%'
 			  AND d.token NOT IN ('main','init','String','Error')
 			  AND t.token IS NULL
 			  AND tc.token IS NULL

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1553,6 +1553,54 @@ func TestFindSmells_UntestedFunctionAcceptsTestCallCoverage(t *testing.T) {
 		"ReadArenaHeader is exercised via call from TestArena_FlipBuffer; only Orphan remains untested")
 }
 
+// TestFindSmells_UntestedFunctionSkipsRegisterPrefix asserts that
+// Register* functions aren't flagged. Go convention: Register* runs
+// at init() time in every consumer — exercised by every test of the
+// package by virtue of import side-effects, but not via a TestFoo
+// counterpart and not from a Test* caller. Static call-graph attributes
+// the caller to functions/init/source, which tested_via_call doesn't
+// recognise. Skip the prefix to avoid the FP.
+func TestFindSmells_UntestedFunctionSkipsRegisterPrefix(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO node_defs VALUES
+		  ('RegisterRefQuery',     'pkg/functions/RegisterRefQuery'),
+		  ('RegisterContextQuery', 'pkg/functions/RegisterContextQuery');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/RegisterRefQuery',        'pkg/functions',           'RegisterRefQuery',     1, 0, '',          ''),
+		  ('pkg/functions/RegisterRefQuery/source', 'pkg/functions/RegisterRefQuery','source',         0, 0, 'r.go',      ''),
+		  ('pkg/functions/RegisterContextQuery',        'pkg/functions',                 'RegisterContextQuery', 1, 0, '',     ''),
+		  ('pkg/functions/RegisterContextQuery/source', 'pkg/functions/RegisterContextQuery', 'source',          0, 0, 'r.go', '');
+
+		-- Real untested helper as control — must still flag.
+		INSERT INTO node_defs VALUES ('OrphanHelper', 'pkg/functions/OrphanHelper');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/OrphanHelper',        'pkg/functions',         'OrphanHelper', 1, 0, '',          ''),
+		  ('pkg/functions/OrphanHelper/source', 'pkg/functions/OrphanHelper','source',  0, 0, 'h.go',     '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "untested_function"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"pkg/functions/OrphanHelper"}, gotIDs,
+		"Register* functions are init-time registrations and must not be flagged; only OrphanHelper remains")
+}
+
 // TestFindSmells_UntestedFunctionSkipsFuzzPrefix asserts that Fuzz*
 // functions (themselves fuzz-test entry points) aren't flagged.
 // They're covered by the testing framework like Test* and Example*,


### PR DESCRIPTION
## Summary
`Register*` functions are by-convention init-time registration handlers (`RegisterRefQuery`, `RegisterAddressRefQuery`, `RegisterContextQuery`, `RegisterFileLevelRefQuery`, `RegisterASTCallPatterns`, `RegisterASTContextKinds`). They run via `init()` in every consumer of the package — every test exercises them by virtue of import side-effects — but the static call-graph view ties their callers to `functions/init/source`, which the rule's `tested_via_call` CTE doesn't recognize as a test caller. So they were flagged as untested.

## Fix
Add `Register%` to the prefix skip list (alongside `Test*` / `Benchmark*` / `Example*` / `Fuzz*`).

## Verification

| | Before | After |
| --- | ---: | ---: |
| `untested_function` on `mache.db` | 31 | **23** |

Dropped 8 `Register*` findings (all `RegisterRefQuery` / `RegisterContextQuery` etc.). The remaining 23 are mostly the public-API class explicitly noted in the rule's description.

## Test plan
- [x] `TestFindSmells_UntestedFunctionSkipsRegisterPrefix` (new) — `RegisterRefQuery` + `RegisterContextQuery` + a real `OrphanHelper` control. Asserts only the helper is flagged.
- [x] All existing `TestFindSmells_UntestedFunction*` tests pass.
- [x] `task lint` clean.