### PR TITLE
docs: ship example external smell rule + extension-point README

### DIFF
--- a/cmd/serve_find_smells_load_test.go
+++ b/cmd/serve_find_smells_load_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -179,10 +180,19 @@ func TestLoadExternalSmellRules_FilePassedAsDirRejected(t *testing.T) {
 // without errors — otherwise the docs lie. If a future contributor
 // adds an example that doesn't validate, this test catches it
 // before merge.
+//
+// Resolves the examples dir via runtime.Caller so the path is
+// anchored to the test source file rather than the package's
+// working directory. macOS CI runners on `go test ./...` produced
+// flaky NotExist errors with a relative `../examples/smell-rules`
+// path; runtime.Caller is invariant across platforms and
+// invocation styles.
 func TestLoadExternalSmellRules_ShippedExamplesLoadCleanly(t *testing.T) {
-	// Path is relative to the package, which sits at cmd/. The
-	// examples dir is at the repo root. Walk up one level.
-	rules, err := LoadExternalSmellRules("../examples/smell-rules")
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok, "runtime.Caller must succeed to resolve the test file path")
+	exampleDir := filepath.Join(filepath.Dir(thisFile), "..", "examples", "smell-rules")
+
+	rules, err := LoadExternalSmellRules(exampleDir)
 	require.NoError(t, err, "examples/smell-rules/ must load without errors — keep the docs honest")
 	require.NotEmpty(t, rules, "at least one example rule should ship")
 	for _, r := range rules {

--- a/cmd/serve_find_smells_load_test.go
+++ b/cmd/serve_find_smells_load_test.go
@@ -172,3 +172,21 @@ func TestLoadExternalSmellRules_FilePassedAsDirRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not a directory")
 }
+
+// TestLoadExternalSmellRules_ShippedExamplesLoadCleanly is the
+// "don't ship a broken example" regression. Anything we put in
+// examples/smell-rules/ has to round-trip through the loader
+// without errors — otherwise the docs lie. If a future contributor
+// adds an example that doesn't validate, this test catches it
+// before merge.
+func TestLoadExternalSmellRules_ShippedExamplesLoadCleanly(t *testing.T) {
+	// Path is relative to the package, which sits at cmd/. The
+	// examples dir is at the repo root. Walk up one level.
+	rules, err := LoadExternalSmellRules("../examples/smell-rules")
+	require.NoError(t, err, "examples/smell-rules/ must load without errors — keep the docs honest")
+	require.NotEmpty(t, rules, "at least one example rule should ship")
+	for _, r := range rules {
+		assert.NotEmpty(t, r.ID)
+		assert.NotEmpty(t, r.Query)
+	}
+}

--- a/examples/smell-rules/README.md
+++ b/examples/smell-rules/README.md
@@ -1,0 +1,90 @@
+# External smell rules
+
+Drop-in `*.json` files that define additional `find_smells` rules,
+loaded at process start when `MACHE_SMELL_RULES_DIR` points at the
+directory containing them.
+
+```bash
+export MACHE_SMELL_RULES_DIR=$(pwd)/examples/smell-rules
+mache serve --http :7532
+```
+
+Each external rule shows up in `find_smells` discovery (the no-arg
+listing) and as a runnable rule (`find_smells rule=<id>`) the same
+way built-ins do.
+
+## File layout
+
+One rule per file. The filename has no semantic meaning beyond
+sort order during load — pick something that matches the rule ID
+for clarity.
+
+## Rule shape
+
+```json
+{
+  "ID": "long_unexported_function",
+  "Description": "Unexported Go functions whose body exceeds 200 lines.",
+  "Requires": ["_ast", "nodes"],
+  "ScopeColumn": "fn.source_id",
+  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn JOIN nodes n ON n.id = fn.node_id WHERE ... %s ORDER BY metric DESC"
+}
+```
+
+| Field         | Required    | Notes                                                                                                                  |
+| ------------- | ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `ID`          | yes         | Stable identifier. Must not collide with a built-in.                                                                   |
+| `Description` | recommended | Shown in the rule listing — agents read this.                                                                          |
+| `Requires`    | recommended | SQL tables the query reads. Used for the pre-flight "this rule needs `_ast`, your backend doesn't have it" diagnostic. |
+| `ScopeColumn` | optional    | SQL expression compared to `source_id` when callers pass a `source_id` arg. Leave blank to disable scoping.            |
+| `Query`       | yes         | SQL with **exactly one `%s`** placeholder for the scope clause.                                                        |
+
+## The query contract
+
+Every query MUST select these seven columns in this order:
+
+```
+source_id, node_id, start_byte, end_byte, start_row, start_col, metric
+```
+
+- `source_id` — the source file path, used for filtering.
+- `node_id` — the construct dir or AST node ID being flagged.
+- `start_byte`, `end_byte` — byte range of the offending span.
+- `start_row`, `start_col` — 0-based line/column (the handler converts to 1-based for the response).
+- `metric` — integer score. Use `0` for binary rules with no metric.
+
+Any rule that doesn't match this column shape will produce a SQL
+error at run time and the agent will get a tool error.
+
+## SQL caveats
+
+- **Escape `%` chars.** The query is `fmt.Sprintf`'d at run time
+  to splice in the optional scope clause. Any `%` that isn't part
+  of `%s` must be escaped as `%%`. The loader rejects rules with
+  unescaped `%` at startup (regression: a stray `%` in a `LIKE`
+  pattern would corrupt the query at the first call).
+- **Table availability.** Built-in mache produces `nodes`,
+  `node_refs`, `node_defs`. ley-line-parsed `.db` files
+  additionally have `_ast`, `_source`, `_imports`, and `_lsp*`.
+  Declare in `Requires` so the pre-flight check catches missing
+  tables before the SQL runs.
+
+## Validation
+
+The loader validates every rule at startup:
+
+- Non-empty `ID`, no collision with a built-in or another external
+- Non-empty `Query` with exactly one `%s` placeholder
+- `fmt.Sprintf` over the query produces no `%!` error markers
+  (catches unescaped `%` chars in `LIKE` patterns and similar)
+
+A validation failure aborts the load and logs a warning — mache
+starts without external rules rather than failing to boot. Tests
+call `LoadExternalSmellRules` directly and assert errors loudly.
+
+## Example rule
+
+[`long_unexported_function.json`](long_unexported_function.json) is
+an example rule that flags Go functions with lowercase names whose
+body spans more than 200 source lines. Drop the file in your
+`MACHE_SMELL_RULES_DIR` and call `find_smells rule=long_unexported_function`.

--- a/examples/smell-rules/long_unexported_function.json
+++ b/examples/smell-rules/long_unexported_function.json
@@ -1,0 +1,7 @@
+{
+  "ID": "long_unexported_function",
+  "Description": "Unexported Go functions whose body exceeds 200 source lines. Long unexported helpers tend to grow without review pressure — they're hidden from the package API surface and nobody complains until they break. Threshold of 200 is deliberately higher than the built-in long_function (80) because a long unexported function is a softer signal than a long exported one.",
+  "Requires": ["_ast", "nodes"],
+  "ScopeColumn": "fn.source_id",
+  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn JOIN nodes n ON n.id = fn.node_id WHERE fn.node_kind = 'function_declaration' AND substr(n.name, 1, 1) = lower(substr(n.name, 1, 1)) AND (fn.end_row - fn.start_row) > 200 %s ORDER BY metric DESC, fn.source_id"
+}


### PR DESCRIPTION
## Summary

Follow-up to #288. The loader is in place; this PR adds the documentation seam users need to actually use it.

- `examples/smell-rules/long_unexported_function.json` — a generic Go-flavored example rule (lowercase function name + body > 200 lines) that demonstrates the schema, the seven-column query contract, and a non-trivial SQL query joining `_ast` and `nodes`.
- `examples/smell-rules/README.md` — full reference: file layout, field-by-field schema, query contract, SQL caveats (especially the `%%` escape for `LIKE` patterns that the loader now validates), and validation rules.

## Test plan

- [x] `TestLoadExternalSmellRules_ShippedExamplesLoadCleanly` — round-trips every file in `examples/smell-rules/` through the loader and asserts no errors. Catches future contributors who add a malformed example before it merges.
- [x] All existing tests still pass.
- [x] `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)