### PR TITLE
test: pin TestBuild_SchemaPathRelative to --backend=tree-sitter

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -190,6 +190,14 @@ func TestBuild_FCAInferenceTagsLanguage(t *testing.T) {
 // We use a tempdir-relative schema file rather than the real
 // examples/go-schema.json so the test isn't tied to that file's
 // content (it'd break if the schema's JSON shape evolved).
+//
+// Pinned to --backend=tree-sitter: resolveSchema only runs on the
+// in-process path. After the ADR-0012 step 3b auto-default flip
+// (#315), --backend=auto prefers leyline when available and logs
+// "--schema is ignored on this path." That short-circuits the very
+// code we're trying to test, so the test would silently stop
+// guarding the double-prepend regression on machines with leyline
+// installed.
 func TestBuild_SchemaPathRelative(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcDir := filepath.Join(tmpDir, "src")
@@ -214,8 +222,10 @@ func TestBuild_SchemaPathRelative(t *testing.T) {
 	defer func() { _ = os.Chdir(oldWD) }()
 
 	oldSchemaPath := schemaPath
+	oldBackend := buildBackend
 	schemaPath = "schemas/minimal.json"
-	defer func() { schemaPath = oldSchemaPath }()
+	buildBackend = "tree-sitter"
+	defer func() { schemaPath = oldSchemaPath; buildBackend = oldBackend }()
 
 	outDB := filepath.Join(tmpDir, "out.db")
 	err = buildCmd.RunE(buildCmd, []string{srcDir, outDB})


### PR DESCRIPTION
## Summary

After ADR-0012 step 3b (#315), \`--backend=auto\` prefers leyline when it's on PATH. The leyline path logs \"--schema is ignored on this path; schema projection happens at serve/mount time\" and skips \`resolveSchema\` entirely.

\`TestBuild_SchemaPathRelative\` was written to guard against a double-prepend regression in \`resolveSchema\` when \`schemaRef\` is a relative path with a directory component (the bug that produced \`examples/examples/go-schema.json\`). On machines with leyline installed, \`--backend=auto\` silently bypasses \`resolveSchema\`, so the test passes for the wrong reason — the regression could return and the suite wouldn't catch it.

Pin \`--backend=tree-sitter\` so the test exercises the in-process path deterministically. Same pattern as the FCA tests fixed in #315.

## Test plan

- [x] \`go test -run TestBuild_SchemaPathRelative -v ./cmd/\` — passes via in-process branch (\`Building ...\` log instead of \`auto-leyline: parsing\`)
- [x] All other TestBuild_* tests still green