### PR TITLE
test: add benchmarks for untested_function / duplicate_definitions / god_file

### DIFF
--- a/cmd/serve_find_smells_bench_test.go
+++ b/cmd/serve_find_smells_bench_test.go
@@ -188,3 +188,73 @@ func BenchmarkFindSmells_RulesListing(b *testing.B) {
 		}
 	}
 }
+
+// BenchmarkFindSmells_UntestedFunction exercises the rule's two
+// LEFT JOINs and the tested_via_call CTE. Worth tracking because
+// each PR in this session added a new clause: TestType* prefix
+// (PR #250), tested_via_call CTE (PR #251), Register* skip (PR
+// #273). Cumulative cost on a 10k-defs fixture is the regression
+// signal we care about.
+func BenchmarkFindSmells_UntestedFunction(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{"rule": "untested_function", "limit": float64(10000)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindSmells_DuplicateDefinitions exercises the inner
+// GROUP BY token + outer JOIN node_defs pattern. Cost scales with
+// distinct-tokens × duplicate-count.
+func BenchmarkFindSmells_DuplicateDefinitions(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{"rule": "duplicate_definitions", "limit": float64(10000)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkFindSmells_GodFile exercises the per_file aggregate +
+// project-mean CROSS JOIN pattern. Cost dominated by the CTE
+// scanning all node_defs once (tracked separately from
+// duplicate_definitions because the JOIN shape differs).
+func BenchmarkFindSmells_GodFile(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("defs=%d", n), func(b *testing.B) {
+			tg := seedSmellBench(b, n)
+			defer func() { _ = tg.db.Close() }()
+			handler := makeFindSmellsHandler(tg)
+			req := makeRequest(map[string]any{"rule": "god_file", "limit": float64(10000)})
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_, err := handler(context.Background(), req)
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Three find_smells rules touched heavily this session lacked benchmarks:

- **`untested_function`**: PRs #250 (`TestType*` prefix), #251 (`tested_via_call` CTE), #273 (`Register*` skip) progressively added clauses. Cumulative SQL cost wasn't being tracked.
- **`duplicate_definitions`**: PRs #234 (qualifier strip), #244 (non-callable skip), #247 (generated-code skip), #266 (vtab/billy/http skip) added filters.
- **`god_file`**: PR #254 added the `child_source` CTE. Worth tracking against the `per_file` aggregate cost.

Three new benchmarks parallel the existing `DeadCode` / `FanOutSkew` / `CyclomaticComplexity` ones — three sizes (100/1000/10000 defs), same fixture seed.

## Sample output (Apple M3 Max, `-benchtime=1x`)

| Bench | defs=10000 | allocs/op |
| --- | ---: | ---: |
| `UntestedFunction` | 5.06 ms/op | 80 |
| `DuplicateDefinitions` | 7.61 ms/op | 78 |
| `GodFile` | 13.86 ms/op | 77 |

Future PRs that touch these rules will surface regressions through this baseline.

## Test plan
- [x] `go test -bench BenchmarkFindSmells_(UntestedFunction|DuplicateDefinitions|GodFile) -benchtime=1x ./cmd/` runs cleanly.
- [x] `task lint` clean.