### PR TITLE
feat(find_smells): dead_code skip-list precise retreat (post-Falsifiability A)

### DIFF
--- a/cmd/dead_code_skip_list_retreat_test.go
+++ b/cmd/dead_code_skip_list_retreat_test.go
@@ -1,0 +1,285 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// dead_code skip-list precise retreat — ADR-0013 follow-up after
+// Falsifiability A passed empirically. The skip-list now has two
+// halves:
+//
+//   - Runtime-invoked names (main, init, Test*, Benchmark*, ...)
+//     stay unconditionally skipped. Lattice ceiling — neither
+//     tree-sitter nor LSP synthesizes references for the Go runtime
+//     loader or test harness's reflective dispatch.
+//
+//   - Interface-method names (Read, Write, ServeHTTP, ...) skip
+//     ONLY when LSP didn't see a binding-fidelity reference to
+//     that specific def. With LSP coverage, the alive-check's
+//     binding arm decides; without LSP coverage, the skip-list
+//     compensates as before.
+//
+// Tests pin both halves of that contract.
+
+func TestDeadCode_InterfaceMethodSkippedWithoutLSP(t *testing.T) {
+	// No _lsp_* tables. An interface-named method (`Read`) with no
+	// node_refs entries falls into the legacy compensation path —
+	// skip-listed, NOT flagged dead.
+	dbPath := filepath.Join(t.TempDir(), "no_lsp.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON, source_file TEXT
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO nodes VALUES
+			('pkg/methods/MyType.Read', NULL, 'Read', 1, 0, 0, NULL, NULL, NULL),
+			('pkg/methods/MyType.Read/source', 'pkg/methods/MyType.Read', 'source', 0, 0, 0, NULL, NULL, 'pkg/mytype.go');
+		INSERT INTO node_defs VALUES ('Read', 'pkg/methods/MyType.Read');
+	`)
+	require.NoError(t, err)
+
+	tg := &smellTestGraph{db: db}
+	handler := makeFindSmellsHandler(tg)
+
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	for _, f := range resp.Findings {
+		assert.NotEqual(t, "pkg/methods/MyType.Read", f.NodeID,
+			"without LSP coverage, interface-named def 'Read' must remain skip-listed (legacy compensation)")
+	}
+}
+
+func TestDeadCode_InterfaceMethodFlaggedWhenLSPSeesNoRefs(t *testing.T) {
+	// LSP indexed the file (binding-fidelity rows exist for OTHER
+	// defs in the package) but found NO references to MyType.Read.
+	// The precise-retreat: skip-list no longer hides Read, so the
+	// alive-check makes the call. With no node_refs and no
+	// binding refs to MyType.Read, the def is flagged dead.
+	//
+	// This is the case the precise retreat unlocks — a method
+	// whose name happens to match the interface skip-list but is
+	// genuinely dead. Pre-retreat: skip-list masked it; post-
+	// retreat: it surfaces as a real finding.
+	dbPath := filepath.Join(t.TempDir(), "lsp_no_refs.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON, source_file TEXT
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL, def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL, referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		INSERT INTO nodes VALUES
+			('pkg/methods/MyType.Read', NULL, 'Read', 1, 0, 0, NULL, NULL, NULL),
+			('pkg/methods/MyType.Read/source', 'pkg/methods/MyType.Read', 'source', 0, 0, 0, NULL, NULL, 'pkg/mytype.go'),
+			('pkg/functions/Other', NULL, 'Other', 1, 0, 0, NULL, NULL, NULL),
+			('pkg/functions/Other/source', 'pkg/functions/Other', 'source', 0, 0, 0, NULL, NULL, 'pkg/other.go');
+
+		INSERT INTO node_defs VALUES
+			('Read', 'pkg/methods/MyType.Read'),
+			('Other', 'pkg/functions/Other');
+
+		-- LSP saw the file (def_token populated, def_uri set) but
+		-- emitted NO _lsp_refs targeting MyType.Read — the method
+		-- has no callers as far as gopls is concerned.
+		INSERT INTO _lsp_defs VALUES
+			('pkg/methods/MyType.Read', 'Read', 'file:///pkg/mytype.go', 10, 5, 10, 9),
+			('pkg/functions/Other', 'Other', 'file:///pkg/other.go', 5, 5, 5, 10);
+
+		-- _lsp_refs intentionally empty for MyType.Read. (We could
+		-- add a binding row for Other to prove other refs in the
+		-- file don't accidentally rescue Read, but the empty case
+		-- is clearer.)
+	`)
+	require.NoError(t, err)
+
+	tg := &smellTestGraph{db: db}
+	handler := makeFindSmellsHandler(tg)
+
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	flagged := map[string]bool{}
+	for _, f := range resp.Findings {
+		flagged[f.NodeID] = true
+	}
+	assert.True(t, flagged["pkg/methods/MyType.Read"],
+		"LSP-aware skip-list retreat: 'Read' is genuinely dead in this fixture (no node_refs, no _lsp_refs targeting it) — flag it instead of masking via the interface-name skip-list")
+}
+
+func TestDeadCode_InterfaceMethodAliveWhenLSPSeesRefs(t *testing.T) {
+	// LSP saw a binding-fidelity reference to MyType.Read. The
+	// alive-check's binding arm matches target_node_id, so the def
+	// is alive. The skip-list retreat doesn't change this case —
+	// it was never going to be flagged in production either (the
+	// skip-list would hide it pre-retreat, the alive-check covers
+	// it post-retreat). Pinning the post-retreat path explicitly.
+	dbPath := filepath.Join(t.TempDir(), "lsp_with_refs.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON, source_file TEXT
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL, def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL, referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		INSERT INTO nodes VALUES
+			('pkg/methods/MyType.Read', NULL, 'Read', 1, 0, 0, NULL, NULL, NULL),
+			('pkg/methods/MyType.Read/source', 'pkg/methods/MyType.Read', 'source', 0, 0, 0, NULL, NULL, 'pkg/mytype.go');
+		INSERT INTO node_defs VALUES ('Read', 'pkg/methods/MyType.Read');
+		INSERT INTO _lsp_defs VALUES
+			('pkg/methods/MyType.Read', 'Read', 'file:///pkg/mytype.go', 10, 5, 10, 9);
+		INSERT INTO _lsp_refs VALUES
+			('pkg/methods/MyType.Read', 'pkg/functions/Caller', 'Read',
+			 'file:///pkg/caller.go', 30, 11, 30, 15);
+	`)
+	require.NoError(t, err)
+
+	tg := &smellTestGraph{db: db}
+	handler := makeFindSmellsHandler(tg)
+
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	for _, f := range resp.Findings {
+		assert.NotEqual(t, "pkg/methods/MyType.Read", f.NodeID,
+			"alive-check binding arm matches the LSP ref → 'Read' is alive, not dead")
+	}
+}
+
+func TestDeadCode_TestPrefixAlwaysSkipped(t *testing.T) {
+	// Test*/Benchmark*/Example*/Fuzz* are lattice-ceiling: invoked
+	// reflectively by `go test`; nothing static can see the
+	// dispatch. The skip-list keeps these unconditionally —
+	// LSP coverage doesn't change anything.
+	dbPath := filepath.Join(t.TempDir(), "test_prefix.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON, source_file TEXT
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		-- _lsp_* present, so binding_covered considered, but Test*
+		-- defs aren't in interface_method category — they're in the
+		-- always-skipped category — so coverage is irrelevant.
+		CREATE TABLE _lsp_defs (
+			node_id TEXT NOT NULL, def_token TEXT NOT NULL DEFAULT '',
+			def_uri TEXT NOT NULL,
+			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+		);
+		CREATE TABLE _lsp_refs (
+			node_id TEXT NOT NULL, referrer_node_id TEXT,
+			ref_token TEXT NOT NULL DEFAULT '',
+			ref_uri TEXT NOT NULL,
+			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
+			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
+		);
+
+		INSERT INTO nodes VALUES
+			('pkg/functions/TestFoo', NULL, 'TestFoo', 1, 0, 0, NULL, NULL, NULL),
+			('pkg/functions/TestFoo/source', 'pkg/functions/TestFoo', 'source', 0, 0, 0, NULL, NULL, 'pkg/foo_test.go');
+		INSERT INTO node_defs VALUES ('TestFoo', 'pkg/functions/TestFoo');
+		-- No _lsp_refs targeting TestFoo. The runtime-invoked
+		-- category skips it regardless.
+	`)
+	require.NoError(t, err)
+
+	tg := &smellTestGraph{db: db}
+	handler := makeFindSmellsHandler(tg)
+
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	for _, f := range resp.Findings {
+		assert.NotEqual(t, "pkg/functions/TestFoo", f.NodeID,
+			"Test* prefix is lattice-ceiling — must stay skip-listed regardless of LSP coverage")
+	}
+}

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -145,32 +145,69 @@ var smellRegistry = []SmellRule{
 				       OR (instr(d.token, '.') > 0 AND r.token = substr(d.token, instr(d.token, '.') + 1))
 				     ))
 			),
-			-- Skip-listed: any token of a construct matches a skip rule.
-			-- ANY-MATCH is the right semantic — a function with both
-			-- 'TestFoo' and 'pkg.TestFoo' should be skipped on the
-			-- testing-framework rule even if only one row triggers.
+			-- Skip-list: defs whose alive-status this rule shouldn't try
+			-- to determine textually. Two categories, with different
+			-- conditions on whether they apply:
 			--
-			-- Token list includes:
-			--   • entry points: main, init
-			--   • io.Reader/Writer/Closer: Read, Write, Close
-			--   • fmt: String, Error, Format, Scan, GoString
-			--   • sort.Interface: Len, Less, Swap
-			--   • encoding: MarshalJSON, UnmarshalJSON
-			--   • SQLite virtual-table (modernc.org/sqlite/vtab):
-			--     BestIndex, Column, Connect, Create, Destroy,
-			--     Disconnect, Eof, Filter, Rowid, Open, Next
-			--   • billy.Filesystem (go-git): Chroot, Readlink, Sys,
-			--     TempFile, MkdirAll, Symlink, Lstat, Stat, ReadDir,
-			--     Capabilities, Root
-			--   • net/http: ServeHTTP
+			-- 1. Runtime-invoked entry points and test prefixes:
+			--      main, init, Test*, Benchmark*, Example*, Fuzz*
+			--    The Go runtime (loader, test harness) calls these
+			--    reflectively. Neither tree-sitter NOR LSP synthesizes
+			--    a reference for those dispatches — nothing static can
+			--    see them. Lattice ceiling — skipped unconditionally.
 			--
-			-- These are interface contracts invoked by external
-			-- runtimes / libraries; static call extraction can't see
-			-- the dispatch site, so the methods always look dead.
+			-- 2. Interface-contract method names:
+			--      Read/Write/Close (io), String/Error (fmt),
+			--      Len/Less/Swap (sort.Interface), MarshalJSON,
+			--      ServeHTTP, the SQLite vtab interface, the
+			--      billy.Filesystem interface, ...
+			--    External runtimes / libraries dispatch to these via
+			--    interface, which tree-sitter's call extractor can't
+			--    see. But LSP can — gopls knows r.Read() on an
+			--    io.Reader resolves to the implementing type's Read
+			--    method. ADR-0013 Falsifiability A confirmed the
+			--    alive-check binding arm (r.target_node_id =
+			--    d.node_id) handles these cases when LSP coverage is
+			--    present. So: skip a def with one of these tokens
+			--    only if NO binding row (v_refs.fidelity='binding')
+			--    points at that specific def. With LSP coverage, the
+			--    alive-check decides; without LSP coverage, the
+			--    skip-list compensates as before. Net: precise
+			--    retreat — skip-list shrinks automatically as LSP
+			--    coverage grows, and a genuinely dead method whose
+			--    name happens to match the list can now be flagged
+			--    when LSP saw the type but no references to that
+			--    method.
 			skipped AS (
-				SELECT DISTINCT node_id FROM v_defs
-				WHERE token IN (
-					'main','init',
+				-- Category 1: always skipped (runtime / test harness).
+				SELECT DISTINCT v_defs.node_id FROM v_defs
+				WHERE v_defs.token IN ('main', 'init')
+				   OR substr(v_defs.token, instr(v_defs.token, '.') + 1) LIKE 'Test%%'
+				   OR substr(v_defs.token, instr(v_defs.token, '.') + 1) LIKE 'Benchmark%%'
+				   OR substr(v_defs.token, instr(v_defs.token, '.') + 1) LIKE 'Example%%'
+				   OR substr(v_defs.token, instr(v_defs.token, '.') + 1) LIKE 'Fuzz%%'
+
+				UNION
+
+				-- Category 2: interface contracts — skipped only when
+				-- LSP did NOT index this def at all. The presence of
+				-- a binding-fidelity v_defs row means LSP saw the
+				-- def; absence means LSP either didn't run or
+				-- couldn't resolve the source file. Three states:
+				--   (a) No binding v_defs row → LSP didn't see this
+				--       def. Tree-sitter compensation still load-
+				--       bearing → SKIP.
+				--   (b) Binding v_defs row exists, NO binding v_refs
+				--       row targets it → LSP saw the def, found no
+				--       references. CONFIRMED DEAD by LSP. Don't
+				--       skip — let alive-check flag it.
+				--   (c) Binding v_defs row exists, ≥1 binding v_refs
+				--       row targets it → ALIVE via alive-check
+				--       binding arm. Don't skip; alive-check makes
+				--       the call via target_node_id match.
+				-- The NOT EXISTS gate triggers (a) only.
+				SELECT DISTINCT v_defs.node_id FROM v_defs
+				WHERE v_defs.token IN (
 					'String','Error','Read','Write','Close','Len','Less','Swap',
 					'MarshalJSON','UnmarshalJSON','Format','Scan','GoString',
 					'BestIndex','Column','Connect','Create','Destroy','Disconnect',
@@ -179,14 +216,11 @@ var smellRegistry = []SmellRule{
 					'Lstat','Stat','ReadDir','Capabilities','Root',
 					'ServeHTTP'
 				)
-				   -- Strip any 'pkg.' qualifier when matching prefixes.
-				   -- instr returns 0 if there's no dot; substr(token, 1)
-				   -- is the full token, so bare and qualified shapes both
-				   -- get the same leaf check.
-				   OR substr(token, instr(token, '.') + 1) LIKE 'Test%%'
-				   OR substr(token, instr(token, '.') + 1) LIKE 'Benchmark%%'
-				   OR substr(token, instr(token, '.') + 1) LIKE 'Example%%'
-				   OR substr(token, instr(token, '.') + 1) LIKE 'Fuzz%%'
+				  AND NOT EXISTS (
+					SELECT 1 FROM v_defs lsp_d
+					WHERE lsp_d.node_id = v_defs.node_id
+					  AND lsp_d.fidelity = 'binding'
+				  )
 			),
 			-- Resolve source_file via children when the construct dir
 			-- itself has none. The schema engine attaches Origin (and


### PR DESCRIPTION
## Summary

- **Skip-list precise retreat** (ADR-0013 follow-up to Falsifiability A passing)
- Splits `dead_code` skip-list into two categories with different trigger conditions
- Preserves correctness on tree-sitter-only `.db`s; lets LSP coverage take over for indexed cases

## Context

[Falsifiability A](https://github.com/agentic-research/mache/issues/3509aa) (mache-3509aa) passed empirically against a real `leyline parse + leyline lsp` build of mache: **0 newly-flagged-dead defs** when dropping the skip-list. That's empirical evidence that LSP binding rows replace the skip-list compensation for the cases LSP indexed.

Wholesale dropping the skip-list would regress on tree-sitter-only `.db`s (no LSP enrichment) — there the skip-list IS load-bearing for interface methods, since tree-sitter's call extractor can't see runtime interface dispatch and would over-flag every `io.Reader.Read()` implementation as dead.

## Approach

Split skip-list into two categories:

**Category 1 — runtime / test-harness invocation** (`main`, `init`, `Test*`, `Benchmark*`, `Example*`, `Fuzz*`):
Lattice ceiling — neither tree-sitter nor LSP synthesizes references for the Go runtime loader or `go test`'s reflective dispatch. Always skipped.

**Category 2 — interface-contract method names** (`String`, `Error`, `Read`, `Write`, `Close`, `MarshalJSON`, `ServeHTTP`, ...):
Three states:

- **(a)** No binding-fidelity `v_defs` row → LSP didn't see this def. Tree-sitter compensation still load-bearing → SKIP.
- **(b)** Binding `v_defs` row exists, no binding `v_refs` targets it → LSP confirmed dead. Don't skip; let alive-check flag it.
- **(c)** Binding `v_defs` row exists, binding `v_refs` targets it → Alive via the binding arm of alive-check. Don't skip.

The `NOT EXISTS` gate triggers (a) only. (b) is the new finding the retreat unlocks.

## Why "no binding v_defs row" (not "no binding v_refs targeting this def")

Was tempted to gate on "LSP saw a reference to this def" but that has a false-positive on case (b): LSP indexed the file, found no callers, that's a *confirmed-dead* signal — not a "fall back to compensation" signal. Looking at `v_defs` presence asks the right question: did LSP see this def at all?

## Tests

`cmd/dead_code_skip_list_retreat_test.go`:

- `InterfaceMethodSkippedWithoutLSP` — pre-retreat behavior preserved for non-LSP `.db`s
- `InterfaceMethodFlaggedWhenLSPSeesNoRefs` — the new state (b) unlocked
- `InterfaceMethodAliveWhenLSPSeesRefs` — state (c), alive-check matches via binding arm
- `TestPrefixAlwaysSkipped` — Test* category 1 stays unconditional

## Test plan

- [x] Full `cmd` suite green (58s)
- [x] Real-db smoke (`leyline parse + lsp` on mache itself): 0 findings → no regression
- [x] `stripSkippedCTE` in falsifiability test still works (CTE name unchanged)
- [x] golangci-lint passes
- [ ] CI green
- [ ] Copilot review (if attached)

Behavioral change on existing fixtures: zero. node_refs-only fixtures hit category (a); the new behavior only manifests when `_lsp_defs` binding rows are present.