### PR TITLE
feat: mache build --backend=leyline opt-in (ADR-0012 step 3 start)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,6 +16,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// buildBackend selects the parsing backend for `mache build`.
+//   - "auto" (default): in-process tree-sitter via SitterWalker — current behavior.
+//   - "leyline": shell out to `leyline parse`. Requires leyline on PATH or
+//     ~/.mache/bin/leyline. Produces a richer .db (carries `_ast`, `_source`,
+//     `_imports`, `_lsp*`) that all 9 find_smells rules can run against.
+//     Schema projection at query time (via SQLiteGraph) — the --schema flag
+//     is ignored on this path because leyline doesn't apply it.
+//
+// Opt-in for now per ADR-0012 step 3. A future PR makes this auto-detect
+// and prefer leyline when available.
+var buildBackend string
+
 var buildCmd = &cobra.Command{
 	Use:   "build [source] [output.db]",
 	Short: "Build a Mache SQLite database from a source directory",
@@ -23,6 +35,15 @@ var buildCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		source := args[0]
 		output := args[1]
+
+		// Backend dispatch (ADR-0012). When --backend=leyline, shell out
+		// to `leyline parse` and copy the result to `output`. Schema
+		// flag is ignored on this path — leyline produces raw _ast /
+		// _source / nodes / node_refs / node_defs; schema projection
+		// happens at serve/mount time via SQLiteGraph.
+		if buildBackend == "leyline" {
+			return runBuildViaLeyline(source, output)
+		}
 
 		// Load or infer schema. Falls back to FCA inference when no schema file is provided.
 		var schema *api.Topology
@@ -157,5 +178,38 @@ func init() {
 	// and have to rely on FCA inference — which doesn't yet produce a
 	// methods/ root for Go (mache-5d1o).
 	buildCmd.Flags().StringVarP(&schemaPath, "schema", "s", "", "Path to topology schema (defaults to FCA inference)")
+	buildCmd.Flags().StringVar(&buildBackend, "backend", "auto", "Parsing backend: 'auto' (in-process tree-sitter, current default) or 'leyline' (delegate to ley-line-open's `leyline parse`; produces richer .db with _ast/_source/_lsp* and is the future default per ADR-0012)")
 	rootCmd.AddCommand(buildCmd)
+}
+
+// runBuildViaLeyline implements --backend=leyline: shells out to
+// `leyline parse <source> -o <tmp.db>` and copies the result to
+// `output`. The ADR-0012 step 3 path that future PRs will make
+// the default.
+//
+// Errors are surfaced as-is; callers shouldn't retry with the
+// in-process backend silently — that masks misconfiguration.
+// If the user explicitly passed --backend=leyline, leyline being
+// missing is a real error worth reporting, not a fallback trigger.
+func runBuildViaLeyline(source, output string) error {
+	if schemaPath != "" {
+		log.Printf("--backend=leyline: --schema=%q is ignored on this path; schema projection happens at serve/mount time", schemaPath)
+	}
+	tmpPath, cleanup, err := autoInvokeLeylineParse(source)
+	if err != nil {
+		return fmt.Errorf("leyline backend: %w", err)
+	}
+	defer cleanup()
+
+	// Move the temp .db to the output path. copyFile (cmd/utils.go)
+	// uses copy + close rather than rename so we don't fail across
+	// filesystems (TMPDIR may be on a different mount than the
+	// target). Pre-truncate the destination to match the prior
+	// `os.Remove(output)` behavior in the auto path.
+	_ = os.Remove(output)
+	if err := copyFile(tmpPath, output); err != nil {
+		return fmt.Errorf("copy leyline output to %s: %w", output, err)
+	}
+	log.Printf("Built %s from %s via leyline", output, source)
+	return nil
 }

--- a/cmd/build_leyline_test.go
+++ b/cmd/build_leyline_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// saveBuildFlags / restoreBuildFlags isolate package-level flag state
+// across tests. Cobra binds buildBackend / schemaPath as package vars
+// so tests that toggle them must restore.
+type buildFlagSnapshot struct {
+	backend, schema string
+}
+
+func saveBuildFlags() buildFlagSnapshot {
+	return buildFlagSnapshot{backend: buildBackend, schema: schemaPath}
+}
+
+func (s buildFlagSnapshot) restore() {
+	buildBackend = s.backend
+	schemaPath = s.schema
+}
+
+// TestBuild_BackendFlagDefaultIsAuto pins the cobra wiring: the
+// `--backend` flag exists on buildCmd and defaults to "auto".
+// Important to lock down because `auto` preserves today's
+// behavior; flipping the default to `leyline` is a separate
+// future change that should land deliberately.
+func TestBuild_BackendFlagDefaultIsAuto(t *testing.T) {
+	flag := buildCmd.Flags().Lookup("backend")
+	require.NotNil(t, flag, "buildCmd must register --backend")
+	assert.Equal(t, "auto", flag.DefValue, "default backend must remain 'auto' until ADR-0012 commits to leyline-default")
+	assert.Contains(t, flag.Usage, "leyline", "help text must mention the leyline option")
+	assert.Contains(t, flag.Usage, "auto", "help text must call out the current default")
+}
+
+// TestRunBuildViaLeyline_ReturnsClearErrorWhenLeylineMissing pins
+// the explicit-flag-no-fallback contract: --backend=leyline with
+// no leyline binary on PATH (and no bundled location) must surface
+// a clear error rather than silently fall back to in-process
+// parsing. Silent fallback would mask misconfiguration in CI/script
+// contexts where the user expects the leyline path.
+func TestRunBuildViaLeyline_ReturnsClearErrorWhenLeylineMissing(t *testing.T) {
+	saved := saveBuildFlags()
+	defer saved.restore()
+
+	// Hide both PATH and the bundled location ($HOME/.mache/bin/leyline).
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),
+		[]byte("package main\nfunc main() {}\n"), 0o644))
+
+	output := filepath.Join(t.TempDir(), "out.db")
+	err := runBuildViaLeyline(src, output)
+	require.Error(t, err, "leyline missing must error, not silently fall back")
+	assert.Contains(t, err.Error(), "leyline backend",
+		"error must identify which backend failed (helps the user diagnose)")
+}
+
+// TestRunBuildViaLeyline_HappyPath skips when leyline isn't
+// available. When it is, parses a tiny Go tree and asserts the
+// output .db exists with non-zero size at the user-supplied path
+// (not the temp path autoInvokeLeylineParse uses internally).
+func TestRunBuildViaLeyline_HappyPath(t *testing.T) {
+	if _, err := exec.LookPath("leyline"); err != nil {
+		t.Skip("leyline binary not on PATH")
+	}
+	saved := saveBuildFlags()
+	defer saved.restore()
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),
+		[]byte("package main\nfunc main() {}\n"), 0o644))
+
+	output := filepath.Join(t.TempDir(), "out.db")
+	require.NoError(t, runBuildViaLeyline(src, output))
+
+	info, err := os.Stat(output)
+	require.NoError(t, err, "output .db must exist at the user-supplied path")
+	assert.Greater(t, info.Size(), int64(0), "output .db must be non-empty")
+}
+
+// TestBuildCmd_BackendDispatch pins that the cobra command actually
+// routes --backend=leyline through runBuildViaLeyline rather than
+// the in-process engine. Uses the missing-leyline error as a
+// detection signal: if the leyline path runs, we get a leyline-
+// flavored error; if the auto path runs, we'd get a tree-sitter-
+// flavored error or success.
+func TestBuildCmd_BackendDispatch(t *testing.T) {
+	saved := saveBuildFlags()
+	defer saved.restore()
+
+	// Force leyline backend, hide the binary.
+	buildBackend = "leyline"
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),
+		[]byte("package main\nfunc main() {}\n"), 0o644))
+	output := filepath.Join(t.TempDir(), "out.db")
+
+	// Run the cobra command directly. ParseFlags + RunE is the same
+	// pattern TestFindSmellsCLI uses (executes without walking up to
+	// rootCmd which expects a mountpoint).
+	require.NoError(t, buildCmd.ParseFlags([]string{}))
+	err := buildCmd.RunE(buildCmd, []string{src, output})
+	require.Error(t, err, "leyline path must error when binary is missing")
+	assert.Contains(t, err.Error(), "leyline backend",
+		"dispatch must reach runBuildViaLeyline, not the in-process engine")
+}
+
+// silence unused-import warning when tests don't reference cobra.
+var _ = cobra.Command{}


### PR DESCRIPTION
## Summary

The first concrete step toward delegating parsing to ley-line. **Default behavior is preserved** (`--backend=auto`, in-process tree-sitter); `--backend=leyline` opts into the new path that shells out to `leyline parse` and copies the result to the user-supplied output.

**No fallback when leyline is missing** — a missing binary on the explicit-flag path is real misconfiguration, not a transient.

## Mechanics

- `buildBackend` package var binds to `--backend`; default `"auto"`
- `buildCmd` dispatches early to `runBuildViaLeyline` when `--backend=leyline`. The auto path (existing tree-sitter `Engine.Ingest`) is **untouched** — nothing in the default user experience changes.
- `runBuildViaLeyline` reuses `autoInvokeLeylineParse` (existing in `serve.go`) and the existing `copyFile` (`cmd/utils.go`). No new helpers; minimal LOC.
- `--schema` is logged-and-ignored on the leyline path (leyline doesn't apply mache schemas; projection happens at serve/mount time via `SQLiteGraph`). Better than silently ignoring.

## Tests

| Test | What it pins |
|---|---|
| `BackendFlagDefaultIsAuto` | Cobra registration sanity. Default stays `\"auto\"` so a future flip to leyline-default lands deliberately. |
| `ReturnsClearErrorWhenLeylineMissing` | `--backend=leyline` with no binary surfaces \"leyline backend: ...\" rather than silent fallback to the in-process engine. |
| `HappyPath` (skips when leyline absent) | End-to-end produces a non-empty `.db` at the user-supplied output path. Verified green locally. |
| `BackendDispatch` | Cobra command-level dispatch — `--backend=leyline` reaches `runBuildViaLeyline` rather than the auto path. |

## What this enables

A future PR can flip the default to auto-detect-and-prefer-leyline; this PR is the opt-in step that lets the path get exercised + tested without changing what existing users see.

**Step 3 of ADR-0012 progresses**; step 4 (delete in-process engine, drop tree-sitter) is the commitment point gated on `mache-33dc5f` (leyline binary bundling) and the auto-detect default flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)