### PR TITLE
fix: find-smells CLI honors rule.DefaultMinMetric like the MCP handler

### DIFF
--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -108,10 +108,19 @@ This tool is observability, not a gate. It never exits non-zero on findings.`,
 			return cliExit(4, fmt.Errorf("rule %q: %w", findSmellsRule, err))
 		}
 
-		if findSmellsMinMetric > 0 {
+		// Mirror the MCP handler's threshold-default semantics. If
+		// the caller passed --min-metric explicitly, that value wins
+		// (including 0 for "show me everything sorted"). If the flag
+		// wasn't set, fall back to rule.DefaultMinMetric so CLI and
+		// MCP consumers see the same default set.
+		minMetric := findSmellsMinMetric
+		if !cmd.Flags().Changed("min-metric") {
+			minMetric = rule.DefaultMinMetric
+		}
+		if minMetric > 0 {
 			filtered := findings[:0]
 			for _, f := range findings {
-				if f.Metric >= findSmellsMinMetric {
+				if f.Metric >= minMetric {
 					filtered = append(filtered, f)
 				}
 			}

--- a/cmd/find_smells_cli_test.go
+++ b/cmd/find_smells_cli_test.go
@@ -118,6 +118,127 @@ func TestFindSmellsCLI_MarkdownRender(t *testing.T) {
 	assert.Contains(t, out, "| pkg/Dead |")
 }
 
+// writeLongFunctionFixture seeds an _ast-bearing fixture for rules
+// like long_function that need it. Three functions: 100/60/5 lines.
+func writeLongFunctionFixture(t *testing.T) string {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "longfn.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT, node_kind TEXT,
+			start_byte INTEGER, end_byte INTEGER,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		INSERT INTO _ast VALUES
+		  ('big',   'main.go', 'function_declaration', 0, 100, 10,  0, 110, 0),
+		  ('mid',   'main.go', 'function_declaration', 100, 200, 200, 0, 260, 0),
+		  ('small', 'main.go', 'function_declaration', 200, 250, 300, 0, 305, 0);
+	`)
+	require.NoError(t, err)
+	return dbPath
+}
+
+// TestFindSmellsCLI_DefaultMinMetricApplied pins the threshold-default
+// fix for the CLI path: running `mache find-smells --rule long_function`
+// without --min-metric must apply rule.DefaultMinMetric=81, mirroring
+// the MCP handler. Pre-fix, the CLI's findSmellsMinMetric defaulted to
+// 0 with no way to distinguish "flag not set" from "flag explicitly 0",
+// so the default threshold was silently ignored on the CLI path.
+func TestFindSmellsCLI_DefaultMinMetricApplied(t *testing.T) {
+	dbPath := writeLongFunctionFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+
+	// Drive the CLI through cobra so flag-parsing actually runs;
+	// setting findSmellsMinMetric directly wouldn't trip
+	// cmd.Flags().Changed("min-metric"), and the test would
+	// silently exercise the wrong branch.
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "long_function",
+		"--format", "json",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	// big (100 lines) ≥ 81 default → fires.
+	// mid (60 lines) < 81 default → filtered.
+	// small (5 lines) < 81 default → filtered.
+	require.Len(t, resp.Findings, 1, "default min_metric=81 must filter mid (60) and small (5)")
+	assert.Equal(t, "big", resp.Findings[0].NodeID)
+}
+
+// TestFindSmellsCLI_ExplicitMinMetricZeroOverridesDefault pins the
+// escape hatch: passing --min-metric 0 explicitly disables the
+// rule's DefaultMinMetric and returns everything sorted by metric.
+// Same semantic as the MCP handler.
+func TestFindSmellsCLI_ExplicitMinMetricZeroOverridesDefault(t *testing.T) {
+	dbPath := writeLongFunctionFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "long_function",
+		"--format", "json",
+		"--min-metric", "0",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	// All three functions surface; explicit 0 overrides default 81.
+	require.Len(t, resp.Findings, 3, "explicit --min-metric 0 must disable DefaultMinMetric")
+}
+
+// TestFindSmellsCLI_ExplicitMinMetricLowersThreshold pins that
+// values BELOW the rule's default work — a bug in the MCP handler
+// fixed in #302 (SQL floor) and now mirrored on the CLI.
+func TestFindSmellsCLI_ExplicitMinMetricLowersThreshold(t *testing.T) {
+	dbPath := writeLongFunctionFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "long_function",
+		"--format", "json",
+		"--min-metric", "50",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &resp))
+
+	// big (100) and mid (60) ≥ 50; small (5) is below.
+	require.Len(t, resp.Findings, 2)
+	gotIDs := []string{resp.Findings[0].NodeID, resp.Findings[1].NodeID}
+	assert.ElementsMatch(t, []string{"big", "mid"}, gotIDs)
+}
+
 // cliFlagSnapshot lets tests mutate the package-level flag vars without
 // leaking state across tests (cobra binds them globally).
 type cliFlagSnapshot struct {


### PR DESCRIPTION
## Summary

Real consistency bug between MCP and CLI consumers of find_smells:

- **MCP handler (#302)**: omitting `min_metric` falls back to `rule.DefaultMinMetric`; explicit `min_metric=0` disables it.
- **CLI (pre-fix)**: `findSmellsMinMetric` defaults to 0 with no way to distinguish \"flag not set\" from \"flag explicitly 0\", so `rule.DefaultMinMetric` was silently ignored. `mache find-smells --rule long_function` returned **all** functions sorted by length, not just those ≥81 lines like the MCP path.

**Fix**: use cobra's `cmd.Flags().Changed(\"min-metric\")` to detect explicit invocation. If unset, fall back to `DefaultMinMetric`. If set (even to `0`), use the caller's value verbatim. Same semantic as the MCP handler.

## Tests

Three new regression tests pin the contract end-to-end:

- `TestFindSmellsCLI_DefaultMinMetricApplied` — no flag → rule default applied (3 functions seeded; only the ≥81-line one fires)
- `TestFindSmellsCLI_ExplicitMinMetricZeroOverridesDefault` — explicit `--min-metric 0` disables the default; all 3 surface
- `TestFindSmellsCLI_ExplicitMinMetricLowersThreshold` — explicit `--min-metric 50` lowers threshold; the previously-hidden 60-line function surfaces

Tests use `ParseFlags` + `RunE` rather than `Execute` (the latter walks up to `rootCmd` which expects a mountpoint). `ParseFlags` sets cobra's `flag.Changed` state that the fix reads.

## Threshold-default arc closed end-to-end

| Layer | PR |
|---|---|
| Field added to `SmellRule` | #302 |
| `long_function` adopts | #302 |
| `long_file` adopts | #303 |
| External JSON loader honors | #304 |
| Discovery exposes | #305 |
| **CLI consumes** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)