### PR TITLE
fix(mcp): get_type_info / get_diagnostics fail fast on non-SQL backends

### DIFF
--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -39,7 +39,15 @@ func makeGetTypeInfoHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultError("symbol is required"), nil
 		}
 
-		qg := g.(refsQuerier)
+		// Fail fast on non-SQL backends with a clear message instead
+		// of the generic post-assertion "LSP data not available" which
+		// is the same string we use for "table missing." Today
+		// lazyGraph always satisfies refsQuerier; this guards a future
+		// backend that drops the method.
+		qg, ok := g.(refsQuerier)
+		if !ok {
+			return mcp.NewToolResultError("get_type_info requires a SQL-capable graph backend (mache standalone or leyline-parsed .db)"), nil
+		}
 
 		// Check if _lsp_hover table exists
 		rows, err := qg.QueryRefs(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_lsp_hover'`)
@@ -74,7 +82,12 @@ func makeGetDiagnosticsHandler(g graph.Graph) server.ToolHandlerFunc {
 		symbol := request.GetString("symbol", "")
 		limit := request.GetInt("limit", 50)
 
-		qg := g.(refsQuerier)
+		// Mirror get_type_info: fail fast with a specific error if
+		// the backend doesn't support SQL queries.
+		qg, ok := g.(refsQuerier)
+		if !ok {
+			return mcp.NewToolResultError("get_diagnostics requires a SQL-capable graph backend (mache standalone or leyline-parsed .db)"), nil
+		}
 
 		// Check if _lsp table exists
 		rows, err := qg.QueryRefs(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_lsp'`)

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -914,6 +914,38 @@ func TestGetDiagnostics_NoLSPTableWithFile(t *testing.T) {
 		"expected LSP or enrichment error, got: %s", text)
 }
 
+// TestGetTypeInfo_RejectsNonRefsQuerierBackend pins the fail-fast
+// contract: if the graph backend doesn't implement refsQuerier
+// (which provides QueryRefs for SQL access), get_type_info must
+// refuse with a clear error mentioning the SQL-backend
+// requirement, not a generic "data not available" message and
+// not an unchecked-assertion panic.
+//
+// Today MemoryStore + lazyGraph both satisfy refsQuerier, so
+// this only fires for a future backend that drops the method.
+// The test uses a minimal Graph implementation that deliberately
+// omits QueryRefs.
+func TestGetTypeInfo_RejectsNonRefsQuerierBackend(t *testing.T) {
+	g := &readOnlyGraph{node: &graph.Node{ID: "x"}}
+	handler := makeGetTypeInfoHandler(g)
+
+	result, err := handler(context.Background(), makeRequest(map[string]any{"symbol": "Foo"}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "non-refsQuerier backend must yield an error result")
+	assert.Contains(t, resultText(t, result), "SQL-capable",
+		"error must explain the missing capability, not say 'data not available'")
+}
+
+func TestGetDiagnostics_RejectsNonRefsQuerierBackend(t *testing.T) {
+	g := &readOnlyGraph{node: &graph.Node{ID: "x"}}
+	handler := makeGetDiagnosticsHandler(g)
+
+	result, err := handler(context.Background(), makeRequest(map[string]any{}))
+	require.NoError(t, err)
+	require.True(t, result.IsError, "non-refsQuerier backend must yield an error result")
+	assert.Contains(t, resultText(t, result), "SQL-capable")
+}
+
 // ---------------------------------------------------------------------------
 // get_impact handler tests
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Same shape as #278's `writeBacker` fix. `makeGetTypeInfoHandler` and `makeGetDiagnosticsHandler` did:

\`\`\`go
qg := g.(refsQuerier)
rows, err := qg.QueryRefs(...)
\`\`\`

Two issues:

- **Unchecked type assertion.** Today `lazyGraph` always satisfies `refsQuerier`, but a future backend that drops `QueryRefs` would panic the handler.
- **The post-assertion error path uses the generic message** \"LSP data not available for this data source\" — same string we use for \"table missing.\" A backend missing SQL entirely got conflated with a backend missing the LSP table.

Add the `ok` check up front. If the backend doesn't satisfy `refsQuerier`, return a specific tool error mentioning the SQL-capable requirement and the difference between mache standalone and a leyline-parsed `.db`. Falls back to the existing \"table missing\" path only when `QueryRefs` is actually available.

## Tests

Two new regression tests using a minimal `readOnlyGraph` (no `QueryRefs` method):

- `TestGetTypeInfo_RejectsNonRefsQuerierBackend` — pins both the error message and the no-panic invariant
- `TestGetDiagnostics_RejectsNonRefsQuerierBackend` — same

All existing LSP tests still pass.

## Test plan

- [x] `go test ./cmd/` — all passing including new + existing LSP tests
- [x] `task lint` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)