### PR TITLE
fix: god_file skips Go test files

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -469,7 +469,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "god_file",
-		Description: "Source files whose distinct-definition count is at least 10 AND more than 3× the project mean — a fuzzy 'god file' detector that surfaces sprawl relative to the codebase's own distribution rather than a hard line-count cutoff. Metric is the def count, sorted descending. Cross-language since node_defs is populated by every backend. source_file is resolved via the construct dir's child leaves (the schema engine attaches Origin to source / ast.json / doc, not the wrapping dir), so this works on FCA-inferred mounts too. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generators produce wide method sets by design, not by sprawl. Pairs with long_file (line-count via _ast) for a 'lots of code' vs 'lots of API' split.",
+		Description: "Source files whose distinct-definition count is at least 10 AND more than 3× the project mean — a fuzzy 'god file' detector that surfaces sprawl relative to the codebase's own distribution rather than a hard line-count cutoff. Metric is the def count, sorted descending. Cross-language since node_defs is populated by every backend. source_file is resolved via the construct dir's child leaves (the schema engine attaches Origin to source / ast.json / doc, not the wrapping dir), so this works on FCA-inferred mounts too. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) and Go test files (`*_test.go`) are excluded — generators produce wide method sets by design and test files accumulate many TestXxx / setupXxx helpers without representing architectural sprawl. Pairs with long_file (line-count via _ast) for a 'lots of code' vs 'lots of API' split.",
 		Requires:    []string{"node_defs", "nodes"},
 		ScopeColumn: "pf.file",
 		Query: `
@@ -515,6 +515,13 @@ var smellRegistry = []SmellRule{
 			  AND pf.file NOT LIKE '%%.pb.go'
 			  AND pf.file NOT LIKE '%%_generated.go'
 			  AND pf.file NOT LIKE '%%.gen.go'
+			  -- Skip Go test files. *_test.go accumulates many
+			  -- TestXxx / setupXxx helpers without representing
+			  -- architectural sprawl — every test func counts as a
+			  -- distinct def. The test-prefix skip in dead_code /
+			  -- untested_function is per-construct; god_file is
+			  -- per-file, so we filter at the file extension level.
+			  AND pf.file NOT LIKE '%%_test.go'
 			%s
 			ORDER BY metric DESC, source_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1317,6 +1317,65 @@ func TestFindSmells_GodFileSkipsGeneratedFiles(t *testing.T) {
 	assert.Empty(t, resp.Findings, "generated capnp.go file must be skipped despite high def count")
 }
 
+// TestFindSmells_GodFileSkipsTestFiles asserts that *_test.go files
+// aren't flagged even with hundreds of test functions — test files
+// accumulate TestXxx + setupXxx helpers without representing
+// architectural sprawl.
+//
+// Surfaced by dogfood: cmd/serve_test.go had 340 defs and topped
+// god_file. After this fix that finding is filtered.
+func TestFindSmells_GodFileSkipsTestFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- 12 defs in a *_test.go file — would normally trigger
+		-- god_file, but must be skipped by the *_test.go suffix.
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/TestA','pkg/functions','TestA',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestB','pkg/functions','TestB',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestC','pkg/functions','TestC',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestD','pkg/functions','TestD',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestE','pkg/functions','TestE',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestF','pkg/functions','TestF',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestG','pkg/functions','TestG',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestH','pkg/functions','TestH',1,0,'foo_test.go',''),
+		  ('pkg/functions/TestI','pkg/functions','TestI',1,0,'foo_test.go',''),
+		  ('pkg/functions/setupX','pkg/functions','setupX',1,0,'foo_test.go',''),
+		  ('pkg/functions/setupY','pkg/functions','setupY',1,0,'foo_test.go',''),
+		  ('pkg/functions/setupZ','pkg/functions','setupZ',1,0,'foo_test.go','');
+		INSERT INTO node_defs VALUES
+		  ('TestA','pkg/functions/TestA'),('TestB','pkg/functions/TestB'),
+		  ('TestC','pkg/functions/TestC'),('TestD','pkg/functions/TestD'),
+		  ('TestE','pkg/functions/TestE'),('TestF','pkg/functions/TestF'),
+		  ('TestG','pkg/functions/TestG'),('TestH','pkg/functions/TestH'),
+		  ('TestI','pkg/functions/TestI'),
+		  ('setupX','pkg/functions/setupX'),('setupY','pkg/functions/setupY'),
+		  ('setupZ','pkg/functions/setupZ');
+
+		-- A few normal files to populate the project mean.
+		INSERT INTO node_defs VALUES
+		  ('N1','functions/N1'),('N2','functions/N2'),('N3','functions/N3');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/N1','functions','N1',1,0,'a.go',''),
+		  ('functions/N2','functions','N2',1,0,'b.go',''),
+		  ('functions/N3','functions','N3',1,0,'c.go','');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "god_file"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.Empty(t, resp.Findings, "*_test.go file must be skipped despite high def count")
+}
+
 // TestFindSmells_FanOutSkew seeds a god-function and several normal
 // callers and asserts only the god-function is flagged. Mean fan-out
 // is (12 + 6×1) / 7 ≈ 2.57; 3×mean ≈ 7.7, well below the god's 12.


### PR DESCRIPTION
## Summary

Surfaced by dogfood: `cmd/serve_test.go` topped god_file with 340 distinct defs. Test files accumulate TestXxx + setupXxx helpers but aren't architectural sprawl — every test func counts as a distinct def, but the file is doing exactly what test files do.

The test-prefix skip in `dead_code` / `untested_function` is per-construct and doesn't help here (god_file is per-file). Filter at the file extension level: `*_test.go` joins the existing generated-code skip group (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`).

Pre/post on dogfood:

| | Before | After |
|---|---|---|
| god_file count | 7 | 6 |
| Top finding | `cmd/serve_test.go` (340 defs) | `internal/ingest/engine.go` (196 defs) |

The remaining 6 are all real source files — genuine \"lots of API\" candidates worth surfacing.

## Test plan

- `TestFindSmells_GodFileSkipsTestFiles` — 12 TestXxx/setupXxx defs in `foo_test.go`; asserts no finding fires.
- All existing god_file tests still pass.
- `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)