### PR TITLE
ci: pin gofumpt version so CI is reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,16 @@ jobs:
         run: go vet ./...
 
       - name: Format check (gofumpt)
+        # Pin gofumpt so CI fails reproducibly. @latest meant a
+        # local pre-commit running an older version could disagree
+        # with CI silently — pin matches the one installed locally
+        # via the Taskfile / pre-commit hooks. Bump together when
+        # we move forward.
+        env:
+          GOTOOLCHAIN: auto
         run: |
           set -euo pipefail
-          go install mvdan.cc/gofumpt@latest
+          go install mvdan.cc/gofumpt@v0.9.2
           gofumpt -d -extra . | tee /dev/stderr | (! grep .)
 
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9


### PR DESCRIPTION
## Summary

The format-check step did `go install mvdan.cc/gofumpt@latest`, which silently drifts between local pre-commit and CI. CI could fail today because gofumpt v0.9.2 adds a rule the local pre-commit doesn't apply yet (or vice versa).

Pin to **v0.9.2** (current latest) so `task fmt` locally and the CI format check produce the same diff. Bump together in one edit when we want to move forward.

Adds `GOTOOLCHAIN=auto` on this step (matches task install in #285): gofumpt's go.mod may require a newer toolchain than mache itself, and we don't want a transitive constraint to fail the install with `GOTOOLCHAIN=local` from setup-go v6.

## Test plan

- [x] Verified `gofumpt v0.9.2 -d -extra .` clean locally on current main
- [x] yaml syntax check passes
- [ ] CI on this PR validates the format step still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)