### PR TITLE
test: cover StreamSQLite + StreamSQLiteRaw loaders

### DIFF
--- a/internal/ingest/sqlite_loader_test.go
+++ b/internal/ingest/sqlite_loader_test.go
@@ -84,6 +84,111 @@ func TestLoadSQLite(t *testing.T) {
 	})
 }
 
+// TestStreamSQLite covers the streaming variant — lower memory
+// footprint than LoadSQLite because only one parsed record is
+// alive at a time. Production callers (engine.go) iterate large
+// .db files this way.
+func TestStreamSQLite(t *testing.T) {
+	t.Run("yields parsed records in id order", func(t *testing.T) {
+		dbPath := createTestDB(t, []string{
+			`{"name":"alpha"}`,
+			`{"name":"beta"}`,
+			`{"name":"gamma"}`,
+		})
+		var ids []string
+		var names []string
+		err := StreamSQLite(dbPath, func(id string, rec any) error {
+			ids = append(ids, id)
+			m, ok := rec.(map[string]any)
+			require.True(t, ok, "record should parse to map")
+			names = append(names, m["name"].(string))
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a", "b", "c"}, ids)
+		assert.Equal(t, []string{"alpha", "beta", "gamma"}, names)
+	})
+
+	t.Run("propagates callback error and stops iteration", func(t *testing.T) {
+		dbPath := createTestDB(t, []string{
+			`{"name":"first"}`,
+			`{"name":"second"}`,
+			`{"name":"third"}`,
+		})
+		count := 0
+		want := assert.AnError
+		err := StreamSQLite(dbPath, func(_ string, _ any) error {
+			count++
+			if count == 2 {
+				return want
+			}
+			return nil
+		})
+		assert.ErrorIs(t, err, want)
+		assert.Equal(t, 2, count, "iteration must stop on first callback error")
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		err := StreamSQLite("/tmp/nonexistent_stream_test.db", func(string, any) error {
+			t.Fatal("callback must not run for missing db")
+			return nil
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("invalid JSON in record column surfaces parse error", func(t *testing.T) {
+		// JSON parsing happens up-front in StreamSQLite (vs StreamSQLiteRaw
+		// which defers it to the worker). Bad JSON here = error here.
+		dbPath := createTestDB(t, []string{`{not valid json`})
+		err := StreamSQLite(dbPath, func(string, any) error {
+			t.Fatal("callback must not run on parse failure")
+			return nil
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse record json")
+	})
+}
+
+// TestStreamSQLiteRaw covers the parse-deferred variant used by
+// the parallel ingestion pipeline — workers handle JSON parsing
+// on their own goroutines, so this loader hands them raw strings.
+func TestStreamSQLiteRaw(t *testing.T) {
+	t.Run("yields raw json strings unchanged", func(t *testing.T) {
+		records := []string{
+			`{"name":"alpha"}`,
+			`{"name":"beta"}`,
+			// Intentionally malformed — Raw doesn't parse, so this is fine.
+			`{not valid json`,
+		}
+		dbPath := createTestDB(t, records)
+
+		var ids, raws []string
+		err := StreamSQLiteRaw(dbPath, func(id, raw string) error {
+			ids = append(ids, id)
+			raws = append(raws, raw)
+			return nil
+		})
+		require.NoError(t, err, "Raw must not parse — malformed JSON is the worker's problem, not the loader's")
+		assert.Equal(t, []string{"a", "b", "c"}, ids)
+		assert.Equal(t, records, raws)
+	})
+
+	t.Run("propagates callback error", func(t *testing.T) {
+		dbPath := createTestDB(t, []string{`{"a":1}`, `{"b":2}`})
+		want := assert.AnError
+		err := StreamSQLiteRaw(dbPath, func(string, string) error { return want })
+		assert.ErrorIs(t, err, want)
+	})
+
+	t.Run("nonexistent file returns error", func(t *testing.T) {
+		err := StreamSQLiteRaw("/tmp/nonexistent_stream_raw_test.db", func(string, string) error {
+			t.Fatal("callback must not run for missing db")
+			return nil
+		})
+		require.Error(t, err)
+	})
+}
+
 func TestLoadSQLite_Integration(t *testing.T) {
 	kevDB := os.Getenv("MACHE_TEST_KEV_DB")
 	if kevDB == "" {


### PR DESCRIPTION
## Summary

\`sqlite_loader.go\` ships three streaming variants but only \`LoadSQLite\` had direct tests. \`find_smells --rule untested_function\` flagged \`ingest/functions/StreamSQLite\` and \`StreamSQLiteRaw\` — both are live in production:

- **\`StreamSQLite\`**: \`engine.go\` uses it for iterating large \`.db\` files with bounded memory (one parsed record alive at a time).
- **\`StreamSQLiteRaw\`**: the parallel ingestion pipeline hands raw strings to worker goroutines that parse JSON on their own threads — keeps the loader off the parse hot path.

## Cases pinned

**\`StreamSQLite\`** (parses up-front):
- yields parsed records in id order (\`alpha\`, \`beta\`, \`gamma\` → \`a\`, \`b\`, \`c\`)
- propagates callback error and stops iteration mid-way
- nonexistent file returns error
- invalid JSON in \`record\` column surfaces parse error *here* (vs Raw which defers it)

**\`StreamSQLiteRaw\`** (defers parsing):
- yields raw json strings unchanged — even malformed JSON, since Raw doesn't parse (callback-side responsibility)
- propagates callback error
- nonexistent file returns error

Test-only — no behavior change.

## Test plan

- [x] \`go test ./internal/ingest/ -run TestStream -v\` — 7 subtests pass