### PR TITLE
feat(ingest): _index_coverage table — ADR-0013 Step 2 (mache-346cfe)

### DIFF
--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -890,11 +890,16 @@ func (e *Engine) processTreeSitterResult(result *parsedTreeSitterFile) error {
 		}
 	}
 
-	// 9. Record file metadata for incremental re-ingestion.
+	// 9. Record file metadata for incremental re-ingestion + coverage row
+	//    for ADR-0013's _index_coverage table (mention-fidelity, since
+	//    tree-sitter is the L_0 producer in the fidelity poset). LSP and
+	//    SSA producers will write their own (binding/reachability) rows
+	//    for the same source_id.
 	if sw, ok := e.Store.(*SQLiteWriter); ok {
 		info, err := os.Stat(result.realPath)
 		if err == nil {
 			sw.RecordFile(result.realPath, info.ModTime(), info.Size())
+			sw.RecordIndexCoverage(result.realPath, "tree-sitter", "mention", time.Now(), true)
 		}
 	}
 

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -20,16 +20,17 @@ const defaultBatchSize = 10_000
 
 // SQLiteWriter implements IngestionTarget for the new high-performance schema.
 type SQLiteWriter struct {
-	db        *sql.DB
-	tx        *sql.Tx
-	stmtNode  *sql.Stmt
-	stmtRef   *sql.Stmt // For adding refs
-	stmtDef   *sql.Stmt // For adding defs
-	stmtFile  *sql.Stmt // For recording file metadata (incremental index)
-	batchSize int
-	count     int
-	firstErr  error // first insert/batch error, surfaced by Close
-	mu        sync.Mutex
+	db           *sql.DB
+	tx           *sql.Tx
+	stmtNode     *sql.Stmt
+	stmtRef      *sql.Stmt // For adding refs
+	stmtDef      *sql.Stmt // For adding defs
+	stmtFile     *sql.Stmt // For recording file metadata (incremental index)
+	stmtCoverage *sql.Stmt // For recording per-source _index_coverage rows
+	batchSize    int
+	count        int
+	firstErr     error // first insert/batch error, surfaced by Close
+	mu           sync.Mutex
 }
 
 // NewSQLiteWriter creates a new writer and initializes the schema.
@@ -82,6 +83,26 @@ func NewSQLiteWriter(dbPath string) (*SQLiteWriter, error) {
 		mod_time INTEGER NOT NULL,
 		size INTEGER NOT NULL
 	);
+
+	-- _index_coverage records which producer indexed each source file at
+	-- which fidelity level, per ADR-0013. Consumers that need to
+	-- distinguish "no binding row exists" from "no binding row was looked
+	-- for" join against this. PRIMARY KEY (source_id, producer) means a
+	-- re-index replaces the prior coverage row for that producer.
+	--
+	-- fidelity values: 'mention' (tree-sitter), 'binding' (LSP),
+	-- 'reachability' (future SSA / call-graph).
+	-- complete: 1 if the indexer claims full coverage of the source,
+	-- 0 if it gave up partway (out-of-memory, timeout, parse errors
+	-- prevented analysis, etc.).
+	CREATE TABLE IF NOT EXISTS _index_coverage (
+		source_id TEXT NOT NULL,
+		producer TEXT NOT NULL,
+		fidelity TEXT NOT NULL,
+		indexed_at INTEGER NOT NULL,
+		complete INTEGER NOT NULL,
+		PRIMARY KEY (source_id, producer)
+	) WITHOUT ROWID;
 	`
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
@@ -127,6 +148,14 @@ func (w *SQLiteWriter) beginTx() error {
 	}
 
 	w.stmtFile, err = w.tx.Prepare(`INSERT OR REPLACE INTO file_index (path, mod_time, size) VALUES (?, ?, ?)`)
+	if err != nil {
+		return err
+	}
+
+	w.stmtCoverage, err = w.tx.Prepare(
+		`INSERT OR REPLACE INTO _index_coverage (source_id, producer, fidelity, indexed_at, complete)
+		 VALUES (?, ?, ?, ?, ?)`,
+	)
 	return err
 }
 
@@ -142,6 +171,9 @@ func (w *SQLiteWriter) commitTx() error {
 	}
 	if w.stmtFile != nil {
 		_ = w.stmtFile.Close()
+	}
+	if w.stmtCoverage != nil {
+		_ = w.stmtCoverage.Close()
 	}
 	if err := w.tx.Commit(); err != nil {
 		return err
@@ -160,6 +192,29 @@ func (w *SQLiteWriter) RecordFile(path string, modTime time.Time, size int64) {
 		log.Printf("SQLiteWriter: record file failed for %s: %v", path, err)
 		if w.firstErr == nil {
 			w.firstErr = fmt.Errorf("record file %s: %w", path, err)
+		}
+	}
+}
+
+// RecordIndexCoverage stores a coverage row for a (source_id, producer)
+// pair, per ADR-0013 Step 2. The fidelity argument is one of "mention",
+// "binding", or "reachability"; complete=true means the indexer claims
+// full coverage of source_id at that fidelity. A re-index replaces the
+// prior row for the same (source_id, producer) — different producers
+// keep distinct rows.
+func (w *SQLiteWriter) RecordIndexCoverage(sourceID, producer, fidelity string, indexedAt time.Time, complete bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	completeInt := 0
+	if complete {
+		completeInt = 1
+	}
+	_, err := w.stmtCoverage.Exec(sourceID, producer, fidelity, indexedAt.UnixNano(), completeInt)
+	if err != nil {
+		log.Printf("SQLiteWriter: record coverage failed for %s/%s: %v", sourceID, producer, err)
+		if w.firstErr == nil {
+			w.firstErr = fmt.Errorf("record coverage %s/%s: %w", sourceID, producer, err)
 		}
 	}
 }
@@ -209,6 +264,66 @@ func LoadFileIndex(dbPath string) (map[string]FileIndexEntry, error) {
 type FileIndexEntry struct {
 	ModTime time.Time
 	Size    int64
+}
+
+// CoverageEntry is one (source_id, producer) row from _index_coverage.
+// A consumer that needs to distinguish "no binding row exists for this
+// source" from "no producer at the binding level ever indexed this
+// source" joins against this — see ADR-0013 wedge case 1.
+type CoverageEntry struct {
+	Producer  string    // 'tree-sitter' | 'lsp' | future
+	Fidelity  string    // 'mention' | 'binding' | 'reachability'
+	IndexedAt time.Time // when the indexer wrote the row
+	Complete  bool      // indexer claims full coverage of source_id at this fidelity
+}
+
+// LoadIndexCoverage reads the _index_coverage table from an existing
+// index database. Returns a map keyed by source_id whose values are the
+// per-producer entries that touched that source. Returns (nil, nil)
+// when the table doesn't exist — the caller treats that as "no
+// coverage info; assume any absence is unknown."
+func LoadIndexCoverage(dbPath string) (map[string][]CoverageEntry, error) {
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro")
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = db.Close() }()
+
+	var tableName string
+	err = db.QueryRow(
+		"SELECT name FROM sqlite_master WHERE type='table' AND name='_index_coverage'",
+	).Scan(&tableName)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := db.Query(
+		"SELECT source_id, producer, fidelity, indexed_at, complete FROM _index_coverage",
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	out := make(map[string][]CoverageEntry)
+	for rows.Next() {
+		var sourceID, producer, fidelity string
+		var indexedAtNano int64
+		var completeInt int
+		if err := rows.Scan(&sourceID, &producer, &fidelity, &indexedAtNano, &completeInt); err != nil {
+			return nil, err
+		}
+		out[sourceID] = append(out[sourceID], CoverageEntry{
+			Producer:  producer,
+			Fidelity:  fidelity,
+			IndexedAt: time.Unix(0, indexedAtNano),
+			Complete:  completeInt != 0,
+		})
+	}
+	return out, rows.Err()
 }
 
 // AddNode writes a node to the database.

--- a/internal/ingest/sqlite_writer_test.go
+++ b/internal/ingest/sqlite_writer_test.go
@@ -112,3 +112,139 @@ func TestLoadFileIndex_EmptyTableReturnsEmptyMap(t *testing.T) {
 	require.NotNil(t, idx)
 	assert.Empty(t, idx)
 }
+
+// _index_coverage exists per ADR-0013 Step 2 (mache-346cfe). Tests
+// pin the producer-agnostic write path, the round-trip through
+// LoadIndexCoverage, and the contract that distinguishes "table
+// missing" (nil) from "table present but empty" (non-nil empty map).
+//
+// Consumers that want to know whether a source was indexed at a
+// given fidelity rely on these distinctions per the ADR's wedge
+// case 1 ("LSP coverage is partial, not total"): "no coverage row
+// exists" must be unambiguous, never confused with "the consumer
+// didn't look."
+
+func TestSQLiteWriter_RecordIndexCoverage_RoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "coverage.db")
+	w, err := NewSQLiteWriter(dbPath)
+	require.NoError(t, err)
+
+	// Two producers cover the same source at different fidelities;
+	// a third source has only tree-sitter coverage. PRIMARY KEY
+	// (source_id, producer) means each (source, producer) pair has
+	// at most one row.
+	t1 := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	w.RecordIndexCoverage("main.go", "tree-sitter", "mention", t1, true)
+	w.RecordIndexCoverage("main.go", "lsp", "binding", t1, true)
+	w.RecordIndexCoverage("util.go", "tree-sitter", "mention", t1, true)
+	// A partial-coverage row — LSP gave up on a generated file.
+	w.RecordIndexCoverage("generated.pb.go", "lsp", "binding", t1, false)
+
+	require.NoError(t, w.Close())
+
+	cov, err := LoadIndexCoverage(dbPath)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+
+	require.Len(t, cov["main.go"], 2, "main.go has both producers")
+	require.Len(t, cov["util.go"], 1, "util.go has only tree-sitter")
+	require.Len(t, cov["generated.pb.go"], 1, "generated.pb.go has only LSP")
+
+	// Find each entry by producer and verify fields. Order within
+	// a source isn't part of the contract (table has no ORDER BY),
+	// so look up by producer rather than indexing.
+	byProd := func(entries []CoverageEntry, producer string) CoverageEntry {
+		for _, e := range entries {
+			if e.Producer == producer {
+				return e
+			}
+		}
+		t.Fatalf("no entry for producer %q", producer)
+		return CoverageEntry{}
+	}
+
+	mainTS := byProd(cov["main.go"], "tree-sitter")
+	assert.Equal(t, "mention", mainTS.Fidelity)
+	assert.True(t, mainTS.Complete)
+	assert.True(t, mainTS.IndexedAt.Equal(t1), "IndexedAt must round-trip via UnixNano")
+
+	mainLSP := byProd(cov["main.go"], "lsp")
+	assert.Equal(t, "binding", mainLSP.Fidelity)
+	assert.True(t, mainLSP.Complete)
+
+	gen := byProd(cov["generated.pb.go"], "lsp")
+	assert.False(t, gen.Complete, "complete=false must round-trip — distinguishes partial-index from full-index")
+}
+
+func TestSQLiteWriter_RecordIndexCoverage_Replaces(t *testing.T) {
+	// PRIMARY KEY (source_id, producer) means a re-index by the same
+	// producer overwrites the prior row — neither a constraint
+	// violation nor an accumulated history. Different producers keep
+	// distinct rows. Pin both halves so a future schema tweak that
+	// breaks either can't slip in unnoticed.
+	dbPath := filepath.Join(t.TempDir(), "replace.db")
+	w, err := NewSQLiteWriter(dbPath)
+	require.NoError(t, err)
+
+	t1 := time.Date(2026, 5, 5, 10, 0, 0, 0, time.UTC)
+	t2 := t1.Add(2 * time.Hour)
+
+	// First indexing: partial.
+	w.RecordIndexCoverage("main.go", "tree-sitter", "mention", t1, false)
+	// Re-index a couple hours later: now complete.
+	w.RecordIndexCoverage("main.go", "tree-sitter", "mention", t2, true)
+	// Different producer: separate row, doesn't collide.
+	w.RecordIndexCoverage("main.go", "lsp", "binding", t1, true)
+
+	require.NoError(t, w.Close())
+
+	cov, err := LoadIndexCoverage(dbPath)
+	require.NoError(t, err)
+	require.Len(t, cov["main.go"], 2,
+		"replacement on (source_id, producer) — not duplication; LSP keeps its own row")
+
+	// The tree-sitter row reflects the re-index, not the first write.
+	for _, e := range cov["main.go"] {
+		if e.Producer == "tree-sitter" {
+			assert.True(t, e.IndexedAt.Equal(t2), "later indexed_at wins on conflict")
+			assert.True(t, e.Complete, "later complete=true wins on conflict")
+		}
+	}
+}
+
+func TestLoadIndexCoverage_NoTableReturnsNilNil(t *testing.T) {
+	// A .db without _index_coverage (e.g. one produced before this
+	// table existed, or by a partial-write producer that didn't
+	// emit coverage rows) returns (nil, nil). The caller treats
+	// nil-map as "no coverage info available; assume any absence
+	// is unknown" — distinct from the "table present, no rows"
+	// case below where a producer ran and observed nothing.
+	dbPath := filepath.Join(t.TempDir(), "no_table.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	cov, err := LoadIndexCoverage(dbPath)
+	require.NoError(t, err, "missing _index_coverage table is not an error")
+	assert.Nil(t, cov, "no table → nil map (caller treats as 'unknown coverage')")
+}
+
+func TestLoadIndexCoverage_NonexistentDBReturnsError(t *testing.T) {
+	cov, err := LoadIndexCoverage("/nonexistent/path/to/coverage.db")
+	require.Error(t, err)
+	assert.Nil(t, cov)
+}
+
+func TestLoadIndexCoverage_EmptyTableReturnsEmptyMap(t *testing.T) {
+	// Distinct from "no table" — table exists, no rows. Returns
+	// non-nil empty map so callers can iterate safely.
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+	w, err := NewSQLiteWriter(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	cov, err := LoadIndexCoverage(dbPath)
+	require.NoError(t, err)
+	require.NotNil(t, cov)
+	assert.Empty(t, cov)
+}


### PR DESCRIPTION
## Summary

Implements Step 2 of [ADR-0013](https://github.com/agentic-research/mache/blob/main/docs/adr/0013-refs-defs-canonical-schema.md): the \`_index_coverage\` table that lets consumers distinguish *\"no binding row exists for this source\"* from *\"no producer at the binding level ever indexed this source.\"*

Without this, \`find_smells\` rules can't reason about ADR-0013's wedge case 1 (partial LSP coverage) and would flag tokens dead just because gopls didn't get to the file.

## Schema

\`\`\`sql
_index_coverage(
  source_id   TEXT NOT NULL,
  producer    TEXT NOT NULL,    -- 'tree-sitter' | 'lsp' | 'ssa' (future)
  fidelity    TEXT NOT NULL,    -- 'mention' | 'binding' | 'reachability'
  indexed_at  INTEGER NOT NULL,
  complete    INTEGER NOT NULL,
  PRIMARY KEY (source_id, producer)
) WITHOUT ROWID
\`\`\`

\`PRIMARY KEY (source_id, producer)\` — re-index overwrites; different producers keep distinct rows.

## API

- **Writer**: \`SQLiteWriter.RecordIndexCoverage(sourceID, producer, fidelity, indexedAt, complete)\`. Wired into \`engine.go\`'s post-ingest hook so every tree-sitter-parsed source gets a \`(tree-sitter, mention, complete=true)\` row.
- **Reader**: \`LoadIndexCoverage(dbPath) → map[string][]CoverageEntry\`. Mirrors \`LoadFileIndex\`'s contract — \`(nil, nil)\` for missing table, non-nil empty map for present-but-empty table, error for missing \`.db\`. The nil-vs-empty distinction *is* the ADR's wedge case 1 expressed in Go.

## Smoke test

Building mache's own source produces 229 rows. 292 source files − 229 coverage rows = 63 files routed to \`_project_files/\` via schema-match failure. Those correctly do **not** write coverage rows — those sources are intentionally not indexed at the canonical-schema level.

## Test plan

- [x] \`RoundTrip\` — write 4 rows across 2 producers and 2 fidelities, read back, IndexedAt survives via \`time.Equal\` (not \`==\`)
- [x] \`Replaces\` — PRIMARY KEY conflict: re-index overwrites; different producer keeps own row
- [x] \`NoTableReturnsNilNil\` — fresh \`.db\` without the table → \`(nil, nil)\`
- [x] \`NonexistentDBReturnsError\` — missing \`.db\` file is an error
- [x] \`EmptyTableReturnsEmptyMap\` — table present, no rows → non-nil empty map
- [x] Full \`internal/ingest\` suite green (3.5s)
- [x] Full \`cmd\` suite green (47s)

## Sister work

Step 1 (producer-side token extraction in \`leyline-lsp\`) writes \`(lsp, binding)\` rows from the ley-line-open side. Tracked at **ley-line-453f7e**.