### PR TITLE
chore: remove dead ingest.GetLanguage deprecated wrapper

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -1764,17 +1764,6 @@ func extractGoPackageName(fileRoot *sitter.Node, source []byte, lang *sitter.Lan
 	return ""
 }
 
-// GetLanguage returns the tree-sitter language for a language name string.
-// Returns nil for unsupported languages.
-// Deprecated: use lang.ForName(name).Grammar() instead.
-func GetLanguage(langName string) *sitter.Language {
-	l := lang.ForName(langName)
-	if l == nil {
-		return nil
-	}
-	return l.Grammar()
-}
-
 // RenderTemplate delegates to internal/template.Render.
 // Kept as a public alias for backward compatibility with existing callers.
 func RenderTemplate(tmpl string, values map[string]any) (string, error) {


### PR DESCRIPTION
## Summary

Another \`find_smells --rule dead_code\` finding. The function was already tagged \`// Deprecated: use lang.ForName(name).Grammar() instead.\` — and consumers all migrated. Zero non-test callers remain (the other \`GetLanguage\` refs in the codebase are \`golang.GetLanguage()\`, \`python.GetLanguage()\`, etc., which are different functions in the tree-sitter grammar packages).

**Net: -10 lines.** Fourth installment in the post-step-3b dead-code sweep:

| PR    | Removed                                | Lines |
|-------|----------------------------------------|------:|
| #319  | \`ingest.DetectLanguageFromExt\`       |   -19 |
| #320  | \`ArenaFlusher.LastError\` + \`Enrich\` |   -29 |
| #321  | \`Inferrer.InferFromSQLiteJSON\`       |   -46 |
| #322  | \`ingest.GetLanguage\` (this PR)       |   -10 |

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/ingest/\` — passes