### PR TITLE
fix(test): TestWatcher_Debounce headroom for slow CI runners

### DIFF
--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -27,7 +27,17 @@ func TestWatcher_Debounce(t *testing.T) {
 	}
 	onDelete := func(path string) {}
 
-	w, err := NewWatcher(tmpDir, onChange, onDelete, WithDebounce(50*time.Millisecond))
+	// Larger debounce window so the inter-write gap is reliably
+	// shorter than the debounce timer even on slow CI runners.
+	// Original 50ms / 10ms ratio (5x headroom) flaked when
+	// scheduler latency stretched a 10ms sleep past 50ms,
+	// causing the timer to fire mid-stream — see PR #294 retry.
+	// 250ms / 25ms keeps the same 10x ratio in absolute terms but
+	// gives ~5x more headroom for jittery runners.
+	const debounce = 250 * time.Millisecond
+	const interWriteGap = 25 * time.Millisecond
+
+	w, err := NewWatcher(tmpDir, onChange, onDelete, WithDebounce(debounce))
 	require.NoError(t, err)
 	defer w.Stop()
 
@@ -36,15 +46,23 @@ func TestWatcher_Debounce(t *testing.T) {
 	for i := range 5 {
 		err := os.WriteFile(goFile, []byte("package main // v"+string(rune('0'+i))), 0o644)
 		require.NoError(t, err)
-		time.Sleep(10 * time.Millisecond) // faster than debounce
+		time.Sleep(interWriteGap)
 	}
 
-	// Wait for debounce to settle.
-	time.Sleep(200 * time.Millisecond)
+	// Wait several debounce windows to be confident the timer
+	// fired AND no late callbacks are still pending. Using a
+	// fixed 4× window instead of polling because the post-condition
+	// is "no MORE callbacks fire after this point" — polling for
+	// "exactly 1" would race with a possible second callback.
+	time.Sleep(4 * debounce)
 
-	// Should have coalesced into a single callback.
+	// Should have coalesced into a single callback. Use LessOrEqual
+	// + GreaterOrEqual to give a clear failure message that
+	// distinguishes "0 fired" (timer leak) from "2+ fired"
+	// (debounce misconfigured / inter-write gap too long).
 	count := callCount.Load()
-	assert.Equal(t, int32(1), count, "rapid writes should produce exactly 1 callback, got %d", count)
+	assert.GreaterOrEqual(t, count, int32(1), "at least one callback must fire")
+	assert.LessOrEqual(t, count, int32(1), "rapid writes within %v should coalesce to 1 callback (got %d) — inter-write gap %v too close to debounce window?", debounce, count, interWriteGap)
 
 	mu.Lock()
 	assert.Equal(t, goFile, lastPath)


### PR DESCRIPTION
## Summary

The original 50ms debounce / 10ms inter-write gap had only 5x headroom — when scheduler latency stretched a 10ms sleep past 50ms, the debounce timer fired mid-stream and the test saw 2 callbacks instead of the expected 1. Bit PR #294's integration job; retry was clean (real flake, not a real bug).

Bump to **250ms debounce / 25ms inter-write gap**. Same 10x ratio in absolute terms but ~5x more wall-clock headroom on jittery runners. Total test time goes from ~250ms to ~1.1s — acceptable for a single-test fix, and well below the suite's other waits (`TestWatcher_NewSubdirectory` polls up to 2s).

Other improvements:

- Wait `4× debounce` instead of fixed 200ms — explicitly tied to the configurable, so changing the debounce constant doesn't silently break the timing assumption
- Split the \"exactly 1\" assertion into `LessOrEqual` + `GreaterOrEqual` so the failure message distinguishes \"timer leak\" (0 fired) from \"debounce misconfigured\" (2+ fired) — faster triage when this flakes again

## Test plan

- [x] Verified stable across 5 consecutive runs locally
- [x] `task lint` clean
- [x] Test time: 1.1s (acceptable; suite already has 2s polls elsewhere)

🤖 Generated with [Claude Code](https://claude.com/claude-code)