### PR TITLE
ci: mirror push paths-ignore on pull_request triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ on:
       - '.gitignore'
   pull_request:
     branches: [main]
+    # Mirror push's paths-ignore so doc-only PRs don't run full CI
+    # (test + integration ≈ 5 min per matrix entry + exposure to
+    # known CGO flakes on changes that don't touch code).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - '.gitignore'
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,6 +4,14 @@ on:
   pull_request:
     branches:
       - main
+    # Mirror push's paths-ignore so doc-only PRs don't pay
+    # the integration suite cost (~3 min per OS).
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'examples/**'
+      - 'LICENSE'
+      - '.gitignore'
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

`ci.yml` and `integration.yml`'s `pull_request:` triggers had no `paths-ignore`, so doc-only PRs ran the full test + integration matrix every time — ~5 min wasted per matrix entry across 4 jobs (ubuntu/macos × test/integration). Plus exposure to the `mache-2y9w` CGO SIGSEGV flake on PRs that change zero Go code, which has cost reruns on **PR #284, #292, #294, and #297** already this session.

Mirror the `push:` `paths-ignore` list on `pull_request:`:

\`\`\`yaml
paths-ignore:
  - '**.md'
  - 'docs/**'
  - 'examples/**'
  - 'LICENSE'
  - '.gitignore'
\`\`\`

`find-smells.yml` already has a tight `paths:` allowlist — no change needed there.

## Trade-off

`examples/**` is included for consistency with the existing `push:` trigger. A malformed example rule wouldn't be caught at PR-time if `examples/` is the only thing touched — but that gap existed pre-this-PR for pushes to main, and isn't introduced here. If we want example-rule validation on every PR, that should be a separate change that drops `examples/**` from BOTH triggers — outside this PR's scope.

## Test plan

- [x] yaml syntax validates (pre-commit hook)
- [ ] Doc-only PRs after merge will be observably faster (no test/integration run)
- [ ] This PR itself touches `.github/workflows/*.yml` so CI **will** run on it (workflows change → not in paths-ignore) — that's the right behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)