### PR TITLE
feat(ingest): canonical views v_defs / v_refs — ADR-0013 Step 3 partial (mache-346d0f)

### DIFF
--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -103,6 +103,29 @@ func NewSQLiteWriter(dbPath string) (*SQLiteWriter, error) {
 		complete INTEGER NOT NULL,
 		PRIMARY KEY (source_id, producer)
 	) WITHOUT ROWID;
+
+	-- v_defs / v_refs: canonical views per ADR-0013 Step 3. Consumers
+	-- query these instead of node_defs / node_refs directly so they're
+	-- producer-agnostic — when LSP-resolved rows land (Step 1, sister
+	-- bead ley-line-453f7e), the view definition expands with a
+	-- UNION ALL and consumer SQL doesn't change.
+	--
+	-- Today the views surface mention-fidelity rows only; Step 1 adds
+	-- referrer_node_id + ref_token columns to _lsp_refs so the binding
+	-- rows can be unioned in trivially. The fidelity column is the
+	-- forward-looking marker — currently always 'mention' from these
+	-- producers.
+	CREATE VIEW IF NOT EXISTS v_defs AS
+		SELECT token, node_id, 'mention' AS fidelity FROM node_defs;
+
+	CREATE VIEW IF NOT EXISTS v_refs AS
+		SELECT node_id AS referrer_node_id,
+		       token,
+		       NULL  AS target_node_id,
+		       NULL  AS ref_uri,
+		       NULL  AS ref_line,
+		       'mention' AS fidelity
+		FROM node_refs;
 	`
 	if _, err := db.Exec(schema); err != nil {
 		_ = db.Close()
@@ -264,6 +287,44 @@ func LoadFileIndex(dbPath string) (map[string]FileIndexEntry, error) {
 type FileIndexEntry struct {
 	ModTime time.Time
 	Size    int64
+}
+
+// CanonicalViewsDDL is the SQL that creates v_defs / v_refs.
+// Exposed so consumers that opened a .db from a different writer
+// (e.g. LLO-built .db without these views, or an older mache build)
+// can install the views on demand. NewSQLiteWriter runs the same
+// DDL inline — repeated execution is safe via CREATE VIEW IF NOT
+// EXISTS.
+//
+// Once Step 1 (sister bead ley-line-453f7e) ships and _lsp_refs /
+// _lsp_defs gain the referrer_node_id / ref_token / def_token
+// columns, the view bodies extend with UNION ALL clauses pulling
+// the binding-fidelity rows. Consumer SQL doesn't change at that
+// point.
+const CanonicalViewsDDL = `
+CREATE VIEW IF NOT EXISTS v_defs AS
+	SELECT token, node_id, 'mention' AS fidelity FROM node_defs;
+
+CREATE VIEW IF NOT EXISTS v_refs AS
+	SELECT node_id AS referrer_node_id,
+	       token,
+	       NULL  AS target_node_id,
+	       NULL  AS ref_uri,
+	       NULL  AS ref_line,
+	       'mention' AS fidelity
+	FROM node_refs;
+`
+
+// EnsureCanonicalViews installs v_defs / v_refs on an existing
+// database connection. Idempotent — uses CREATE VIEW IF NOT EXISTS.
+// Useful for callers that opened a .db produced by something other
+// than mache's writer (e.g. an LLO build that hasn't been migrated
+// yet, or a pre-Step-3 mache .db on disk).
+func EnsureCanonicalViews(db *sql.DB) error {
+	if _, err := db.Exec(CanonicalViewsDDL); err != nil {
+		return fmt.Errorf("ensure canonical views: %w", err)
+	}
+	return nil
 }
 
 // CoverageEntry is one (source_id, producer) row from _index_coverage.

--- a/internal/ingest/sqlite_writer_test.go
+++ b/internal/ingest/sqlite_writer_test.go
@@ -248,3 +248,146 @@ func TestLoadIndexCoverage_EmptyTableReturnsEmptyMap(t *testing.T) {
 	require.NotNil(t, cov)
 	assert.Empty(t, cov)
 }
+
+// v_defs / v_refs canonical views — ADR-0013 Step 3 (mache-346d0f).
+// The contract: consumers query these views instead of node_defs /
+// node_refs directly. Today the views surface mention-fidelity rows
+// only; Step 1 (sister bead ley-line-453f7e) extends the view body
+// with binding-fidelity rows from _lsp_*. Consumer SQL stays
+// stable across that expansion.
+//
+// Tests pin the view shape (columns, fidelity tag) and the
+// idempotence of EnsureCanonicalViews so Step 4 can adopt it on
+// .dbs that don't already have the views.
+
+// queryRows is a small helper that scans (token, node_id, fidelity)
+// triples from any view shaped like v_defs.
+func queryRows(t *testing.T, db *sql.DB, q string) []defRow {
+	t.Helper()
+	rows, err := db.Query(q)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var out []defRow
+	for rows.Next() {
+		var r defRow
+		require.NoError(t, rows.Scan(&r.token, &r.nodeID, &r.fidelity))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+type defRow struct{ token, nodeID, fidelity string }
+
+func TestCanonicalViews_MentionFidelityRoundTrip(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "views.db")
+	w, err := NewSQLiteWriter(dbPath)
+	require.NoError(t, err)
+
+	// Tree-sitter rows go straight into node_defs / node_refs via
+	// the writer's own statements. Bypass AddNode and write a few
+	// rows directly to keep the test focused on the view layer.
+	_, err = w.tx.Exec("INSERT INTO node_defs (token, node_id) VALUES (?, ?), (?, ?)",
+		"Validate", "auth/functions/Validate",
+		"Charge", "billing/functions/Charge")
+	require.NoError(t, err)
+	_, err = w.tx.Exec("INSERT INTO node_refs (token, node_id) VALUES (?, ?)",
+		"Validate", "billing/functions/Charge")
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	// Reopen read-only and query the views.
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	defs := queryRows(t, db, "SELECT token, node_id, fidelity FROM v_defs ORDER BY token")
+	require.Len(t, defs, 2)
+	assert.Equal(t, "Charge", defs[0].token)
+	assert.Equal(t, "Validate", defs[1].token)
+	for _, d := range defs {
+		assert.Equal(t, "mention", d.fidelity,
+			"v_defs surfaces only mention-fidelity rows pre-Step-1; binding rows arrive once ley-line-453f7e ships")
+	}
+
+	// v_refs has more columns; just confirm the tagged-fidelity
+	// row is there and the LSP-only columns are NULL until Step 1.
+	type refRow struct {
+		referrer, token, fidelity        string
+		targetNodeID, refURI, refLineRaw sql.NullString
+	}
+	rows, err := db.Query(`SELECT referrer_node_id, token, target_node_id, ref_uri, ref_line, fidelity FROM v_refs`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var got []refRow
+	for rows.Next() {
+		var r refRow
+		require.NoError(t, rows.Scan(&r.referrer, &r.token, &r.targetNodeID, &r.refURI, &r.refLineRaw, &r.fidelity))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	require.Len(t, got, 1)
+	assert.Equal(t, "billing/functions/Charge", got[0].referrer)
+	assert.Equal(t, "Validate", got[0].token)
+	assert.Equal(t, "mention", got[0].fidelity)
+	assert.False(t, got[0].targetNodeID.Valid, "binding columns are NULL at L_0")
+	assert.False(t, got[0].refURI.Valid, "binding columns are NULL at L_0")
+}
+
+func TestCanonicalViews_EmptyTablesYieldEmptyViews(t *testing.T) {
+	// Fresh writer with no rows inserted. Views resolve, return
+	// zero rows, no errors. Callers (Step 4 rule rewrites) need to
+	// handle the empty case without special-casing.
+	dbPath := filepath.Join(t.TempDir(), "empty_views.db")
+	w, err := NewSQLiteWriter(dbPath)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+
+	db, err := sql.Open("sqlite", dbPath+"?mode=ro")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var defCount, refCount int
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM v_defs").Scan(&defCount))
+	require.NoError(t, db.QueryRow("SELECT COUNT(*) FROM v_refs").Scan(&refCount))
+	assert.Equal(t, 0, defCount)
+	assert.Equal(t, 0, refCount)
+}
+
+func TestEnsureCanonicalViews_Idempotent(t *testing.T) {
+	// EnsureCanonicalViews installs the views on a .db that doesn't
+	// have them yet — e.g. an LLO build pre-migration. Running it
+	// twice in a row is safe (CREATE VIEW IF NOT EXISTS).
+	dbPath := filepath.Join(t.TempDir(), "ensure.db")
+
+	// Hand-build a .db with node_defs / node_refs but NO views. This
+	// simulates a producer that wrote the underlying tables without
+	// running mache's NewSQLiteWriter — exactly the LLO situation.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id));
+		INSERT INTO node_defs (token, node_id) VALUES ('Foo', 'pkg/Foo');
+	`)
+	require.NoError(t, err)
+
+	// Confirm view doesn't exist yet.
+	var name string
+	err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='view' AND name='v_defs'").Scan(&name)
+	assert.ErrorIs(t, err, sql.ErrNoRows, "v_defs should not exist on a hand-built .db")
+
+	// Install. Then install again — must be idempotent.
+	require.NoError(t, EnsureCanonicalViews(db))
+	require.NoError(t, EnsureCanonicalViews(db))
+
+	// View now resolves and surfaces the underlying row.
+	defs := queryRows(t, db, "SELECT token, node_id, fidelity FROM v_defs")
+	require.Len(t, defs, 1)
+	assert.Equal(t, "Foo", defs[0].token)
+	assert.Equal(t, "mention", defs[0].fidelity)
+
+	require.NoError(t, db.Close())
+}


### PR DESCRIPTION
## Summary

Lands the consumer-side abstraction Step 4 needs to adopt. Today the views surface **mention-fidelity** rows only (from \`node_defs\` / \`node_refs\`); Step 1 (sister bead ley-line-453f7e) adds \`referrer_node_id\` + \`ref_token\` columns to \`_lsp_refs\` so the binding rows union in trivially. The view body expands then; **consumer SQL — the rule rewrites in Step 4 — does not.**

## Schema

\`\`\`sql
CREATE VIEW v_defs AS
  SELECT token, node_id, 'mention' AS fidelity FROM node_defs;

CREATE VIEW v_refs AS
  SELECT node_id AS referrer_node_id,
         token,
         NULL  AS target_node_id,
         NULL  AS ref_uri,
         NULL  AS ref_line,
         'mention' AS fidelity
  FROM node_refs;
\`\`\`

The \`NULL\` columns on \`v_refs\` hold the binding-only fields. The schema doesn't change when Step 1 unions in rows that populate them.

## API

- **\`NewSQLiteWriter\`** installs the views automatically (idempotent — \`CREATE VIEW IF NOT EXISTS\`)
- **\`EnsureCanonicalViews(*sql.DB)\`** for adopting on a \`.db\` produced by something other than mache's writer (LLO-built \`.db\`s pre-migration, older mache \`.db\`s from disk)
- **\`CanonicalViewsDDL\`** raw DDL string for callers embedding into other schema migrations

## Smoke test

Self-build of mache: \`v_defs\` surfaces **9,144** rows, \`v_refs\` surfaces **24,428** rows, all with \`fidelity='mention'\`.

## Test plan

- [x] **MentionFidelityRoundTrip** — write rows to \`node_defs\`/\`node_refs\`, query views, assert columns + fidelity tag + NULL binding columns
- [x] **EmptyTablesYieldEmptyViews** — fresh writer, no rows; views return 0 rows. Step 4 callers don't need empty-special-case
- [x] **EnsureCanonicalViews_Idempotent** — hand-built \`.db\` without the views, install twice, queries work. Pins the LLO-adoption path
- [x] Full \`internal/ingest\` suite (3.5s) + \`cmd\` suite (43s) green

## Status

Step 3 is **partial**. The mention-fidelity half ships now. Binding-fidelity expansion lands once Step 1 (\`ley-line-453f7e\`) adds the \`referrer_node_id\`+\`ref_token\` columns to \`_lsp_refs\`. Step 4 rule rewrites can begin against today's view shape; the binding rows arriving later strictly improve their findings.