### PR TITLE
fix: TestArenaFlusher_Coalesce — tolerate CI scheduler delay (mache-02a9ab)

### DIFF
--- a/internal/graph/arena_writer_test.go
+++ b/internal/graph/arena_writer_test.go
@@ -141,8 +141,16 @@ func TestArenaFlusher_Coalesce(t *testing.T) {
 	require.NoError(t, err)
 	_ = f.Close()
 
-	// Sequence should be 2 (initial=1, one coalesced flush), not 11
-	assert.Equal(t, uint64(2), h.Sequence, "10 rapid requests should coalesce into 1 flush")
+	// Sequence should be 2 in the steady case (initial=1 + one coalesced
+	// flush) and at most 3 under CI load where scheduler delay can push
+	// the wall-clock-based 80ms sleep past a second tick. Either way it
+	// must be far below 11 — the coalescing guarantee is "10 rapid
+	// requests collapse to ≤2 flushes," not "exactly one flush."
+	// (mache-02a9ab)
+	assert.GreaterOrEqual(t, h.Sequence, uint64(2),
+		"at least one flush should have run after 10 RequestFlush + 80ms")
+	assert.LessOrEqual(t, h.Sequence, uint64(3),
+		"10 rapid requests must coalesce — observed sequence %d implies they did not", h.Sequence)
 
 	require.NoError(t, flusher.Close())
 }


### PR DESCRIPTION
## Summary

Closes **mache-02a9ab**.

The test asserted \`Sequence == 2\` (initial=1 + one coalesced flush from 10 rapid \`RequestFlush()\` calls). On PR #324's first \`ubuntu-latest\` integration run, scheduler delay pushed the wall-clock \`80ms\` sleep past the second \`50ms\` tick, producing \`Sequence = 3\` and a failed assertion. Rerun went green — confirmed flake, not a real bug.

## Why the loosened bound is still correct

The coalescing guarantee the test should defend is \"10 rapid requests collapse to ≤2 flushes,\" not \"exactly one flush.\" Loosen the assertion to:

\`\`\`go
Sequence >= 2  // at least one flush actually ran
Sequence <= 3  // ≤2 flushes ≪ the 11 we'd see without coalescing
\`\`\`

Anything \`≤3\` still proves coalescing happened — the failure mode the test is designed to catch (no coalescing, one flush per \`RequestFlush\`) would produce \`Sequence == 11\`.

## Test plan

- [x] \`go test ./internal/graph/ -run TestArenaFlusher -v -count=10\` — 10 consecutive runs pass on this machine