### PR TITLE
chore: add `task smells` shortcut for local find_smells dogfooding

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -106,6 +106,23 @@ tasks:
     cmds:
       - go run main.go -file subject/parser.go -target FuzzParseToken
 
+  smells:
+    desc: Dogfood — index this repo and run the standalone find_smells rules locally
+    deps: [build]
+    vars:
+      DB: /tmp/mache-smells.db
+    cmds:
+      # Mirror what the find-smells GHA does (.github/workflows/find-smells.yml)
+      # so local results match what the workflow will report on a PR.
+      # The five rules below are the standalone (no-LLO) set that work
+      # against node_defs / node_refs / nodes — the same ones the GHA runs.
+      - rm -f {{.DB}}
+      - ./{{.BINARY_NAME}} build --schema examples/go-schema.json . {{.DB}}
+      - for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
+          printf "\n=== %s ===\n" "$rule";
+          ./{{.BINARY_NAME}} find-smells --db {{.DB}} --rule "$rule" --format md --limit 200;
+        done
+
   check:
     desc: Run all checks (fmt, vet, lint, test, validate)
     cmds:


### PR DESCRIPTION
## Summary

The find-smells GHA (`.github/workflows/find-smells.yml`) builds mache, indexes the repo, and runs five rules — same dogfood pattern I've been hitting manually all session for measuring smell-rule fixes. Codify it as a Taskfile target so:

- **Local repro of GHA findings is one command, not five**
- Reviewers can verify a smell-rule PR's claimed counts before merge without spinning up the workflow
- The \"five rules that work standalone (no LLO)\" set is documented in one canonical place — `Taskfile.yml` — instead of duplicated in workflow YAML and tribal knowledge

Builds via `deps: [build]` so the binary is fresh; uses markdown format for human-readable output (vs the workflow's JSON which gets piped into jq for filtering).

Mirrors the GHA's rule set exactly:

```
dead_code untested_function duplicate_definitions fan_out_skew god_file
```

The four `_ast`-only rules (`cyclomatic_complexity`, `long_function`, `long_file`, `magic_int_in_comparison`) need an LLO-built `.db` which standalone `mache build` doesn't produce — same omission as the GHA, intentionally.

## Test plan

- [x] `task smells` runs to completion locally
- [x] Counts roughly match what I've been seeing through the dogfood investigations this session
- [x] yaml syntax check passes (pre-commit hook)
- [x] No code change — Taskfile-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)