### PR TITLE
feat(find_smells): canonical views UNION ALL with _lsp_* binding rows — ADR-0013 Step 3 expansion (mache-346d0f)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -913,29 +914,71 @@ func missingTables(qg refsQuerier, required []string) ([]string, error) {
 	return missing, nil
 }
 
-// ensureCanonicalViews installs v_defs / v_refs (ADR-0013 Step 3) on the
-// active database via the refsQuerier interface. Idempotent — uses
-// CREATE VIEW IF NOT EXISTS — so safe to call before every rule
-// execution. Necessary because rules query the views (Step 4); .dbs
-// produced by anything other than mache's NewSQLiteWriter (e.g.
-// ley-line-open's `leyline parse`) don't have the views yet, and we
-// don't want consumers to need a separate migration step.
+// ensureCanonicalViews installs v_defs / v_refs (ADR-0013 Step 3) as
+// TEMP views scoped to the active connection. Probes for ley-line-open's
+// post-Step-1 _lsp_* columns (referrer_node_id, ref_token, def_token)
+// and includes a UNION ALL with binding-fidelity rows when those
+// columns are available; otherwise falls back to mention-only.
 //
-// Mirrors EnsureCanonicalViews in internal/ingest, but plumbed through
-// the QueryRefs interface rather than *sql.DB so it works against any
-// graph backend that satisfies refsQuerier.
+// Why TEMP views rather than persistent ones:
+//
+//   - SQLiteGraph opens .dbs read-only (mode=ro). Persistent DDL fails;
+//     TEMP objects live in a per-connection in-memory schema and work
+//     even on RO connections.
+//   - The view body depends on what columns the producer wrote. With
+//     TEMP views we can recompute the body per-connection rather than
+//     locking in a stale shape on disk.
+//   - Temp objects shadow same-named main-schema objects for the
+//     current connection, so the legacy persistent mention-only views
+//     installed by NewSQLiteWriter (PR #341) get overridden cleanly
+//     without a migration.
+//
+// Idempotent — DROP VIEW IF EXISTS before each CREATE — so safe to
+// call before every rule execution.
 func ensureCanonicalViews(qg refsQuerier) error {
+	hasLSPDefsToken, err := tableHasColumn(qg, "_lsp_defs", "def_token")
+	if err != nil {
+		return fmt.Errorf("probe _lsp_defs: %w", err)
+	}
+	hasLSPRefsCols, err := tableHasColumn(qg, "_lsp_refs", "ref_token")
+	if err != nil {
+		return fmt.Errorf("probe _lsp_refs: %w", err)
+	}
+
+	defsBody := `SELECT token, node_id, 'mention' AS fidelity FROM node_defs`
+	if hasLSPDefsToken {
+		defsBody += `
+			UNION ALL
+			SELECT def_token AS token, node_id, 'binding' AS fidelity
+			FROM _lsp_defs
+			WHERE def_token != ''`
+	}
+
+	refsBody := `SELECT node_id AS referrer_node_id,
+	       token,
+	       NULL  AS target_node_id,
+	       NULL  AS ref_uri,
+	       NULL  AS ref_line,
+	       'mention' AS fidelity
+	FROM node_refs`
+	if hasLSPRefsCols {
+		refsBody += `
+			UNION ALL
+			SELECT referrer_node_id,
+			       ref_token AS token,
+			       node_id   AS target_node_id,
+			       ref_uri,
+			       ref_start_line AS ref_line,
+			       'binding' AS fidelity
+			FROM _lsp_refs
+			WHERE ref_token != '' AND referrer_node_id IS NOT NULL`
+	}
+
 	stmts := []string{
-		`CREATE VIEW IF NOT EXISTS v_defs AS
-			SELECT token, node_id, 'mention' AS fidelity FROM node_defs`,
-		`CREATE VIEW IF NOT EXISTS v_refs AS
-			SELECT node_id AS referrer_node_id,
-			       token,
-			       NULL  AS target_node_id,
-			       NULL  AS ref_uri,
-			       NULL  AS ref_line,
-			       'mention' AS fidelity
-			FROM node_refs`,
+		"DROP VIEW IF EXISTS temp.v_defs",
+		"DROP VIEW IF EXISTS temp.v_refs",
+		"CREATE TEMP VIEW v_defs AS " + defsBody,
+		"CREATE TEMP VIEW v_refs AS " + refsBody,
 	}
 	for _, s := range stmts {
 		rows, err := qg.QueryRefs(s)
@@ -945,6 +988,71 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		_ = rows.Close()
 	}
 	return nil
+}
+
+// tableHasColumn returns true iff the given table exists AND contains
+// a column of the given name. Implemented via PRAGMA table_info, which
+// returns zero rows for missing tables (rather than erroring), so this
+// helper collapses "table missing" and "column missing" into false.
+//
+// Used by ensureCanonicalViews to decide whether to add the binding-
+// fidelity UNION ALL clause to the v_defs / v_refs body. A pre-Step-1
+// _lsp_refs table (without referrer_node_id / ref_token) reads as
+// "no binding-fidelity rows available" and the views fall back to
+// mention-only — same shape as today.
+func tableHasColumn(qg refsQuerier, table, col string) (bool, error) {
+	// Table name is interpolated directly; PRAGMA table_info doesn't
+	// accept positional parameters. table comes from a hardcoded
+	// constant in this file (not user input), so injection risk is
+	// nil — but assert anyway via a defensive check.
+	if !isSimpleIdent(table) {
+		return false, fmt.Errorf("invalid table name: %q", table)
+	}
+	rows, err := qg.QueryRefs(fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		// SQLite returns rows (possibly zero) for valid PRAGMA calls
+		// whether or not the table exists; an error here is genuine.
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			typ       string
+			notnull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &typ, &notnull, &dfltValue, &pk); err != nil {
+			return false, err
+		}
+		if name == col {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
+// isSimpleIdent guards against SQL injection in PRAGMA table_info
+// where the table name can't be parameterized. Allows ASCII letters,
+// digits, and underscores — the shape of every table mache writes.
+func isSimpleIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case 'a' <= r && r <= 'z':
+		case 'A' <= r && r <= 'Z':
+		case '0' <= r && r <= '9':
+		case r == '_':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // runSmellRule executes the rule's SQL, optionally scoped to one source.

--- a/cmd/serve_find_smells_views_test.go
+++ b/cmd/serve_find_smells_views_test.go
@@ -1,0 +1,279 @@
+package cmd
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// ensureCanonicalViews — ADR-0013 Step 3 expansion (mache-346d0f
+// closeout). Tests pin the producer-detection logic: when ley-line-
+// open's post-Step-1 _lsp_* tables are present (with referrer_node_id /
+// ref_token / def_token columns), the views UNION ALL with binding-
+// fidelity rows. When missing or pre-Step-1 schema, the views fall
+// back to mention-only — same shape as PR #341.
+
+// sqlDBQuerier wraps a *sql.DB as a refsQuerier. The smellTestGraph
+// in serve_find_smells_test.go is heavier than these tests need
+// (full graph + AST plumbing); a thin wrapper is enough.
+type sqlDBQuerier struct{ db *sql.DB }
+
+func (q *sqlDBQuerier) QueryRefs(query string, args ...any) (*sql.Rows, error) {
+	return q.db.Query(query, args...)
+}
+
+func TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "binding.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Mention-fidelity tables (mache's own schema) + post-Step-1
+	// _lsp_* shape (referrer_node_id, ref_token, def_token).
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL,
+			def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL,
+			referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		-- Mention-fidelity: tree-sitter saw 'Validate' textually.
+		INSERT INTO node_defs VALUES ('Validate', 'auth/functions/Validate');
+		INSERT INTO node_refs VALUES ('Validate', 'billing/functions/Charge');
+
+		-- Binding-fidelity: gopls resolved obj.Validate() at billing's
+		-- byte range to auth/functions/Validate. ref_token = 'Validate'
+		-- because that's the textual lemma at the source byte range.
+		INSERT INTO _lsp_defs VALUES
+			('auth/functions/Validate', 'Validate', 'file:///auth/auth.go', 10, 5, 10, 13);
+		INSERT INTO _lsp_refs VALUES
+			('auth/functions/Validate', 'billing/functions/Charge', 'Validate',
+			 'file:///billing/billing.go', 42, 11, 42, 19);
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// v_defs: one mention row + one binding row.
+	type defRow struct {
+		token, nodeID, fidelity string
+	}
+	rows, err := db.Query(`SELECT token, node_id, fidelity FROM v_defs ORDER BY fidelity, token`)
+	require.NoError(t, err)
+	var defs []defRow
+	for rows.Next() {
+		var r defRow
+		require.NoError(t, rows.Scan(&r.token, &r.nodeID, &r.fidelity))
+		defs = append(defs, r)
+	}
+	require.NoError(t, rows.Close())
+	require.Len(t, defs, 2)
+	assert.Equal(t, "binding", defs[0].fidelity)
+	assert.Equal(t, "Validate", defs[0].token)
+	assert.Equal(t, "auth/functions/Validate", defs[0].nodeID)
+	assert.Equal(t, "mention", defs[1].fidelity)
+
+	// v_refs: one mention row + one binding row. Binding row carries
+	// the resolved target_node_id; mention row has NULL there.
+	type refRow struct {
+		referrer, token, fidelity string
+		target                    sql.NullString
+	}
+	rrows, err := db.Query(`SELECT referrer_node_id, token, target_node_id, fidelity FROM v_refs ORDER BY fidelity, token`)
+	require.NoError(t, err)
+	var refs []refRow
+	for rrows.Next() {
+		var r refRow
+		require.NoError(t, rrows.Scan(&r.referrer, &r.token, &r.target, &r.fidelity))
+		refs = append(refs, r)
+	}
+	require.NoError(t, rrows.Close())
+	require.Len(t, refs, 2)
+	assert.Equal(t, "binding", refs[0].fidelity)
+	assert.Equal(t, "billing/functions/Charge", refs[0].referrer)
+	assert.Equal(t, "Validate", refs[0].token)
+	assert.True(t, refs[0].target.Valid, "binding row must populate target_node_id")
+	assert.Equal(t, "auth/functions/Validate", refs[0].target.String)
+	assert.Equal(t, "mention", refs[1].fidelity)
+	assert.False(t, refs[1].target.Valid, "mention row's target_node_id is NULL")
+}
+
+func TestEnsureCanonicalViews_HandlesMissingLSPTables(t *testing.T) {
+	// .db without _lsp_* tables — what mache build produces today.
+	// Views must still resolve and surface only mention rows.
+	dbPath := filepath.Join(t.TempDir(), "no_lsp.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo');
+		INSERT INTO node_refs VALUES ('Foo', 'pkg/Bar');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	var defCount, refCount int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'mention'`).Scan(&defCount))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'mention'`).Scan(&refCount))
+	assert.Equal(t, 1, defCount)
+	assert.Equal(t, 1, refCount)
+
+	// Querying for binding rows must succeed (the column exists in the
+	// view shape) and return zero — no _lsp_* tables, no binding data.
+	var bindingDefs, bindingRefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'binding'`).Scan(&bindingDefs))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
+	assert.Zero(t, bindingDefs, "no _lsp_defs → no binding rows")
+	assert.Zero(t, bindingRefs, "no _lsp_refs → no binding rows")
+}
+
+func TestEnsureCanonicalViews_HandlesLegacyLSPTables(t *testing.T) {
+	// Pre-Step-1 _lsp_* schema (no def_token / referrer_node_id /
+	// ref_token columns). The probe must detect the absence and fall
+	// back to mention-only views — querying the old _lsp_* via the
+	// new view body would error with "no such column."
+	dbPath := filepath.Join(t.TempDir(), "legacy_lsp.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		-- Pre-Step-1 shape: no def_token, no referrer_node_id, no ref_token.
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL, def_uri TEXT NOT NULL,
+			def_start_line INTEGER, def_start_col INTEGER,
+			def_end_line INTEGER, def_end_col INTEGER
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL, ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER, ref_start_col INTEGER,
+			ref_end_line INTEGER, ref_end_col INTEGER
+		);
+
+		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo');
+		INSERT INTO _lsp_defs VALUES ('pkg/Foo', 'file:///x.go', 1, 0, 1, 3);
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// v_defs surfaces only the mention row. The legacy _lsp_defs row
+	// is silently skipped — the consumer can't recover def_token from
+	// it, so projecting it as binding-fidelity would misrepresent.
+	var bindingDefs, mentionDefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'mention'`).Scan(&mentionDefs))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'binding'`).Scan(&bindingDefs))
+	assert.Equal(t, 1, mentionDefs)
+	assert.Zero(t, bindingDefs, "legacy _lsp_defs (no def_token) must not produce binding rows")
+}
+
+func TestEnsureCanonicalViews_SkipsEmptyTokenRows(t *testing.T) {
+	// LSP_REFS_DDL declares ref_token NOT NULL DEFAULT ''. Rows where
+	// the producer couldn't extract the byte range (cross-repo refs,
+	// missing source) carry empty tokens. The view body filters those
+	// out — they'd contribute false matches in token-keyed rule
+	// queries (especially dead_code's mention fallback arm).
+	dbPath := filepath.Join(t.TempDir(), "empty_token.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL,
+			def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL,
+			referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		-- One def row with a real token (kept), one with empty (dropped).
+		INSERT INTO _lsp_defs VALUES
+			('pkg/Real',  'Real',  'file:///x.go', 1, 0, 1, 3),
+			('pkg/Empty', '',      'file:///x.go', 5, 0, 5, 3);
+
+		-- One ref with token + referrer (kept), one with empty token
+		-- (dropped), one with NULL referrer (dropped).
+		INSERT INTO _lsp_refs VALUES
+			('pkg/Real',  'pkg/Caller',  'Real',  'file:///c.go', 9, 0, 9, 3),
+			('pkg/Empty', 'pkg/Caller',  '',      'file:///c.go', 10, 0, 10, 3),
+			('pkg/Real',  NULL,           'Real',  'file:///c.go', 11, 0, 11, 3);
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	var bindingDefs, bindingRefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'binding'`).Scan(&bindingDefs))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
+	assert.Equal(t, 1, bindingDefs, "only the row with non-empty def_token survives")
+	assert.Equal(t, 1, bindingRefs, "only the row with non-empty ref_token AND non-NULL referrer survives")
+}
+
+func TestTableHasColumn(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "probe.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`CREATE TABLE present (a TEXT, b INTEGER)`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+
+	// Existing table, existing column.
+	got, err := tableHasColumn(qg, "present", "a")
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	// Existing table, missing column — collapses with "table missing"
+	// into false; consumer doesn't need to distinguish.
+	got, err = tableHasColumn(qg, "present", "missing")
+	require.NoError(t, err)
+	assert.False(t, got)
+
+	// Missing table — also false (PRAGMA table_info returns 0 rows).
+	got, err = tableHasColumn(qg, "absent", "a")
+	require.NoError(t, err)
+	assert.False(t, got)
+
+	// Injection-defense: invalid identifier rejected.
+	_, err = tableHasColumn(qg, "no spaces; DROP TABLE present", "a")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

**Step 3 closeout.** ley-line-open shipped Step 1 at \`12330fc\` — \`_lsp_refs\` now carries \`(referrer_node_id, ref_token)\`, \`_lsp_defs\` carries \`def_token\`. Mache's canonical views (PR #341) were mention-only passthrough; this PR teaches them to detect the post-Step-1 schema and \`UNION ALL\` with binding-fidelity rows.

This is the PR where ADR-0013's design starts producing actual value: \`dead_code\`'s rule SQL automatically gets type-resolved binding rows when LSP indexed the source. The skip-list survives only as the lattice-ceiling fallback for reflection / runtime dispatch (Falsifiability A — \`mache-3509aa\` — proves the rest).

## How it works

\`ensureCanonicalViews\` probes the active database for the new columns via \`PRAGMA table_info\`, then assembles the view body conditionally:

\`\`\`
v_defs = node_defs (mention)
       [+ _lsp_defs (binding) WHEN def_token column exists]

v_refs = node_refs (mention, NULL target_node_id)
       [+ _lsp_refs (binding, target_node_id populated)
          WHEN ref_token + referrer_node_id columns exist]
\`\`\`

## TEMP views — why

Views are now installed as **TEMP** views (per-connection, in-memory). \`SQLiteGraph\` opens \`.db\`s read-only; persistent DDL fails on those connections, but TEMP objects always work because they live in a per-connection in-memory schema. Temp views shadow same-named main-schema objects, so the legacy persistent mention-only views from PR #341 get cleanly overridden without any disk-side migration.

## Defensive filtering

- **Empty tokens** (producer emits \`''\` when byte range couldn't be extracted — cross-repo refs, missing source) are filtered. Including them would contribute false matches on token-keyed rule joins.
- **Pre-Step-1 \`_lsp_*\` schemas** (no \`def_token\` / \`referrer_node_id\` / \`ref_token\`) are detected and skipped — querying via the new view body would error with \"no such column.\"
- **Injection defense**: \`tableHasColumn\` rejects table names that aren't simple identifiers, since \`PRAGMA table_info\` can't be parameterized.

## Test plan

- [x] \`BindingFidelityWhenLSPColumnsPresent\` — full Step-1-shaped tables; v_defs surfaces both fidelities; v_refs binding row carries resolved \`target_node_id\`
- [x] \`HandlesMissingLSPTables\` — today's mache build; mention only
- [x] \`HandlesLegacyLSPTables\` — pre-Step-1 \`_lsp_*\` schema; mention only; legacy rows silently dropped
- [x] \`SkipsEmptyTokenRows\` — producer-emitted \`''\` tokens / \`NULL\` referrers filtered
- [x] \`TestTableHasColumn\` — PRAGMA probe helper with injection-defense check
- [x] Full \`cmd\` suite green (48s)

## What's next

| Step | Bead | Status |
|---|---|---|
| Step 5 — drop suffix-then-LIKE fallback | \`mache-346d2b\` | unblocked |
| Falsifiability B — π_{1→0} round-trip | \`mache-354464\` | unblocked |
| Falsifiability A — skip-list ablation | \`mache-3509aa\` | unblocked |