### PR TITLE
feat: rules listing surfaces DefaultMinMetric for discovery

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -810,18 +810,20 @@ func allRuleIDs() []string {
 // without a rule. Stable order so agents can cache the listing.
 func rulesListing() any {
 	type ruleSummary struct {
-		ID          string   `json:"id"`
-		Languages   []string `json:"languages,omitempty"`
-		Description string   `json:"description"`
-		Requires    []string `json:"requires,omitempty"`
+		ID               string   `json:"id"`
+		Languages        []string `json:"languages,omitempty"`
+		Description      string   `json:"description"`
+		Requires         []string `json:"requires,omitempty"`
+		DefaultMinMetric int64    `json:"default_min_metric,omitempty"`
 	}
 	out := make([]ruleSummary, 0, len(smellRegistry))
 	for _, r := range smellRegistry {
 		out = append(out, ruleSummary{
-			ID:          r.ID,
-			Languages:   r.Languages,
-			Description: r.Description,
-			Requires:    r.Requires,
+			ID:               r.ID,
+			Languages:        r.Languages,
+			Description:      r.Description,
+			Requires:         r.Requires,
+			DefaultMinMetric: r.DefaultMinMetric,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
@@ -829,7 +831,7 @@ func rulesListing() any {
 		Help  string        `json:"help"`
 		Rules []ruleSummary `json:"rules"`
 	}{
-		Help:  "find_smells runs structural pattern queries against the _ast / nodes / node_defs / node_refs tables. Pass `rule` to scan; omit it (this response) to list available rules. Each rule entry includes a `requires` list of SQL tables it reads — agents can use it to skip rules whose tables aren't present on the active backend (e.g. _ast is only populated by ley-line-open's leyline parse). Optional `source_id` filters to one parsed file; `limit` caps results (default 200); `min_metric` drops findings whose metric column is below the threshold (default 0).",
+		Help:  "find_smells runs structural pattern queries against the _ast / nodes / node_defs / node_refs tables. Pass `rule` to scan; omit it (this response) to list available rules. Each rule entry includes a `requires` list of SQL tables it reads — agents can use it to skip rules whose tables aren't present on the active backend (e.g. _ast is only populated by ley-line-open's leyline parse). Optional `source_id` filters to one parsed file; `limit` caps results (default 200); `min_metric` drops findings whose metric column is below the threshold. Rules that surface a `default_min_metric` apply that as the threshold when the caller omits `min_metric`; an explicit `min_metric=0` overrides the default and returns everything sorted by metric.",
 		Rules: out,
 	}
 }

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -160,6 +160,50 @@ func TestFindSmells_ListsRulesWhenNoRule(t *testing.T) {
 	assert.Contains(t, byID["dead_code"], "node_defs")
 }
 
+// TestFindSmells_ListsRulesSurfacesDefaultMinMetric pins that the
+// rule listing exposes DefaultMinMetric as a structured field.
+// Agents discovering rules need to know the rule's threshold
+// programmatically — without this, they have to parse the
+// description text to learn what the default is, which is fragile
+// and silent when descriptions evolve.
+func TestFindSmells_ListsRulesSurfacesDefaultMinMetric(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Rules []struct {
+			ID               string `json:"id"`
+			DefaultMinMetric int64  `json:"default_min_metric"`
+		} `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	byID := make(map[string]int64, len(resp.Rules))
+	for _, r := range resp.Rules {
+		byID[r.ID] = r.DefaultMinMetric
+	}
+
+	// Rules with a hardcoded historical floor (lifted to
+	// DefaultMinMetric in #302/#303) must surface the value.
+	assert.Equal(t, int64(81), byID["long_function"],
+		"long_function default threshold (81 = `>= 81` matches old `> 80`) must reach the listing")
+	assert.Equal(t, int64(1501), byID["long_file"],
+		"long_file default threshold (1501 = `>= 1501` matches old `> 1500`) must reach the listing")
+
+	// Rules without a default — caller-set contract — must NOT
+	// surface a stray non-zero value (zero-valued struct field
+	// is fine; the JSON omitempty drops the key entirely).
+	assert.Equal(t, int64(0), byID["dead_code"],
+		"dead_code has no DefaultMinMetric — listing must not invent one")
+	assert.Equal(t, int64(0), byID["cyclomatic_complexity"],
+		"cyclomatic_complexity is caller-threshold by contract — must surface zero")
+}
+
 func TestFindSmells_MagicIntInComparison(t *testing.T) {
 	tg := seedSmellAST(t)
 	defer func() { _ = tg.db.Close() }()


### PR DESCRIPTION
## Summary

The `DefaultMinMetric` field added in #302 is currently visible to agents only via the description text. That's fragile — the threshold a rule actually applies (`81` for `long_function`, `1501` for `long_file`) becomes silent when descriptions evolve, and agents have to regex the prose to extract it.

Add `default_min_metric` as a structured field to the rule summary returned by `find_smells` discovery. Uses `omitempty` so rules without a default (most) don't include a stray zero.

Help text gains one sentence explaining the field's semantics + the explicit-zero-overrides-default escape hatch.

## Tests

`TestFindSmells_ListsRulesSurfacesDefaultMinMetric`:

- `long_function` listing carries `default_min_metric=81`
- `long_file` listing carries `default_min_metric=1501`
- `dead_code` (no default) carries `0` (omitempty drops the key)
- `cyclomatic_complexity` (caller-threshold by contract) carries `0`

## Closing the loop

Rule authors set `DefaultMinMetric` → it's loaded correctly (#304) → it's actually applied (#302/#303) → and now agents can see it programmatically (this PR). Discovery-side parity for the threshold-default story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)