### PR TITLE
fix(mcp): mount annotation works through lazyGraph wrapper

### DIFF
--- a/cmd/serve_find_callers_mount_test.go
+++ b/cmd/serve_find_callers_mount_test.go
@@ -101,6 +101,66 @@ func TestFindCallers_CompositeNoCallersKeepsLegacyShape(t *testing.T) {
 		"empty-result path keeps the bare-array response (backward-compat)")
 }
 
+// TestLazyGraph_MountPrefixOf_ForwardsToCompositeInner pins the
+// production wiring: the registry hands MCP handlers a *lazyGraph
+// that wraps the actual CompositeGraph. Earlier code asserted
+// `g.(*graph.CompositeGraph)` directly in annotateMounts, which
+// silently missed every cross-mount call in production (tests
+// passed because they bypassed the wrapper).
+//
+// The fix: lazyGraph.MountPrefixOf forwards to its inner so the
+// mountPrefixer interface assertion sees through the wrapper.
+func TestLazyGraph_MountPrefixOf_ForwardsToCompositeInner(t *testing.T) {
+	auth, billing := twoMountStores(t)
+	cg := graph.NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	// Construct a lazyGraph with inner pre-set, then burn the
+	// once.Do so init() won't overwrite when get() runs.
+	lg := &lazyGraph{inner: cg}
+	lg.once.Do(func() {})
+
+	// Sanity: lazyGraph satisfies mountPrefixer.
+	mp, ok := graph.Graph(lg).(mountPrefixer)
+	require.True(t, ok, "lazyGraph must satisfy mountPrefixer (handlers depend on this)")
+
+	assert.Equal(t, "auth", mp.MountPrefixOf("auth/functions/AuthCaller/source"))
+	assert.Equal(t, "billing", mp.MountPrefixOf("billing/functions/Charge/source"))
+	assert.Equal(t, "", mp.MountPrefixOf("not-a-mount/foo"),
+		"unknown prefix must return '' so handlers can fall back to legacy shape")
+}
+
+// TestFindCallers_AnnotatesMountThroughLazyGraph is the integration
+// counterpart: drive the handler via a lazyGraph wrapper (the
+// production shape) and assert the annotated response surfaces.
+// Caught the regression where lazyGraph swallowed the composite type.
+func TestFindCallers_AnnotatesMountThroughLazyGraph(t *testing.T) {
+	auth, billing := twoMountStores(t)
+	cg := graph.NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	lg := &lazyGraph{inner: cg}
+	lg.once.Do(func() {})
+
+	handler := makeFindCallersHandler(lg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"token": "Validate"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Callers []scopedCallerRow `json:"callers"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Callers, 2,
+		"both auth and billing callers must surface — production wraps in lazyGraph")
+
+	mounts := []string{resp.Callers[0].Mount, resp.Callers[1].Mount}
+	assert.Contains(t, mounts, "auth", "auth mount label must reach the response")
+	assert.Contains(t, mounts, "billing", "billing mount label must reach the response")
+}
+
 // TestCompositeGraph_MountPrefixOf is the unit test for the public
 // accessor added in this PR. Empty / virtual-root / unknown-prefix
 // inputs all return "" so handlers can distinguish "this id is

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -686,6 +686,102 @@ func TestFindSmells_DeadCodeStripsReceiverPrefixForLeafMatch(t *testing.T) {
 		"Greeter.Greet is alive (Greet ref matches the leaf-strip); only Greeter.Sing remains dead")
 }
 
+// TestFindSmells_DeadCodeRegressionFloor exercises the dead_code
+// rule end-to-end against a synthetic graph that combines every
+// production-relevant facet — bare-leaf alias resolution, qualified
+// shapes, the named skip list, the testing-framework prefix skip,
+// generated-code exclusion, the orphan filter, and a real dead
+// construct as the control. Pins both *which* nodes fire and the
+// total count.
+//
+// dead_code is the load-bearing rule of the smell suite — every
+// unintended re-inflation has cost real signal in the past
+// (PR #244 dropped 306→32, PR #246 SQL receiver-strip dropped 510→32,
+// PR #259 orphan filter, PR #281 duplicate_definitions ripple).
+// This test catches future refactors that silently regress the rule
+// by changing only the synthetic fixture's expected output.
+func TestFindSmells_DeadCodeRegressionFloor(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- Group 1: live free function (called from another).
+		INSERT INTO node_defs VALUES
+		  ('LiveHelper',     'pkg/functions/LiveHelper'),
+		  ('pkg.LiveHelper', 'pkg/functions/LiveHelper');
+		INSERT INTO node_refs VALUES ('LiveHelper', 'pkg/functions/Caller/source');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/LiveHelper', 'pkg/functions', 'LiveHelper', 1, 0, 'helper.go', ''),
+		  ('pkg/functions/Caller',     'pkg/functions', 'Caller',     1, 0, 'caller.go', '');
+
+		-- Group 2: live method via SQL receiver-strip (Greet ref → Greeter.Greet def).
+		INSERT INTO node_defs VALUES
+		  ('Greeter.Greet',     'pkg/methods/Greeter.Greet'),
+		  ('pkg.Greeter.Greet', 'pkg/methods/Greeter.Greet'),
+		  ('Greet',             'pkg/methods/Greeter.Greet');
+		INSERT INTO node_refs VALUES ('Greet', 'pkg/functions/CallSite/source');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/Greeter.Greet', 'pkg/methods',   'Greeter.Greet', 1, 0, 'greet.go',     ''),
+		  ('pkg/functions/CallSite',    'pkg/functions', 'CallSite',      1, 0, 'callsite.go',  '');
+
+		-- Group 3: skip-listed interface method (vtab.Module.BestIndex).
+		INSERT INTO node_defs VALUES
+		  ('Cursor.BestIndex', 'pkg/methods/Cursor.BestIndex'),
+		  ('BestIndex',        'pkg/methods/Cursor.BestIndex');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/methods/Cursor.BestIndex', 'pkg/methods', 'Cursor.BestIndex', 1, 0, 'vtab.go', '');
+
+		-- Group 4: skip-listed by Test prefix (testing-framework reflection).
+		INSERT INTO node_defs VALUES
+		  ('TestSomething', 'pkg/functions/TestSomething');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/TestSomething', 'pkg/functions', 'TestSomething', 1, 0, 'foo_test.go', '');
+
+		-- Group 5: skip-listed by generated-file suffix (capnp.go).
+		INSERT INTO node_defs VALUES
+		  ('GeneratedFn', 'pkg/functions/GeneratedFn');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/GeneratedFn', 'pkg/functions', 'GeneratedFn', 1, 0, 'foo.capnp.go', '');
+
+		-- Group 6: orphan (no resolvable source_file, even via children) — must be filtered.
+		INSERT INTO node_defs VALUES
+		  ('OrphanFn', 'pkg/functions/OrphanFn');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/OrphanFn', 'pkg/functions', 'OrphanFn', 1, 0, '', '');
+
+		-- Group 7: the actual dead control. Defined, referenced
+		-- nowhere, not skip-listed, has a source_file. Must fire.
+		INSERT INTO node_defs VALUES
+		  ('TrulyDead',     'pkg/functions/TrulyDead'),
+		  ('pkg.TrulyDead', 'pkg/functions/TrulyDead');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/functions/TrulyDead', 'pkg/functions', 'TrulyDead', 1, 0, 'truly_dead.go', '');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code", "limit": 100}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	// Exactly one node fires: TrulyDead. Every other group is alive
+	// or correctly skipped. If this assertion ever fails, the
+	// failing diff is the regression — read it before silencing.
+	assert.Equal(t, []string{"pkg/functions/TrulyDead"}, gotIDs,
+		"dead_code must surface exactly the truly-dead control; any other diff is a regression")
+	assert.Equal(t, 1, resp.Total, "dead_code total must match findings length")
+}
+
 // TestFindSmells_DeadCodeSourceFileFallsBackToChildren asserts that
 // when the construct dir itself has source_file = ” (the schema
 // engine attaches Origin/source_file to leaf children — source,

--- a/cmd/serve_mount_annotate.go
+++ b/cmd/serve_mount_annotate.go
@@ -13,20 +13,36 @@ type scopedItem struct {
 	Mount string `json:"mount,omitempty"`
 }
 
-// annotateMounts returns scoped items if g is a *CompositeGraph and
-// at least one path actually carries a mount prefix; nil otherwise.
-// Handlers can emit the annotated shape only when annotation adds
-// information — single-source serves and composite serves where the
-// query never crosses a mount keep the legacy shape.
+// mountPrefixer is satisfied by anything that can resolve a node ID
+// to its mount prefix. *graph.CompositeGraph implements this directly;
+// *lazyGraph implements it by delegating to its inner graph if that
+// inner is itself a CompositeGraph. The interface lets annotateMounts
+// reach the composite even when handlers receive a wrapped graph.
+type mountPrefixer interface {
+	MountPrefixOf(id string) string
+}
+
+// annotateMounts returns scoped items if g exposes a mount-prefix
+// resolver and at least one path actually carries a mount prefix;
+// nil otherwise. Handlers emit the annotated shape only when
+// annotation adds information — single-source serves and composite
+// serves where the query never crosses a mount keep the legacy shape.
+//
+// Used to fail in production: g passed to MCP handlers is a *lazyGraph
+// (the registry wrapper), not the underlying *CompositeGraph, so the
+// type assertion missed and every cross-mount call emitted the legacy
+// single-string shape. Tests bypassed lazyGraph and looked correct;
+// production never hit the annotated branch. Switching to an interface
+// lets lazyGraph forward MountPrefixOf to its inner.
 func annotateMounts(g graph.Graph, paths []string) []scopedItem {
-	cg, ok := g.(*graph.CompositeGraph)
+	mp, ok := g.(mountPrefixer)
 	if !ok || len(paths) == 0 {
 		return nil
 	}
 	out := make([]scopedItem, 0, len(paths))
 	anyMounted := false
 	for _, p := range paths {
-		m := cg.MountPrefixOf(p)
+		m := mp.MountPrefixOf(p)
 		if m != "" {
 			anyMounted = true
 		}

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -593,6 +593,22 @@ func (lg *lazyGraph) ShiftOrigins(filePath string, afterByte uint32, delta int32
 	}
 }
 
+// MountPrefixOf forwards to the inner CompositeGraph so MCP handlers'
+// annotateMounts() can find a mount-prefix resolver even though the
+// registry hands them a lazyGraph wrapper. Returns "" when the inner
+// isn't a composite (single-source serves) — same semantics agents
+// already see for non-composite shapes.
+func (lg *lazyGraph) MountPrefixOf(id string) string {
+	g, err := lg.get()
+	if err != nil || g == nil {
+		return ""
+	}
+	if cg, ok := g.(*graph.CompositeGraph); ok {
+		return cg.MountPrefixOf(id)
+	}
+	return ""
+}
+
 // ---------------------------------------------------------------------------
 // Interface types for optional graph backend capabilities
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Real production bug: `annotateMounts()` asserted `g.(*graph.CompositeGraph)` directly, but every MCP handler receives a `*lazyGraph` (the registry wrapper). The type assertion silently missed and every cross-mount `find_callers` / `find_callees` / `find_definition` response fell back to the legacy single-string shape. Tests passed because they bypassed the wrapper and called handlers with the composite directly.

Switch to a `mountPrefixer` interface — any wrapper that can resolve a node ID to its mount prefix participates. `lazyGraph` implements `MountPrefixOf` by forwarding to its inner if that inner is itself a `CompositeGraph`.

Unblocks all three handlers at once — they all relied on the same broken `annotateMounts`. This is `mache-iegm` step (2) (find_definition mount annotation), shipped as a fix not a feature because the wiring was the blocker, not missing logic.

## Tests

- `TestLazyGraph_MountPrefixOf_ForwardsToCompositeInner` — lazyGraph satisfies `mountPrefixer` and returns the right prefix.
- `TestFindCallers_AnnotatesMountThroughLazyGraph` — end-to-end with the production wrapper shape; asserts both `auth` and `billing` mounts surface.
- `TestFindSmells_DeadCodeRegressionFloor` — synthetic graph covering bare-leaf alias, qualified shapes, named skip list, testing-prefix skip, generated-file exclusion, orphan filter, and a real dead control. Pins exactly one finding fires. Anchors `dead_code` (load-bearing rule of the smell suite) against silent re-inflation.

## Test plan

- [x] `go test -v ./cmd/` — 100% pass, including all 13 dead_code unit tests
- [x] `task lint` — 0 issues
- [x] `gofumpt` clean

## Note on smell suite organization

User plans to extract `find_smells` into its own workspace package / eventually a separate tool (spanning what ruff does + gopls + similar). Each rule is already self-contained SQL + skip list + tests, and `internal/lang` is the cross-cutting registry — the move when ready is a directory split, not a rewrite. The new dead_code regression test acts as a fixture-level boundary that survives such a move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)