### PR TITLE
test: pin GetGitHints inference-hint contract

### DIFF
--- a/internal/ingest/git_test.go
+++ b/internal/ingest/git_test.go
@@ -48,3 +48,22 @@ func runGit(t *testing.T, dir string, args ...string) {
 	err := cmd.Run()
 	require.NoError(t, err, "git %v failed", args)
 }
+
+// TestGetGitHints pins the inference hint contract that ties git
+// commit fields to FCA scaling kinds. The map is small and static
+// today, but its keys are part of the schema-inference public
+// surface — losing or renaming an entry here silently changes
+// what attributes BuildContext treats as identifier / reference /
+// temporal. The test documents the wire shape and catches
+// accidental edits.
+func TestGetGitHints(t *testing.T) {
+	hints := GetGitHints()
+	want := map[string]string{
+		"sha":     "id",
+		"tree":    "reference",
+		"parents": "reference",
+		"date":    "temporal",
+	}
+	assert.Equal(t, want, hints,
+		"GetGitHints map is part of the schema-inference public surface; updates require a deliberate change to the inferrer contract")
+}


### PR DESCRIPTION
## Summary

\`GetGitHints\` is a small static map but its keys are part of the schema-inference public surface — losing or renaming an entry silently changes what attributes \`BuildContext\` treats as identifier / reference / temporal during FCA inference over git commit records.

\`find_smells --rule untested_function\` flagged it as untested. The test documents the wire shape (\`sha → id\`, \`tree\`/\`parents → reference\`, \`date → temporal\`) and catches accidental edits in code review by failing loudly when the map's contents drift from the expected contract.

Test-only — no behavior change.

## Test plan

- [x] \`go test ./internal/ingest/ -run TestGetGitHints -v\` — passes