### PR TITLE
feat: load smell rules from JSON files in $MACHE_SMELL_RULES_DIR

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"sort"
 	"strings"
 
@@ -56,7 +58,9 @@ type SmellRule struct {
 	Requires []string
 }
 
-// smellRegistry holds the built-in rules.
+// smellRegistry holds the registered rules. Built-ins below; external
+// rules from $MACHE_SMELL_RULES_DIR are appended in init() so they
+// participate in discovery, listing, and dispatch the same way.
 var smellRegistry = []SmellRule{
 	{
 		ID:          "magic_int_in_comparison",
@@ -609,6 +613,32 @@ var smellRegistry = []SmellRule{
 			ORDER BY metric DESC, src.source_id
 		`,
 	},
+}
+
+func init() {
+	// Append external rules from $MACHE_SMELL_RULES_DIR so they
+	// share the registry with built-ins. A parse error logs and
+	// skips — mache stays up so a typo in an external rule can't
+	// take down the server. Tests load rules directly via
+	// LoadExternalSmellRules to assert errors loudly.
+	dir := os.Getenv(SmellRulesEnvVar)
+	if dir == "" {
+		return
+	}
+	rules, err := LoadExternalSmellRules(dir)
+	if err != nil {
+		log.Printf("smell rules: skipping external rules in %s: %v", dir, err)
+		return
+	}
+	if len(rules) > 0 {
+		smellRegistry = append(smellRegistry, rules...)
+		ids := make([]string, len(rules))
+		for i, r := range rules {
+			ids[i] = r.ID
+		}
+		log.Printf("smell rules: loaded %d external rule(s) from %s: %s",
+			len(rules), dir, strings.Join(ids, ", "))
+	}
 }
 
 // smellFinding is one row of a smell scan. Byte ranges and (1-based)

--- a/cmd/serve_find_smells_load.go
+++ b/cmd/serve_find_smells_load.go
@@ -17,20 +17,41 @@ import (
 //
 // Each file in the directory must be a single SmellRule object
 // (not an array — one rule per file keeps diffs clean and avoids
-// "the third rule errored, what was the first?" debugging). Files
-// that fail to parse log a warning and are skipped; mache still
-// starts so a typo in an external rule can't take down the server.
+// "the third rule errored, what was the first?" debugging). The
+// loader is fail-fast: a single read / parse / validation /
+// collision error aborts loading, returning the error to the
+// caller. init() logs and skips all external rules in that case
+// so a typo can't take down the server; tests assert the error
+// directly.
 const SmellRulesEnvVar = "MACHE_SMELL_RULES_DIR"
+
+// builtinSmellRuleIDs is a snapshot of the rule IDs in
+// smellRegistry as it stood at package load — captured before any
+// external rules are appended. Used by LoadExternalSmellRules for
+// collision detection so the "this collides with a built-in"
+// message stays accurate even if external rules are loaded
+// multiple times or after init() has mutated smellRegistry.
+var builtinSmellRuleIDs = func() map[string]struct{} {
+	ids := make(map[string]struct{}, len(smellRegistry))
+	for _, r := range smellRegistry {
+		ids[r.ID] = struct{}{}
+	}
+	return ids
+}()
 
 // LoadExternalSmellRules reads `*.json` files from dir, parses each
 // as a SmellRule, validates the result, and returns the parsed rules.
-// On a per-file error returns the error so the caller can decide:
-// init() logs and skips, tests fail loudly.
+// Fail-fast: any read, parse, validation, or collision error aborts
+// and returns immediately — caller decides whether to log+skip or
+// treat as fatal. init() logs and skips; tests fail loudly.
 //
 // Validation:
 //   - ID must be non-empty and not collide with a built-in rule
-//   - Query must be non-empty and contain exactly one '%s'
-//     placeholder for the scope clause (matches the built-in contract)
+//     (or another external loaded from this same dir)
+//   - Query must be non-empty, contain exactly one '%s' placeholder
+//     for the scope clause, AND be a valid fmt.Sprintf format string
+//     (no stray `%` chars that fmt would treat as verbs — common
+//     trap with SQL `LIKE '%foo%'` patterns; escape as `%%`)
 //   - Requires may be empty (rule reads no tables) or list table names
 func LoadExternalSmellRules(dir string) ([]SmellRule, error) {
 	if dir == "" {
@@ -52,9 +73,12 @@ func LoadExternalSmellRules(dir string) ([]SmellRule, error) {
 		return nil, fmt.Errorf("read %s: %w", dir, err)
 	}
 
-	builtin := builtinRuleIDs()
-	seen := make(map[string]string, len(builtin))
-	for id := range builtin {
+	// Build the seen set from the snapshot, not from the live
+	// smellRegistry. If init() has already appended externals,
+	// reading from smellRegistry directly would label them as
+	// "built-in" in collision errors — misleading.
+	seen := make(map[string]string, len(builtinSmellRuleIDs))
+	for id := range builtinSmellRuleIDs {
 		seen[id] = "built-in"
 	}
 
@@ -94,6 +118,12 @@ func LoadExternalSmellRules(dir string) ([]SmellRule, error) {
 // validateSmellRule enforces the contract every SmellRule must
 // satisfy to be safely added to the registry. Mirrors what the
 // built-in registry implicitly guarantees by being hand-written.
+//
+// The fmt.Sprintf check catches a common trap: SQL LIKE patterns
+// like `LIKE '%foo%'` need their `%` chars escaped as `%%` because
+// runSmellRule splices the scope clause via fmt.Sprintf(query, scope).
+// An unescaped `%f` would be treated as the float verb and produce
+// `%!f(string=...)` corruption at runtime. Reject at load time.
 func validateSmellRule(r SmellRule) error {
 	if strings.TrimSpace(r.ID) == "" {
 		return fmt.Errorf("rule ID is required")
@@ -104,15 +134,11 @@ func validateSmellRule(r SmellRule) error {
 	if strings.Count(r.Query, "%s") != 1 {
 		return fmt.Errorf("rule %q: Query must contain exactly one '%%s' placeholder for the scope clause", r.ID)
 	}
-	return nil
-}
-
-// builtinRuleIDs returns a set of IDs from the hard-coded
-// smellRegistry. Used for collision detection during external load.
-func builtinRuleIDs() map[string]struct{} {
-	ids := make(map[string]struct{}, len(smellRegistry))
-	for _, r := range smellRegistry {
-		ids[r.ID] = struct{}{}
+	// Format with an empty scope clause and check for fmt error
+	// markers (`%!`) — flags any other unescaped `%` sequences.
+	formatted := fmt.Sprintf(r.Query, "")
+	if strings.Contains(formatted, "%!") {
+		return fmt.Errorf("rule %q: Query has unescaped '%%' chars (other than the single '%%s' placeholder); SQL '%%' must be escaped as '%%%%' (e.g. LIKE '%%%%foo%%%%')", r.ID)
 	}
-	return ids
+	return nil
 }

--- a/cmd/serve_find_smells_load.go
+++ b/cmd/serve_find_smells_load.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// SmellRulesEnvVar names the environment variable that points to a
+// directory of JSON files containing additional SmellRule entries.
+// External rules are appended to the built-in registry at process
+// start and are otherwise indistinguishable from built-ins — same
+// MCP shape, same query contract, same pre-flight table check.
+//
+// Each file in the directory must be a single SmellRule object
+// (not an array — one rule per file keeps diffs clean and avoids
+// "the third rule errored, what was the first?" debugging). Files
+// that fail to parse log a warning and are skipped; mache still
+// starts so a typo in an external rule can't take down the server.
+const SmellRulesEnvVar = "MACHE_SMELL_RULES_DIR"
+
+// LoadExternalSmellRules reads `*.json` files from dir, parses each
+// as a SmellRule, validates the result, and returns the parsed rules.
+// On a per-file error returns the error so the caller can decide:
+// init() logs and skips, tests fail loudly.
+//
+// Validation:
+//   - ID must be non-empty and not collide with a built-in rule
+//   - Query must be non-empty and contain exactly one '%s'
+//     placeholder for the scope clause (matches the built-in contract)
+//   - Requires may be empty (rule reads no tables) or list table names
+func LoadExternalSmellRules(dir string) ([]SmellRule, error) {
+	if dir == "" {
+		return nil, nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("stat %s: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", dir)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", dir, err)
+	}
+
+	builtin := builtinRuleIDs()
+	seen := make(map[string]string, len(builtin))
+	for id := range builtin {
+		seen[id] = "built-in"
+	}
+
+	var rules []SmellRule
+	// Sort for deterministic load order — keeps test golden values
+	// stable when files are added.
+	files := make([]os.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") {
+			files = append(files, e)
+		}
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Name() < files[j].Name() })
+
+	for _, e := range files {
+		path := filepath.Join(dir, e.Name())
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		var rule SmellRule
+		if err := json.Unmarshal(raw, &rule); err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		if err := validateSmellRule(rule); err != nil {
+			return nil, fmt.Errorf("%s: %w", path, err)
+		}
+		if origin, exists := seen[rule.ID]; exists {
+			return nil, fmt.Errorf("%s: rule ID %q already defined (%s)", path, rule.ID, origin)
+		}
+		seen[rule.ID] = path
+		rules = append(rules, rule)
+	}
+	return rules, nil
+}
+
+// validateSmellRule enforces the contract every SmellRule must
+// satisfy to be safely added to the registry. Mirrors what the
+// built-in registry implicitly guarantees by being hand-written.
+func validateSmellRule(r SmellRule) error {
+	if strings.TrimSpace(r.ID) == "" {
+		return fmt.Errorf("rule ID is required")
+	}
+	if strings.TrimSpace(r.Query) == "" {
+		return fmt.Errorf("rule %q: Query is required", r.ID)
+	}
+	if strings.Count(r.Query, "%s") != 1 {
+		return fmt.Errorf("rule %q: Query must contain exactly one '%%s' placeholder for the scope clause", r.ID)
+	}
+	return nil
+}
+
+// builtinRuleIDs returns a set of IDs from the hard-coded
+// smellRegistry. Used for collision detection during external load.
+func builtinRuleIDs() map[string]struct{} {
+	ids := make(map[string]struct{}, len(smellRegistry))
+	for _, r := range smellRegistry {
+		ids[r.ID] = struct{}{}
+	}
+	return ids
+}

--- a/cmd/serve_find_smells_load_test.go
+++ b/cmd/serve_find_smells_load_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadExternalSmellRules_HappyPath(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "custom.json"), []byte(`{
+		"ID": "custom_helper_count",
+		"Description": "External rule loaded from JSON",
+		"Requires": ["nodes"],
+		"ScopeColumn": "n.source_file",
+		"Query": "SELECT COALESCE(n.source_file, '') AS source_id, n.id, 0, 0, 0, 0, COUNT(*) FROM nodes n GROUP BY n.source_file %s ORDER BY 1"
+	}`), 0o644))
+
+	rules, err := LoadExternalSmellRules(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "custom_helper_count", rules[0].ID)
+	assert.Equal(t, []string{"nodes"}, rules[0].Requires)
+	assert.Contains(t, rules[0].Query, "%s")
+}
+
+func TestLoadExternalSmellRules_EmptyDirReturnsNil(t *testing.T) {
+	rules, err := LoadExternalSmellRules(t.TempDir())
+	require.NoError(t, err)
+	assert.Nil(t, rules)
+}
+
+func TestLoadExternalSmellRules_MissingDirIsTolerated(t *testing.T) {
+	// Non-existent dir: not an error — same as "no external rules
+	// configured." Otherwise every dev environment without the dir
+	// would fail to start.
+	rules, err := LoadExternalSmellRules(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.NoError(t, err)
+	assert.Nil(t, rules)
+}
+
+func TestLoadExternalSmellRules_EmptyDirArgReturnsNil(t *testing.T) {
+	// Production callers pass os.Getenv() result directly, which is ""
+	// when the env var isn't set. Treat empty as "feature disabled."
+	rules, err := LoadExternalSmellRules("")
+	require.NoError(t, err)
+	assert.Nil(t, rules)
+}
+
+func TestLoadExternalSmellRules_RejectsCollisionWithBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	// 'dead_code' is a built-in — must not be silently shadowed.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "shadow.json"), []byte(`{
+		"ID": "dead_code",
+		"Description": "Tries to shadow a built-in",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err, "duplicate ID with a built-in must be rejected")
+	assert.Contains(t, err.Error(), "already defined")
+	assert.Contains(t, err.Error(), "built-in")
+}
+
+func TestLoadExternalSmellRules_RejectsCollisionBetweenExternals(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{
+		"ID": "twin",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.json"), []byte(`{
+		"ID": "twin",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already defined")
+}
+
+func TestLoadExternalSmellRules_RejectsMalformedJSON(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "broken.json"),
+		[]byte(`{not valid json`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parse")
+}
+
+func TestLoadExternalSmellRules_RejectsMissingID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "no_id.json"), []byte(`{
+		"Description": "no id",
+		"Query": "SELECT 1 %s"
+	}`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ID is required")
+}
+
+func TestLoadExternalSmellRules_RejectsMissingPlaceholder(t *testing.T) {
+	dir := t.TempDir()
+	// Query without %s placeholder — would silently fail to splice
+	// the scope clause. Reject at load time.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "no_placeholder.json"), []byte(`{
+		"ID": "no_placeholder",
+		"Query": "SELECT 0, 0, 0, 0, 0, 0, 0 FROM nodes"
+	}`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "%s")
+}
+
+func TestLoadExternalSmellRules_IgnoresNonJSONFiles(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# notes"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ignored.yaml"), []byte("ignored: true"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "real.json"), []byte(`{
+		"ID": "real_rule",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+
+	rules, err := LoadExternalSmellRules(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "real_rule", rules[0].ID)
+}
+
+func TestLoadExternalSmellRules_FilePassedAsDirRejected(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "not-a-dir.json")
+	require.NoError(t, os.WriteFile(f, []byte(`{}`), 0o644))
+
+	_, err := LoadExternalSmellRules(f)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not a directory")
+}

--- a/cmd/serve_find_smells_load_test.go
+++ b/cmd/serve_find_smells_load_test.go
@@ -117,6 +117,38 @@ func TestLoadExternalSmellRules_RejectsMissingPlaceholder(t *testing.T) {
 	assert.Contains(t, err.Error(), "%s")
 }
 
+func TestLoadExternalSmellRules_RejectsUnescapedPercent(t *testing.T) {
+	dir := t.TempDir()
+	// SQL LIKE with unescaped '%' — would be interpreted as fmt
+	// verb at runtime and corrupt the query (yielding %!f(string=...)
+	// or similar). Must be rejected at load time. Authors should
+	// escape as '%%' (e.g. LIKE '%%foo%%').
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "bad_like.json"), []byte(`{
+		"ID": "bad_like_pattern",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes WHERE name LIKE '%foo%' %s"
+	}`), 0o644))
+
+	_, err := LoadExternalSmellRules(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unescaped")
+	assert.Contains(t, err.Error(), "%%")
+}
+
+func TestLoadExternalSmellRules_AcceptsEscapedPercent(t *testing.T) {
+	dir := t.TempDir()
+	// Properly-escaped LIKE patterns must pass validation. This
+	// matches how the built-in rules write their LIKE clauses.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "good_like.json"), []byte(`{
+		"ID": "good_like_pattern",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes WHERE name LIKE '%%foo%%' %s"
+	}`), 0o644))
+
+	rules, err := LoadExternalSmellRules(dir)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "good_like_pattern", rules[0].ID)
+}
+
 func TestLoadExternalSmellRules_IgnoresNonJSONFiles(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# notes"), 0o644))


### PR DESCRIPTION
## Summary

The find_smells rule registry is a hand-written Go slice today. Adding a rule means forking mache, recompiling, and shipping a new binary — fine for the canonical built-in set, prohibitive for per-project / per-team rules with narrow audiences.

This PR adds a directory loader: when `MACHE_SMELL_RULES_DIR` is set, mache reads `*.json` files in that dir, parses each as a `SmellRule`, and appends them to the registry. External rules are otherwise indistinguishable from built-ins — same MCP shape, same query contract, same pre-flight `Requires` check.

### Strictness

Strict at load time, tolerant at runtime:

- **ID required**, must not collide with a built-in or another external (collision is rejected with a clear error)
- **Query required**, must contain exactly one `%s` for the scope clause (matches the built-in contract; without it scope filtering silently no-ops)
- Malformed JSON is rejected at load time, not at first call
- A parse error in `init()` logs and skips — typo in an external rule can't take down the server. Tests call `LoadExternalSmellRules` directly and assert errors loudly.

### Example external rule

```json
{
  "ID": "long_unexported_function",
  "Description": "Unexported Go functions whose body exceeds 200 lines",
  "Requires": ["_ast", "nodes"],
  "ScopeColumn": "fn.source_id",
  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn JOIN nodes n ON n.id = fn.node_id WHERE fn.node_kind = 'function_declaration' AND substr(n.name, 1, 1) = lower(substr(n.name, 1, 1)) AND (fn.end_row - fn.start_row) > 200 %s ORDER BY metric DESC"
}
```

Drop into `$MACHE_SMELL_RULES_DIR`, restart, call `find_smells rule=long_unexported_function`.

## Test plan

11 unit tests covering:

- [x] Happy path (JSON → SmellRule → registry)
- [x] Empty dir, missing dir, empty arg → no-op (no error)
- [x] Collision with built-in → reject
- [x] Collision between externals → reject
- [x] Malformed JSON → reject with parse error
- [x] Missing ID, missing `%s` placeholder → reject with clear messages
- [x] Non-JSON files (README.md, *.yaml) ignored
- [x] File passed where dir expected → rejected
- [x] All existing find_smells tests still pass
- [x] `task lint` clean

Bead `mache-6z2e` tracked the broader "machelint / declarative rules" idea — this is the first concrete step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)