### PR TITLE
refactor: extract testable appendExternalRulesFromEnv helper

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -617,28 +617,46 @@ var smellRegistry = []SmellRule{
 
 func init() {
 	// Append external rules from $MACHE_SMELL_RULES_DIR so they
-	// share the registry with built-ins. A parse error logs and
-	// skips — mache stays up so a typo in an external rule can't
-	// take down the server. Tests load rules directly via
-	// LoadExternalSmellRules to assert errors loudly.
-	dir := os.Getenv(SmellRulesEnvVar)
+	// share the registry with built-ins. Delegates to
+	// appendExternalRulesFromEnv so the wiring is testable —
+	// init() itself can't be re-run with different env values
+	// across tests, but the helper takes the value as a param.
+	// Errors are already logged inside the helper; init() just
+	// drops the return value.
+	_, _ = appendExternalRulesFromEnv(os.Getenv(SmellRulesEnvVar))
+}
+
+// appendExternalRulesFromEnv loads external rules from the given
+// directory path (typically `$MACHE_SMELL_RULES_DIR`) and appends
+// them to smellRegistry. A load error logs and skips the
+// extension entirely — mache stays up so a typo in an external
+// rule can't take down the server. Tests call
+// LoadExternalSmellRules directly to assert errors loudly; this
+// helper exercises the full append + log path.
+//
+// Returns (added, err): the count of appended rules and any
+// load error. err is nil-on-empty-dir (no env, no error). Tests
+// inspect the return; init() ignores it (logs at the source).
+func appendExternalRulesFromEnv(dir string) (int, error) {
 	if dir == "" {
-		return
+		return 0, nil
 	}
 	rules, err := LoadExternalSmellRules(dir)
 	if err != nil {
 		log.Printf("smell rules: skipping external rules in %s: %v", dir, err)
-		return
+		return 0, err
 	}
-	if len(rules) > 0 {
-		smellRegistry = append(smellRegistry, rules...)
-		ids := make([]string, len(rules))
-		for i, r := range rules {
-			ids[i] = r.ID
-		}
-		log.Printf("smell rules: loaded %d external rule(s) from %s: %s",
-			len(rules), dir, strings.Join(ids, ", "))
+	if len(rules) == 0 {
+		return 0, nil
 	}
+	smellRegistry = append(smellRegistry, rules...)
+	ids := make([]string, len(rules))
+	for i, r := range rules {
+		ids[i] = r.ID
+	}
+	log.Printf("smell rules: loaded %d external rule(s) from %s: %s",
+		len(rules), dir, strings.Join(ids, ", "))
+	return len(rules), nil
 }
 
 // smellFinding is one row of a smell scan. Byte ranges and (1-based)

--- a/cmd/serve_find_smells_load_test.go
+++ b/cmd/serve_find_smells_load_test.go
@@ -174,6 +174,83 @@ func TestLoadExternalSmellRules_FilePassedAsDirRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "not a directory")
 }
 
+// snapshotSmellRegistry captures the current registry so a test
+// that mutates it via appendExternalRulesFromEnv can restore the
+// original state. The package-level smellRegistry is the source
+// of truth for the rules listing — tests that leave it dirty
+// would corrupt subsequent test cases that expect only built-ins.
+func snapshotSmellRegistry(t *testing.T) {
+	t.Helper()
+	saved := make([]SmellRule, len(smellRegistry))
+	copy(saved, smellRegistry)
+	t.Cleanup(func() { smellRegistry = saved })
+}
+
+func TestAppendExternalRulesFromEnv_EmptyEnvIsNoOp(t *testing.T) {
+	snapshotSmellRegistry(t)
+	added, err := appendExternalRulesFromEnv("")
+	require.NoError(t, err)
+	assert.Equal(t, 0, added)
+}
+
+func TestAppendExternalRulesFromEnv_AppendsLoadedRules(t *testing.T) {
+	snapshotSmellRegistry(t)
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ext1.json"), []byte(`{
+		"ID": "test_appender_rule_1",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ext2.json"), []byte(`{
+		"ID": "test_appender_rule_2",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+
+	beforeCount := len(smellRegistry)
+	added, err := appendExternalRulesFromEnv(dir)
+	require.NoError(t, err)
+	assert.Equal(t, 2, added)
+	assert.Len(t, smellRegistry, beforeCount+2)
+
+	// Both rules are findable through the listing path.
+	ids := allRuleIDs()
+	assert.Contains(t, ids, "test_appender_rule_1")
+	assert.Contains(t, ids, "test_appender_rule_2")
+}
+
+func TestAppendExternalRulesFromEnv_LoadErrorSkipsAllRules(t *testing.T) {
+	snapshotSmellRegistry(t)
+	dir := t.TempDir()
+	// One valid rule, one collision with a built-in. The whole
+	// load fails (fail-fast), so neither is appended — even the
+	// valid one is dropped, mirroring the init() "skip the whole
+	// extension on any error" contract.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a_valid.json"), []byte(`{
+		"ID": "test_skip_appender_valid",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b_collide.json"), []byte(`{
+		"ID": "dead_code",
+		"Query": "SELECT 0,0,0,0,0,0,0 FROM nodes %s"
+	}`), 0o644))
+
+	beforeCount := len(smellRegistry)
+	added, err := appendExternalRulesFromEnv(dir)
+	require.Error(t, err, "collision must be returned, not swallowed")
+	assert.Equal(t, 0, added)
+	assert.Len(t, smellRegistry, beforeCount, "registry must be untouched after a load error")
+	assert.NotContains(t, allRuleIDs(), "test_skip_appender_valid",
+		"the valid rule must NOT leak in when its sibling fails (atomic load)")
+}
+
+func TestAppendExternalRulesFromEnv_MissingDirIsNoOp(t *testing.T) {
+	snapshotSmellRegistry(t)
+	beforeCount := len(smellRegistry)
+	added, err := appendExternalRulesFromEnv(filepath.Join(t.TempDir(), "no-such-dir"))
+	require.NoError(t, err, "missing dir is treated as 'extension not configured'")
+	assert.Equal(t, 0, added)
+	assert.Len(t, smellRegistry, beforeCount)
+}
+
 // TestLoadExternalSmellRules_ShippedExamplesLoadCleanly is the
 // "don't ship a broken example" regression. Anything we put in
 // examples/smell-rules/ has to round-trip through the loader


### PR DESCRIPTION
## Summary

`init()` reads `\$MACHE_SMELL_RULES_DIR`, loads rules, and appends them to `smellRegistry`. That whole wiring path was untested because `sync.Once`-bound `init()` can't be re-run with different env values across test cases.

Extract `appendExternalRulesFromEnv(dir string) (int, error)` that takes the value as a parameter; `init()` now just calls it with `os.Getenv`. The helper is testable in isolation, exercises the full append + log + error-skip path, and pins the contract that load errors leave `smellRegistry` untouched (atomic — even the valid rules in a dir with one bad file get dropped, matching the fail-fast contract from #288).

## Tests

Four new tests covering:

- `TestAppendExternalRulesFromEnv_EmptyEnvIsNoOp` — empty env value → no-op
- `TestAppendExternalRulesFromEnv_AppendsLoadedRules` — valid load → rules appended, listing surfaces them
- `TestAppendExternalRulesFromEnv_LoadErrorSkipsAllRules` — load error → registry untouched (atomic), even sibling-valid rules dropped
- `TestAppendExternalRulesFromEnv_MissingDirIsNoOp` — missing dir → no error, no append

`snapshotSmellRegistry` test helper restores the registry after each test so subsequent tests see only the built-ins (registry is package-level state shared across tests).

## Test plan

- [x] All 15 loader tests pass (4 new + 11 existing)
- [x] `task lint` clean
- [x] No behavior change in `init()` — pure refactor + tests for the previously-untested wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)