### PR TITLE
fix: fan_out_skew skips Go test files

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -528,7 +528,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "fan_out_skew",
-		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* — tests are expected to call many things, no signal there. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generated dispatchers naturally have wide fan-out. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
+		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (per-construct) and Go test files *_test.go (per-file) — tests and test helpers are expected to call many things, no signal there. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generated dispatchers naturally have wide fan-out. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
 		Requires:    []string{"node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -578,6 +578,13 @@ var smellRegistry = []SmellRule{
 			  AND COALESCE(n.source_file, '') NOT LIKE '%%.pb.go'
 			  AND COALESCE(n.source_file, '') NOT LIKE '%%_generated.go'
 			  AND COALESCE(n.source_file, '') NOT LIKE '%%.gen.go'
+			  -- Go test files: test helpers (RunSuite, runParity,
+			  -- setup, realWriteBack) legitimately call many things
+			  -- to build fixtures. The Test*/Benchmark*/Example*/Fuzz*
+			  -- per-construct filter above doesn't catch helpers
+			  -- with non-test names, so add a per-file filter to
+			  -- match god_file.
+			  AND COALESCE(n.source_file, '') NOT LIKE '%%_test.go'
 			%s
 			ORDER BY metric DESC, source_id, node_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1562,6 +1562,70 @@ func TestFindSmells_FanOutSkewSkipsGeneratedFiles(t *testing.T) {
 		"Dispatcher (production) is flagged; CapnpStruct (generated) is skipped via source_file suffix")
 }
 
+// TestFindSmells_FanOutSkewSkipsTestFiles asserts that test helpers
+// in *_test.go files (e.g., setup, RunSuite, runParityTest) aren't
+// flagged. The Test*/Benchmark*/Example*/Fuzz* per-construct filter
+// catches actual test functions, but test helpers with non-test
+// names slip through — match god_file's per-file extension filter.
+//
+// Surfaced by dogfood: 4 of 50 fan_out_skew findings were test
+// helpers (RunGraphSuiteWithOpts, runParityTest, setup,
+// realWriteBack). After this fix: 46.
+func TestFindSmells_FanOutSkewSkipsTestFiles(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE IF NOT EXISTS node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions',                  '',                  'functions', 1, 0, '',              ''),
+		  ('functions/setup',            'functions',         'setup',     1, 0, '',              ''),
+		  ('functions/setup/source',     'functions/setup',   'source',    0, 0, 'foo_test.go',   ''),
+		  ('functions/Dispatcher',       'functions',         'Dispatcher',1, 0, '',              ''),
+		  ('functions/Dispatcher/source','functions/Dispatcher','source', 0, 0, 'dispatcher.go', '');
+
+		-- Both have 12 distinct callees. setup is in *_test.go (test
+		-- helper, non-test name) so must be skipped; Dispatcher is
+		-- production code and must be flagged.
+		INSERT INTO node_refs VALUES
+		  ('A','functions/setup/source'),('B','functions/setup/source'),('C','functions/setup/source'),
+		  ('D','functions/setup/source'),('E','functions/setup/source'),('F','functions/setup/source'),
+		  ('G','functions/setup/source'),('H','functions/setup/source'),('I','functions/setup/source'),
+		  ('J','functions/setup/source'),('K','functions/setup/source'),('L','functions/setup/source');
+
+		INSERT INTO node_refs VALUES
+		  ('M','functions/Dispatcher/source'),('N','functions/Dispatcher/source'),('O','functions/Dispatcher/source'),
+		  ('P','functions/Dispatcher/source'),('Q','functions/Dispatcher/source'),('R','functions/Dispatcher/source'),
+		  ('S','functions/Dispatcher/source'),('T','functions/Dispatcher/source'),('U','functions/Dispatcher/source'),
+		  ('V','functions/Dispatcher/source'),('W','functions/Dispatcher/source'),('X','functions/Dispatcher/source');
+
+		-- Tiny callers to bring project mean down so 12 trips the threshold.
+		INSERT INTO node_refs VALUES
+		  ('z1','functions/n1'),('z2','functions/n2'),('z3','functions/n3'),
+		  ('z4','functions/n4'),('z5','functions/n5'),('z6','functions/n6');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "fan_out_skew"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Dispatcher/source"}, gotIDs,
+		"Dispatcher (production) is flagged; setup (test helper in *_test.go) is skipped")
+}
+
 // TestFindSmells_UntestedFunctionAcceptsTestCallCoverage asserts
 // that a function called from inside any Test*/Benchmark*/Example*/
 // Fuzz* construct's source is treated as covered, even without a


### PR DESCRIPTION
## Summary

Surfaced by dogfood: 4 of 50 fan_out_skew findings were test helpers (`RunGraphSuiteWithOpts`, `runParityTest`, `setup`, `realWriteBack`). Their non-test names slip past the per-construct `Test*/Benchmark*/Example*/Fuzz*` filter.

Match god_file's per-file extension filter (#282) — `*_test.go` joins the existing skip group. Test helpers legitimately call many things to build fixtures; that's the helper's job, not architectural sprawl.

Pre/post on dogfood: **fan_out_skew: 50 → 46**.

## Test plan

- `TestFindSmells_FanOutSkewSkipsTestFiles` — seeds a `setup` helper with 12 callees in `foo_test.go` alongside a production `Dispatcher` with 12 callees; asserts only Dispatcher is flagged.
- All existing fan_out_skew tests still pass.
- `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)