### PR TITLE
feat(find_smells): canonical-view capnp readthrough (mache-190508 step 3)

### DIFF
--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -16,11 +16,19 @@ import (
 // interface runSmellRule / missingTables / populateSnippets need.
 // Lets the CLI run rules against any SQLite db (mache-built or
 // LLO-built) without touching the graph stack.
-type dbQuerier struct{ db *sql.DB }
+type dbQuerier struct {
+	db   *sql.DB
+	path string // mache-190508 step 3: source for sibling .bindings.capnp lookup
+}
 
 func (q *dbQuerier) QueryRefs(query string, args ...any) (*sql.Rows, error) {
 	return q.db.Query(query, args...)
 }
+
+// DBPath implements the dbPathProvider opt-in (cmd/serve_find_smells.go)
+// so canonical-view setup can find the sibling .bindings.capnp event
+// log next to this .db.
+func (q *dbQuerier) DBPath() string { return q.path }
 
 var (
 	findSmellsDBPath    string
@@ -74,7 +82,14 @@ This tool is observability, not a gate. It never exits non-zero on findings.`,
 		if err := db.Ping(); err != nil {
 			return cliExit(4, fmt.Errorf("ping db: %w", err))
 		}
-		qg := &dbQuerier{db: db}
+		// SetMaxOpenConns(1) pins all queries to a single connection so
+		// the TEMP _capnp_binding_refs table created by ensureCanonicalViews
+		// + LoadCapnpBindings stays visible to subsequent queries.
+		// modernc/sqlite spreads queries across the pool by default,
+		// which would put the TEMP-table population on a connection
+		// the rule SELECT never sees.
+		db.SetMaxOpenConns(1)
+		qg := &dbQuerier{db: db, path: findSmellsDBPath}
 
 		var rule *SmellRule
 		for i := range smellRegistry {

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/lsp"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -1023,9 +1025,41 @@ func ensureCanonicalViews(qg refsQuerier) error {
 			WHERE ref_token != '' AND referrer_node_id IS NOT NULL`
 	}
 
+	// Capnp readthrough (mache-190508 step 3): every connection that
+	// gets canonical views also gets an empty _capnp_binding_refs
+	// TEMP table that v_refs UNIONs over. When LoadCapnpBindings is
+	// called for this connection, the table fills with binding-
+	// fidelity rows from the sibling .bindings.capnp event log; when
+	// it's not called, the table stays empty and the UNION arm
+	// contributes nothing — legacy behavior preserved.
+	//
+	// The capnp rows are surfaced AS WELL AS the legacy _lsp_refs SQL
+	// arm rather than instead of it. Producers that write both will
+	// produce duplicate rows; that's fine for find_smells consumers
+	// (alive-check is set membership, deduplicates naturally) and
+	// gives us a transition window to validate the capnp source
+	// before retiring the SQL one.
+	refsBody += `
+		UNION ALL
+		SELECT referrer_node_id,
+		       token,
+		       target_node_id,
+		       ref_uri,
+		       ref_line,
+		       'binding' AS fidelity
+		FROM _capnp_binding_refs`
+
 	stmts := []string{
 		"DROP VIEW IF EXISTS temp.v_defs",
 		"DROP VIEW IF EXISTS temp.v_refs",
+		"DROP TABLE IF EXISTS temp._capnp_binding_refs",
+		`CREATE TEMP TABLE _capnp_binding_refs (
+			referrer_node_id TEXT NOT NULL,
+			token TEXT NOT NULL,
+			target_node_id TEXT,
+			ref_uri TEXT,
+			ref_line INTEGER
+		)`,
 		"CREATE TEMP VIEW v_defs AS " + defsBody,
 		"CREATE TEMP VIEW v_refs AS " + refsBody,
 	}
@@ -1033,6 +1067,54 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		rows, err := qg.QueryRefs(s)
 		if err != nil {
 			return fmt.Errorf("ensure canonical views: %w", err)
+		}
+		_ = rows.Close()
+	}
+	return nil
+}
+
+// LoadCapnpBindings populates the per-connection _capnp_binding_refs
+// TEMP table from the sibling .bindings.capnp event log of dbPath.
+// Must be called AFTER ensureCanonicalViews on the same connection
+// (the TEMP table is created there).
+//
+// No-op when the sibling log is missing (returns nil) — the canonical
+// view's UNION arm just stays empty. Returns an error when the log
+// exists but is corrupt.
+//
+// Producers that write to BOTH _lsp_refs AND .bindings.capnp will
+// produce duplicate-shaped rows in v_refs (one per producer); set-
+// membership consumers (alive-check in dead_code) deduplicate
+// naturally, so this isn't a correctness issue. Once the capnp event
+// log is the canonical producer (post-T8.5), the _lsp_refs UNION arm
+// in ensureCanonicalViews can be removed.
+func LoadCapnpBindings(qg refsQuerier, dbPath string) error {
+	if dbPath == "" {
+		return nil
+	}
+	logPath := lsp.SiblingBindingLogPath(dbPath)
+	records, err := lsp.ReadBindingLog(logPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("load capnp bindings: %w", err)
+	}
+	if len(records) == 0 {
+		return nil
+	}
+
+	// Single-row INSERTs are ~30K syscalls on a typical mache-scale
+	// log. Acceptable for the first pass; if it shows up in profiles
+	// switch to a multi-row INSERT or a prepared-stmt loop.
+	for _, r := range records {
+		stmt := `INSERT INTO _capnp_binding_refs
+			(referrer_node_id, token, target_node_id, ref_uri, ref_line)
+			VALUES (?, ?, ?, ?, ?)`
+		rows, err := qg.QueryRefs(stmt, r.ConstructNodeID, r.RefToken,
+			r.TargetNodeID, r.RefURI, int64(r.RefRange.StartLine))
+		if err != nil {
+			return fmt.Errorf("insert capnp binding: %w", err)
 		}
 		_ = rows.Close()
 	}
@@ -1104,10 +1186,30 @@ func isSimpleIdent(s string) bool {
 	return true
 }
 
+// dbPathProvider is the opt-in interface a refsQuerier implements
+// when it knows its backing .db file path. The path is only used to
+// locate the sibling .bindings.capnp event log for capnp-readthrough
+// (mache-190508 step 3); queriers that don't know the path (in-memory
+// test fixtures, the in-process arena) skip the capnp source
+// silently. The mention + legacy SQL binding paths still apply.
+type dbPathProvider interface {
+	DBPath() string
+}
+
 // runSmellRule executes the rule's SQL, optionally scoped to one source.
 func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) ([]smellFinding, error) {
 	if err := ensureCanonicalViews(qg); err != nil {
 		return nil, err
+	}
+	// Capnp readthrough (mache-190508 step 3): if this querier knows
+	// its dbPath AND a sibling .bindings.capnp event log exists, load
+	// its records into the per-connection _capnp_binding_refs TEMP
+	// table. v_refs is already configured to UNION over that table
+	// (in ensureCanonicalViews); empty table → no extra rows.
+	if dp, ok := qg.(dbPathProvider); ok {
+		if err := LoadCapnpBindings(qg, dp.DBPath()); err != nil {
+			return nil, err
+		}
 	}
 
 	scope := ""

--- a/cmd/serve_find_smells_views_test.go
+++ b/cmd/serve_find_smells_views_test.go
@@ -2,9 +2,13 @@ package cmd
 
 import (
 	"database/sql"
+	"os"
 	"path/filepath"
 	"testing"
 
+	capnp "capnproto.org/go/capnp/v3"
+	"github.com/agentic-research/mache/internal/lsp"
+	"github.com/agentic-research/mache/internal/lsp/bindings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
@@ -20,11 +24,19 @@ import (
 // sqlDBQuerier wraps a *sql.DB as a refsQuerier. The smellTestGraph
 // in serve_find_smells_test.go is heavier than these tests need
 // (full graph + AST plumbing); a thin wrapper is enough.
-type sqlDBQuerier struct{ db *sql.DB }
+type sqlDBQuerier struct {
+	db   *sql.DB
+	path string // optional: when set, exposed via DBPath() for capnp readthrough
+}
 
 func (q *sqlDBQuerier) QueryRefs(query string, args ...any) (*sql.Rows, error) {
 	return q.db.Query(query, args...)
 }
+
+// DBPath implements dbPathProvider when path is set, opting this
+// querier into the capnp-readthrough path. Tests that don't set path
+// keep the legacy mention + SQL-binding view shape.
+func (q *sqlDBQuerier) DBPath() string { return q.path }
 
 func TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "binding.db")
@@ -244,6 +256,156 @@ func TestEnsureCanonicalViews_SkipsEmptyTokenRows(t *testing.T) {
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
 	assert.Equal(t, 1, bindingDefs, "only the row with non-empty def_token survives")
 	assert.Equal(t, 1, bindingRefs, "only the row with non-empty ref_token AND non-NULL referrer survives")
+}
+
+// TestLoadCapnpBindings_PopulatesViewFromSiblingLog asserts the
+// step 3 capnp readthrough end-to-end: ensureCanonicalViews creates
+// the empty _capnp_binding_refs TEMP table, LoadCapnpBindings reads
+// the sibling .bindings.capnp event log and inserts records, and
+// the v_refs UNION arm surfaces them as binding-fidelity rows
+// alongside the mention-only node_refs rows.
+func TestLoadCapnpBindings_PopulatesViewFromSiblingLog(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "self.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// Per-connection TEMP table — pin to one connection so the table
+	// LoadCapnpBindings populates is the same one the v_refs SELECT
+	// reads from.
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO node_refs VALUES ('Validate', 'billing/functions/Charge');
+	`)
+	require.NoError(t, err)
+
+	// Write a sibling .bindings.capnp with two records: one for the
+	// same Validate call billing makes (so we get a binding-fidelity
+	// confirmation alongside the mention) and one for a totally new
+	// reference (so we know the capnp arm is genuinely contributing
+	// rows the SQL doesn't have).
+	logPath := lsp.SiblingBindingLogPath(dbPath)
+	f, err := os.Create(logPath)
+	require.NoError(t, err)
+	enc := capnp.NewEncoder(f)
+	for _, r := range []struct {
+		target, token, construct, refSite, uri string
+		startLine                              uint32
+	}{
+		{"auth/functions/Validate", "Validate", "billing/functions/Charge", "billing/.../field_identifier", "file:///billing.go", 42},
+		{"stdlib/io/Reader.Read", "Read", "pkg/functions/Loop", "pkg/.../field_identifier", "file:///pkg.go", 17},
+	} {
+		msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+		require.NoError(t, err)
+		rec, err := bindings.NewRootBindingRecord(seg)
+		require.NoError(t, err)
+		require.NoError(t, rec.SetTargetNodeId(r.target))
+		require.NoError(t, rec.SetRefToken(r.token))
+		require.NoError(t, rec.SetConstructNodeId(r.construct))
+		require.NoError(t, rec.SetRefSiteNodeId(r.refSite))
+		require.NoError(t, rec.SetRefUri(r.uri))
+		rng, err := rec.NewRefRange()
+		require.NoError(t, err)
+		start, err := rng.NewStart()
+		require.NoError(t, err)
+		start.SetLine(r.startLine)
+		_, err = rng.NewEnd()
+		require.NoError(t, err)
+		require.NoError(t, enc.Encode(msg))
+	}
+	require.NoError(t, f.Close())
+
+	qg := &sqlDBQuerier{db: db, path: dbPath}
+	require.NoError(t, ensureCanonicalViews(qg))
+	require.NoError(t, LoadCapnpBindings(qg, qg.DBPath()))
+
+	// v_refs should now surface 1 mention row + 2 binding rows.
+	var mentionRefs, bindingRefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'mention'`).Scan(&mentionRefs))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
+	assert.Equal(t, 1, mentionRefs, "mention arm preserved (node_refs row)")
+	assert.Equal(t, 2, bindingRefs, "capnp arm contributes both records")
+
+	// Pin the projection: capnp's constructNodeId becomes
+	// referrer_node_id in v_refs (matches node_refs.node_id shape).
+	// This is the structural fix for Falsifiability B.
+	rows, err := db.Query(`SELECT referrer_node_id, token, target_node_id
+	                       FROM v_refs WHERE fidelity = 'binding' ORDER BY token`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	type bindingRow struct{ ref, tok, tgt string }
+	var got []bindingRow
+	for rows.Next() {
+		var b bindingRow
+		require.NoError(t, rows.Scan(&b.ref, &b.tok, &b.tgt))
+		got = append(got, b)
+	}
+	require.Equal(t, []bindingRow{
+		{"pkg/functions/Loop", "Read", "stdlib/io/Reader.Read"},
+		{"billing/functions/Charge", "Validate", "auth/functions/Validate"},
+	}, got, "constructNodeId → referrer_node_id projection (the Falsifiability B fix)")
+}
+
+// TestLoadCapnpBindings_NoSiblingLogIsNoOp asserts the function is a
+// silent no-op when the sibling .bindings.capnp file doesn't exist.
+// LLO doesn't write the log when no LSP-resolved refs exist; mache
+// must treat that as "no enrichment", not as an error.
+func TestLoadCapnpBindings_NoSiblingLogIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "no-log.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO node_refs VALUES ('Foo', 'pkg/functions/Bar');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db, path: dbPath}
+	require.NoError(t, ensureCanonicalViews(qg))
+	// Should not error even though no sibling .bindings.capnp exists.
+	require.NoError(t, LoadCapnpBindings(qg, qg.DBPath()))
+
+	var bindingRefs, mentionRefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'mention'`).Scan(&mentionRefs))
+	assert.Equal(t, 0, bindingRefs, "no capnp log → no binding rows")
+	assert.Equal(t, 1, mentionRefs, "mention arm still works")
+}
+
+// TestLoadCapnpBindings_EmptyDBPathIsNoOp asserts a refsQuerier
+// without a known path (e.g. in-memory test fixtures) skips the
+// capnp readthrough silently. This is the "querier doesn't implement
+// dbPathProvider" branch as exercised through the CLI/MCP entry
+// points.
+func TestLoadCapnpBindings_EmptyDBPathIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	db, err := sql.Open("sqlite", filepath.Join(dir, "empty.db"))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	db.SetMaxOpenConns(1)
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+	require.NoError(t, LoadCapnpBindings(qg, ""))
+
+	var bindingRefs int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
+	assert.Equal(t, 0, bindingRefs, "no path → silent skip, no binding rows")
 }
 
 func TestTableHasColumn(t *testing.T) {

--- a/internal/graph/sqlite_graph.go
+++ b/internal/graph/sqlite_graph.go
@@ -284,6 +284,14 @@ func (g *SQLiteGraph) SetCallExtractor(fn CallExtractor) {
 	g.extractor = fn
 }
 
+// DBPath returns the source .db file path. Implements the cmd-side
+// dbPathProvider opt-in (see cmd/serve_find_smells.go) so canonical-
+// view setup can locate the sibling .bindings.capnp event log next
+// to this .db (mache-190508 step 3).
+func (g *SQLiteGraph) DBPath() string {
+	return g.dbPath
+}
+
 // AddDef records that a construct (dirID) defines the given token.
 func (g *SQLiteGraph) AddDef(token, dirID string) error {
 	g.pendingMu.Lock()


### PR DESCRIPTION
## Summary

Step 3 of `mache-190508`. Wires the binding-log reader from #354 into the find_smells canonical-view path. `v_refs` now surfaces binding-fidelity rows from the sibling `.bindings.capnp` event log alongside the existing mention (`node_refs`) and legacy SQL (`_lsp_refs`) arms.

This is the **structural fix** Falsifiability B was diagnosing. LLO's `BindingRecord` schema (T8.2, ley-line-open-49475bc) emits `constructNodeId` directly — the function/method-scope path that matches `node_refs.node_id` shape. Mache no longer needs the AST walk-up from leaf identifier to enclosing call_expression that the SQL `_lsp_refs.referrer_node_id` path required.

## Architecture

`ensureCanonicalViews` always creates an empty per-connection `_capnp_binding_refs` TEMP table; `v_refs` UNIONs over it unconditionally. When `LoadCapnpBindings` is called for the connection, the table fills with capnp records; when not called, the UNION arm contributes zero rows. Legacy callers get the same view shape as before.

The capnp source is **additive** to the existing `_lsp_refs` SQL arm, not a replacement. Producers that write both will produce duplicate-shaped rows; downstream consumers (alive-check is set membership) deduplicate naturally. Once the capnp event log is the canonical producer (post-T8.5), the `_lsp_refs` SQL arm can be removed.

## Opt-in via `dbPathProvider`

```go
type dbPathProvider interface { DBPath() string }
```

Capnp readthrough only fires when both:
1. The querier opts in (knows its path)
2. The sibling `.bindings.capnp` file exists at `SiblingBindingLogPath`

`dbQuerier` (CLI) and `SQLiteGraph` (MCP serve) implement `DBPath()`. In-memory test fixtures that don't know a path silently skip the capnp source.

## Connection pinning

CLI now sets `db.SetMaxOpenConns(1)` on the find_smells connection. modernc/sqlite spreads queries across the pool by default, which would put the TEMP-table population on a connection the rule SELECT never sees.

## Tests

`cmd/serve_find_smells_views_test.go` +3:

- `LoadCapnpBindings_PopulatesViewFromSiblingLog` — end-to-end through `ensureCanonicalViews` → `LoadCapnpBindings` → `v_refs` query. Asserts 1 mention + 2 binding rows and pins the `constructNodeId → referrer_node_id` projection (the Falsifiability B fix).
- `LoadCapnpBindings_NoSiblingLogIsNoOp` — missing log → silent skip, no error, no binding rows.
- `LoadCapnpBindings_EmptyDBPathIsNoOp` — querier without a known path → silent skip.

Existing canonical-view tests still pass.

## Falsifiability B status

Real-LLO integration: **0.0% (0/12)** call-site discrepancies via the existing `_lsp_refs` path with AST walk-up. Well under the <5% target. The capnp readthrough provides the structural fix (`constructNodeId` direct, no walk-up needed) — pinned by the new unit test rather than a separate integration harness, since the projection correctness is decided at the schema boundary, not at the consumer.

## Test plan

- [x] All 3 new `LoadCapnpBindings*` tests pass
- [x] Existing canonical-view tests still pass
- [x] Full `cmd` suite green (88s)
- [x] `internal/lsp` + `internal/graph` suites green
- [x] golangci-lint passes
- [x] Falsifiability B integration: 0/12 discrepancies on real LLO build
- [ ] CI green
- [ ] Copilot review

Refs: `mache-190508` step 3 (closes the migration arc).