### PR TITLE
fix: long_function min_metric is the sole threshold (not just an upper-bound filter)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -56,6 +56,17 @@ type SmellRule struct {
 	// `_source`, `_imports`, `_lsp*`. See docs/ARCHITECTURE.md
 	// "Interplay with ley-line-open" for the full table.
 	Requires []string
+	// DefaultMinMetric is the rule's recommended metric threshold
+	// when the request omits min_metric. Zero means "no default
+	// threshold; return all rows." Used for metric-bearing rules
+	// where the query's natural output includes a long tail of
+	// uninteresting low-metric rows (e.g. long_function returns
+	// every function regardless of size; without a default
+	// threshold the response is dominated by 1-line setters).
+	// Callers can pass min_metric=0 explicitly to override the
+	// default and see everything; any non-zero min_metric also
+	// overrides.
+	DefaultMinMetric int64
 }
 
 // smellRegistry holds the registered rules. Built-ins below; external
@@ -248,9 +259,15 @@ var smellRegistry = []SmellRule{
 	{
 		ID:          "long_function",
 		Languages:   []string{"go"},
-		Description: "Functions and methods whose body spans more than 80 source lines (end_row - start_row). Sorted descending by line count. The 80-line floor is hardcoded in SQL; min_metric raises the cutoff but cannot lower it (e.g. min_metric=50 still returns only >80, since the SQL filter runs before the handler-side min_metric drop). Effective threshold is max(80, min_metric). Use min_metric=200 for 'definitely review now', min_metric=120 for 'noteworthy'. Pair with cyclomatic_complexity for a sister metric on the same nodes.",
+		Description: "Functions and methods sorted descending by body line count (end_row - start_row). Default threshold is 81 lines — matches the historical strict `> 80` SQL floor exactly, so agents calling without min_metric see the same long-function set as before. Pass min_metric to adjust: 200 for 'definitely review now', 120 for 'noteworthy', 0 to see everything sorted by length. Pair with cyclomatic_complexity for a sister metric on the same nodes.",
 		Requires:    []string{"_ast"},
 		ScopeColumn: "fn.source_id",
+		// 81 not 80: the old SQL filter was strict `> 80`, so 80-line
+		// functions were excluded. min_metric is `>=`, so mapping
+		// `> 80` → `>= 81` preserves the boundary exactly. Tests that
+		// assert "only the 100-line one fires when 80-line is at the
+		// boundary" stay green.
+		DefaultMinMetric: 81,
 		Query: `
 			SELECT fn.source_id,
 			       fn.node_id,
@@ -261,7 +278,6 @@ var smellRegistry = []SmellRule{
 			       (fn.end_row - fn.start_row) AS metric
 			FROM _ast fn
 			WHERE fn.node_kind IN ('function_declaration','method_declaration')
-			  AND (fn.end_row - fn.start_row) > 80
 			%s
 			ORDER BY metric DESC, fn.source_id, fn.start_byte
 		`,
@@ -686,7 +702,6 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 		if limit <= 0 {
 			limit = 200
 		}
-		minMetric := int64(request.GetFloat("min_metric", 0))
 
 		if ruleID == "" {
 			// Discovery mode — list rules.
@@ -705,6 +720,20 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 				"unknown rule %q — available: %s. Call this tool with no rule for full descriptions.",
 				ruleID, strings.Join(allRuleIDs(), ", "),
 			)), nil
+		}
+
+		// Resolve min_metric AFTER rule lookup so we can fall back
+		// to the rule's DefaultMinMetric when the request omits it.
+		// An explicit `min_metric=0` from the caller still wins —
+		// it disables the default and returns everything sorted by
+		// metric. Only an absent key activates the default.
+		minMetric := int64(0)
+		if v, ok := request.GetArguments()["min_metric"]; ok {
+			if f, ok := v.(float64); ok {
+				minMetric = int64(f)
+			}
+		} else {
+			minMetric = rule.DefaultMinMetric
 		}
 
 		// Need a *sql.DB to run the rule. Today we hand-shake via the

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1097,6 +1097,87 @@ func TestFindSmells_CyclomaticOnlyCountsBranchesUnderFunction(t *testing.T) {
 	assert.Equal(t, 2, len(got), "topif is not under any function — no extra finding")
 }
 
+// TestFindSmells_LongFunction_MinMetricLowersThreshold pins the
+// behavior fix that retired the hardcoded SQL `> 80` floor: when
+// the caller passes min_metric < 81, functions below the historical
+// default surface in the response. Pre-fix, min_metric=50 returned
+// the same set as min_metric=81 because the SQL filtered first.
+func TestFindSmells_LongFunction_MinMetricLowersThreshold(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('big_fn',   'main.go', 'function_declaration', 100, 200, 10,  0, 110, 0),  -- 100 lines
+		  ('mid_fn',   'main.go', 'function_declaration', 300, 400, 200, 0, 260, 0),  -- 60 lines
+		  ('small_fn', 'main.go', 'function_declaration', 500, 550, 300, 0, 305, 0);  -- 5 lines
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "long_function",
+		"min_metric": float64(50),
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	// big_fn (100) and mid_fn (60) both ≥ 50; small_fn (5) is below.
+	// Pre-fix this test would have returned only big_fn because the
+	// SQL `> 80` floor excluded mid_fn before min_metric ever ran.
+	assert.ElementsMatch(t, []string{"big_fn", "mid_fn"}, gotIDs,
+		"min_metric=50 must surface 60-line mid_fn (was hidden behind hardcoded `> 80` SQL floor)")
+}
+
+// TestFindSmells_LongFunction_MinMetricZeroDisablesDefault pins
+// that an explicit min_metric=0 disables the rule's
+// DefaultMinMetric — agents that want to see every function
+// sorted by length can opt out of the default threshold.
+func TestFindSmells_LongFunction_MinMetricZeroDisablesDefault(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('tiny',  'main.go', 'function_declaration', 100, 200, 10, 0, 12, 0),  -- 2 lines
+		  ('huge',  'main.go', 'function_declaration', 300, 400, 50, 0, 250, 0); -- 200 lines
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "long_function",
+		"min_metric": float64(0),
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.ElementsMatch(t, []string{"tiny", "huge"}, gotIDs,
+		"min_metric=0 must override DefaultMinMetric and return all functions")
+}
+
 // TestFindSmells_LongFunction seeds two functions of different sizes
 // and asserts the rule flags only the one over the threshold (80 lines).
 func TestFindSmells_LongFunction(t *testing.T) {


### PR DESCRIPTION
## Summary

PR #301 documented the bug; this PR fixes it. The `long_function` rule's SQL hardcoded `> 80` and the handler's `min_metric` ran as a post-filter, so callers passing `min_metric=50` got the same result as `min_metric=81` — the SQL excluded everything ≤80 before the handler ever ran.

Generic fix via a new `SmellRule` field:

\`\`\`go
DefaultMinMetric int64
\`\`\`

The handler resolves `min_metric` **after** rule lookup. If the caller omitted the key, fall back to `rule.DefaultMinMetric`. An explicit `min_metric=0` still disables the default and returns everything sorted by metric — agents that want the unfiltered view can opt out.

`long_function` gets `DefaultMinMetric=81` — `>= 81` is exactly the same boundary as the old `> 80`, so the historical default behavior is preserved at the 80-line edge.

The `DefaultMinMetric` field is **general** — future metric-bearing rules (`cyclomatic_complexity`, `long_file`) can adopt it the same way without touching the handler.

## Tests

Two new regression tests:

- `TestFindSmells_LongFunction_MinMetricLowersThreshold` — `min_metric=50` now surfaces a 60-line function that was previously hidden behind the SQL floor
- `TestFindSmells_LongFunction_MinMetricZeroDisablesDefault` — explicit `min_metric=0` returns even tiny 2-line functions

The original `TestFindSmells_LongFunction` (default, expects only the 100-line function) still passes — boundary preserved.

## Test plan

- [x] All 3 long_function tests pass
- [x] All other find_smells tests still pass
- [x] `task lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)