### PR TITLE
fix: leyline materializers skip file-level sentinel rows

### DIFF
--- a/cmd/leyline.go
+++ b/cmd/leyline.go
@@ -97,8 +97,16 @@ func materializeCallers(tx *sql.Tx, now int64) error {
 		return nil // no refs table, nothing to do
 	}
 
-	// Read all refs: token -> list of calling node IDs
-	rows, err := tx.Query(`SELECT token, node_id FROM node_refs`)
+	// Read all refs: token -> list of calling node IDs.
+	// Skip the engine's '_file_level:%' sentinel rows (PR #270) —
+	// they're synthetic caller_ids the engine uses to mark
+	// file-level fn-value refs as alive without polluting
+	// per-construct counts. Materializing them as caller entries
+	// would surface internal state ('callers/path' from the
+	// sentinel's path component) and store the sentinel string
+	// itself as caller content. find_callers / search already
+	// filter these; the materializer does so for the same reason.
+	rows, err := tx.Query(`SELECT token, node_id FROM node_refs WHERE node_id NOT LIKE '_file_level:%'`)
 	if err != nil {
 		return fmt.Errorf("query node_refs: %w", err)
 	}
@@ -215,7 +223,12 @@ func materializeCallees(tx *sql.Tx, now int64) error {
 	}
 
 	// Read all refs and resolve callees via the pre-loaded defs map.
-	rows, err := tx.Query(`SELECT token, node_id FROM node_refs`)
+	// Skip sentinel rows (see materializeCallers above for the rationale).
+	// extractCallerDir would resolve a sentinel node_id to itself;
+	// the subsequent "exists in nodes" check filters it accidentally,
+	// but we'd rather not depend on that — explicit is better, and
+	// the SQL filter is cheaper than the per-row JOIN check.
+	rows, err := tx.Query(`SELECT token, node_id FROM node_refs WHERE node_id NOT LIKE '_file_level:%'`)
 	if err != nil {
 		return fmt.Errorf("query node_refs: %w", err)
 	}

--- a/cmd/leyline_test.go
+++ b/cmd/leyline_test.go
@@ -98,6 +98,74 @@ func TestMaterializeCallers(t *testing.T) {
 	}
 }
 
+// TestMaterializeCallers_FiltersFileLevelSentinel pins that
+// engine sentinel rows ('_file_level:%') don't surface as
+// caller entries in the materialized callers/ virtual dirs.
+//
+// Without the filter, a sentinel ref like
+//
+//	('HandleRequest', '_file_level:/abs/path/main.go')
+//
+// would produce a 'callers/path' entry (extractFuncName takes
+// the second-to-last path component, which is "path" for the
+// sentinel string), and the entry's content would be the
+// sentinel itself — surfacing internal engine state to agents.
+func TestMaterializeCallers_FiltersFileLevelSentinel(t *testing.T) {
+	db := setupTestDB(t)
+	defer func() { _ = db.Close() }()
+
+	// Add a sentinel ref alongside the legitimate one.
+	_, err := db.Exec(`INSERT INTO node_refs VALUES ('HandleRequest', '_file_level:/abs/path/main.go')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := materializeCallers(tx, 9999); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real caller still surfaces.
+	var record string
+	if err := db.QueryRow(
+		`SELECT record FROM nodes WHERE id = 'functions/HandleRequest/callers/ProcessOrder'`,
+	).Scan(&record); err != nil {
+		t.Fatalf("real caller missing: %v", err)
+	}
+	if record != "functions/ProcessOrder/source" {
+		t.Fatalf("real caller content corrupted: %q", record)
+	}
+
+	// Sentinel-derived entry MUST NOT exist. Two possible names
+	// extractFuncName could produce: "path" (penultimate of
+	// "_file_level:/abs/path/main.go") or anything containing
+	// the sentinel marker. Assert neither leaks.
+	var phantomCount int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM nodes WHERE id LIKE 'functions/HandleRequest/callers/%' AND record LIKE '%_file_level:%'`,
+	).Scan(&phantomCount); err != nil {
+		t.Fatal(err)
+	}
+	if phantomCount != 0 {
+		t.Fatalf("sentinel content leaked into %d caller entries", phantomCount)
+	}
+	// The penultimate-component naming would also produce just
+	// "path" — pin that explicitly.
+	var pathCount int
+	_ = db.QueryRow(
+		`SELECT COUNT(*) FROM nodes WHERE id = 'functions/HandleRequest/callers/path'`,
+	).Scan(&pathCount)
+	if pathCount != 0 {
+		t.Fatalf("phantom callers/path entry created from sentinel row")
+	}
+}
+
 func TestMaterializeCallersNoRefs(t *testing.T) {
 	// If node_refs table doesn't exist, materializeCallers should be a no-op.
 	db, err := sql.Open("sqlite", ":memory:")


### PR DESCRIPTION
## Summary

Same-shape leak as #292 fixed for `search/role=reference`. `materializeCallers` and `materializeCallees` both queried `node_refs` without filtering the engine's `'_file_level:%'` sentinel rows (PR #270).

The materializers build the `callers/` and `callees/` virtual dirs that show up in mounted graphs. For a sentinel ref like:

\`\`\`
('HandleRequest', '_file_level:/abs/path/main.go')
\`\`\`

`materializeCallers`'s `extractFuncName` would take the second-to-last path component (`'path'`), creating a phantom `callers/path` entry whose content is the literal sentinel string — surfacing engine internal state as if it were a caller location.

`materializeCallees` was accidentally protected by the \"caller dir exists in nodes\" check (sentinel IDs aren't in `nodes`), but explicit filtering is cheaper and clearer than relying on that incidental safety net.

## Tests

- `TestMaterializeCallers_FiltersFileLevelSentinel` — adds a sentinel ref alongside a real one, asserts:
  - Real caller surfaces unchanged
  - No phantom `callers/path` entry exists
  - No caller entry has record-content matching the sentinel pattern
- All existing leyline materialize tests still pass.
- `task lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)