### PR TITLE
fix: surface mount-mode graph-stale state via WriteStatus

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -800,9 +800,18 @@ func mountNFS(schema *api.Topology, g graph.Graph, engine *ingest.Engine, mountP
 				if fi, err := os.Stat(origin.FilePath); err == nil {
 					modTime = fi.ModTime()
 				}
-				_ = store.UpdateNodeContent(nodeID, formatted, newOrigin, modTime)
+				if err := store.UpdateNodeContent(nodeID, formatted, newOrigin, modTime); err != nil {
+					// Splice already touched disk; the graph is now stale.
+					// Surface via WriteStatus so the _diagnostics virtual
+					// dir reflects reality (file on disk is correct,
+					// in-memory graph is wrong, re-read to refresh).
+					log.Printf("writeback: graph update failed after splice for %s: %v", nodeID, err)
+					store.WriteStatus.Store(filepath.Dir(nodeID),
+						fmt.Sprintf("graph stale (splice succeeded, graph update failed): %v", err))
+				} else {
+					store.WriteStatus.Store(filepath.Dir(nodeID), "ok")
+				}
 				store.RecordFileMtime(origin.FilePath, modTime)
-				store.WriteStatus.Store(filepath.Dir(nodeID), "ok")
 			}
 
 			// 5. Invalidate cached size/content


### PR DESCRIPTION
## Summary

Mirror of #279 on the NFS mount write-back path. The `SetWriteBack` callback in `cmd/mount.go` discarded `UpdateNodeContent`'s error with `_ = ...`, so a post-splice graph update failure left `WriteStatus` reading `"ok"` — the `_diagnostics` virtual dir said everything was fine while the in-memory graph was actually stale.

Capture the error, log it, and store an explicit \"graph stale\" message in `WriteStatus` keyed on the construct dir. Mount-mode callers see this through `_diagnostics/<dir>`; serve-mode callers already get the `graph_warning` field via #279. Same disk-correct, graph-stale split, just exposed through the appropriate channel.

## Test plan

- [x] `go test ./cmd/` — passes (54s; full suite including mount-related tests)
- [x] `task lint` — 0 issues
- [x] Manual review of the change — the only behavior delta is when `UpdateNodeContent` returns non-nil; previously silently masked, now reflected in `WriteStatus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)