### PR TITLE
docs: explain mache-2y9w race-detector interaction in reingest_test

### DIFF
--- a/internal/ingest/reingest_test.go
+++ b/internal/ingest/reingest_test.go
@@ -13,6 +13,18 @@ import (
 
 // Test that Engine.ReIngestFile re-ingests a single file
 // without changing RootPath (needed for live graph updates).
+//
+// mache-2y9w note: these tests sometimes flake with SIGSEGV
+// during CGO execution under `-race`. PR #257 + #299 added
+// runtime.LockOSThread() to both ingestion paths to address
+// goroutine migration, which dropped the flake rate from 60%
+// to 20% on macOS arm64. The residual flake is specifically
+// the race detector's instrumentation interacting with
+// tree-sitter's CGO bindings (10/10 runs PASS without -race).
+// LockOSThread mitigations are exhausted; the full fix is
+// CGO removal (mache-37ae8b). When this test is the source
+// of a CI rerun, `gh run rerun --failed` is the operational
+// mitigation — don't waste time bisecting.
 
 func TestEngine_ReIngestFile(t *testing.T) {
 	schema := loadGoSchema(t)


### PR DESCRIPTION
## Summary

Future maintainers will inevitably hit a CGO SIGSEGV from `TestEngine_ReIngestFile_PreservesRootPath` on a `-race` CI run and start bisecting. Save them the trip with an inline comment that pins the diagnostic findings:

- **LockOSThread mitigations are exhausted as a class.** PR #257 (parallel path) and #299 (single-file path) fix goroutine-migration bugs, not race-detector instrumentation interactions.
- **10/10 runs pass without `-race`**; with `-race`, ~20% local flake rate persists. Stack consistently lands inside `smacker/go-tree-sitter/bindings.go:1026`.
- **Full fix is CGO removal** (`mache-37ae8b`). Until then, `gh run rerun --failed` is the operational mitigation.

## Test plan

- [x] `go test ./internal/ingest/` passes (no behavior change)
- [x] `task lint` clean
- [x] Comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)