### PR TITLE
fix: write_file fails fast on non-writeBacker backend

### DIFF
--- a/cmd/serve_write.go
+++ b/cmd/serve_write.go
@@ -42,6 +42,14 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("%s has no source origin — only source-code nodes support write-back", path)), nil
 		}
 
+		// Fail fast on unsupported backends BEFORE splice runs. Otherwise
+		// the unchecked type assertion below panics after the source file
+		// has already been written, leaving disk and graph out of sync.
+		wb, ok := g.(writeBacker)
+		if !ok {
+			return mcp.NewToolResultError("backend does not support write-back"), nil
+		}
+
 		origin := *node.Origin
 		newContent := []byte(content)
 
@@ -76,8 +84,7 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultError(fmt.Sprintf("splice failed: %v", err)), nil
 		}
 
-		// 4. Surgical node update
-		wb := g.(writeBacker)
+		// 4. Surgical node update (wb captured above so we can fail fast).
 		newOrigin := &graph.SourceOrigin{
 			FilePath:  origin.FilePath,
 			StartByte: origin.StartByte,

--- a/cmd/serve_write_test.go
+++ b/cmd/serve_write_test.go
@@ -188,6 +188,72 @@ func TestWriteFile_ValidationStillRunsWhenFormatFalse(t *testing.T) {
 	assert.Equal(t, original, after, "validation failure must not touch the source file")
 }
 
+// TestWriteFile_RejectsNonWriteBackerBackend pins the fail-fast contract:
+// if the graph backend doesn't implement writeBacker (UpdateNodeContent +
+// ShiftOrigins), write_file must refuse the request BEFORE running splice.
+// Otherwise the on-disk file is modified, the unchecked type assertion
+// panics, and disk and graph end up out of sync.
+//
+// readOnlyGraph satisfies graph.Graph but not writeBacker, simulating a
+// future backend (or a test harness) that exposes nodes with Origin but
+// can't persist updates.
+func TestWriteFile_RejectsNonWriteBackerBackend(t *testing.T) {
+	original := "package main\n\nfunc Hello() {}\n"
+	srcPath := filepath.Join(t.TempDir(), "main.go")
+	require.NoError(t, os.WriteFile(srcPath, []byte(original), 0o644))
+
+	g := &readOnlyGraph{
+		node: &graph.Node{
+			ID:   "pkg/Hello",
+			Mode: 0,
+			Origin: &graph.SourceOrigin{
+				FilePath:  srcPath,
+				StartByte: 14,
+				EndByte:   uint32(len(original)),
+			},
+		},
+	}
+	handler := makeWriteFileHandler(g)
+
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    "pkg/Hello",
+		"content": "func Hello() { return }\n",
+	}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "non-writeBacker backend must yield an error result")
+	assert.Contains(t, resultText(t, result), "does not support write-back")
+
+	// Source file must be untouched — the splice must not have run.
+	after, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(after), "splice must not run when backend can't accept the update")
+}
+
+// readOnlyGraph satisfies graph.Graph but explicitly omits writeBacker.
+// Used by TestWriteFile_RejectsNonWriteBackerBackend to exercise the
+// fail-fast path in makeWriteFileHandler.
+type readOnlyGraph struct {
+	node *graph.Node
+}
+
+func (g *readOnlyGraph) GetNode(id string) (*graph.Node, error) {
+	if id == g.node.ID {
+		return g.node, nil
+	}
+	return nil, graph.ErrNotFound
+}
+func (*readOnlyGraph) ListChildren(string) ([]string, error)           { return nil, nil }
+func (*readOnlyGraph) ListChildStats(string) ([]graph.NodeStat, error) { return nil, nil }
+func (*readOnlyGraph) ReadContent(string, []byte, int64) (int, error)  { return 0, nil }
+func (*readOnlyGraph) GetCallers(string) ([]*graph.Node, error)        { return nil, nil }
+func (*readOnlyGraph) GetCallees(string) ([]*graph.Node, error)        { return nil, nil }
+func (*readOnlyGraph) Invalidate(string)                               {}
+func (*readOnlyGraph) Act(string, string, string) (*graph.ActionResult, error) {
+	return nil, graph.ErrActNotSupported
+}
+
+var _ graph.Graph = (*readOnlyGraph)(nil)
+
 func TestWriteFile_FormatChangedFalseWhenAlreadyClean(t *testing.T) {
 	// When format=true but the input is already gofumpt-clean,
 	// FormatApplied is true (we ran the formatter) but FormatChanged


### PR DESCRIPTION
## Summary

`makeWriteFileHandler` did the writeBacker type assertion **after** splice already wrote to disk:

```go
if err := writeback.Splice(origin, formatted); err != nil { ... }
// ...
wb := g.(writeBacker)  // ← unchecked, panics if not writeBacker
```

Today the panic never fires (lazyGraph always wraps and satisfies the interface). But a future backend or test harness that drops one of the writeBacker methods would leave the source file modified, the in-memory graph stale, and the handler panicked.

Move the assertion above the splice — fail fast with a clean tool error if the backend can't accept the update, and never touch disk.

## Test plan

- `TestWriteFile_RejectsNonWriteBackerBackend` — minimal `readOnlyGraph` deliberately omits writeBacker; pins both the error message and the "splice didn't run" contract
- All existing write_file tests still pass
- `task lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)