### PR TITLE
docs: update mache-iegm status — cross-mount callees + annotations landed

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -94,7 +94,7 @@ Each mount becomes a top-level virtual directory. `find_callers Validate` walks 
 
 Mounts compose any source `mache serve` accepts — directories, `.db` files, or a mix. `--mount` and a positional source are mutually exclusive (use one or the other).
 
-See [ARCHITECTURE.md § Cross-repo serve](docs/ARCHITECTURE.md#cross-repo-serve---mount) for the design and what's not yet wired (cross-repo `find_callees` resolution lands separately under `mache-iegm`).
+See [ARCHITECTURE.md § Cross-repo serve](docs/ARCHITECTURE.md#cross-repo-serve---mount) for the full design. Cross-mount `find_callees` / `find_definition` / `find_callers` all resolve and annotate today; `search` and `get_impact` still emit the legacy single-string shape on cross-mount results.
 
 ## Mount as a filesystem (optional)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -185,11 +185,15 @@ Under the composite:
 
 This is the first concrete implementation of the **`Ref` pointer kind** from [ADR-0011](adr/0011-pointer-abstraction.md): a name-scoped pointer that resolves through a registry of named graphs.
 
-**What's not yet wired (tracked in `mache-iegm`):**
+**What's wired today (was tracked under `mache-iegm`):**
 
-- Cross-repo `find_callees` resolution — when a function in mount A calls a function defined in mount B, the callee resolver doesn't yet walk into B's defs index. Today each mount resolves callees within itself.
-- `find_definition` mount annotation — same shape as `find_callers` annotation but on the def lookup; currently emits the legacy single-string response.
-- `search` and `get_impact` mount annotation — same idea, lower priority.
+- **Cross-repo `find_callees` resolution.** When a function in mount A calls a function defined in mount B, `CompositeGraph.GetCallees` runs a phase-2 cross-mount pass via `crossMountCallees()` (`internal/graph/composite.go`): re-extracts calls from the source, resolves each token against the federated `DefsMap` across all mounts, and returns the cross-mount matches alongside any local resolution. Pinned by `TestFindCallees_CrossMountResolvesAndAnnotates`.
+- **`find_definition` mount annotation.** Same `{path, mount}` shape as `find_callers`. The wiring goes through `lazyGraph.MountPrefixOf` so the annotation reaches handlers despite the wrapper.
+- **`find_callers` mount annotation.** Federates across mounts and emits the annotated shape when any result carries a mount prefix.
+
+**What's still not wired:**
+
+- `search` and `get_impact` mount annotation — same idea, lower priority. `search role=reference` and `get_impact` still emit the legacy single-string shape on cross-mount results.
 
 ## Virtual Directories
 


### PR DESCRIPTION
## Summary

The \"What's not yet wired (tracked in `mache-iegm`)\" section in `ARCHITECTURE.md` was written before three landed PRs:

- **#284**: `lazyGraph.MountPrefixOf` forwards through the wrapper, so `annotateMounts` works in production for `find_callers`, `find_callees`, and `find_definition` (was silently disabled pre-#284 because `g.(*graph.CompositeGraph)` missed the wrapper)
- **#286**: `lazyGraph.LookupDef` forwards too, so the federated `defsLookuper` path stays fast
- **#296**: `TestFindCallees_CrossMountResolvesAndAnnotates` pins the cross-mount happy path end-to-end — auth/Caller calls Validate, billing/Validate is the cross-mount target, response surfaces `billing/functions/Validate` with `mount=\"billing\"`

The wiring exists in `CompositeGraph.GetCallees` (phase 2 calls `crossMountCallees` → federated `LookupDef` across mounts). Move those bullets out of \"not wired\" into a new \"wired today\" list with the test name as inline citation. The remaining gaps (`search`, `get_impact` mount annotation) stay in the \"still not wired\" list — same priority ordering, just the truthful set.

Also updates the `GETTING-STARTED.md` pointer that said \"cross-repo find_callees resolution lands separately under mache-iegm\" — that's no longer accurate.

## Test plan

- [x] Doc-only change; no code touched
- [x] mdformat hook passes (the doc was reformatted slightly by mdformat — accepted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)