### PR TITLE
fix(mcp): search/role=reference filters file-level sentinel rows

### DIFF
--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -621,6 +621,14 @@ func makeSearchHandler(g graph.Graph) server.ToolHandlerFunc {
 
 		// Reference search (default): query mache_refs (vtab) or node_refs (real table).
 		// Leyline-parsed .dbs have node_refs (token, node_id); legacy sidecar has mache_refs (token, path).
+		//
+		// `path NOT LIKE '_file_level:%'` filters the engine's
+		// file-level sentinel rows (from PR #270) — synthetic
+		// caller_ids the engine uses to mark file-level fn-value
+		// refs (mache-02r9) as alive. They're not real source
+		// locations and would surface as fake "/path/file.go"
+		// results. NodesTableReader.GetCallers applies the same
+		// filter; this puts search/role=reference in agreement.
 		qg, ok := g.(refsQuerier)
 		if !ok {
 			return mcp.NewToolResultError("reference search requires a SQLite-backed graph; use role=definition for in-memory search"), nil
@@ -629,12 +637,12 @@ func makeSearchHandler(g graph.Graph) server.ToolHandlerFunc {
 		var err error
 		if typeFilter != "" {
 			rows, err = qg.QueryRefs(
-				"SELECT token, path FROM mache_refs WHERE token LIKE ? AND path LIKE ? LIMIT ?",
+				"SELECT token, path FROM mache_refs WHERE token LIKE ? AND path LIKE ? AND path NOT LIKE '_file_level:%' LIMIT ?",
 				pattern, "%/"+typeFilter+"/%", limit,
 			)
 		} else {
 			rows, err = qg.QueryRefs(
-				"SELECT token, path FROM mache_refs WHERE token LIKE ? LIMIT ?",
+				"SELECT token, path FROM mache_refs WHERE token LIKE ? AND path NOT LIKE '_file_level:%' LIMIT ?",
 				pattern, limit,
 			)
 		}
@@ -642,12 +650,12 @@ func makeSearchHandler(g graph.Graph) server.ToolHandlerFunc {
 		if err != nil && strings.Contains(err.Error(), "no such table") {
 			if typeFilter != "" {
 				rows, err = qg.QueryRefs(
-					"SELECT token, node_id AS path FROM node_refs WHERE token LIKE ? AND node_id LIKE ? LIMIT ?",
+					"SELECT token, node_id AS path FROM node_refs WHERE token LIKE ? AND node_id LIKE ? AND node_id NOT LIKE '_file_level:%' LIMIT ?",
 					pattern, "%/"+typeFilter+"/%", limit,
 				)
 			} else {
 				rows, err = qg.QueryRefs(
-					"SELECT token, node_id AS path FROM node_refs WHERE token LIKE ? LIMIT ?",
+					"SELECT token, node_id AS path FROM node_refs WHERE token LIKE ? AND node_id NOT LIKE '_file_level:%' LIMIT ?",
 					pattern, limit,
 				)
 			}

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -482,6 +482,55 @@ func TestSearch_Found(t *testing.T) {
 	assert.Equal(t, "Helper", results[0].Token)
 }
 
+// TestSearch_FiltersFileLevelSentinel pins that search results
+// from role=reference (the default) never include the engine's
+// '_file_level:<path>' sentinel rows added in PR #270 to mark
+// file-level fn-value refs as alive without polluting per-construct
+// caller counts.
+//
+// Without the filter, an agent searching for a token referenced
+// only at file scope (e.g. cobra var declarations using
+// RunE: someFunc) would see results like:
+//
+//	{"token": "someFunc", "path": "_file_level:/abs/path/file.go"}
+//
+// — surfacing internal sentinel state as if it were a real
+// caller location. NodesTableReader.GetCallers already filters
+// these for find_callers; this puts search/role=reference in
+// agreement.
+func TestSearch_FiltersFileLevelSentinel(t *testing.T) {
+	store := buildTestGraph(t)
+	require.NoError(t, store.InitRefsDB())
+	defer func() { _ = store.Close() }()
+
+	// Add a sentinel ref alongside the legitimate one. The token
+	// "Helper" already has one real caller (pkg/main/source) from
+	// buildTestGraph; adding the sentinel mirrors what the engine
+	// produces when a file-level pattern (e.g. cobra var decl)
+	// references the same token at file scope.
+	require.NoError(t, store.AddRef("Helper", "_file_level:/some/file.go"))
+	require.NoError(t, store.FlushRefs())
+
+	handler := makeSearchHandler(store)
+	result, err := handler(context.Background(), makeRequest(map[string]any{"pattern": "Helper"}))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	type searchResult struct {
+		Token string `json:"token"`
+		Path  string `json:"path"`
+	}
+	var results []searchResult
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &results))
+
+	for _, r := range results {
+		assert.NotContains(t, r.Path, "_file_level:",
+			"sentinel rows must be filtered from search results")
+	}
+	// Sanity: the legitimate caller is still surfaced.
+	require.NotEmpty(t, results, "real caller must still be returned")
+}
+
 func TestSearch_NoResults(t *testing.T) {
 	store := buildTestGraph(t)
 	require.NoError(t, store.InitRefsDB())


### PR DESCRIPTION
## Summary

The search handler's reference-mode SQL queried `node_refs` / `mache_refs` without the `'_file_level:%'` sentinel filter that `NodesTableReader.GetCallers` applies. PR #270 introduced those sentinel rows as synthetic caller_ids the engine uses to mark file-level fn-value refs (e.g. cobra var decls using `RunE: someFunc`) as alive without inflating `fan_out_skew`.

Without the filter, an agent searching for a token referenced only at file scope sees:

\`\`\`json
{"token": "someFunc", "path": "_file_level:/abs/path/file.go"}
\`\`\`

— internal sentinel state surfacing as if it were a caller location. **find_callers and search now agree**: sentinel rows participate in `dead_code`'s alive set but not in any agent-facing ref enumeration.

Filter applied to all four query branches: `mache_refs` vtab with/without typeFilter, `node_refs` fallback with/without typeFilter.

## Tests

- `TestSearch_FiltersFileLevelSentinel` — adds a sentinel ref alongside a real one, asserts only the real caller surfaces. Pins both the filter behavior and the "real callers still surface" sanity check.
- All existing search tests still pass.
- `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)