### PR TITLE
fix: TestWatcher_NewSubdirectory — bump FSEvents bounds (mache-402c60)

### DIFF
--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -191,19 +191,22 @@ func TestWatcher_NewSubdirectory(t *testing.T) {
 	// higher latency than Linux inotify, so the sub-watcher install can
 	// take >50ms — wait long enough for it to settle before the file
 	// write, otherwise the watcher misses the create event entirely.
+	//
+	// Bumped warmup 250ms → 500ms and the eventually window 2s → 5s
+	// (mache-402c60). Under noisy macos-latest CI the previous bounds
+	// produced occasional flakes — assertion never satisfied, retry
+	// always green. The happy path stays sub-second on inotify; the
+	// 5s ceiling only kicks in when something has genuinely gone wrong.
 	subDir := filepath.Join(tmpDir, "pkg")
 	require.NoError(t, os.MkdirAll(subDir, 0o755))
-	time.Sleep(250 * time.Millisecond)
+	time.Sleep(500 * time.Millisecond)
 
 	goFile := filepath.Join(subDir, "lib.go")
 	require.NoError(t, os.WriteFile(goFile, []byte("package pkg"), 0o644))
 
-	// Poll for the callback instead of sleeping a fixed window — bounded
-	// at 2s with 25ms ticks, which is generous on inotify and tolerable
-	// on FSEvents without making the happy path slow.
 	require.Eventually(t, func() bool {
 		return callCount.Load() >= 1
-	}, 2*time.Second, 25*time.Millisecond, "should detect file in new subdirectory")
+	}, 5*time.Second, 25*time.Millisecond, "should detect file in new subdirectory")
 
 	mu.Lock()
 	assert.Equal(t, goFile, lastPath)


### PR DESCRIPTION
## Summary

Closes **mache-402c60**.

PR #325 hit this flake on its first \`macos-latest\` integration run: the test never observed the file-creation callback within the 2s \`require.Eventually\` window, even after the existing 250ms warmup sleep meant to let the FSEvents sub-watcher install. Rerun went green — confirmed flake, not a regression.

Same shape as **mache-02a9ab** (\`TestArenaFlusher_Coalesce\`): wall-clock timing assumption that holds locally and on inotify but breaks on noisy \`macos-latest\` CI.

## Bump

- warmup sleep:  \`250ms → 500ms\` (sub-watcher install settles)
- eventually:    \`2s → 5s\` (callback observation deadline)

Happy path stays sub-second on inotify (Linux still completes the sub-test in ≈0.5s post-bump, verified locally with \`-count=5\`). The 5s ceiling only matters when something has genuinely gone wrong, in which case the failure surfaces as before.

The deeper fix — replacing FSEvents-driven assertions with a deterministic event-injection seam — is the right answer eventually but not for a one-line flake.

## Test plan

- [x] \`go test ./internal/ingest/ -run TestWatcher -v -count=5\` — all 5 runs pass on this machine, sub-test completes in 0.53s