### PR TITLE
feat: CompositeGraph per-mount call extractor picker (ADR-0012 step 2)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -468,6 +468,20 @@ func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph,
 	// federated DefsMap. Without this, callees only route per-mount.
 	composite.SetCallExtractor(newCallExtractor())
 
+	// And wire the per-mount picker (ADR-0012): for SQLiteGraph mounts
+	// that carry `_ast`, prefer the pure-Go extractor; the picker
+	// returns nil for other backends so cross-mount resolution falls
+	// through to the global CGO extractor above. Each mount picks
+	// independently — heterogeneous fleets (e.g. one ll-open .db and
+	// one mache-built .db) get the right extractor per mount.
+	composite.SetCallExtractorPicker(func(local graph.Graph) graph.CallExtractor {
+		sg, ok := local.(*graph.SQLiteGraph)
+		if !ok {
+			return nil
+		}
+		return pickCallExtractor(sg.DB())
+	})
+
 	var cleanups []func()
 	runAll := func() {
 		// Reverse order so later mounts close before earlier ones.

--- a/internal/graph/composite.go
+++ b/internal/graph/composite.go
@@ -34,6 +34,15 @@ type CompositeGraph struct {
 	// extra results in the merged response. nil means cross-mount callees
 	// are off — sub-graphs still run their own GetCallees as before.
 	extractor CallExtractor
+
+	// extractorPicker, when set, is consulted at extract time to pick the
+	// right extractor for the local mount (the mount the caller node lives
+	// in). Used to dispatch between the CGO SitterWalker extractor and the
+	// pure-Go ASTWalker extractor based on whether the local mount has an
+	// `_ast` table — see ADR-0012's CGO removal arc. Returning nil from the
+	// picker falls through to `extractor`. nil picker means "use extractor
+	// unconditionally" (legacy behavior).
+	extractorPicker func(local Graph) CallExtractor
 }
 
 // NewCompositeGraph creates an empty composite graph.
@@ -353,10 +362,21 @@ func (c *CompositeGraph) GetCallees(id string) ([]*Node, error) {
 	c.mu.RLock()
 	prefix, subPath, g := c.resolve(id)
 	extractor := c.extractor
+	picker := c.extractorPicker
 	c.mu.RUnlock()
 
 	if g == nil {
 		return nil, ErrNotFound
+	}
+
+	// Per-mount extractor dispatch (ADR-0012): if a picker is wired,
+	// ask it for the right extractor given the local mount g. Picker
+	// returning nil falls through to the global `extractor` set via
+	// SetCallExtractor, preserving legacy behavior.
+	if picker != nil {
+		if perMount := picker(g); perMount != nil {
+			extractor = perMount
+		}
 	}
 
 	// Phase 1: route to local mount and re-prefix the results.
@@ -476,6 +496,22 @@ func (c *CompositeGraph) SetCallExtractor(fn CallExtractor) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.extractor = fn
+}
+
+// SetCallExtractorPicker wires a per-mount extractor selector. At
+// extract time, GetCallees calls picker(localMount); a non-nil
+// return value wins over the global extractor set via
+// SetCallExtractor. Used to dispatch between CGO and pure-Go
+// extractors based on the local mount's capabilities (e.g. presence
+// of an `_ast` table). See ADR-0012.
+//
+// Composing both: the picker is consulted first; if it returns nil,
+// fall through to the SetCallExtractor-supplied global extractor.
+// Callers that don't want per-mount dispatch can leave this unset.
+func (c *CompositeGraph) SetCallExtractorPicker(picker func(local Graph) CallExtractor) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.extractorPicker = picker
 }
 
 // Invalidate implements Graph.

--- a/internal/graph/composite_callees_test.go
+++ b/internal/graph/composite_callees_test.go
@@ -125,6 +125,117 @@ func TestCompositeGraph_CrossMountCalleesDedupes(t *testing.T) {
 	assert.Equal(t, 1, gotIDs["billing/functions/Validate"], "cross-mount def appears exactly once")
 }
 
+// TestCompositeGraph_CallExtractorPickerWinsOverGlobal pins the
+// per-mount dispatch contract added for ADR-0012's CGO removal arc:
+// when SetCallExtractorPicker returns a non-nil extractor, it
+// overrides the global SetCallExtractor for cross-mount resolution
+// against THAT local mount. The picker is consulted at extract time
+// with the routed local Graph.
+func TestCompositeGraph_CallExtractorPickerWinsOverGlobal(t *testing.T) {
+	auth := NewMemoryStore()
+	auth.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&Node{
+		ID:         "functions/Charge",
+		Mode:       fs.ModeDir,
+		Children:   []string{"functions/Charge/source"},
+		Properties: map[string][]byte{"lang": []byte("go")},
+	})
+	auth.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	require.NoError(t, auth.AddDef("Charge", "functions/Charge"))
+
+	billing := NewMemoryStore()
+	billing.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	billing.AddNode(&Node{ID: "functions/Validate/source", Mode: 0})
+	require.NoError(t, billing.AddDef("Validate", "functions/Validate"))
+
+	cg := NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	// Global extractor returns "WrongCall" — would NOT resolve.
+	cg.SetCallExtractor(fakeCallExtractor([]QualifiedCall{{Token: "WrongCall"}}))
+
+	// Picker returns the right extractor for this local mount.
+	// Picker getting called proves the per-mount dispatch path runs.
+	var pickerCalled int
+	cg.SetCallExtractorPicker(func(local Graph) CallExtractor {
+		pickerCalled++
+		return fakeCallExtractor([]QualifiedCall{{Token: "Validate"}})
+	})
+
+	callees, err := cg.GetCallees("auth/functions/Charge")
+	require.NoError(t, err)
+	assert.Equal(t, 1, pickerCalled, "picker must be consulted on cross-mount extract")
+
+	gotIDs := make([]string, len(callees))
+	for i, c := range callees {
+		gotIDs[i] = c.ID
+	}
+	assert.Contains(t, gotIDs, "billing/functions/Validate",
+		"picker's extractor must win over the global; Validate must resolve")
+}
+
+// TestCompositeGraph_CallExtractorPickerNilFallsThrough pins the
+// fallback contract: when the picker returns nil, GetCallees uses
+// the global extractor set via SetCallExtractor. Lets callers wire
+// a picker that opts out for some mounts while keeping the global
+// path for others.
+func TestCompositeGraph_CallExtractorPickerNilFallsThrough(t *testing.T) {
+	auth := NewMemoryStore()
+	auth.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	auth.AddNode(&Node{
+		ID:         "functions/Charge",
+		Mode:       fs.ModeDir,
+		Children:   []string{"functions/Charge/source"},
+		Properties: map[string][]byte{"lang": []byte("go")},
+	})
+	auth.AddNode(&Node{
+		ID:   "functions/Charge/source",
+		Mode: 0,
+		Data: []byte("func Charge() { Validate() }"),
+	})
+	require.NoError(t, auth.AddDef("Charge", "functions/Charge"))
+
+	billing := NewMemoryStore()
+	billing.AddRoot(&Node{ID: "functions", Mode: fs.ModeDir})
+	billing.AddNode(&Node{
+		ID:       "functions/Validate",
+		Mode:     fs.ModeDir,
+		Children: []string{"functions/Validate/source"},
+	})
+	billing.AddNode(&Node{ID: "functions/Validate/source", Mode: 0})
+	require.NoError(t, billing.AddDef("Validate", "functions/Validate"))
+
+	cg := NewCompositeGraph()
+	require.NoError(t, cg.Mount("auth", auth))
+	require.NoError(t, cg.Mount("billing", billing))
+
+	// Global extractor returns the right call.
+	cg.SetCallExtractor(fakeCallExtractor([]QualifiedCall{{Token: "Validate"}}))
+
+	// Picker returns nil — fall through to global.
+	cg.SetCallExtractorPicker(func(local Graph) CallExtractor { return nil })
+
+	callees, err := cg.GetCallees("auth/functions/Charge")
+	require.NoError(t, err)
+
+	gotIDs := make([]string, len(callees))
+	for i, c := range callees {
+		gotIDs[i] = c.ID
+	}
+	assert.Contains(t, gotIDs, "billing/functions/Validate",
+		"picker returning nil must fall through to the global extractor")
+}
+
 // TestCompositeGraph_CrossMountCalleesNoExtractor proves the feature
 // is opt-in: without SetCallExtractor, GetCallees only consults the
 // local mount (the previously-shipped behavior).


### PR DESCRIPTION
## Summary

Heterogeneous-mount support for cross-mount callee resolution.

Until now `CompositeGraph` stored ONE extractor; cross-mount queries used it regardless of which mount the caller node lived in. That worked when all mounts were the same shape (all CGO, all AST), but falls down for the realistic mixed case: an ll-open `.db` (has `_ast`, wants `ASTWalker`) plus a mache-built `.db` (no `_ast`, needs CGO) under one composite.

Add `SetCallExtractorPicker(func(local Graph) CallExtractor)`. At extract time, `GetCallees` consults `picker(local)`; a non-nil return overrides the global `SetCallExtractor` for THAT call. nil falls through to the global, preserving legacy behavior. **Both APIs coexist** — callers don't have to migrate.

Wired in `cmd/serve.go`'s composite path: per-mount picker checks if `local` is a `*SQLiteGraph` and runs `pickCallExtractor(sg.DB())` for it. SQLiteGraphs with `_ast` get the pure-Go extractor; others fall through to the global CGO one. Heterogeneous fleets get the right extractor per mount.

## Tests

| Test | What it pins |
|---|---|
| `CallExtractorPickerWinsOverGlobal` | Global returns \"WrongCall\", picker returns \"Validate\", asserts Validate resolves AND picker was called exactly once |
| `CallExtractorPickerNilFallsThrough` | Global returns \"Validate\", picker returns nil, asserts global path runs and Validate still resolves |
| All existing `TestCompositeGraph_*` tests still pass |

## Where this lands ADR-0012

Closes the picker-side wiring for step 2.5. Remaining CGO surface in the wiring layer:

- `cmd/serve.go:395` (MemoryStore — source-code mount, removed at step 3)
- `cmd/mount.go:437` (MemoryStore — same, removed at step 3)
- `newCallExtractor` itself (CGO closure body — removed at step 4)

Step 3 (`mache build` → `leyline parse` subprocess) eliminates the remaining MemoryStore wiring sites along with the standalone ingest path. After that, step 4 deletes `newCallExtractor` + `SitterWalker` + the `smacker/go-tree-sitter` dep.

## Test plan

- [x] All composite tests pass
- [x] Full test suite passes on this branch
- [x] `task lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)