### PR TITLE
chore: task smells uses --limit 1000 to match the find-smells GHA

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,9 +118,13 @@ tasks:
       # against node_defs / node_refs / nodes — the same ones the GHA runs.
       - rm -f {{.DB}}
       - ./{{.BINARY_NAME}} build --schema examples/go-schema.json . {{.DB}}
+      # --limit 1000 matches the GHA so local dogfood produces the
+      # same finding set as a CI run on the same revision (the GHA
+      # then filters to PR-changed files; locally we don't, since
+      # the goal is "see everything in main").
       - for rule in dead_code untested_function duplicate_definitions fan_out_skew god_file; do
           printf "\n=== %s ===\n" "$rule";
-          ./{{.BINARY_NAME}} find-smells --db {{.DB}} --rule "$rule" --format md --limit 200;
+          ./{{.BINARY_NAME}} find-smells --db {{.DB}} --rule "$rule" --format md --limit 1000;
         done
 
   check:


### PR DESCRIPTION
## Summary

#307 codified the dogfood workflow as `task smells` but used `--limit 200` (the `find_smells` handler's default), while the GHA uses `--limit 1000`. Local results were therefore undercounting any rule that produced >200 findings.

Bring them into alignment with `--limit 1000` so:

- Local repro of GHA findings is byte-equivalent (modulo the GHA's PR-change filtering, which `task smells` deliberately skips since the goal is \"see everything in main\")
- Reviewers verifying smell-rule PRs locally see the same numbers the workflow will report

Trivial follow-up to #307; 1-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)