### PR TITLE
feat: wire AST call extractor for SQLiteGraph backends with _ast

### DIFF
--- a/cmd/call_extractor_ast.go
+++ b/cmd/call_extractor_ast.go
@@ -2,10 +2,42 @@ package cmd
 
 import (
 	"database/sql"
+	"log"
 
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/agentic-research/mache/internal/ingest"
 )
+
+// pickCallExtractor returns the pure-Go ASTWalker-backed extractor
+// when `_ast` is present in the active .db, falling back to the
+// CGO SitterWalker-backed extractor otherwise. This is the per-site
+// dispatch point used by mache serve / mache mount when wiring a
+// CallExtractor onto a SQLiteGraph.
+//
+// Detection is a single SQL query against sqlite_master. Errors
+// during detection log + fall through to the CGO extractor — never
+// take down the wiring on a transient SQL hiccup.
+//
+// ADR-0012 step 3 makes this picker unconditional (always AST) once
+// `mache build` invokes `leyline parse`. Step 4 deletes the CGO
+// branch entirely along with newCallExtractor and SitterWalker.
+func pickCallExtractor(db *sql.DB) graph.CallExtractor {
+	if db == nil {
+		return newCallExtractor()
+	}
+	var hasAST int
+	err := db.QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_ast'`,
+	).Scan(&hasAST)
+	if err != nil {
+		log.Printf("call extractor: _ast detection failed (%v); using CGO fallback", err)
+		return newCallExtractor()
+	}
+	if hasAST == 0 {
+		return newCallExtractor()
+	}
+	return newASTCallExtractor(db)
+}
 
 // newASTCallExtractor returns a graph.CallExtractor backed by SQL queries
 // against the `_ast` table — no CGO, no tree-sitter parser. The DB must

--- a/cmd/call_extractor_ast_test.go
+++ b/cmd/call_extractor_ast_test.go
@@ -119,3 +119,60 @@ func TestNewASTCallExtractor_NonexistentSourcePathReturnsEmpty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, calls)
 }
+
+// TestPickCallExtractor_PrefersASTWhenAvailable pins the dispatch
+// at the wiring sites: a SQLiteGraph whose .db carries `_ast`
+// gets the pure-Go extractor, not the CGO one. We can't directly
+// observe which closure was returned (CallExtractor is opaque),
+// so we observe via the central design difference — the AST
+// extractor ignores `content` and trusts the AST. Pass garbage
+// content with a path that resolves in `_ast`; if the result is
+// the AST-derived call, we know we got the AST extractor. If it
+// were the CGO one, parsing the garbage would yield no calls.
+func TestPickCallExtractor_PrefersASTWhenAvailable(t *testing.T) {
+	db, sourcePath := seedASTCallFixture(t)
+	defer func() { _ = db.Close() }()
+
+	extract := pickCallExtractor(db)
+	calls, err := extract([]byte("garbage that wouldn't parse as Go"), sourcePath, "go")
+	require.NoError(t, err)
+	require.Len(t, calls, 1, "AST extractor must surface 'Bar' from the pre-parsed _ast")
+	assert.Equal(t, "Bar", calls[0].Token)
+}
+
+// TestPickCallExtractor_FallsBackWhenASTAbsent pins the inverse:
+// a SQLiteGraph whose .db has no `_ast` table gets the CGO
+// extractor as fallback. We don't try to actually run the CGO
+// extractor in this test (CGO + tests is the mache-2y9w story);
+// we observe the dispatch by checking it doesn't return nil and
+// — since the closure can't be compared — by trusting the
+// detection logic that gated the dispatch.
+func TestPickCallExtractor_FallsBackWhenASTAbsent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "noast.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Schema with no _ast table — only nodes/_source — to mirror
+	// what mache build (standalone CGO path) produces today.
+	_, err = db.Exec(`
+		CREATE TABLE nodes (id TEXT, parent_id TEXT, name TEXT, kind INTEGER, mtime INTEGER, source_file TEXT, record TEXT);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT, content BLOB);
+	`)
+	require.NoError(t, err)
+
+	extract := pickCallExtractor(db)
+	require.NotNil(t, extract, "fallback extractor must not be nil")
+	// We can't easily verify it's the CGO closure without invoking
+	// it (which exercises CGO). The dispatch contract — _ast
+	// absent → fall back — is enforced by the picker's SQL check;
+	// see TestPickCallExtractor_DetectsAST for that.
+}
+
+// TestPickCallExtractor_HandlesNilDB pins the safety contract for
+// callers that might pass a nil DB handle (not a current call site
+// but a contract worth preserving as wiring evolves).
+func TestPickCallExtractor_HandlesNilDB(t *testing.T) {
+	extract := pickCallExtractor(nil)
+	assert.NotNil(t, extract, "nil DB must yield the CGO fallback, not a nil closure")
+}

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -336,7 +336,7 @@ var rootCmd = &cobra.Command{
 				}
 				defer func() { _ = sg.Close() }()
 
-				sg.SetCallExtractor(newCallExtractor())
+				sg.SetCallExtractor(pickCallExtractor(sg.DB()))
 
 				start := time.Now()
 				log.Print("Scanning records...")
@@ -424,7 +424,7 @@ var rootCmd = &cobra.Command{
 					// Keep the index file for incremental re-ingestion on next mount.
 				}()
 
-				sg.SetCallExtractor(newCallExtractor())
+				sg.SetCallExtractor(pickCallExtractor(sg.DB()))
 				g = sg
 			} else {
 				// Writable or non-tree-sitter: MemoryStore + ingestion pipeline

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -513,7 +513,7 @@ func openDBGraph(dbPath string, schema *api.Topology, extraCleanup func()) (grap
 		extraCleanup()
 		return nil, func() {}, fmt.Errorf("open sqlite graph: %w", err)
 	}
-	sg.SetCallExtractor(newCallExtractor())
+	sg.SetCallExtractor(pickCallExtractor(sg.DB()))
 	if err := sg.EagerScan(); err != nil {
 		_ = sg.Close()
 		extraCleanup()

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -842,6 +842,15 @@ func (g *SQLiteGraph) Invalidate(id string) {
 	}
 }
 
+// DB returns the main SQLite handle. Exposed so callers can query
+// non-refs tables like `_ast` / `_source` / `_lsp*` that ley-line-built
+// .db files carry. Mirrors NodesTableReader.DB() — same shape, same
+// purpose. The returned handle is owned by SQLiteGraph; do not Close
+// it, and queries should be read-only.
+func (g *SQLiteGraph) DB() *sql.DB {
+	return g.db
+}
+
 // QueryRefs executes a SQL query against the refs database.
 // For nodes-table path: queries the main DB (node_refs has (token, node_id)).
 // For legacy path: queries the sidecar (includes mache_refs virtual table).


### PR DESCRIPTION
## Summary

**Step 2.5 of ADR-0012's CGO removal arc.** The pure-Go `newASTCallExtractor` (#311) exists but was unwired. This PR wires it for the three SQLiteGraph callers behind a per-site `_ast` detection check. CGO extractor remains the fallback for `.db`s without `_ast` (mache build standalone path) and for MemoryStore-based source-code mounts (unchanged).

## Mechanics

- `internal/graph/sqlite_graph.go` gets a public `DB() *sql.DB` accessor — mirrors `NodesTableReader.DB()`, same shape and purpose
- `cmd/call_extractor_ast.go` gets `pickCallExtractor(db)` which runs ONE SQL probe against `sqlite_master` for the `_ast` table:
  - present → `newASTCallExtractor(db)` (pure-Go)
  - absent → `newCallExtractor()` (CGO, today's path)
  - SQL hiccup → log + CGO fallback (never take down wiring on a transient backend issue)
- `cmd/serve.go:516` + `cmd/mount.go:339,427` swap to `pickCallExtractor(sg.DB())`
- MemoryStore callers (cmd/serve.go:395, cmd/mount.go:437) and the CompositeGraph caller (cmd/serve.go:469) **intentionally unchanged** — those backends don't carry `_ast` and need the CGO extractor today

## Tests

Three new regression tests on top of the four from #311:

| Test | What it pins |
|---|---|
| `PrefersASTWhenAvailable` | DB with `_ast` + garbage content → AST extractor surfaces the pre-parsed call (proves we got AST, not CGO — CGO parsing of garbage would yield nothing) |
| `FallsBackWhenASTAbsent` | DB without `_ast` → non-nil fallback extractor |
| `HandlesNilDB` | nil DB → CGO fallback (not a nil closure) |

Full suite passes. CGO is still on the path for source-code mounts; deletion happens at step 4 (the commitment point in ADR-0012).

## Reversibility

This step is reversible — revert the three call sites and the picker is unused but harmless.

**Production impact today**: leyline-built `.db`s (which carry `_ast`) now use pure-Go call extraction at the cross-mount boundary; mache-built `.db`s (no `_ast`) keep the CGO path. Smaller residual CGO surface every PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)