### PR TITLE
feat: mache build --backend=auto prefers leyline (ADR-0012 step 3b)

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -17,15 +18,19 @@ import (
 )
 
 // buildBackend selects the parsing backend for `mache build`.
-//   - "auto" (default): in-process tree-sitter via SitterWalker — current behavior.
-//   - "leyline": shell out to `leyline parse`. Requires leyline on PATH or
-//     ~/.mache/bin/leyline. Produces a richer .db (carries `_ast`, `_source`,
-//     `_imports`, `_lsp*`) that all 9 find_smells rules can run against.
-//     Schema projection at query time (via SQLiteGraph) — the --schema flag
-//     is ignored on this path because leyline doesn't apply it.
+//   - "auto" (default): prefer leyline when on PATH or at
+//     ~/.mache/bin/leyline; otherwise fall back to in-process
+//     tree-sitter. The detection runs once per invocation; users
+//     without leyline see today's behavior unchanged.
+//   - "leyline": force the leyline path. Errors if leyline is missing
+//     (no silent fallback — explicit-flag misconfiguration should be loud).
+//   - "tree-sitter": force the in-process path even if leyline is
+//     available. Escape hatch for users debugging the legacy ingest
+//     or comparing outputs.
 //
-// Opt-in for now per ADR-0012 step 3. A future PR makes this auto-detect
-// and prefer leyline when available.
+// ADR-0012 step 3 — auto-detect with leyline preference. Step 4
+// (CGO removal commitment point) deletes "tree-sitter" / "auto"
+// fallback once leyline is bundled in mache releases (mache-33dc5f).
 var buildBackend string
 
 var buildCmd = &cobra.Command{
@@ -36,13 +41,21 @@ var buildCmd = &cobra.Command{
 		source := args[0]
 		output := args[1]
 
-		// Backend dispatch (ADR-0012). When --backend=leyline, shell out
-		// to `leyline parse` and copy the result to `output`. Schema
-		// flag is ignored on this path — leyline produces raw _ast /
-		// _source / nodes / node_refs / node_defs; schema projection
-		// happens at serve/mount time via SQLiteGraph.
-		if buildBackend == "leyline" {
+		// Backend dispatch (ADR-0012):
+		//   leyline      → force leyline path (errors if missing)
+		//   tree-sitter  → force in-process path (skip detection)
+		//   auto / ""    → prefer leyline when available, else in-process
+		switch buildBackend {
+		case "leyline":
 			return runBuildViaLeyline(source, output)
+		case "tree-sitter":
+			// Fall through to in-process path below.
+		default: // "auto" or empty
+			if leylineAvailable() {
+				log.Printf("--backend=auto: leyline detected, using leyline path; pass --backend=tree-sitter to force in-process")
+				return runBuildViaLeyline(source, output)
+			}
+			// No leyline → use in-process. Same as today's behavior.
 		}
 
 		// Load or infer schema. Falls back to FCA inference when no schema file is provided.
@@ -178,8 +191,31 @@ func init() {
 	// and have to rely on FCA inference — which doesn't yet produce a
 	// methods/ root for Go (mache-5d1o).
 	buildCmd.Flags().StringVarP(&schemaPath, "schema", "s", "", "Path to topology schema (defaults to FCA inference)")
-	buildCmd.Flags().StringVar(&buildBackend, "backend", "auto", "Parsing backend: 'auto' (in-process tree-sitter, current default) or 'leyline' (delegate to ley-line-open's `leyline parse`; produces richer .db with _ast/_source/_lsp* and is the future default per ADR-0012)")
+	buildCmd.Flags().StringVar(&buildBackend, "backend", "auto", "Parsing backend: 'auto' (prefer leyline when on PATH, else in-process tree-sitter), 'leyline' (force leyline; errors if missing), 'tree-sitter' (force in-process even when leyline is available). Per ADR-0012; step 4 deletes the in-process fallback.")
 	rootCmd.AddCommand(buildCmd)
+}
+
+// leylineAvailable returns true when `leyline` is on PATH or at
+// ~/.mache/bin/leyline. Mirrors the lookup autoInvokeLeylineParse
+// does, but as a probe: callers use it to choose between the
+// leyline path and the in-process fallback before any I/O.
+//
+// Cheap call: exec.LookPath consults PATH only; the home-dir check
+// is a single os.Stat. No subprocess invocation. Safe to call
+// repeatedly.
+func leylineAvailable() bool {
+	if _, err := exec.LookPath("leyline"); err == nil {
+		return true
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	bundled := filepath.Join(home, ".mache", "bin", "leyline")
+	if _, err := os.Stat(bundled); err == nil {
+		return true
+	}
+	return false
 }
 
 // runBuildViaLeyline implements --backend=leyline: shells out to

--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -67,6 +67,12 @@ func TestBuild_ProducesDB(t *testing.T) {
 // no methods. Without multi-file accumulation the schema would lack
 // methods/, so the method's call to standaloneFunc would not appear
 // in node_refs.
+//
+// Pinned to --backend=tree-sitter: FCA inference is an in-process
+// feature that doesn't apply to the leyline path. After the
+// ADR-0012 step 3b auto-default flip, "auto" prefers leyline when
+// available; this test explicitly requests the in-process path so
+// the FCA assertions stay valid.
 func TestBuild_FCAInferenceCoversMethods(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcDir := filepath.Join(tmpDir, "src")
@@ -85,10 +91,14 @@ func TestBuild_FCAInferenceCoversMethods(t *testing.T) {
 
 	outDB := filepath.Join(tmpDir, "out.db")
 
-	// Empty schemaPath forces the FCA-inference branch.
+	// Empty schemaPath forces the FCA-inference branch; explicit
+	// --backend=tree-sitter pins the in-process path so leyline
+	// auto-detection (PR #315) doesn't shortcut FCA.
 	oldSchemaPath := schemaPath
+	oldBackend := buildBackend
 	schemaPath = ""
-	defer func() { schemaPath = oldSchemaPath }()
+	buildBackend = "tree-sitter"
+	defer func() { schemaPath = oldSchemaPath; buildBackend = oldBackend }()
 
 	require.NoError(t, buildCmd.RunE(buildCmd, []string{srcDir, outDB}))
 
@@ -133,9 +143,13 @@ func TestBuild_FCAInferenceTagsLanguage(t *testing.T) {
 
 	outDB := filepath.Join(tmpDir, "out.db")
 
+	// Pin --backend=tree-sitter: FCA inference is in-process-only;
+	// auto-default-to-leyline (PR #315) would skip it.
 	oldSchemaPath := schemaPath
+	oldBackend := buildBackend
 	schemaPath = ""
-	defer func() { schemaPath = oldSchemaPath }()
+	buildBackend = "tree-sitter"
+	defer func() { schemaPath = oldSchemaPath; buildBackend = oldBackend }()
 
 	require.NoError(t, buildCmd.RunE(buildCmd, []string{srcDir, outDB}))
 


### PR DESCRIPTION
## Summary

Flips the `--backend=auto` heuristic to prefer leyline when available, with in-process tree-sitter as fallback. Step 3b in the ADR-0012 CGO removal arc.

- **auto** (default): prefer leyline when on PATH or at \`~/.mache/bin/leyline\`; else fall through to in-process. Users without leyline see today's behavior unchanged.
- **leyline**: force leyline; errors if missing (no silent fallback — explicit-flag misconfiguration should be loud).
- **tree-sitter**: force in-process even if leyline is available. Escape hatch for debugging/comparison.

## Why now

Step 3a (PR #314) shipped \`--backend=leyline\` as opt-in. Step 3b makes the default reflect that the leyline path produces a richer \`.db\` (carries \`_ast\`/\`_source\`/\`_imports\`/\`_lsp*\`) — which all 9 \`find_smells\` rules can run against. Step 4 deletes the in-process fallback entirely once mache-33dc5f bundles leyline in mache releases.

## Test plan

- [x] TestBuild_BackendFlagDefaultIsAuto — default still \"auto\"
- [x] TestBuildCmd_BackendDispatch — \`--backend=leyline\` errors when missing (no silent fallback)
- [x] TestBuild_FCAInferenceCoversMethods — pins \`--backend=tree-sitter\` (FCA is in-process-only)
- [x] TestBuild_FCAInferenceTagsLanguage — same pin
- [x] Full \`cmd\` suite passes locally (52s)