### PR TITLE
ci: install Task via 'go install' instead of arduino/setup-task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,12 @@ jobs:
         # (e.g., PR #284 rerun). Go's module proxy is far more
         # reliable, and pinning the version here keeps CI
         # reproducible. Side benefit: no Node 20 deprecation shim.
+        #
+        # GOTOOLCHAIN=auto so Go can fetch the toolchain task v3.50.0
+        # requires (>=1.25.8) without forcing the same upgrade on
+        # mache itself. setup-go v6 defaults to GOTOOLCHAIN=local.
+        env:
+          GOTOOLCHAIN: auto
         run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,6 @@ on:
 permissions:
   contents: read
 
-# arduino/setup-task hasn't shipped a Node 24 release yet
-# (https://github.com/arduino/setup-task/issues/1359). The runner
-# warns and will hard-fail in June 2026. Opt in to GitHub's forced
-# Node 24 shim until upstream releases v3.
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   test:
     strategy:
@@ -38,10 +31,12 @@ jobs:
           go-version-file: go.mod
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Use `go install` instead of arduino/setup-task to bypass
+        # GitHub's release CDN — that download has 502'd on us
+        # (e.g., PR #284 rerun). Go's module proxy is far more
+        # reliable, and pinning the version here keeps CI
+        # reproducible. Side benefit: no Node 20 deprecation shim.
+        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Build
         run: task build

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,11 +17,6 @@ on:
 permissions:
   contents: read
 
-# Opt into Node 24 shim until arduino/setup-task ships a Node 24
-# release (https://github.com/arduino/setup-task/issues/1359).
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 jobs:
   integration:
     strategy:
@@ -43,10 +38,8 @@ jobs:
           check-latest: true
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # See ci.yml — go install bypasses GitHub's release CDN.
+        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Run Integration Tests
         run: task test -- -run TestIntegration -v ./tests/

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Install Task
         # See ci.yml — go install bypasses GitHub's release CDN.
+        env:
+          GOTOOLCHAIN: auto
         run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Run Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,6 @@ permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.event.client_payload.tag || github.ref_name }}
-  # arduino/setup-task hasn't shipped Node 24 yet — opt into the
-  # forced shim (https://github.com/arduino/setup-task/issues/1359).
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
   build:
@@ -62,10 +59,8 @@ jobs:
         run: ${{ matrix.fuse_setup }}
 
       - name: Install Task
-        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2
-        with:
-          version: 3.x
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # See ci.yml — go install bypasses GitHub's release CDN.
+        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Exchange OIDC → GitHub token (octo-sts)
         id: octo-sts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Install Task
         # See ci.yml — go install bypasses GitHub's release CDN.
+        env:
+          GOTOOLCHAIN: auto
         run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
       - name: Exchange OIDC → GitHub token (octo-sts)


### PR DESCRIPTION
## Summary

The `arduino/setup-task` action downloads task from GitHub's release CDN, which has 502'd intermittently — most recently on PR #284's `ubuntu-latest` job, which only passed after a manual rerun. The action's built-in retry (17s, then 11s) wasn't enough.

Switch all three workflows (ci, integration, release) to:

```yaml
- name: Install Task
  run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
```

This:

- Hits **Go's module proxy** (`proxy.golang.org`), which has materially better availability than GitHub's release CDN.
- **Pins** task to `v3.50.0` (matches what `version: 3.x` resolved to today).
- **Removes** the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` shim entirely — no JS action means no Node 20 deprecation. Closes the upstream issue we were pinned on (https://github.com/arduino/setup-task/issues/1359).
- Drops one external action dependency.

**Trade-off**: ~30s slower per fresh CI run (compile from source vs prebuilt download). That's a fixed cost; the cost of CDN-flake reruns + manual unstuck-time is unbounded.

`setup-go` puts `$GOPATH/bin` on PATH automatically, so `task` resolves the same way it did under `arduino/setup-task`.

## Test plan

- [x] Verified `go install github.com/go-task/task/v3/cmd/task@v3.50.0` works locally; produces v3.50.0 binary in `$GOPATH/bin`.
- [x] All three workflows simplified consistently.
- [ ] Will be validated by CI on this PR (test, integration, lint, scan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)