### PR TITLE
chore: remove dead methods — ArenaFlusher.LastError + SocketClient.Enrich

### DIFF
--- a/internal/graph/arena_writer.go
+++ b/internal/graph/arena_writer.go
@@ -36,12 +36,11 @@ type ArenaFlusher struct {
 	ctrl         *control.Controller
 
 	// Coalescing state
-	mu       sync.Mutex
-	dirty    bool
-	flushErr error // last flush error, readable via LastError()
-	tick     *time.Ticker
-	stopCh   chan struct{}
-	stopped  bool
+	mu      sync.Mutex
+	dirty   bool
+	tick    *time.Ticker
+	stopCh  chan struct{}
+	stopped bool
 }
 
 // NewArenaFlusher creates a flusher that targets the given arena file
@@ -80,9 +79,6 @@ func (f *ArenaFlusher) coalesceLoop() {
 				f.dirty = false
 				f.mu.Unlock()
 				if err := f.flushInternal(); err != nil {
-					f.mu.Lock()
-					f.flushErr = err
-					f.mu.Unlock()
 					log.Printf("arena flush: %v", err)
 				}
 			} else {
@@ -109,13 +105,6 @@ func (f *ArenaFlusher) FlushNow() error {
 	f.dirty = false
 	f.mu.Unlock()
 	return f.flushInternal()
-}
-
-// LastError returns the last error from the coalescing goroutine.
-func (f *ArenaFlusher) LastError() error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.flushErr
 }
 
 // Close stops the coalescing goroutine and performs a final synchronous

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -427,19 +427,6 @@ func (c *SocketClient) Prioritize(files []string) error {
 	return err
 }
 
-// Enrich triggers an enrichment pass on the daemon.
-// Pass name is e.g. "lsp", "tree-sitter". Files is optional (nil = all).
-func (c *SocketClient) Enrich(pass string, files []string) (map[string]any, error) {
-	req := map[string]any{
-		"op":   "enrich",
-		"pass": pass,
-	}
-	if files != nil {
-		req["files"] = files
-	}
-	return c.SendOp(req)
-}
-
 // downloadLeyline fetches the leyline binary from the latest GitHub release
 // to the specified path. Returns the path on success.
 func downloadLeyline(destPath string) (string, error) {


### PR DESCRIPTION
## Summary

Two unambiguous dead-code findings from \`mache find-smells --rule dead_code\` against the self-built \`.db\`. Both are publicly-exported methods with zero callers in production or tests.

### \`ArenaFlusher.LastError\` + \`flushErr\` field

The accessor read \`f.flushErr\`; nothing else in the codebase read it. The coalescing goroutine assigned to it before this PR — purely write-only since \`LastError\` had no callers.

The error is also logged via \`log.Printf(\"arena flush: %v\", err)\` in the same branch, so observability is preserved without the field. Drop the field assignment, the field, and the accessor.

### \`SocketClient.Enrich\`

12-line shim that wraps \`SendOp\` with \`op=\"enrich\"\`. Zero callers. The leyline daemon's enrich endpoint can still be invoked directly via \`SendOp\` if a future caller needs it; this layer was speculative.

**Net: -29 / +5 lines.** Continues the post-step-3b dead-code sweep (see also #319 for \`ingest.DetectLanguageFromExt\`).

## Note on `.query/`

The same smell scan also flagged \`Resolver.EnableQuery\` as dead, but that's a stranded feature — the \`.query/\` virtual directory is wired but never activated post-FUSE-removal in PR #160. Filed as **mache-d375ec** for separate triage — needs a deliberate \"reconnect or delete\" decision rather than a quiet removal here.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/graph/ -run ArenaFlusher\` — TestArenaFlusher_FlipBuffer + TestArenaFlusher_Coalesce pass
- [x] \`go test ./internal/leyline/\` — passes