### PR TITLE
feat(find_smells): rules query v_defs / v_refs — ADR-0013 Step 4 (mache-346d1e)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -117,12 +117,32 @@ var smellRegistry = []SmellRule{
 			-- method like 'AddDef' or 'Read' would show up N copies,
 			-- one per implementing type, even though the implementations
 			-- are conceptually distinct).
+			-- Per ADR-0013 Step 4: query v_defs / v_refs (the canonical
+			-- views) rather than node_defs / node_refs directly. The
+			-- alive-check has two arms:
+			--   L_1 binding: r.target_node_id = d.node_id — exact match
+			--                from an LSP-resolved reference. Only fires
+			--                on rows where Step 1 (ley-line-453f7e) wrote
+			--                referrer_node_id + ref_token to _lsp_refs.
+			--   L_0 mention: token-textual fallback for tree-sitter rows
+			--                (target_node_id IS NULL). Includes the
+			--                first-dot strip for 'Receiver.Method' →
+			--                'Method' that handles methods rendered as
+			--                'Receiver.Method'.
+			-- Today (pre-Step-1), v_refs only surfaces L_0 rows so the
+			-- fallback always runs and the result is identical to the
+			-- legacy node_refs query. Once binding rows arrive, the
+			-- L_1 arm dominates and the skip-list below becomes
+			-- redundant for the cases LSP actually sees.
 			WITH alive AS (
 				SELECT DISTINCT d.node_id
-				FROM node_defs d
-				JOIN node_refs r
-				  ON r.token = d.token
-				  OR (instr(d.token, '.') > 0 AND r.token = substr(d.token, instr(d.token, '.') + 1))
+				FROM v_defs d
+				JOIN v_refs r
+				  ON r.target_node_id = d.node_id
+				  OR (r.target_node_id IS NULL AND (
+				       r.token = d.token
+				       OR (instr(d.token, '.') > 0 AND r.token = substr(d.token, instr(d.token, '.') + 1))
+				     ))
 			),
 			-- Skip-listed: any token of a construct matches a skip rule.
 			-- ANY-MATCH is the right semantic — a function with both
@@ -147,7 +167,7 @@ var smellRegistry = []SmellRule{
 			-- runtimes / libraries; static call extraction can't see
 			-- the dispatch site, so the methods always look dead.
 			skipped AS (
-				SELECT DISTINCT node_id FROM node_defs
+				SELECT DISTINCT node_id FROM v_defs
 				WHERE token IN (
 					'main','init',
 					'String','Error','Read','Write','Close','Len','Less','Swap',
@@ -199,7 +219,7 @@ var smellRegistry = []SmellRule{
 			-- content. They have no source data and can't be navigated
 			-- to, so flagging them is pure noise.
 			WHERE COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') != ''
-			  AND n.id IN (SELECT DISTINCT node_id FROM node_defs)
+			  AND n.id IN (SELECT DISTINCT node_id FROM v_defs)
 			  AND n.id NOT IN (SELECT node_id FROM alive)
 			  AND n.id NOT IN (SELECT node_id FROM skipped)
 			  -- Skip non-callable categories. node_refs is populated
@@ -304,16 +324,22 @@ var smellRegistry = []SmellRule{
 			--   pkg/functions/TestFoo/source        (go-schema)
 			-- 'BenchmarkFoo' / 'ExampleFoo' / 'FuzzFoo' too.
 			tested_via_call AS (
+				-- Per ADR-0013 Step 4: query v_refs. The referrer column
+				-- in the view is referrer_node_id (was node_id on
+				-- node_refs); LSP-resolved binding rows will populate it
+				-- the same way mention-fidelity rows do today, so this
+				-- query naturally picks up both fidelities once Step 1
+				-- (ley-line-453f7e) ships.
 				SELECT DISTINCT token
-				FROM node_refs
-				WHERE node_id LIKE '%%/Test%%/source'
-				   OR node_id LIKE 'Test%%/source'
-				   OR node_id LIKE '%%/Benchmark%%/source'
-				   OR node_id LIKE 'Benchmark%%/source'
-				   OR node_id LIKE '%%/Example%%/source'
-				   OR node_id LIKE 'Example%%/source'
-				   OR node_id LIKE '%%/Fuzz%%/source'
-				   OR node_id LIKE 'Fuzz%%/source'
+				FROM v_refs
+				WHERE referrer_node_id LIKE '%%/Test%%/source'
+				   OR referrer_node_id LIKE 'Test%%/source'
+				   OR referrer_node_id LIKE '%%/Benchmark%%/source'
+				   OR referrer_node_id LIKE 'Benchmark%%/source'
+				   OR referrer_node_id LIKE '%%/Example%%/source'
+				   OR referrer_node_id LIKE 'Example%%/source'
+				   OR referrer_node_id LIKE '%%/Fuzz%%/source'
+				   OR referrer_node_id LIKE 'Fuzz%%/source'
 			)
 			SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') AS source_id,
 			       d.node_id,
@@ -322,7 +348,7 @@ var smellRegistry = []SmellRule{
 			       0 AS start_row,
 			       0 AS start_col,
 			       0 AS metric
-			FROM node_defs d
+			FROM v_defs d
 			JOIN nodes n ON n.id = d.node_id
 			LEFT JOIN child_source cs ON cs.node_id = n.id
 			-- Accept either an exact 'Test<Foo>' counterpart (the
@@ -331,7 +357,7 @@ var smellRegistry = []SmellRule{
 			-- match for the constructor's bare type name. NewMemoryStore
 			-- is overwhelmingly tested via TestMemoryStore_TracksMtimes
 			-- and friends, never via TestNewMemoryStore.
-			LEFT JOIN node_defs t
+			LEFT JOIN v_defs t
 			  ON t.token = 'Test' || d.token
 			  OR (
 			    substr(d.token, 1, 3) = 'New'
@@ -399,7 +425,7 @@ var smellRegistry = []SmellRule{
 			       c.copies AS metric
 			FROM (
 				SELECT token, COUNT(*) AS copies
-				FROM node_defs
+				FROM v_defs
 				-- Skip-list match against the unqualified leaf, so
 				-- both bare tokens ('init') and qualified shapes
 				-- ('cmd.init', 'lang.init') get skipped uniformly.
@@ -456,7 +482,7 @@ var smellRegistry = []SmellRule{
 				GROUP BY token
 				HAVING copies > 1
 			) c
-			JOIN node_defs d ON d.token = c.token
+			JOIN v_defs d ON d.token = c.token
 			JOIN nodes n ON n.id = d.node_id
 			LEFT JOIN child_source cs ON cs.node_id = n.id
 			-- Apply the same filters to the join so partial matches
@@ -509,7 +535,7 @@ var smellRegistry = []SmellRule{
 			per_file AS (
 				SELECT COALESCE(NULLIF(n.source_file, ''), cs.source_file) AS file,
 				       COUNT(DISTINCT d.token) AS n
-				FROM node_defs d
+				FROM v_defs d
 				JOIN nodes n ON n.id = d.node_id
 				LEFT JOIN child_source cs ON cs.node_id = n.id
 				WHERE COALESCE(NULLIF(n.source_file, ''), cs.source_file, '') != ''
@@ -560,10 +586,18 @@ var smellRegistry = []SmellRule{
 				-- callee counts. Counting them here would attribute the
 				-- file-level refs to a 'caller' that isn't a real
 				-- construct, inflating fan_out_skew with virtual rows.
-				SELECT node_id AS caller_id, COUNT(DISTINCT token) AS n
-				FROM node_refs
-				WHERE node_id NOT LIKE '_file_level:%%'
-				GROUP BY node_id
+				--
+				-- Per ADR-0013 Step 4: query v_refs. The referrer column
+				-- in the view is referrer_node_id (was node_id on the
+				-- raw table). Counting DISTINCT token preserves today's
+				-- semantics; once Step 1 ships LSP rows, the metric
+				-- could refine to COUNT(DISTINCT COALESCE(target_node_id,
+				-- token)) for binding-aware deduplication, but that's a
+				-- semantic shift left for a follow-up bead.
+				SELECT referrer_node_id AS caller_id, COUNT(DISTINCT token) AS n
+				FROM v_refs
+				WHERE referrer_node_id NOT LIKE '_file_level:%%'
+				GROUP BY referrer_node_id
 			),
 			proj AS (
 				SELECT AVG(n) AS mu FROM fanout
@@ -879,8 +913,46 @@ func missingTables(qg refsQuerier, required []string) ([]string, error) {
 	return missing, nil
 }
 
+// ensureCanonicalViews installs v_defs / v_refs (ADR-0013 Step 3) on the
+// active database via the refsQuerier interface. Idempotent — uses
+// CREATE VIEW IF NOT EXISTS — so safe to call before every rule
+// execution. Necessary because rules query the views (Step 4); .dbs
+// produced by anything other than mache's NewSQLiteWriter (e.g.
+// ley-line-open's `leyline parse`) don't have the views yet, and we
+// don't want consumers to need a separate migration step.
+//
+// Mirrors EnsureCanonicalViews in internal/ingest, but plumbed through
+// the QueryRefs interface rather than *sql.DB so it works against any
+// graph backend that satisfies refsQuerier.
+func ensureCanonicalViews(qg refsQuerier) error {
+	stmts := []string{
+		`CREATE VIEW IF NOT EXISTS v_defs AS
+			SELECT token, node_id, 'mention' AS fidelity FROM node_defs`,
+		`CREATE VIEW IF NOT EXISTS v_refs AS
+			SELECT node_id AS referrer_node_id,
+			       token,
+			       NULL  AS target_node_id,
+			       NULL  AS ref_uri,
+			       NULL  AS ref_line,
+			       'mention' AS fidelity
+			FROM node_refs`,
+	}
+	for _, s := range stmts {
+		rows, err := qg.QueryRefs(s)
+		if err != nil {
+			return fmt.Errorf("ensure canonical views: %w", err)
+		}
+		_ = rows.Close()
+	}
+	return nil
+}
+
 // runSmellRule executes the rule's SQL, optionally scoped to one source.
 func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) ([]smellFinding, error) {
+	if err := ensureCanonicalViews(qg); err != nil {
+		return nil, err
+	}
+
 	scope := ""
 	args := []any{}
 	if sourceID != "" && rule.ScopeColumn != "" {


### PR DESCRIPTION
## Summary

Migrates the five \`find_smells\` rules that consume \`node_defs\` / \`node_refs\` to the canonical views from Step 3 (#341). **Pre-Step-1** (sister bead \`ley-line-453f7e\`) the views surface only mention-fidelity rows, so the migration is **semantically a no-op** — the OR-fallback in the new \`dead_code\` alive-check matches exactly what the old \`node_refs\` join did. Once Step 1 ships LSP-resolved binding rows, the rules immediately benefit; consumer SQL doesn't change again.

## Rules migrated

| Rule | What changed |
|---|---|
| \`dead_code\` | alive-check joins \`v_refs\` with two-arm matching: binding via \`target_node_id\` OR mention via \`token\` (with Receiver.Method first-dot strip preserved on the mention arm). Skip-list survives as the lattice-ceiling fallback for reflection / runtime dispatch. |
| \`untested_function\` | \`tested_via_call\` CTE queries \`v_refs\` (column rename \`node_id\` → \`referrer_node_id\`); test-counterpart joins go through \`v_defs\`. |
| \`duplicate_definitions\` | Count + lookup on \`v_defs\`. |
| \`god_file\` | Per-file def aggregation on \`v_defs\`. |
| \`fan_out_skew\` | Count distinct callee tokens per referrer on \`v_refs\` (referrer column rename). Comment flags future refinement: \`COUNT(DISTINCT COALESCE(target_node_id, token))\` for binding-aware dedup. |

## Plumbing

\`ensureCanonicalViews(refsQuerier)\` helper installs the views via \`QueryRefs\` before each rule executes. Idempotent (\`CREATE VIEW IF NOT EXISTS\`), cheap. Necessary because \`.db\`s produced by anything other than mache's \`NewSQLiteWriter\` (e.g. ley-line-open's \`leyline parse\`) don't have the views yet, and we don't want consumers to need a separate migration step.

## Smoke test

On a self-build of mache:

\`\`\`
dead_code              4 findings
untested_function      6 findings
duplicate_definitions  8 findings
god_file               6 findings
fan_out_skew          47 findings
\`\`\`

Matches the legacy-table baseline — views are passthrough today.

## Test plan

- [x] Full \`cmd\` suite green (50.9s)
- [x] Full \`internal/ingest\` suite green (3.6s)
- [x] All existing \`find_smells\` fixtures still pass — they hand-build \`node_defs\`/\`node_refs\` without views; \`ensureCanonicalViews\` installs them at query time
- [x] End-to-end smoke against a real mache self-build

## Status

**Step 4: complete.** Step 5 (drop the suffix-then-LIKE fallback in \`queryLSPRefs\`/\`queryLSPDefs\`) is still gated on Step 1 since it depends on \`_lsp_refs.referrer_node_id\` being a real column.