### PR TITLE
fix: surface graph-stale state when UpdateNodeContent fails post-splice

### DIFF
--- a/cmd/serve_write.go
+++ b/cmd/serve_write.go
@@ -99,7 +99,17 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 		if fi, err := os.Stat(origin.FilePath); err == nil {
 			modTime = fi.ModTime()
 		}
-		_ = wb.UpdateNodeContent(path, formatted, newOrigin, modTime)
+
+		// Splice already touched disk; if the graph update fails (e.g.
+		// node was concurrently invalidated) we surface that explicitly
+		// so callers know to re-read. Status "ok_graph_stale" signals
+		// "file is on disk; in-memory graph state may be wrong".
+		status := "ok"
+		var graphWarning string
+		if err := wb.UpdateNodeContent(path, formatted, newOrigin, modTime); err != nil {
+			status = "ok_graph_stale"
+			graphWarning = fmt.Sprintf("graph update failed after splice: %v (file on disk is correct; re-read to refresh graph)", err)
+		}
 		g.Invalidate(path)
 
 		type writeResult struct {
@@ -109,14 +119,16 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 			FormatApplied bool                `json:"format_applied"`           // formatter ran (format=true)
 			FormatChanged bool                `json:"format_changed,omitempty"` // formatter actually altered the bytes
 			BytesDelta    int32               `json:"bytes_delta"`
+			GraphWarning  string              `json:"graph_warning,omitempty"`
 		}
 		data, _ := json.MarshalIndent(writeResult{
-			Status:        "ok",
+			Status:        status,
 			Path:          path,
 			Origin:        newOrigin,
 			FormatApplied: format,
 			FormatChanged: format && string(formatted) != content,
 			BytesDelta:    delta,
+			GraphWarning:  graphWarning,
 		}, "", "  ")
 		return mcp.NewToolResultText(string(data)), nil
 	}

--- a/cmd/serve_write_test.go
+++ b/cmd/serve_write_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/stretchr/testify/assert"
@@ -187,6 +188,73 @@ func TestWriteFile_ValidationStillRunsWhenFormatFalse(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, original, after, "validation failure must not touch the source file")
 }
+
+// TestWriteFile_SurfacesStaleGraphAfterSplice pins the post-splice
+// failure contract: if UpdateNodeContent fails (e.g., the node was
+// concurrently invalidated/deleted between GetNode and the update), the
+// splice has already written disk but the in-memory graph is stale.
+// write_file must surface that to the caller via "ok_graph_stale" plus
+// a graph_warning, not silently report "ok".
+func TestWriteFile_SurfacesStaleGraphAfterSplice(t *testing.T) {
+	original := "package main\n\nfunc Hello() {}\n"
+	srcPath := filepath.Join(t.TempDir(), "main.go")
+	require.NoError(t, os.WriteFile(srcPath, []byte(original), 0o644))
+
+	// staleUpdateGraph reports the node on GetNode but errors on
+	// UpdateNodeContent — simulating the race where the node disappears
+	// after splice but before the graph update.
+	g := &staleUpdateGraph{
+		readOnlyGraph: readOnlyGraph{
+			node: &graph.Node{
+				ID:   "pkg/Hello",
+				Mode: 0,
+				Origin: &graph.SourceOrigin{
+					FilePath:  srcPath,
+					StartByte: 14,
+					EndByte:   uint32(len(original)),
+				},
+			},
+		},
+	}
+	handler := makeWriteFileHandler(g)
+
+	// Use the original byte range so Splice succeeds (we already wrote
+	// the source above with that exact length).
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    "pkg/Hello",
+		"content": "func Hello() { return }\n",
+		"format":  false,
+	}))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "stale-graph is a non-error result with a warning, not a tool error")
+
+	var resp struct {
+		Status       string `json:"status"`
+		GraphWarning string `json:"graph_warning"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "ok_graph_stale", resp.Status,
+		"UpdateNodeContent failure must downgrade status from ok to ok_graph_stale")
+	assert.Contains(t, resp.GraphWarning, "graph update failed after splice",
+		"graph_warning must explain the on-disk-correct, graph-stale split")
+
+	// Sanity check: splice DID happen — disk has the new content.
+	got, err := os.ReadFile(srcPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "return", "splice must succeed even when the graph update fails")
+}
+
+// staleUpdateGraph extends readOnlyGraph with writeBacker methods that
+// simulate a node disappearing after splice. ShiftOrigins is a no-op;
+// UpdateNodeContent returns ErrNotFound to exercise the stale-graph path.
+type staleUpdateGraph struct {
+	readOnlyGraph
+}
+
+func (*staleUpdateGraph) UpdateNodeContent(string, []byte, *graph.SourceOrigin, time.Time) error {
+	return graph.ErrNotFound
+}
+func (*staleUpdateGraph) ShiftOrigins(string, uint32, int32) {}
 
 // TestWriteFile_RejectsNonWriteBackerBackend pins the fail-fast contract:
 // if the graph backend doesn't implement writeBacker (UpdateNodeContent +


### PR DESCRIPTION
## Summary

`write_file` used to discard the post-splice graph update with `_ = wb.UpdateNodeContent(...)`. If that call failed (e.g., node concurrently invalidated between GetNode and update), splice had already touched disk but the graph was silently stale — and the response still said \"ok\". Caller had no way to know to re-read.

Capture the error, downgrade the response to a new status `ok_graph_stale`, and add a `graph_warning` field that explains the split: file on disk is correct, graph state may be wrong, re-read to refresh. Status `ok_graph_stale` preserves the \"splice succeeded\" signal so callers can distinguish this from a hard failure.

## Test plan

- `TestWriteFile_SurfacesStaleGraphAfterSplice` — `staleUpdateGraph` fake whose `UpdateNodeContent` returns `ErrNotFound`; pins response shape + the disk-correct, graph-stale contract.
- All existing write_file tests still pass.
- \`task lint\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)