### PR TITLE
fix: long_file adopts DefaultMinMetric (parallel to #302's long_function)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -611,9 +611,13 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "long_file",
-		Description: "Source files exceeding 1500 lines (end_row reported on the source-file root AST node). Cross-language since the rule joins by node_kind = 'source_file' which most tree-sitter grammars use as the root kind. Threshold hard-coded today.",
+		Description: "Source files sorted descending by total line count (end_row of the source_file root AST node). Default threshold is 1501 lines — matches the historical strict `> 1500` SQL floor exactly, so agents calling without min_metric see the same long-file set as before. Pass min_metric to adjust: 3000 for 'definitely review now', 800 for 'noteworthy', 0 to see everything sorted by length. Cross-language since the rule joins by node_kind = 'source_file' which most tree-sitter grammars use as the root kind.",
 		Requires:    []string{"_ast"},
 		ScopeColumn: "src.source_id",
+		// 1501 not 1500: old SQL `> 1500` excluded files at exactly
+		// 1500 lines; min_metric is `>=`, so 1501 preserves the
+		// boundary. Same pattern as long_function (#302).
+		DefaultMinMetric: 1501,
 		Query: `
 			SELECT src.source_id,
 			       src.node_id,
@@ -624,7 +628,6 @@ var smellRegistry = []SmellRule{
 			       src.end_row AS metric
 			FROM _ast src
 			WHERE src.node_kind = 'source_file'
-			  AND src.end_row > 1500
 			%s
 			ORDER BY metric DESC, src.source_id
 		`,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -2614,6 +2614,48 @@ func TestFindSmells_DuplicateDefinitionsExcludesAllMethods(t *testing.T) {
 	)
 }
 
+// TestFindSmells_LongFile_MinMetricLowersThreshold pins the same
+// behavior fix as #302 applied to long_file: callers passing
+// min_metric < 1501 now see files between min_metric and 1500
+// lines, where the old SQL `> 1500` floor silently excluded them.
+func TestFindSmells_LongFile_MinMetricLowersThreshold(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES
+		  ('huge_root',   'huge.go',   'source_file', 0, 999999, 0, 0, 2000, 0),  -- 2000 lines
+		  ('medium_root', 'medium.go', 'source_file', 0, 600000, 0, 0, 1000, 0),  -- 1000 lines
+		  ('small_root',  'small.go',  'source_file', 0, 1234,   0, 0, 50,   0);  -- 50 lines
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "long_file",
+		"min_metric": float64(800),
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.SourceID
+	}
+	// huge.go (2000) and medium.go (1000) both ≥ 800; small.go (50)
+	// is below. Pre-fix this would have returned only huge.go because
+	// the SQL `> 1500` floor excluded medium.go before min_metric ran.
+	assert.ElementsMatch(t, []string{"huge.go", "medium.go"}, gotIDs,
+		"min_metric=800 must surface 1000-line medium.go (was hidden behind hardcoded `> 1500` SQL floor)")
+}
+
 // TestFindSmells_LongFile flags _ast source_file rows over 1500 lines.
 func TestFindSmells_LongFile(t *testing.T) {
 	tg := seedSmellAST(t)


### PR DESCRIPTION
## Summary

Same shape as #302. `long_file`'s SQL hardcoded `> 1500` and the handler's `min_metric` ran as a post-filter, so callers passing `min_metric=800` got the same result as `min_metric=1501` — the SQL excluded everything ≤1500 before the handler ever ran.

Lift the SQL floor; set `DefaultMinMetric=1501` (preserves the historical `> 1500` boundary exactly via `>= 1501`). Uses the generic `DefaultMinMetric` field added in #302 — no handler changes.

## Behavior

| Caller | Before | After |
|---|---|---|
| no `min_metric` | files ≥1501 lines | **same** (boundary preserved) |
| `min_metric=800` | silently raised to ≥1501 | files ≥800 lines |
| `min_metric=0` explicit | silently raised to ≥1501 | everything sorted by length |

## Tests

- `TestFindSmells_LongFile_MinMetricLowersThreshold` — 3 files at 2000/1000/50 lines, `min_metric=800` returns huge.go + medium.go (pre-fix: only huge.go).
- Original `TestFindSmells_LongFile` (default) still passes — boundary preserved at 1500.

## Note: why not cyclomatic_complexity?

`cyclomatic_complexity`'s description explicitly says **\"pair with `min_metric` to set a cutoff\"** — caller-set threshold is the documented contract. Adding a `DefaultMinMetric` would silently break existing tests that assert low-metric findings, and it'd change the rule's user-facing contract. The two `long_*` rules had a different shape: their SQL had a hardcoded floor that masquerading as the threshold, which `min_metric` couldn't lower. That's the bug class being fixed; cyclomatic doesn't have it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)