### PR TITLE
fix(find_smells): exempt projection-function naming convention from fan_out_skew

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -609,7 +609,7 @@ var smellRegistry = []SmellRule{
 	},
 	{
 		ID:          "fan_out_skew",
-		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (per-construct) and Go test files *_test.go (per-file) — tests and test helpers are expected to call many things, no signal there. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generated dispatchers naturally have wide fan-out. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
+		Description: "Constructs whose distinct callee count via node_refs is at least 5 AND more than 3× the project mean — likely god-functions / orchestrators that touch too many neighbors. Metric is the fan-out count, sorted descending. Language-agnostic (every leyline parser populates node_refs by token). Skip-listed: testing-framework prefixes Test*/Benchmark*/Example*/Fuzz* (per-construct) and Go test files *_test.go (per-file) — tests and test helpers are expected to call many things, no signal there. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded — generated dispatchers naturally have wide fan-out. **Projection-function naming convention** is also exempt: names matching `*FromRecord`, `*FromMessage`, `*FromCapnp`, `*ToRecord`, `*ToMessage`, `*ToCapnp`, or `Project*` are mechanical translators between wire formats and Go-native types. Capnp's accessor-per-field API forces N calls to project N fields onto one receiver — that's structurally required, not a code-smell. Adopt the convention for new projection functions to suppress this signal at the call site rather than at the rule level. The 3× threshold and 5-call floor are heuristics; adjust by editing the rule body. Pairs with get_communities for 'this construct sprawls across community boundaries' analysis.",
 		Requires:    []string{"node_refs", "nodes"},
 		ScopeColumn: "COALESCE(n.source_file, '')",
 		Query: `
@@ -660,6 +660,21 @@ var smellRegistry = []SmellRule{
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Benchmark%%'
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Example%%'
 			  AND COALESCE(ctor.name, '') NOT LIKE 'Fuzz%%'
+			  -- Projection-function naming convention — mechanical
+			  -- wire-format ↔ Go-native translators. Capnp / protobuf
+			  -- generators produce one accessor per field, so a
+			  -- function projecting an N-field record makes N calls
+			  -- on one receiver. That's not orchestration; it's
+			  -- structural translation. Adopt the convention for new
+			  -- projection functions to suppress this signal at the
+			  -- call site (and have a self-documenting name).
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%FromRecord'
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%FromMessage'
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%FromCapnp'
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%ToRecord'
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%ToMessage'
+			  AND COALESCE(ctor.name, '') NOT LIKE '%%ToCapnp'
+			  AND COALESCE(ctor.name, '') NOT LIKE 'Project%%'
 			  -- Generated dispatchers (capnp / protobuf / *_generated /
 			  -- *.gen) have intentionally wide fan-out; flagging them
 			  -- buries real findings under generated-code noise.

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -1929,6 +1929,118 @@ func TestFindSmells_FanOutSkewSkipsTestFiles(t *testing.T) {
 		"Dispatcher (production) is flagged; setup (test helper in *_test.go) is skipped")
 }
 
+// TestFindSmells_FanOutSkewSkipsProjectionFunctions asserts that
+// functions following the projection-naming convention
+// (`*FromRecord`, `*FromMessage`, `*FromCapnp`, `*ToRecord`,
+// `*ToMessage`, `*ToCapnp`, `Project*`) are NOT flagged regardless
+// of fan-out. Capnp / protobuf generators emit one accessor per
+// field; a function projecting an N-field record makes N method
+// calls on one receiver — that's structural translation, not
+// orchestration.
+//
+// Surfaced by mache-190508 step 2 (PR #354): bindingFromRecord
+// projects the BindingRecord capnp struct's 7 fields + nested
+// Range's 6 fields onto Go-native types. 18 distinct callees
+// against a project mean of ~3.5; the rule fired despite the
+// function being trivially mechanical.
+func TestFindSmells_FanOutSkewSkipsProjectionFunctions(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		CREATE TABLE IF NOT EXISTS node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions',                              '',                          'functions',         1, 0, '',                ''),
+		  -- One representative of each name shape covered by the new
+		  -- exemption. Keeping the count low so the project mean
+		  -- stays below the negative control's threshold.
+		  ('functions/bindingFromRecord',            'functions',                 'bindingFromRecord', 1, 0, 'binding_log.go',  ''),
+		  ('functions/bindingFromRecord/source',     'functions/bindingFromRecord','source',           0, 0, 'binding_log.go',  ''),
+		  ('functions/decodeFromMessage',            'functions',                 'decodeFromMessage', 1, 0, 'codec.go',        ''),
+		  ('functions/decodeFromMessage/source',     'functions/decodeFromMessage','source',           0, 0, 'codec.go',        ''),
+		  ('functions/recordFromCapnp',              'functions',                 'recordFromCapnp',   1, 0, 'shim.go',         ''),
+		  ('functions/recordFromCapnp/source',       'functions/recordFromCapnp', 'source',            0, 0, 'shim.go',         ''),
+		  ('functions/ProjectAst',                   'functions',                 'ProjectAst',        1, 0, 'project.go',      ''),
+		  ('functions/ProjectAst/source',            'functions/ProjectAst',      'source',            0, 0, 'project.go',      ''),
+		  -- Negative control: production code with the same fan-out
+		  -- that should still be flagged.
+		  ('functions/Dispatcher',                   'functions',                 'Dispatcher',        1, 0, 'dispatcher.go',   ''),
+		  ('functions/Dispatcher/source',            'functions/Dispatcher',      'source',            0, 0, 'dispatcher.go',   '');
+
+		-- Each projection function and the negative control gets 12
+		-- distinct callees. With enough tiny callers, the project mean
+		-- stays around ~3.5 so 12 trips the 3× threshold for everyone
+		-- — only the naming-convention skip-list saves the projections.
+		INSERT INTO node_refs VALUES
+		  ('a01','functions/bindingFromRecord/source'),('a02','functions/bindingFromRecord/source'),
+		  ('a03','functions/bindingFromRecord/source'),('a04','functions/bindingFromRecord/source'),
+		  ('a05','functions/bindingFromRecord/source'),('a06','functions/bindingFromRecord/source'),
+		  ('a07','functions/bindingFromRecord/source'),('a08','functions/bindingFromRecord/source'),
+		  ('a09','functions/bindingFromRecord/source'),('a10','functions/bindingFromRecord/source'),
+		  ('a11','functions/bindingFromRecord/source'),('a12','functions/bindingFromRecord/source');
+		INSERT INTO node_refs VALUES
+		  ('b01','functions/decodeFromMessage/source'),('b02','functions/decodeFromMessage/source'),
+		  ('b03','functions/decodeFromMessage/source'),('b04','functions/decodeFromMessage/source'),
+		  ('b05','functions/decodeFromMessage/source'),('b06','functions/decodeFromMessage/source'),
+		  ('b07','functions/decodeFromMessage/source'),('b08','functions/decodeFromMessage/source'),
+		  ('b09','functions/decodeFromMessage/source'),('b10','functions/decodeFromMessage/source'),
+		  ('b11','functions/decodeFromMessage/source'),('b12','functions/decodeFromMessage/source');
+		INSERT INTO node_refs VALUES
+		  ('c01','functions/recordFromCapnp/source'),('c02','functions/recordFromCapnp/source'),
+		  ('c03','functions/recordFromCapnp/source'),('c04','functions/recordFromCapnp/source'),
+		  ('c05','functions/recordFromCapnp/source'),('c06','functions/recordFromCapnp/source'),
+		  ('c07','functions/recordFromCapnp/source'),('c08','functions/recordFromCapnp/source'),
+		  ('c09','functions/recordFromCapnp/source'),('c10','functions/recordFromCapnp/source'),
+		  ('c11','functions/recordFromCapnp/source'),('c12','functions/recordFromCapnp/source');
+		INSERT INTO node_refs VALUES
+		  ('g01','functions/ProjectAst/source'),('g02','functions/ProjectAst/source'),
+		  ('g03','functions/ProjectAst/source'),('g04','functions/ProjectAst/source'),
+		  ('g05','functions/ProjectAst/source'),('g06','functions/ProjectAst/source'),
+		  ('g07','functions/ProjectAst/source'),('g08','functions/ProjectAst/source'),
+		  ('g09','functions/ProjectAst/source'),('g10','functions/ProjectAst/source'),
+		  ('g11','functions/ProjectAst/source'),('g12','functions/ProjectAst/source');
+
+		-- Negative control: Dispatcher (no convention name, production
+		-- code) gets the same 12 callees and MUST still be flagged.
+		INSERT INTO node_refs VALUES
+		  ('h01','functions/Dispatcher/source'),('h02','functions/Dispatcher/source'),
+		  ('h03','functions/Dispatcher/source'),('h04','functions/Dispatcher/source'),
+		  ('h05','functions/Dispatcher/source'),('h06','functions/Dispatcher/source'),
+		  ('h07','functions/Dispatcher/source'),('h08','functions/Dispatcher/source'),
+		  ('h09','functions/Dispatcher/source'),('h10','functions/Dispatcher/source'),
+		  ('h11','functions/Dispatcher/source'),('h12','functions/Dispatcher/source');
+
+		-- Tiny callers to bring project mean low enough that 12 trips
+		-- the 3× threshold (mean ~3.3 with 5 high + 15 tiny callers).
+		INSERT INTO node_refs VALUES
+		  ('z01','functions/n01'),('z02','functions/n02'),('z03','functions/n03'),
+		  ('z04','functions/n04'),('z05','functions/n05'),('z06','functions/n06'),
+		  ('z07','functions/n07'),('z08','functions/n08'),('z09','functions/n09'),
+		  ('z10','functions/n10'),('z11','functions/n11'),('z12','functions/n12'),
+		  ('z13','functions/n13'),('z14','functions/n14'),('z15','functions/n15');
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "fan_out_skew"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	gotIDs := make([]string, len(resp.Findings))
+	for i, f := range resp.Findings {
+		gotIDs[i] = f.NodeID
+	}
+	assert.Equal(t, []string{"functions/Dispatcher/source"}, gotIDs,
+		"Only Dispatcher (no convention name) is flagged; the seven projection functions are skipped via name patterns")
+}
+
 // TestFindSmells_UntestedFunctionAcceptsTestCallCoverage asserts
 // that a function called from inside any Test*/Benchmark*/Example*/
 // Fuzz* construct's source is treated as covered, even without a


### PR DESCRIPTION
## Summary

Surfaced by PR #354 (mache-190508 step 2): `bindingFromRecord` flagged with metric 18 because it projects all 7 `BindingRecord` capnp fields plus the nested `Range`'s 6 sub-fields onto a Go-native struct. Capnp's accessor-per-field API forces N calls on one receiver to project N fields — that's structural translation, not orchestration, and the rule's "high fan-out = god-function" heuristic doesn't apply.

The cognitive cost of triaging this kind of false positive every time a new wire-format consumer ships is real, so adopting a naming convention and pushing the exemption into the rule pays off fast.

## What lands

Names matching the following are now skip-listed by `fan_out_skew`:

```
*FromRecord    *FromMessage    *FromCapnp
*ToRecord      *ToMessage      *ToCapnp
Project*
```

These cover the six common shapes (capnp record ↔ Go struct, similarly for protobuf, plus a `Project*` prefix for upstream-shape-to-internal-shape translators that don't fit the From/To pattern).

## Why naming and not structural detection

Proper structural detection — "all fan-out targets are method calls on a single receiver type" — needs qualifier data (`QualifiedCall.Qualifier` from the call extractor). That data is extracted by `sitter_walker` but discarded at the `node_refs` storage boundary. Adding the qualifier column is a separate, larger change touching the writer, the engine path, and the SQLiteGraph fast-path lookup — filed as **`mache-42118e`** so it can be sized properly.

This fix is shippable in one PR and addresses the immediate problem (CI noise on the next PR).

## Convention has dual value

1. Suppresses the false positive at the call site without an opaque rule-level path skip. Reviewers reading `bindingFromRecord` see the function's job from the name.
2. Self-documents projection-vs-orchestration intent. New developers adopt the pattern and get the exemption for free instead of re-litigating "is this a real smell?" every PR.

## Tests

`TestFindSmells_FanOutSkewSkipsProjectionFunctions`:
- 4 projection functions (one per name pattern: `FromRecord`, `FromMessage`, `FromCapnp`, `Project*`), each with 12 callees → all skipped
- 1 negative control (`Dispatcher`, no convention name) with the same 12 callees → still flagged
- 15 tiny callers calibrate the project mean so 12 trips the 3× threshold for the negative control

Existing `fan_out_skew` tests (test prefixes, generated files, test files) still pass — the new clauses are additional, not modifications.

## Test plan

- [x] All four `TestFindSmells_FanOut*` tests pass
- [x] Full `cmd` suite green (50s)
- [x] golangci-lint passes
- [ ] CI green
- [ ] Copilot review

Refs: `mache-190508` (surfaced the false positive), `mache-42118e` (proper structural fix)