### PR TITLE
docs: long_function describes actual min_metric semantics

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -248,7 +248,7 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "long_function",
 		Languages:   []string{"go"},
-		Description: "Functions and methods whose body spans more than 80 source lines (end_row - start_row). Sorted descending by line count. Threshold is hard-coded today — use cyclomatic_complexity for a sister metric on the same nodes.",
+		Description: "Functions and methods whose body spans more than 80 source lines (end_row - start_row). Sorted descending by line count. The 80-line floor is hardcoded in SQL; min_metric raises the cutoff but cannot lower it (e.g. min_metric=50 still returns only >80, since the SQL filter runs before the handler-side min_metric drop). Effective threshold is max(80, min_metric). Use min_metric=200 for 'definitely review now', min_metric=120 for 'noteworthy'. Pair with cyclomatic_complexity for a sister metric on the same nodes.",
 		Requires:    []string{"_ast"},
 		ScopeColumn: "fn.source_id",
 		Query: `


### PR DESCRIPTION
## Summary

The `long_function` rule's SQL hardcodes a `> 80` floor; the handler then applies `min_metric` as a post-filter. Effective threshold is `max(80, min_metric)` — setting `min_metric=50` returns the same results as `min_metric=80`, which silently surprises users calling the discovery endpoint expecting `min_metric` to be the sole control.

Fix the description so agents reading the rules listing see the actual semantics + concrete recommended values (`min_metric=200` for \"review now\", `120` for \"noteworthy\"). **Doc-only change; no behavior change.**

The full fix would be removing the SQL floor and making `min_metric` the sole threshold. That's a non-trivial behavior change (default would shift from \"only >80 functions\" to \"all functions sorted by length\") and merits its own PR.

## Test plan

- [x] `TestFindSmells_LongFunction` passes
- [x] `task lint` clean
- [x] No code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)