### PR TITLE
fix(mcp): lazyGraph forwards LookupDef so find_definition takes the fast path

### DIFF
--- a/cmd/serve_find_callers_mount_test.go
+++ b/cmd/serve_find_callers_mount_test.go
@@ -161,6 +161,31 @@ func TestFindCallers_AnnotatesMountThroughLazyGraph(t *testing.T) {
 	assert.Contains(t, mounts, "billing", "billing mount label must reach the response")
 }
 
+// TestLazyGraph_LookupDef_ForwardsToInner pins the same
+// wrapper-passthrough invariant as MountPrefixOf, but for the
+// defsLookuper interface used by find_definition. Without
+// passthrough, the production handler always took the O(N)
+// DefsMap snapshot path because lazyGraph doesn't satisfy
+// defsLookuper directly — its inner does.
+func TestLazyGraph_LookupDef_ForwardsToInner(t *testing.T) {
+	store := graph.NewMemoryStore()
+	store.AddRoot(&graph.Node{ID: "pkg/funcs/Foo", Mode: 0})
+	require.NoError(t, store.AddDef("Foo", "pkg/funcs/Foo"))
+
+	lg := &lazyGraph{inner: store}
+	lg.once.Do(func() {})
+
+	// Sanity: lazyGraph satisfies defsLookuper through the wrapper.
+	dl, ok := graph.Graph(lg).(defsLookuper)
+	require.True(t, ok, "lazyGraph must satisfy defsLookuper (find_definition fast path depends on this)")
+
+	got := dl.LookupDef("Foo")
+	assert.Equal(t, []string{"pkg/funcs/Foo"}, got, "Foo def must surface through the wrapper")
+
+	// Unknown token returns nil/empty, not a phantom hit.
+	assert.Empty(t, dl.LookupDef("DoesNotExist"))
+}
+
 // TestCompositeGraph_MountPrefixOf is the unit test for the public
 // accessor added in this PR. Empty / virtual-root / unknown-prefix
 // inputs all return "" so handlers can distinguish "this id is

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -609,6 +609,26 @@ func (lg *lazyGraph) MountPrefixOf(id string) string {
 	return ""
 }
 
+// LookupDef forwards the optional defsLookuper interface so
+// find_definition's anchored-exact path can use the O(1) lookup
+// instead of falling through to the O(N) DefsMap snapshot. Without
+// this passthrough, every find_definition call in production paid
+// the snapshot cost even when the inner backend (MemoryStore,
+// SQLiteGraph, CompositeGraph) had a fast lookup available.
+//
+// Returns nil when the inner doesn't implement defsLookuper —
+// callers fall through to DefsMap as before.
+func (lg *lazyGraph) LookupDef(token string) []string {
+	g, err := lg.get()
+	if err != nil || g == nil {
+		return nil
+	}
+	if dl, ok := g.(interface{ LookupDef(string) []string }); ok {
+		return dl.LookupDef(token)
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Interface types for optional graph backend capabilities
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Same shape as #284's mount-annotation fix. The registry hands MCP handlers a `*lazyGraph` wrapper, and `serve_handlers.go:914` does:

\`\`\`go
if dl, ok := g.(defsLookuper); ok {
    if dirIDs := dl.LookupDef(symbol); len(dirIDs) > 0 { ... }
}
\`\`\`

`lazyGraph` didn't implement `LookupDef`, so the assertion silently missed and **every** `find_definition` call fell through to the O(N) `DefsMap()` snapshot. The inner backends (MemoryStore, SQLiteGraph, CompositeGraph) all expose O(1) `LookupDef`; lazyGraph just wasn't passing it through.

Forward `LookupDef` from `lazyGraph` to its inner. Returns nil when the inner doesn't implement it (so existing fall-through behavior is preserved for those backends).

Audited the other optional interfaces — `QueryRefs`, `RefsMap`, `DefsMap`, `UpdateNodeContent`, `ShiftOrigins`, `Schema`, `MountPrefixOf` (#284). `LookupDef` was the only remaining gap.

## Test plan

- `TestLazyGraph_LookupDef_ForwardsToInner` — asserts lazyGraph satisfies `defsLookuper` and returns the right defs for both hit and miss cases.
- All existing find_definition tests still pass.
- `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)