### PR TITLE
feat(serve_lsp): drop suffix-then-LIKE fallback when ref_token/def_token present — ADR-0013 Step 5 (mache-346d2b)

### DIFF
--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -54,12 +54,12 @@ func makeGetTypeInfoHandler(g graph.Graph) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError("LSP data not available for this data source"), nil
 		}
-		var tableExists int
+		var refsTableExists int
 		if rows.Next() {
-			_ = rows.Scan(&tableExists)
+			_ = rows.Scan(&refsTableExists)
 		}
 		_ = rows.Close()
-		if tableExists == 0 {
+		if refsTableExists == 0 {
 			filePath := request.GetString("file", "")
 			if filePath == "" {
 				return lspTableMissing("_lsp_hover", "type info"), nil
@@ -94,12 +94,12 @@ func makeGetDiagnosticsHandler(g graph.Graph) server.ToolHandlerFunc {
 		if err != nil {
 			return mcp.NewToolResultError("LSP data not available for this data source"), nil
 		}
-		var tableExists int
+		var refsTableExists int
 		if rows.Next() {
-			_ = rows.Scan(&tableExists)
+			_ = rows.Scan(&refsTableExists)
 		}
 		_ = rows.Close()
-		if tableExists == 0 {
+		if refsTableExists == 0 {
 			filePath := request.GetString("file", "")
 			if filePath == "" {
 				return lspTableMissing("_lsp", "diagnostics"), nil
@@ -383,32 +383,110 @@ type lspRefLocation struct {
 	EndCol    int    `json:"end_col"`
 }
 
-// queryLSPDefs queries the _lsp_defs table for definition locations of a symbol.
-// Returns nil, nil if the table does not exist.
+// queryLSPDefs queries the _lsp_defs table for definition locations
+// of a symbol. Returns (nil, nil) if the table does not exist.
+//
+// Per ADR-0013 Step 5 (mache-346d2b), this prefers the direct
+// def_token match when ley-line-open's post-Step-1 column is
+// present. The legacy suffix-then-broader-LIKE fallback survives
+// for pre-Step-1 .dbs that still have only the (node_id, def_uri,
+// ...) columns.
 func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
-	// Check if _lsp_defs table exists
-	rows, err := qg.QueryRefs(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_lsp_defs'`)
+	hasDefToken, err := tableHasColumn(qg, "_lsp_defs", "def_token")
 	if err != nil {
-		return nil, fmt.Errorf("check _lsp_defs existence: %w", err)
+		return nil, fmt.Errorf("probe _lsp_defs schema: %w", err)
 	}
-	var tableExists int
-	if rows.Next() {
-		_ = rows.Scan(&tableExists)
+	if !hasDefToken {
+		// Pre-Step-1 schema (or table missing entirely). Fall back to
+		// node_id LIKE matching against the trailing component, with
+		// a broader substring fallback if that returns nothing.
+		return queryLSPDefsLegacy(qg, symbol)
 	}
-	_ = rows.Close()
-	if tableExists == 0 {
+
+	rows, err := qg.QueryRefs(
+		`SELECT node_id, def_uri, def_start_line, def_start_col, def_end_line, def_end_col
+		 FROM _lsp_defs
+		 WHERE def_token = ?`,
+		symbol,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query _lsp_defs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []lspDefLocation
+	for rows.Next() {
+		var r lspDefLocation
+		if err := rows.Scan(&r.NodeID, &r.URI, &r.StartLine, &r.StartCol, &r.EndLine, &r.EndCol); err != nil {
+			continue
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// queryLSPRefs queries the _lsp_refs table for reference locations
+// of a symbol. Returns (nil, nil) if the table does not exist.
+//
+// Per ADR-0013 Step 5 (mache-346d2b), prefers the direct ref_token
+// match when ley-line-open's post-Step-1 column is present. Legacy
+// LIKE fallback survives for pre-Step-1 .dbs.
+func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
+	hasRefToken, err := tableHasColumn(qg, "_lsp_refs", "ref_token")
+	if err != nil {
+		return nil, fmt.Errorf("probe _lsp_refs schema: %w", err)
+	}
+	if !hasRefToken {
+		return queryLSPRefsLegacy(qg, symbol)
+	}
+
+	rows, err := qg.QueryRefs(
+		`SELECT node_id, ref_uri, ref_start_line, ref_start_col, ref_end_line, ref_end_col
+		 FROM _lsp_refs
+		 WHERE ref_token = ?`,
+		symbol,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query _lsp_refs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []lspRefLocation
+	for rows.Next() {
+		var r lspRefLocation
+		if err := rows.Scan(&r.NodeID, &r.URI, &r.StartLine, &r.StartCol, &r.EndLine, &r.EndCol); err != nil {
+			continue
+		}
+		results = append(results, r)
+	}
+	return results, rows.Err()
+}
+
+// queryLSPDefsLegacy is the pre-Step-1 query path: node_id suffix
+// match, then broader substring LIKE if that returns nothing. Kept
+// for .dbs that still have the legacy _lsp_defs schema (no def_token
+// column). New consumers should rely on queryLSPDefs which prefers
+// the direct token match when available.
+func queryLSPDefsLegacy(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
+	// First confirm the table exists at all — tableHasColumn returns
+	// false for both "no table" and "table without column", so we
+	// have to disambiguate here for the legacy code path.
+	exists, err := refsTableExists(qg, "_lsp_defs")
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
 		return nil, nil
 	}
 
-	// Try node_id suffix match (symbol is the trailing component of node_id)
 	escaped := escapeLikeMeta(symbol)
-	rows, err = qg.QueryRefs(
+	rows, err := qg.QueryRefs(
 		`SELECT node_id, def_uri, def_start_line, def_start_col, def_end_line, def_end_col
 		 FROM _lsp_defs WHERE node_id LIKE ? ESCAPE '\'`,
 		"%/"+escaped,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query _lsp_defs: %w", err)
+		return nil, fmt.Errorf("query _lsp_defs (legacy suffix): %w", err)
 	}
 
 	var results []lspDefLocation
@@ -421,7 +499,6 @@ func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
 	}
 	_ = rows.Close()
 
-	// Fallback: broader LIKE match
 	if len(results) == 0 {
 		rows, err = qg.QueryRefs(
 			`SELECT node_id, def_uri, def_start_line, def_start_col, def_end_line, def_end_col
@@ -429,7 +506,7 @@ func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
 			"%"+escaped+"%",
 		)
 		if err != nil {
-			return nil, fmt.Errorf("query _lsp_defs (broad): %w", err)
+			return nil, fmt.Errorf("query _lsp_defs (legacy broad): %w", err)
 		}
 		for rows.Next() {
 			var r lspDefLocation
@@ -440,36 +517,27 @@ func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
 		}
 		_ = rows.Close()
 	}
-
 	return results, nil
 }
 
-// queryLSPRefs queries the _lsp_refs table for reference locations of a symbol.
-// Returns nil, nil if the table does not exist.
-func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
-	// Check if _lsp_refs table exists
-	rows, err := qg.QueryRefs(`SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='_lsp_refs'`)
+// queryLSPRefsLegacy mirrors queryLSPDefsLegacy for the refs table.
+func queryLSPRefsLegacy(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
+	exists, err := refsTableExists(qg, "_lsp_refs")
 	if err != nil {
-		return nil, fmt.Errorf("check _lsp_refs existence: %w", err)
+		return nil, err
 	}
-	var tableExists int
-	if rows.Next() {
-		_ = rows.Scan(&tableExists)
-	}
-	_ = rows.Close()
-	if tableExists == 0 {
+	if !exists {
 		return nil, nil
 	}
 
-	// Try node_id suffix match
 	escaped := escapeLikeMeta(symbol)
-	rows, err = qg.QueryRefs(
+	rows, err := qg.QueryRefs(
 		`SELECT node_id, ref_uri, ref_start_line, ref_start_col, ref_end_line, ref_end_col
 		 FROM _lsp_refs WHERE node_id LIKE ? ESCAPE '\'`,
 		"%/"+escaped,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query _lsp_refs: %w", err)
+		return nil, fmt.Errorf("query _lsp_refs (legacy suffix): %w", err)
 	}
 
 	var results []lspRefLocation
@@ -482,7 +550,6 @@ func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
 	}
 	_ = rows.Close()
 
-	// Fallback: broader LIKE match
 	if len(results) == 0 {
 		rows, err = qg.QueryRefs(
 			`SELECT node_id, ref_uri, ref_start_line, ref_start_col, ref_end_line, ref_end_col
@@ -490,7 +557,7 @@ func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
 			"%"+escaped+"%",
 		)
 		if err != nil {
-			return nil, fmt.Errorf("query _lsp_refs (broad): %w", err)
+			return nil, fmt.Errorf("query _lsp_refs (legacy broad): %w", err)
 		}
 		for rows.Next() {
 			var r lspRefLocation
@@ -501,8 +568,26 @@ func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
 		}
 		_ = rows.Close()
 	}
-
 	return results, nil
+}
+
+// refsTableExists returns true iff the named SQLite table is present in
+// the active database. Used by queryLSP*Legacy to short-circuit when
+// the table doesn't exist (consistent with the original "(nil, nil)
+// = no table" contract).
+func refsTableExists(qg refsQuerier, name string) (bool, error) {
+	if !isSimpleIdent(name) {
+		return false, fmt.Errorf("invalid table name: %q", name)
+	}
+	rows, err := qg.QueryRefs(
+		`SELECT 1 FROM sqlite_master WHERE type='table' AND name = ?`,
+		name,
+	)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = rows.Close() }()
+	return rows.Next(), rows.Err()
 }
 
 // escapeLikeMeta escapes SQL LIKE metacharacters (%, _, \) only.

--- a/cmd/serve_lsp_step5_test.go
+++ b/cmd/serve_lsp_step5_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// queryLSPDefs / queryLSPRefs — ADR-0013 Step 5 (mache-346d2b).
+// Tests pin the dispatch: when ley-line-open's post-Step-1 columns
+// (def_token / ref_token) are present, the queries use direct token
+// match. When absent, they fall through to the legacy
+// suffix-then-broader-LIKE pattern. Existing fixtures in serve_test.go
+// already exercise the legacy path; this file covers the new path
+// and the boundary between them.
+
+// stepOneLSPDB builds a fixture with the post-Step-1 _lsp_* schema —
+// def_token populated on _lsp_defs and (referrer_node_id, ref_token)
+// populated on _lsp_refs. Returns the *sql.DB wrapped as a refsQuerier.
+func stepOneLSPDB(t *testing.T) *sqlDBQuerier {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "step1.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL,
+			def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL,
+			referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		-- Two defs of 'Read': one on MyReader, one on OtherReader.
+		-- Direct token match must surface BOTH (without disambiguating
+		-- by node_id) — same semantic as today's broader-LIKE fallback.
+		INSERT INTO _lsp_defs VALUES
+			('pkg/methods/MyReader.Read',    'Read', 'file:///pkg/my.go',    10, 5, 10, 9),
+			('pkg/methods/OtherReader.Read', 'Read', 'file:///pkg/other.go', 20, 5, 20, 9),
+			('pkg/functions/Validate',       'Validate', 'file:///pkg/v.go',  5, 5,  5, 13);
+
+		-- Refs to Read from two different referrers, plus a ref to
+		-- Validate from one referrer.
+		INSERT INTO _lsp_refs VALUES
+			('pkg/methods/MyReader.Read',    'pkg/functions/Caller1', 'Read',     'file:///pkg/c1.go', 30, 11, 30, 15),
+			('pkg/methods/OtherReader.Read', 'pkg/functions/Caller2', 'Read',     'file:///pkg/c2.go', 40, 11, 40, 15),
+			('pkg/functions/Validate',       'pkg/functions/Caller3', 'Validate', 'file:///pkg/c3.go', 50, 11, 50, 19);
+	`)
+	require.NoError(t, err)
+	return &sqlDBQuerier{db: db}
+}
+
+func TestQueryLSPDefs_DirectTokenMatch_Step1(t *testing.T) {
+	qg := stepOneLSPDB(t)
+
+	// Direct match on def_token. Must return BOTH Read defs (the
+	// node_id LIKE '%/Read' suffix would also match both, but only
+	// because Read happens to be the trailing component — for
+	// methods rendered as 'Receiver.Method' the suffix would NOT
+	// match and the broader fallback would be needed. The new
+	// direct match handles methods correctly without the fallback.)
+	defs, err := queryLSPDefs(qg, "Read")
+	require.NoError(t, err)
+	require.Len(t, defs, 2)
+
+	uris := []string{defs[0].URI, defs[1].URI}
+	assert.Contains(t, uris, "file:///pkg/my.go")
+	assert.Contains(t, uris, "file:///pkg/other.go")
+}
+
+func TestQueryLSPDefs_DirectTokenMatch_NoBroaderLIKE(t *testing.T) {
+	// Defining a func 'Bar' and a func 'BarHelper' — direct token
+	// match on 'Bar' returns only the Bar def, NOT BarHelper. The
+	// legacy broader-LIKE ('%Bar%') would match both; the new direct
+	// match is more precise.
+	dbPath := filepath.Join(t.TempDir(), "narrow.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL,
+			def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		INSERT INTO _lsp_defs VALUES
+			('pkg/functions/Bar',       'Bar',       'file:///x.go', 1, 0, 1, 3),
+			('pkg/functions/BarHelper', 'BarHelper', 'file:///x.go', 5, 0, 5, 9);
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+
+	defs, err := queryLSPDefs(qg, "Bar")
+	require.NoError(t, err)
+	require.Len(t, defs, 1, "direct token match must NOT spuriously match 'BarHelper'")
+	assert.Equal(t, "pkg/functions/Bar", defs[0].NodeID)
+}
+
+func TestQueryLSPRefs_DirectTokenMatch_Step1(t *testing.T) {
+	qg := stepOneLSPDB(t)
+
+	refs, err := queryLSPRefs(qg, "Read")
+	require.NoError(t, err)
+	require.Len(t, refs, 2, "two refs to 'Read' from distinct callers")
+
+	uris := []string{refs[0].URI, refs[1].URI}
+	assert.Contains(t, uris, "file:///pkg/c1.go")
+	assert.Contains(t, uris, "file:///pkg/c2.go")
+}
+
+func TestQueryLSPDefs_TableMissing_StillReturnsNilNil(t *testing.T) {
+	// Contract preservation: a .db without _lsp_defs returns
+	// (nil, nil). The Step-5 migration must keep this invariant
+	// because callers (find_definition handler) treat nil as "no
+	// LSP enrichment available, fall back to ordinary def lookup."
+	dbPath := filepath.Join(t.TempDir(), "no_lsp.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	qg := &sqlDBQuerier{db: db}
+
+	defs, err := queryLSPDefs(qg, "Anything")
+	require.NoError(t, err)
+	assert.Nil(t, defs, "no _lsp_defs table → nil result, no error")
+
+	refs, err := queryLSPRefs(qg, "Anything")
+	require.NoError(t, err)
+	assert.Nil(t, refs, "no _lsp_refs table → nil result, no error")
+}
+
+func TestRefsTableExists(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "exists.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`CREATE TABLE present (a TEXT)`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+
+	got, err := refsTableExists(qg, "present")
+	require.NoError(t, err)
+	assert.True(t, got)
+
+	got, err = refsTableExists(qg, "absent")
+	require.NoError(t, err)
+	assert.False(t, got)
+
+	// Injection-defense: rejects names that aren't simple identifiers.
+	_, err = refsTableExists(qg, "evil; DROP TABLE present")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

**Step 5 closeout.** With ley-line-open's post-Step-1 \`_lsp_defs.def_token\` and \`_lsp_refs.ref_token\` columns populated (PR #347 plumbed them through the canonical views; this PR plumbs them through the symbol-lookup path), \`queryLSPDefs\` and \`queryLSPRefs\` can do direct equality matches instead of reverse-engineering the token from \`node_id LIKE\` matching.

The legacy suffix-then-broader-LIKE path was a consumer-side compensation for the producer not emitting the token. With the producer fix landed, the consumer-side hack goes away — for .dbs that have the new columns. Pre-Step-1 .dbs still take the legacy path via \`queryLSPDefsLegacy\` / \`queryLSPRefsLegacy\`.

## How it works

- \`queryLSPDefs\` / \`queryLSPRefs\` probe via \`tableHasColumn\` for the Step-1 columns at first call. If present: \`SELECT ... WHERE def_token = ?\` (or \`ref_token = ?\`) directly. If absent: dispatch to \`*Legacy\` which preserves today's behavior verbatim.
- New \`refsTableExists\` helper for the legacy code path's \"table doesn't exist → return (nil, nil)\" contract. Distinct from \`tableHasColumn\`'s \"false on either missing-table or missing-column\" collapse — the legacy path needs the disambiguation.
- Both helpers have an \`isSimpleIdent\` injection guard since \`PRAGMA\`/\`sqlite_master\` queries can't parameterize the identifier.

## Why direct token match is strictly more precise

The legacy broader-LIKE fallback (\`'%symbol%'\`) matches things like \`BarHelper\` when querying for \`Bar\`. The new direct match returns exactly the rows the producer tagged with \`token = 'Bar'\`. The \`Receiver.Method\` case (where suffix LIKE fails for methods on typed receivers and the broader fallback rescues) is handled correctly by direct match because LSP extracts \`def_token = 'Method'\` from the source byte range — not from the \`node_id\` path component.

## Test plan

- [x] \`TestQueryLSPDefs_DirectTokenMatch_Step1\` — two defs of \`Read\` on different types; direct match returns both
- [x] \`TestQueryLSPDefs_DirectTokenMatch_NoBroaderLIKE\` — defining \`Bar\` and \`BarHelper\`; direct match for \`Bar\` returns ONLY \`Bar\` (legacy fallback would over-match)
- [x] \`TestQueryLSPRefs_DirectTokenMatch_Step1\` — refs lookup mirror
- [x] \`TestQueryLSPDefs_TableMissing_StillReturnsNilNil\` — contract preservation; caller relies on nil to mean \"no LSP, fall back to ordinary lookup\"
- [x] \`TestRefsTableExists\` — helper with injection-defense check
- [x] All existing \`TestQueryLSP*\` / \`TestFindDefinition*\` / \`TestFindCallers*\` tests continue to pass — they use the legacy fixture (no \`def_token\` column) so they exercise the \`*Legacy\` fallback path unchanged
- [x] Full \`cmd\` suite green (49s)

Closes \`mache-346d2b\`.