### PR TITLE
test: pin NewDefaultResolver chain shape + post-construction wiring

### DIFF
--- a/internal/vfs/resolver_test.go
+++ b/internal/vfs/resolver_test.go
@@ -1,6 +1,8 @@
 package vfs
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/agentic-research/mache/internal/graph"
@@ -80,4 +82,75 @@ func TestResolver_FirstMatchWins(t *testing.T) {
 	e := r.Resolve("/dup")
 	require.NotNil(t, e)
 	assert.Equal(t, int64(1), e.Size) // h1 wins
+}
+
+// TestNewDefaultResolver pins the chain shape that mounts depend on:
+// the standard handler set, in registration order, with typed
+// references for post-construction configuration. The order matters
+// because Resolve uses first-match-wins — _schema.json before paths
+// that could shadow it, callers/callees last so they fall through to
+// the graph lookup when no virtual entry matches.
+func TestNewDefaultResolver_ChainShape(t *testing.T) {
+	g := graph.NewMemoryStore()
+	r := NewDefaultResolver(g, []byte(`{"version":"v1"}`))
+	require.NotNil(t, r)
+
+	// Seven handlers in this order: schema, prompt, diag, context,
+	// location, callers, callees (one for each * Handler type below
+	// the SchemaHandler).
+	require.Len(t, r.handlers, 7, "default chain length is fixed at 7")
+	wantTypes := []string{
+		"*vfs.SchemaHandler",
+		"*vfs.PromptHandler",
+		"*vfs.DiagnosticsHandler",
+		"*vfs.ContextHandler",
+		"*vfs.LocationHandler",
+		"*vfs.CallersHandler",
+		"*vfs.CalleesHandler",
+	}
+	for i, h := range r.handlers {
+		// fmt.Sprintf("%T", ...) renders the concrete type; checking
+		// it pins the chain shape without committing the test to the
+		// internal layout of each handler struct.
+		assert.Equal(t, wantTypes[i], typeName(h),
+			"handler[%d] should be %s", i, wantTypes[i])
+	}
+
+	// Typed references are wired so SetPromptContent/SetWritable
+	// reach the right handler instance.
+	require.NotNil(t, r.promptH, "promptH typed ref must be wired")
+	require.NotNil(t, r.diagH, "diagH typed ref must be wired")
+}
+
+func TestNewDefaultResolver_SetPromptContent(t *testing.T) {
+	r := NewDefaultResolver(graph.NewMemoryStore(), nil)
+	r.SetPromptContent([]byte("hello"))
+	assert.Equal(t, []byte("hello"), r.promptH.Content,
+		"SetPromptContent must mutate the typed-ref handler")
+}
+
+func TestNewDefaultResolver_SetWritable(t *testing.T) {
+	r := NewDefaultResolver(graph.NewMemoryStore(), nil)
+
+	// Default: not writable.
+	assert.False(t, r.diagH.Writable)
+
+	// Enable writable + supply a fresh diagStatus map.
+	var diagStatus sync.Map
+	r.SetWritable(true, &diagStatus)
+	assert.True(t, r.diagH.Writable)
+	assert.Same(t, &diagStatus, r.diagH.DiagStatus,
+		"diag handler should hold the caller-provided status map")
+
+	// SetWritable(_, nil) preserves the existing status map.
+	r.SetWritable(false, nil)
+	assert.False(t, r.diagH.Writable)
+	assert.Same(t, &diagStatus, r.diagH.DiagStatus,
+		"nil diagStatus must not stomp the previously-set map")
+}
+
+// typeName returns "*vfs.FooHandler" for h. Used to pin the chain
+// shape without depending on each handler's internal layout.
+func typeName(h any) string {
+	return fmt.Sprintf("%T", h)
 }


### PR DESCRIPTION
## Summary

\`NewDefaultResolver\` assembles the standard handler chain that NFS mounts depend on. \`find_smells --rule untested_function\` flagged it as untested — the existing \`TestResolver_*\` tests use \`stubHandler\` fixtures and don't exercise the production factory.

## Cases pinned

**\`TestNewDefaultResolver_ChainShape\`** — pins the seven-handler chain in registration order: schema, prompt, diag, context, location, callers, callees. Order matters because \`Resolve\` uses first-match-wins; \`_schema.json\` must come before paths that could shadow it, and \`callers\`/\`callees\` come last so unmatched paths fall through to graph lookup. Asserts each slot's concrete type via \`fmt.Sprintf(\"%T\", ...)\` so the pin survives internal layout churn in the handler structs themselves.

Also asserts the typed references (\`promptH\`, \`diagH\`) are wired — without these, post-construction \`SetPromptContent\`/\`SetWritable\` calls would silently no-op.

**\`TestNewDefaultResolver_SetPromptContent\`** — \`SetPromptContent\` mutates the typed-ref handler.

**\`TestNewDefaultResolver_SetWritable\`** — three slices of behaviour:
- default state is not writable
- \`SetWritable(true, &m)\` wires the caller-provided status map (\`assert.Same\`, not \`Equal\` — pointer identity matters)
- \`SetWritable(false, nil)\` preserves the existing status map rather than stomping it; lets callers toggle writable without re-supplying the map every time

Test-only — no behavior change.

## Test plan

- [x] \`go test ./internal/vfs/ -run NewDefaultResolver -v\` — 3 tests pass