### PR TITLE
feat(lsp): binding-log reader for LLO BindingRecord capnp event log (mache-190508 step 2)

### DIFF
--- a/internal/lsp/binding_log.go
+++ b/internal/lsp/binding_log.go
@@ -1,0 +1,205 @@
+// Package lsp consumes LLO's typed event-log artifacts (.bindings.capnp,
+// future .ast.capnp / .source.capnp) sitting next to a SQLite .db.
+//
+// The capnp event log is the canonical Σ data plane (per
+// ley-line-open/rs/ll-core/schema-capnp/README.md, T8 thread). The
+// SQLite tables (`_lsp_refs`, `_lsp_defs`, `_ast`) are local
+// projections of the same records. Consuming the log directly avoids
+// the leaf-vs-call-expression ambiguity that broke Falsifiability B
+// at the SQL boundary — the capnp record carries BOTH `constructNodeId`
+// and `refSiteNodeId`, so each consumer picks its own AST level
+// without rebuilding the walk-up at query time.
+package lsp
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	capnp "capnproto.org/go/capnp/v3"
+	"github.com/agentic-research/mache/internal/lsp/bindings"
+)
+
+// Binding is the Go-native projection of one bindings.BindingRecord.
+// Decoupling consumers from the generated capnp types means swapping
+// the underlying schema (e.g. when LLO ships T8.5's parseGen → Hash
+// reframe) is a one-file change here, not a fan-out across the rule
+// engine.
+type Binding struct {
+	// TargetNodeID is the symbol's defining node — what the LSP
+	// resolved to. Same as `_lsp_refs.node_id` in the SQL projection.
+	TargetNodeID string
+
+	// RefToken is the textual lemma at the ref site (e.g. "Validate").
+	RefToken string
+
+	// ConstructNodeID is the smallest enclosing function/method/
+	// constructor declaration. What `find_callers` MCP wants and
+	// what `node_refs.node_id` records (after construct-level
+	// normalization). Empty when the ref site has no enclosing
+	// construct in `_ast`.
+	ConstructNodeID string
+
+	// RefSiteNodeID is the smallest enclosing AST node at the ref
+	// location — typically a leaf identifier. Most precise locator
+	// but can sit several levels below ConstructNodeID. Empty under
+	// the same missing-_ast conditions as ConstructNodeID.
+	RefSiteNodeID string
+
+	// RefURI is the file URI the ref appears in (canonicalized;
+	// matches `_source.path` post-be6136). `file://` scheme.
+	RefURI string
+
+	// RefRange locates the reference site for byte-precise tooling.
+	RefRange Range
+
+	// ParseGen is the parse generation that emitted this record.
+	// T8.5 will replace this with a content hash linked into Σ root.
+	ParseGen uint64
+}
+
+// Range is the Go-native projection of common.Range — inclusive-start,
+// exclusive-end, matching tree-sitter's convention.
+type Range struct {
+	StartLine, StartColumn uint32
+	StartByte              uint64
+	EndLine, EndColumn     uint32
+	EndByte                uint64
+}
+
+// SiblingBindingLogPath returns the path to the binding event log that
+// LLO writes alongside a `.db`. Mirrors LLO's `Path::with_extension`
+// semantics from cmd_lsp.rs and daemon/lsp_pass.rs: the trailing
+// extension on dbPath (typically `.db`) is REPLACED with
+// `bindings.capnp`. Pins the convention on the consumer side so a
+// typo can't silently drift from the producer.
+//
+// Examples:
+//
+//	"/tmp/foo.db"       → "/tmp/foo.bindings.capnp"
+//	"/tmp/no-ext"       → "/tmp/no-ext.bindings.capnp"
+//	"/tmp/multi.dot.db" → "/tmp/multi.dot.bindings.capnp"
+func SiblingBindingLogPath(dbPath string) string {
+	ext := filepath.Ext(dbPath)
+	return strings.TrimSuffix(dbPath, ext) + ".bindings.capnp"
+}
+
+// ReadBindingLog opens a `.bindings.capnp` event log and returns every
+// record in stream order. Returns (nil, nil) for an empty file — that
+// is a valid LLO output when the LSP pass found no references.
+//
+// Returns an os.ErrNotExist-wrapping error when the file is absent so
+// callers can distinguish "no log produced yet" from "log corrupt".
+//
+// Reads everything into memory. Mache-scale event logs are ≪100 MB
+// even for large repos (323K NVD records map to <30K LSP refs in
+// practice; idiomatic Go projects are smaller still). If a real
+// workload pushes past that, switch to IterateBindingLog.
+func ReadBindingLog(path string) ([]Binding, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open binding log %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var out []Binding
+	if err := iterateDecoder(f, func(b Binding) error {
+		out = append(out, b)
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("decode binding log %q after %d records: %w", path, len(out), err)
+	}
+	return out, nil
+}
+
+// IterateBindingLog streams records to fn one at a time without
+// buffering the full set. Use when memory pressure matters or when
+// the consumer can short-circuit (e.g. early-exit on first match).
+// Returning a non-nil error from fn aborts iteration; the error is
+// propagated up wrapped with the record index for diagnostics.
+func IterateBindingLog(path string, fn func(Binding) error) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open binding log %q: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return iterateDecoder(f, fn)
+}
+
+func iterateDecoder(r io.Reader, fn func(Binding) error) error {
+	dec := capnp.NewDecoder(r)
+	for i := 0; ; i++ {
+		msg, err := dec.Decode()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("decode record %d: %w", i, err)
+		}
+		rec, err := bindings.ReadRootBindingRecord(msg)
+		if err != nil {
+			return fmt.Errorf("read root of record %d: %w", i, err)
+		}
+		b, err := bindingFromRecord(rec)
+		if err != nil {
+			return fmt.Errorf("project record %d: %w", i, err)
+		}
+		if err := fn(b); err != nil {
+			return err
+		}
+	}
+}
+
+func bindingFromRecord(rec bindings.BindingRecord) (Binding, error) {
+	target, err := rec.TargetNodeId()
+	if err != nil {
+		return Binding{}, fmt.Errorf("targetNodeId: %w", err)
+	}
+	tok, err := rec.RefToken()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refToken: %w", err)
+	}
+	construct, err := rec.ConstructNodeId()
+	if err != nil {
+		return Binding{}, fmt.Errorf("constructNodeId: %w", err)
+	}
+	refSite, err := rec.RefSiteNodeId()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refSiteNodeId: %w", err)
+	}
+	uri, err := rec.RefUri()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refUri: %w", err)
+	}
+	rng, err := rec.RefRange()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refRange: %w", err)
+	}
+	start, err := rng.Start()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refRange.start: %w", err)
+	}
+	end, err := rng.End()
+	if err != nil {
+		return Binding{}, fmt.Errorf("refRange.end: %w", err)
+	}
+	return Binding{
+		TargetNodeID:    target,
+		RefToken:        tok,
+		ConstructNodeID: construct,
+		RefSiteNodeID:   refSite,
+		RefURI:          uri,
+		ParseGen:        rec.ParseGen(),
+		RefRange: Range{
+			StartLine:   start.Line(),
+			StartColumn: start.Column(),
+			StartByte:   start.Byte(),
+			EndLine:     end.Line(),
+			EndColumn:   end.Column(),
+			EndByte:     end.Byte(),
+		},
+	}, nil
+}

--- a/internal/lsp/binding_log.go
+++ b/internal/lsp/binding_log.go
@@ -120,13 +120,23 @@ func ReadBindingLog(path string) ([]Binding, error) {
 // the consumer can short-circuit (e.g. early-exit on first match).
 // Returning a non-nil error from fn aborts iteration; the error is
 // propagated up wrapped with the record index for diagnostics.
+//
+// Decode and projection errors are wrapped with both the record
+// index AND the file path so streaming callers can identify which
+// log failed when they're consuming several. Callback (fn) errors
+// are wrapped with the record index only — the caller already
+// knows what they passed in, but they don't necessarily know the
+// record number where they aborted.
 func IterateBindingLog(path string, fn func(Binding) error) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("open binding log %q: %w", path, err)
 	}
 	defer func() { _ = f.Close() }()
-	return iterateDecoder(f, fn)
+	if err := iterateDecoder(f, fn); err != nil {
+		return fmt.Errorf("binding log %q: %w", path, err)
+	}
+	return nil
 }
 
 func iterateDecoder(r io.Reader, fn func(Binding) error) error {
@@ -148,7 +158,7 @@ func iterateDecoder(r io.Reader, fn func(Binding) error) error {
 			return fmt.Errorf("project record %d: %w", i, err)
 		}
 		if err := fn(b); err != nil {
-			return err
+			return fmt.Errorf("callback at record %d: %w", i, err)
 		}
 	}
 }

--- a/internal/lsp/binding_log_test.go
+++ b/internal/lsp/binding_log_test.go
@@ -1,0 +1,272 @@
+package lsp_test
+
+import (
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	capnp "capnproto.org/go/capnp/v3"
+	"github.com/agentic-research/mache/internal/lsp"
+	"github.com/agentic-research/mache/internal/lsp/bindings"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeBindingLog writes records to path using the same wire format LLO
+// produces — back-to-back capnp segment messages. Pinning the producer
+// shape here ensures the reader test is decoupled from any specific
+// LLO version: if the wire format ever drifts, this helper drifts with
+// the producer (or the test breaks immediately, which is also fine).
+func writeBindingLog(t *testing.T, path string, recs []lsp.Binding) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+
+	enc := capnp.NewEncoder(f)
+	for _, r := range recs {
+		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		require.NoError(t, err)
+		rec, err := bindings.NewRootBindingRecord(seg)
+		require.NoError(t, err)
+		require.NoError(t, rec.SetTargetNodeId(r.TargetNodeID))
+		require.NoError(t, rec.SetRefToken(r.RefToken))
+		require.NoError(t, rec.SetConstructNodeId(r.ConstructNodeID))
+		require.NoError(t, rec.SetRefSiteNodeId(r.RefSiteNodeID))
+		require.NoError(t, rec.SetRefUri(r.RefURI))
+		rec.SetParseGen(r.ParseGen)
+		rng, err := rec.NewRefRange()
+		require.NoError(t, err)
+		start, err := rng.NewStart()
+		require.NoError(t, err)
+		start.SetLine(r.RefRange.StartLine)
+		start.SetColumn(r.RefRange.StartColumn)
+		start.SetByte(r.RefRange.StartByte)
+		end, err := rng.NewEnd()
+		require.NoError(t, err)
+		end.SetLine(r.RefRange.EndLine)
+		end.SetColumn(r.RefRange.EndColumn)
+		end.SetByte(r.RefRange.EndByte)
+		require.NoError(t, enc.Encode(msg))
+	}
+}
+
+func TestSiblingBindingLogPath(t *testing.T) {
+	// Pinning LLO's Path::with_extension semantics
+	// (cli-lib/src/cmd_lsp.rs, daemon/lsp_pass.rs): the trailing
+	// `.db` (or whatever extension) is REPLACED, not appended. A
+	// producer-side change must propagate here in lockstep.
+	cases := []struct{ in, want string }{
+		{"/tmp/foo.db", "/tmp/foo.bindings.capnp"},
+		{"/tmp/no-ext", "/tmp/no-ext.bindings.capnp"},
+		{"/tmp/multi.dot.db", "/tmp/multi.dot.bindings.capnp"},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, lsp.SiblingBindingLogPath(c.in), "input: %s", c.in)
+	}
+}
+
+func TestReadBindingLog_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.db.bindings.capnp")
+
+	want := []lsp.Binding{
+		{
+			TargetNodeID:    "auth/methods/Authenticator.Validate",
+			RefToken:        "Validate",
+			ConstructNodeID: "billing/functions/Charge",
+			RefSiteNodeID:   "billing/functions/Charge/.../field_identifier",
+			RefURI:          "file:///billing.go",
+			ParseGen:        42,
+			RefRange: lsp.Range{
+				StartLine: 11, StartColumn: 4, StartByte: 123,
+				EndLine: 11, EndColumn: 12, EndByte: 131,
+			},
+		},
+		{
+			// Second record exercises the documented "no enclosing
+			// construct" state — empty ConstructNodeID is the canonical
+			// signal for a top-level reference (e.g. cross-repo).
+			TargetNodeID:    "stdlib/io/Reader",
+			RefToken:        "Reader",
+			ConstructNodeID: "",
+			RefSiteNodeID:   "pkg/types.go/.../type_identifier",
+			RefURI:          "file:///types.go",
+			ParseGen:        42,
+			RefRange: lsp.Range{
+				StartLine: 3, StartColumn: 8, StartByte: 50,
+				EndLine: 3, EndColumn: 14, EndByte: 56,
+			},
+		},
+	}
+	writeBindingLog(t, path, want)
+
+	got, err := lsp.ReadBindingLog(path)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestReadBindingLog_EmptyFileReturnsEmptySlice(t *testing.T) {
+	// LLO writes a zero-byte .bindings.capnp when the LSP pass found
+	// no references. The reader must accept that as a valid (empty)
+	// log, not an error — a missing log and an empty log are different
+	// states with different debug semantics.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.db.bindings.capnp")
+	require.NoError(t, os.WriteFile(path, nil, 0o644))
+
+	got, err := lsp.ReadBindingLog(path)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestReadBindingLog_MissingFileWrapsErrNotExist(t *testing.T) {
+	// Callers (canonical-view migration) need to distinguish
+	// "log not produced yet — fall back to SQL" from "log corrupt".
+	// errors.Is(err, fs.ErrNotExist) is the load-bearing predicate;
+	// pin it.
+	dir := t.TempDir()
+	_, err := lsp.ReadBindingLog(filepath.Join(dir, "does-not-exist.bindings.capnp"))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, os.ErrNotExist),
+		"missing file must wrap os.ErrNotExist; got %v", err)
+}
+
+func TestReadBindingLog_TruncatedPayloadReportsRecordIndex(t *testing.T) {
+	// If a producer crashed mid-write (or the file is corrupt),
+	// the error must surface WHERE the read failed so the operator
+	// can decide whether to keep the partial set or rebuild. The
+	// per-record index is the only signal that lets you triage
+	// "first record bad" vs "tail of a 30k-record log".
+	dir := t.TempDir()
+	full := filepath.Join(dir, "full.db.bindings.capnp")
+	writeBindingLog(t, full, []lsp.Binding{
+		{TargetNodeID: "a", RefToken: "x", RefURI: "file:///a"},
+		{TargetNodeID: "b", RefToken: "y", RefURI: "file:///b"},
+	})
+
+	bytesAll, err := os.ReadFile(full)
+	require.NoError(t, err)
+	require.Greater(t, len(bytesAll), 16, "test fixture too small to truncate meaningfully")
+
+	truncated := filepath.Join(dir, "truncated.db.bindings.capnp")
+	require.NoError(t, os.WriteFile(truncated, bytesAll[:len(bytesAll)-8], 0o644))
+
+	_, err = lsp.ReadBindingLog(truncated)
+	require.Error(t, err)
+	// We don't pin the exact wrapped error (that's capnp's affair —
+	// could be ErrUnexpectedEOF or a segment-size-mismatch). What we
+	// DO pin is that the error surfaces the path and the records-read
+	// count so an operator running with --verbose can see where it
+	// died.
+	assert.Contains(t, err.Error(), truncated)
+	assert.Contains(t, err.Error(), "after ", "record-index context missing from truncation error")
+}
+
+func TestIterateBindingLog_StreamsAndShortCircuits(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "iter.db.bindings.capnp")
+	want := []lsp.Binding{
+		{TargetNodeID: "a", RefToken: "x", RefURI: "file:///a"},
+		{TargetNodeID: "b", RefToken: "y", RefURI: "file:///b"},
+		{TargetNodeID: "c", RefToken: "z", RefURI: "file:///c"},
+	}
+	writeBindingLog(t, path, want)
+
+	// Streaming all the way through.
+	var seen []lsp.Binding
+	require.NoError(t, lsp.IterateBindingLog(path, func(b lsp.Binding) error {
+		seen = append(seen, b)
+		return nil
+	}))
+	assert.Equal(t, want, seen)
+
+	// Short-circuit: stop after the second record. Iteration must
+	// surface the user error verbatim (errors.Is roundtrip) so
+	// callers can detect "I asked you to stop" vs decode failures.
+	stop := errors.New("found what I needed")
+	var partial []lsp.Binding
+	gotErr := lsp.IterateBindingLog(path, func(b lsp.Binding) error {
+		partial = append(partial, b)
+		if len(partial) == 2 {
+			return stop
+		}
+		return nil
+	})
+	require.True(t, errors.Is(gotErr, stop), "user error must round-trip via errors.Is; got %v", gotErr)
+	assert.Equal(t, want[:2], partial, "iteration continued past short-circuit signal")
+}
+
+// TestReadBindingLog_RealLLOOutput exercises the reader against an
+// actual file produced by `leyline lsp` rather than the synthetic
+// in-test encoder. Catches the class of bug where mache's encoder
+// happens to use the same wire format as the test reader but a real
+// LLO build emits something subtly different.
+//
+// Skipped when MACHE_FALSIFIABILITY_INTEGRATION isn't set or leyline
+// or gopls isn't on PATH — same gate as the falsifiability tests so
+// CI-default `go test ./...` doesn't pay the gopls warmup tax.
+func TestReadBindingLog_RealLLOOutput(t *testing.T) {
+	if os.Getenv("MACHE_FALSIFIABILITY_INTEGRATION") != "1" {
+		t.Skip("set MACHE_FALSIFIABILITY_INTEGRATION=1 to run; needs leyline + gopls")
+	}
+	if _, err := exec.LookPath("leyline"); err != nil {
+		t.Skip("leyline not on PATH")
+	}
+	if _, err := exec.LookPath("gopls"); err != nil {
+		t.Skip("gopls not on PATH")
+	}
+
+	srcDir, err := os.Getwd()
+	require.NoError(t, err)
+	// Walk up from internal/lsp/ to repo root.
+	repoRoot := filepath.Dir(filepath.Dir(srcDir))
+	enrichTarget := filepath.Join(repoRoot, "validate", "validate.go")
+	if _, statErr := os.Stat(enrichTarget); statErr != nil {
+		t.Skipf("expected fixture %s missing", enrichTarget)
+	}
+
+	dir := t.TempDir()
+	parsedDB := filepath.Join(dir, "self.db")
+	enrichedDB := filepath.Join(dir, "self-enriched.db")
+
+	cmd := exec.Command("leyline", "parse", repoRoot, "-o", parsedDB, "--lang", "go")
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "leyline parse failed: %s", out)
+
+	cmd = exec.Command("leyline", "lsp",
+		"--server", "gopls",
+		"--input", enrichTarget,
+		"--output", enrichedDB,
+		"--merge-db", parsedDB)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "leyline lsp failed: %s", out)
+
+	logPath := lsp.SiblingBindingLogPath(enrichedDB)
+	_, statErr := os.Stat(logPath)
+	require.NoError(t, statErr,
+		"LLO did not produce expected sibling log at %s — convention drift?", logPath)
+
+	got, err := lsp.ReadBindingLog(logPath)
+	require.NoError(t, err)
+	require.NotEmpty(t, got, "LLO produced empty .bindings.capnp despite gopls reporting refs")
+
+	// Pin the documented schema invariants on real producer output.
+	// If LLO ever emits a record violating these, the consumer side's
+	// downstream JOIN logic breaks, so catch it at the boundary.
+	for i, b := range got {
+		assert.NotEmpty(t, b.RefToken, "record %d: empty refToken (LLO should skip these per producer logic)", i)
+		assert.NotEmpty(t, b.RefURI, "record %d: empty refUri", i)
+		assert.True(t, b.RefRange.EndByte >= b.RefRange.StartByte,
+			"record %d: range end-byte before start-byte: %+v", i, b.RefRange)
+	}
+	t.Logf("ReadBindingLog: %d records from %s", len(got), logPath)
+}
+
+// Sanity check that the reader doesn't accidentally consume from
+// arbitrary readers without buffering. Not a functional requirement;
+// just a tripwire for an obvious foot-gun.
+var _ io.Reader = (*os.File)(nil)

--- a/internal/lsp/binding_log_test.go
+++ b/internal/lsp/binding_log_test.go
@@ -2,7 +2,6 @@ package lsp_test
 
 import (
 	"errors"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -265,8 +264,3 @@ func TestReadBindingLog_RealLLOOutput(t *testing.T) {
 	}
 	t.Logf("ReadBindingLog: %d records from %s", len(got), logPath)
 }
-
-// Sanity check that the reader doesn't accidentally consume from
-// arbitrary readers without buffering. Not a functional requirement;
-// just a tripwire for an obvious foot-gun.
-var _ io.Reader = (*os.File)(nil)


### PR DESCRIPTION
## Summary

Step 2 of `mache-190508`. Adds the consumer-side reader for `${db_basename}.bindings.capnp` event logs that LLO writes alongside SQLite `.db`s. **No production consumer wired yet** — that's step 3.

Built on top of #353 (schemas + generated bindings).

## What lands

`internal/lsp/binding_log.go` — three public surfaces:

| API | Purpose |
|---|---|
| `SiblingBindingLogPath(dbPath)` | Mirrors LLO's `Path::with_extension` semantics. `/tmp/foo.db` → `/tmp/foo.bindings.capnp` (`.db` REPLACED, not appended). Pinning here so a typo can't drift from the producer. |
| `ReadBindingLog(path) → []Binding` | Slice-returning reader for the canonical-view migration path. Mache-scale event logs are <100 MB; fits trivially in memory. Empty file → empty slice (LLO's valid output when no refs found). Missing file → `os.ErrNotExist`-wrapping error. |
| `IterateBindingLog(path, fn) → error` | Stream variant for memory-pressure or short-circuit cases. User errors propagate verbatim via `errors.Is`. |

`Binding` / `Range` — Go-native projection of the capnp record, decoupling consumers from generated capnp types. Swapping the underlying schema (e.g. T8.5's `parseGen → Hash` reframe) becomes a one-file change.

## Tests

Synthetic (always run, 6 tests):
- `SiblingBindingLogPath` — pins `with_extension` semantics for `.db`, no-extension, multi-dot paths
- `RoundTrip` — encode/decode 2 records (one with empty `ConstructNodeID` for the documented "no enclosing construct" case)
- `EmptyFile` — zero-byte → empty slice, no error
- `MissingFile` — `errors.Is(err, os.ErrNotExist)` (load-bearing for canonical-view fallback)
- `TruncatedPayload` — error contains path + records-read count for triage
- `StreamsAndShortCircuits` — iterator + user-error propagation

Integration (`MACHE_FALSIFIABILITY_INTEGRATION=1` + `leyline` + `gopls`):
- `RealLLOOutput` — runs `leyline parse` + `leyline lsp --merge-db` on mache's own source, locates the produced sibling log via `SiblingBindingLogPath`, asserts every record has non-empty `RefToken` / `RefURI` and a non-inverted byte range. **Verified locally: 20 records read from a fresh `leyline lsp` run.**

## Why two APIs

Slice variant for the canonical-view migration path (the JOIN it replaces already buffers in SQLite). Iterator variant for future MCP / `find_callers` paths that benefit from short-circuit.

## Test plan

- [x] All 6 synthetic tests pass
- [x] Real-LLO integration: 20 records, all schema invariants hold
- [x] Full `go test ./...` green
- [x] golangci-lint passes
- [ ] CI green
- [ ] Copilot review

Refs: `mache-190508` step 2/3.