### PR TITLE
feat(find_smells): retire SQL _lsp_refs consumers, capnp is canonical (mache-6bd4d8)

### DIFF
--- a/cmd/dead_code_skip_list_retreat_test.go
+++ b/cmd/dead_code_skip_list_retreat_test.go
@@ -4,13 +4,47 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"testing"
 
+	capnp "capnproto.org/go/capnp/v3"
+	"github.com/agentic-research/mache/internal/lsp"
+	"github.com/agentic-research/mache/internal/lsp/bindings"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
 )
+
+// writeBindingLogForTest writes a single-record .bindings.capnp log
+// next to dbPath for the test. Mirrors LLO's wire format (back-to-back
+// capnp segment messages). Used by tests that need binding-fidelity
+// rows in v_refs after mache-6bd4d8 retired the SQL _lsp_refs UNION
+// arm.
+func writeBindingLogForTest(t *testing.T, dbPath, target, token, construct, refURI string) {
+	t.Helper()
+	logPath := lsp.SiblingBindingLogPath(dbPath)
+	f, err := os.Create(logPath)
+	require.NoError(t, err)
+	defer func() { _ = f.Close() }()
+	enc := capnp.NewEncoder(f)
+	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(nil))
+	require.NoError(t, err)
+	rec, err := bindings.NewRootBindingRecord(seg)
+	require.NoError(t, err)
+	require.NoError(t, rec.SetTargetNodeId(target))
+	require.NoError(t, rec.SetRefToken(token))
+	require.NoError(t, rec.SetConstructNodeId(construct))
+	require.NoError(t, rec.SetRefSiteNodeId(""))
+	require.NoError(t, rec.SetRefUri(refURI))
+	rng, err := rec.NewRefRange()
+	require.NoError(t, err)
+	_, err = rng.NewStart()
+	require.NoError(t, err)
+	_, err = rng.NewEnd()
+	require.NoError(t, err)
+	require.NoError(t, enc.Encode(msg))
+}
 
 // dead_code skip-list precise retreat — ADR-0013 follow-up after
 // Falsifiability A passed empirically. The skip-list now has two
@@ -197,13 +231,19 @@ func TestDeadCode_InterfaceMethodAliveWhenLSPSeesRefs(t *testing.T) {
 		INSERT INTO node_defs VALUES ('Read', 'pkg/methods/MyType.Read');
 		INSERT INTO _lsp_defs VALUES
 			('pkg/methods/MyType.Read', 'Read', 'file:///pkg/mytype.go', 10, 5, 10, 9);
-		INSERT INTO _lsp_refs VALUES
-			('pkg/methods/MyType.Read', 'pkg/functions/Caller', 'Read',
-			 'file:///pkg/caller.go', 30, 11, 30, 15);
 	`)
 	require.NoError(t, err)
 
-	tg := &smellTestGraph{db: db}
+	// Post-mache-6bd4d8: binding-fidelity refs come from the sibling
+	// .bindings.capnp event log, not the legacy _lsp_refs SQL table.
+	// Write the equivalent record there.
+	writeBindingLogForTest(t, dbPath,
+		"pkg/methods/MyType.Read", // targetNodeId
+		"Read",                    // refToken
+		"pkg/functions/Caller",    // constructNodeId (referrer)
+		"file:///pkg/caller.go")   // refUri
+
+	tg := &smellTestGraph{db: db, path: dbPath}
 	handler := makeFindSmellsHandler(tg)
 
 	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
@@ -217,7 +257,7 @@ func TestDeadCode_InterfaceMethodAliveWhenLSPSeesRefs(t *testing.T) {
 
 	for _, f := range resp.Findings {
 		assert.NotEqual(t, "pkg/methods/MyType.Read", f.NodeID,
-			"alive-check binding arm matches the LSP ref → 'Read' is alive, not dead")
+			"alive-check binding arm matches the capnp ref → 'Read' is alive, not dead")
 	}
 }
 

--- a/cmd/falsifiability_skip_list_ablation_test.go
+++ b/cmd/falsifiability_skip_list_ablation_test.go
@@ -244,17 +244,22 @@ func TestFalsifiabilityA_SyntheticHarness(t *testing.T) {
 
 		-- node_refs: empty. tree-sitter call-extraction can't resolve
 		-- io.Reader.Read() back to MyType, so NO mention rows.
-
-		-- _lsp_refs: gopls resolved a call site for MyType.Read but
-		-- not Quux (Quux is unused even by LSP's eyes).
-		INSERT INTO _lsp_refs VALUES
-			('pkg/methods/MyType.Read', 'pkg/functions/Caller', 'Read',
-			 'file:///caller.go', 30, 11, 30, 15);
 	`)
 	require.NoError(t, err)
 
-	qg := &sqlDBQuerier{db: db}
+	// Post-mache-6bd4d8: binding-fidelity rows come from the capnp
+	// event log, not the legacy _lsp_refs SQL table. Write a single
+	// record for MyType.Read (Quux deliberately omitted — it's the
+	// "LSP didn't see this" wedge-case 1 control).
+	writeBindingLogForTest(t, dbPath,
+		"pkg/methods/MyType.Read", // targetNodeId
+		"Read",                    // refToken
+		"pkg/functions/Caller",    // constructNodeId (referrer)
+		"file:///caller.go")       // refUri
+
+	qg := &sqlDBQuerier{db: db, path: dbPath}
 	require.NoError(t, ensureCanonicalViews(qg))
+	require.NoError(t, LoadCapnpBindings(qg, qg.DBPath()))
 
 	withSkip, withoutSkip := runDeadCodeWithAndWithout(t, db)
 

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -987,13 +987,14 @@ func missingTables(qg refsQuerier, required []string) ([]string, error) {
 // Idempotent — DROP VIEW IF EXISTS before each CREATE — so safe to
 // call before every rule execution.
 func ensureCanonicalViews(qg refsQuerier) error {
+	// _lsp_defs probe still runs because v_defs's binding-fidelity
+	// arm has not yet migrated to capnp — BindingRecord covers refs
+	// (the link from a call site to a definition), not standalone
+	// def metadata. _lsp_defs migration is tracked separately; for
+	// now the def-side dual-read mirrors the pre-mache-6bd4d8 shape.
 	hasLSPDefsToken, err := tableHasColumn(qg, "_lsp_defs", "def_token")
 	if err != nil {
 		return fmt.Errorf("probe _lsp_defs: %w", err)
-	}
-	hasLSPRefsCols, err := tableHasColumn(qg, "_lsp_refs", "ref_token")
-	if err != nil {
-		return fmt.Errorf("probe _lsp_refs: %w", err)
 	}
 
 	defsBody := `SELECT token, node_id, 'mention' AS fidelity FROM node_defs`
@@ -1012,33 +1013,20 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	       NULL  AS ref_line,
 	       'mention' AS fidelity
 	FROM node_refs`
-	if hasLSPRefsCols {
-		refsBody += `
-			UNION ALL
-			SELECT referrer_node_id,
-			       ref_token AS token,
-			       node_id   AS target_node_id,
-			       ref_uri,
-			       ref_start_line AS ref_line,
-			       'binding' AS fidelity
-			FROM _lsp_refs
-			WHERE ref_token != '' AND referrer_node_id IS NOT NULL`
-	}
-
-	// Capnp readthrough (mache-190508 step 3): every connection that
-	// gets canonical views also gets an empty _capnp_binding_refs
-	// TEMP table that v_refs UNIONs over. When LoadCapnpBindings is
-	// called for this connection, the table fills with binding-
-	// fidelity rows from the sibling .bindings.capnp event log; when
-	// it's not called, the table stays empty and the UNION arm
-	// contributes nothing — legacy behavior preserved.
+	// Binding-fidelity rows come from the per-connection
+	// _capnp_binding_refs TEMP table, populated from the sibling
+	// .bindings.capnp event log by LoadCapnpBindings (mache-190508).
+	// When LoadCapnpBindings hasn't run for this connection, the
+	// table stays empty and v_refs surfaces only mention-fidelity
+	// rows from node_refs — same as the pre-LSP behavior.
 	//
-	// The capnp rows are surfaced AS WELL AS the legacy _lsp_refs SQL
-	// arm rather than instead of it. Producers that write both will
-	// produce duplicate rows; that's fine for find_smells consumers
-	// (alive-check is set membership, deduplicates naturally) and
-	// gives us a transition window to validate the capnp source
-	// before retiring the SQL one.
+	// The legacy _lsp_refs SQL UNION arm was retired in mache-6bd4d8
+	// (T8.8 mirror): SQL columns are no longer the consumer-side
+	// contract, the capnp event log is. Removing the arm structurally
+	// precludes be6136-class column-name-as-protocol disagreements
+	// between LLO writer and mache reader (rather than only
+	// preventing them by flag). LLO continues writing _lsp_refs in
+	// the transition window; mache no longer reads it.
 	refsBody += `
 		UNION ALL
 		SELECT referrer_node_id,

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -18,12 +18,18 @@ import (
 // don't want to spin up a full SQLiteGraph just to run a SQL pattern.
 type smellTestGraph struct {
 	*graph.MemoryStore
-	db *sql.DB
+	db   *sql.DB
+	path string // optional: when set, exposed via DBPath() for capnp readthrough
 }
 
 func (s *smellTestGraph) QueryRefs(query string, args ...any) (*sql.Rows, error) {
 	return s.db.Query(query, args...)
 }
+
+// DBPath implements dbPathProvider when path is set, opting this
+// test graph into capnp readthrough (mache-190508 step 3 / mache-6bd4d8).
+// Tests that don't set path keep the legacy mention-only view shape.
+func (s *smellTestGraph) DBPath() string { return s.path }
 
 // seedSmellAST creates a minimal _ast database modeling the Go statements
 //

--- a/cmd/serve_find_smells_views_test.go
+++ b/cmd/serve_find_smells_views_test.go
@@ -38,14 +38,18 @@ func (q *sqlDBQuerier) QueryRefs(query string, args ...any) (*sql.Rows, error) {
 // keep the legacy mention + SQL-binding view shape.
 func (q *sqlDBQuerier) DBPath() string { return q.path }
 
-func TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent(t *testing.T) {
+// TestEnsureCanonicalViews_DefBindingFidelityFromLSPSQL pins the
+// def-side binding arm, which still reads from the SQL `_lsp_defs`
+// table (BindingRecord covers refs only — the def-side migration is
+// tracked separately, post-mache-6bd4d8). The ref-side binding arm
+// is exercised by TestLoadCapnpBindings_PopulatesViewFromSiblingLog,
+// which uses the sibling .bindings.capnp event log instead.
+func TestEnsureCanonicalViews_DefBindingFidelityFromLSPSQL(t *testing.T) {
 	dbPath := filepath.Join(t.TempDir(), "binding.db")
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
 	defer func() { _ = db.Close() }()
 
-	// Mention-fidelity tables (mache's own schema) + post-Step-1
-	// _lsp_* shape (referrer_node_id, ref_token, def_token).
 	_, err = db.Exec(`
 		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
 		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
@@ -56,34 +60,16 @@ func TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent(t *testing.T)
 			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
 			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
 		);
-		CREATE TABLE _lsp_refs (
-			node_id TEXT NOT NULL,
-			referrer_node_id TEXT,
-			ref_token TEXT NOT NULL DEFAULT '',
-			ref_uri TEXT NOT NULL,
-			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
-			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
-		);
 
-		-- Mention-fidelity: tree-sitter saw 'Validate' textually.
 		INSERT INTO node_defs VALUES ('Validate', 'auth/functions/Validate');
-		INSERT INTO node_refs VALUES ('Validate', 'billing/functions/Charge');
-
-		-- Binding-fidelity: gopls resolved obj.Validate() at billing's
-		-- byte range to auth/functions/Validate. ref_token = 'Validate'
-		-- because that's the textual lemma at the source byte range.
 		INSERT INTO _lsp_defs VALUES
 			('auth/functions/Validate', 'Validate', 'file:///auth/auth.go', 10, 5, 10, 13);
-		INSERT INTO _lsp_refs VALUES
-			('auth/functions/Validate', 'billing/functions/Charge', 'Validate',
-			 'file:///billing/billing.go', 42, 11, 42, 19);
 	`)
 	require.NoError(t, err)
 
 	qg := &sqlDBQuerier{db: db}
 	require.NoError(t, ensureCanonicalViews(qg))
 
-	// v_defs: one mention row + one binding row.
 	type defRow struct {
 		token, nodeID, fidelity string
 	}
@@ -96,35 +82,11 @@ func TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent(t *testing.T)
 		defs = append(defs, r)
 	}
 	require.NoError(t, rows.Close())
-	require.Len(t, defs, 2)
+	require.Len(t, defs, 2, "one mention row from node_defs + one binding row from _lsp_defs")
 	assert.Equal(t, "binding", defs[0].fidelity)
 	assert.Equal(t, "Validate", defs[0].token)
 	assert.Equal(t, "auth/functions/Validate", defs[0].nodeID)
 	assert.Equal(t, "mention", defs[1].fidelity)
-
-	// v_refs: one mention row + one binding row. Binding row carries
-	// the resolved target_node_id; mention row has NULL there.
-	type refRow struct {
-		referrer, token, fidelity string
-		target                    sql.NullString
-	}
-	rrows, err := db.Query(`SELECT referrer_node_id, token, target_node_id, fidelity FROM v_refs ORDER BY fidelity, token`)
-	require.NoError(t, err)
-	var refs []refRow
-	for rrows.Next() {
-		var r refRow
-		require.NoError(t, rrows.Scan(&r.referrer, &r.token, &r.target, &r.fidelity))
-		refs = append(refs, r)
-	}
-	require.NoError(t, rrows.Close())
-	require.Len(t, refs, 2)
-	assert.Equal(t, "binding", refs[0].fidelity)
-	assert.Equal(t, "billing/functions/Charge", refs[0].referrer)
-	assert.Equal(t, "Validate", refs[0].token)
-	assert.True(t, refs[0].target.Valid, "binding row must populate target_node_id")
-	assert.Equal(t, "auth/functions/Validate", refs[0].target.String)
-	assert.Equal(t, "mention", refs[1].fidelity)
-	assert.False(t, refs[1].target.Valid, "mention row's target_node_id is NULL")
 }
 
 func TestEnsureCanonicalViews_HandlesMissingLSPTables(t *testing.T) {
@@ -204,12 +166,18 @@ func TestEnsureCanonicalViews_HandlesLegacyLSPTables(t *testing.T) {
 	assert.Zero(t, bindingDefs, "legacy _lsp_defs (no def_token) must not produce binding rows")
 }
 
-func TestEnsureCanonicalViews_SkipsEmptyTokenRows(t *testing.T) {
-	// LSP_REFS_DDL declares ref_token NOT NULL DEFAULT ''. Rows where
-	// the producer couldn't extract the byte range (cross-repo refs,
-	// missing source) carry empty tokens. The view body filters those
+func TestEnsureCanonicalViews_SkipsEmptyDefTokenRows(t *testing.T) {
+	// _lsp_defs.def_token is NOT NULL DEFAULT ''. Rows where the
+	// producer couldn't extract a token (cross-repo defs, missing
+	// source) carry empty tokens. v_defs's binding arm filters them
 	// out — they'd contribute false matches in token-keyed rule
-	// queries (especially dead_code's mention fallback arm).
+	// queries (dead_code's mention fallback arm in particular).
+	//
+	// Post-mache-6bd4d8 this assertion is def-side only. The
+	// equivalent ref-side filter is now enforced at the producer
+	// boundary (LLO's BindingRecord generation skips empty refToken)
+	// — see TestReadBindingLog_RealLLOOutput which pins refToken
+	// non-empty as a producer invariant.
 	dbPath := filepath.Join(t.TempDir(), "empty_token.db")
 	db, err := sql.Open("sqlite", dbPath)
 	require.NoError(t, err)
@@ -225,37 +193,20 @@ func TestEnsureCanonicalViews_SkipsEmptyTokenRows(t *testing.T) {
 			def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
 			def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
 		);
-		CREATE TABLE _lsp_refs (
-			node_id TEXT NOT NULL,
-			referrer_node_id TEXT,
-			ref_token TEXT NOT NULL DEFAULT '',
-			ref_uri TEXT NOT NULL,
-			ref_start_line INTEGER NOT NULL, ref_start_col INTEGER NOT NULL,
-			ref_end_line INTEGER NOT NULL, ref_end_col INTEGER NOT NULL
-		);
 
 		-- One def row with a real token (kept), one with empty (dropped).
 		INSERT INTO _lsp_defs VALUES
 			('pkg/Real',  'Real',  'file:///x.go', 1, 0, 1, 3),
 			('pkg/Empty', '',      'file:///x.go', 5, 0, 5, 3);
-
-		-- One ref with token + referrer (kept), one with empty token
-		-- (dropped), one with NULL referrer (dropped).
-		INSERT INTO _lsp_refs VALUES
-			('pkg/Real',  'pkg/Caller',  'Real',  'file:///c.go', 9, 0, 9, 3),
-			('pkg/Empty', 'pkg/Caller',  '',      'file:///c.go', 10, 0, 10, 3),
-			('pkg/Real',  NULL,           'Real',  'file:///c.go', 11, 0, 11, 3);
 	`)
 	require.NoError(t, err)
 
 	qg := &sqlDBQuerier{db: db}
 	require.NoError(t, ensureCanonicalViews(qg))
 
-	var bindingDefs, bindingRefs int
+	var bindingDefs int
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs WHERE fidelity = 'binding'`).Scan(&bindingDefs))
-	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs WHERE fidelity = 'binding'`).Scan(&bindingRefs))
 	assert.Equal(t, 1, bindingDefs, "only the row with non-empty def_token survives")
-	assert.Equal(t, 1, bindingRefs, "only the row with non-empty ref_token AND non-NULL referrer survives")
 }
 
 // TestLoadCapnpBindings_PopulatesViewFromSiblingLog asserts the

--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -3,13 +3,16 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/agentic-research/mache/internal/lsp"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 )
@@ -425,41 +428,82 @@ func queryLSPDefs(qg refsQuerier, symbol string) ([]lspDefLocation, error) {
 	return results, rows.Err()
 }
 
-// queryLSPRefs queries the _lsp_refs table for reference locations
-// of a symbol. Returns (nil, nil) if the table does not exist.
+// queryLSPRefs returns reference locations for a symbol.
 //
-// Per ADR-0013 Step 5 (mache-346d2b), prefers the direct ref_token
-// match when ley-line-open's post-Step-1 column is present. Legacy
-// LIKE fallback survives for pre-Step-1 .dbs.
+// Per mache-6bd4d8 (T8.8 mirror): the primary source is the sibling
+// `.bindings.capnp` event log, read via internal/lsp.ReadBindingLog.
+// `_lsp_refs` SQL columns were retired as the consumer-side contract
+// — capnp records carry the full (refToken, refUri, refRange) tuple
+// without a SQL JOIN, structurally precluding be6136-class column-
+// name-as-protocol disagreements.
+//
+// Falls back to the legacy SQL path (queryLSPRefsLegacy) only when
+// the sibling capnp log is absent AND the .db has the pre-Step-1
+// `_lsp_refs` schema (no ref_token column). That window is narrow:
+// post-LLO-T8.2 builds always emit the capnp log.
+//
+// Returns (nil, nil) when neither source has data for the symbol.
 func queryLSPRefs(qg refsQuerier, symbol string) ([]lspRefLocation, error) {
-	hasRefToken, err := tableHasColumn(qg, "_lsp_refs", "ref_token")
-	if err != nil {
-		return nil, fmt.Errorf("probe _lsp_refs schema: %w", err)
-	}
-	if !hasRefToken {
-		return queryLSPRefsLegacy(qg, symbol)
+	// Capnp source: requires the querier to know its dbPath
+	// (dbPathProvider opt-in, mache-190508 step 3). When available,
+	// it's the canonical source.
+	if dp, ok := qg.(dbPathProvider); ok {
+		if results, err := readLSPRefsFromCapnp(dp.DBPath(), symbol); err != nil {
+			return nil, err
+		} else if results != nil {
+			return results, nil
+		}
+		// Capnp present but no match for this symbol → empty slice
+		// vs nil distinction handled by readLSPRefsFromCapnp:
+		// nil means "no log to consult", []lspRefLocation{} means
+		// "log present, zero matches". Fall through only on nil.
 	}
 
-	rows, err := qg.QueryRefs(
-		`SELECT node_id, ref_uri, ref_start_line, ref_start_col, ref_end_line, ref_end_col
-		 FROM _lsp_refs
-		 WHERE ref_token = ?`,
-		symbol,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("query _lsp_refs: %w", err)
-	}
-	defer func() { _ = rows.Close() }()
+	// Legacy path: only fires when capnp is absent. queryLSPRefsLegacy
+	// handles both the post-Step-1 schema (with ref_token column) and
+	// the pre-Step-1 LIKE-suffix shape.
+	return queryLSPRefsLegacy(qg, symbol)
+}
 
-	var results []lspRefLocation
-	for rows.Next() {
-		var r lspRefLocation
-		if err := rows.Scan(&r.NodeID, &r.URI, &r.StartLine, &r.StartCol, &r.EndLine, &r.EndCol); err != nil {
+// readLSPRefsFromCapnp reads the sibling .bindings.capnp event log and
+// filters records by RefToken == symbol. Returns:
+//
+//	(nil, nil)      — no sibling log exists; caller should fall back
+//	([]..., nil)    — log exists; slice contains all matches (possibly empty)
+//	(nil, err)      — log exists but couldn't be read
+//
+// dbPath empty string is treated as "no source" (nil, nil).
+func readLSPRefsFromCapnp(dbPath, symbol string) ([]lspRefLocation, error) {
+	if dbPath == "" {
+		return nil, nil
+	}
+	logPath := lsp.SiblingBindingLogPath(dbPath)
+	records, err := lsp.ReadBindingLog(logPath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read binding log %s: %w", logPath, err)
+	}
+
+	// Intentional empty (not nil) slice: "log present, zero matches"
+	// is meaningfully different from "no log to consult" — see the
+	// caller's nil-check.
+	results := []lspRefLocation{}
+	for _, r := range records {
+		if r.RefToken != symbol {
 			continue
 		}
-		results = append(results, r)
+		results = append(results, lspRefLocation{
+			NodeID:    r.TargetNodeID,
+			URI:       r.RefURI,
+			StartLine: int(r.RefRange.StartLine),
+			StartCol:  int(r.RefRange.StartColumn),
+			EndLine:   int(r.RefRange.EndLine),
+			EndCol:    int(r.RefRange.EndColumn),
+		})
 	}
-	return results, rows.Err()
+	return results, nil
 }
 
 // queryLSPDefsLegacy is the pre-Step-1 query path: node_id suffix


### PR DESCRIPTION
## Summary

T8.8 mirror — closes the consumer-side migration started in mache-190508. The SQL `_lsp_refs` arm of `v_refs` is gone, replaced by the capnp-backed `_capnp_binding_refs` TEMP table. Same for `queryLSPRefs` (the `find_callers` MCP backend). 

**Why this matters:** PR #356 shipped capnp readthrough as additive (UNION arm alongside SQL). This PR makes capnp the only binding source for refs — once LLO ships T8.9 (retire `_lsp_refs` writers), the be6136-class column-name-as-protocol disagreement becomes **structurally impossible** rather than flag-preventable.

## What lands

**`cmd/serve_find_smells.go::ensureCanonicalViews`**
- Drops the `_lsp_refs` UNION arm from `v_refs`. Binding-fidelity rows now come exclusively from `_capnp_binding_refs`.
- Probe + conditional UNION for `ref_token` column removed.
- Comment block explains structural-vs-flag preclusion.
- The def-side `_lsp_defs` SQL arm **stays** — `BindingRecord` covers refs only; def migration is tracked separately (BindingRecord lacks standalone def metadata like location/range).

**`cmd/serve_lsp.go::queryLSPRefs`**
- Reads from capnp via `dbPathProvider` opt-in + `internal/lsp.ReadBindingLog`.
- Falls back to `queryLSPRefsLegacy` only when sibling capnp log is absent (narrow window: pre-LLO-T8.2 builds).
- New helper `readLSPRefsFromCapnp` documents the `(nil, nil)` vs `([]..., nil)` contract for fallback decisions.

## Tests updated

- `smellTestGraph` gains `path` field + `DBPath()` method (opts test fixtures into capnp readthrough)
- `TestEnsureCanonicalViews_BindingFidelityWhenLSPColumnsPresent` → renamed `_DefBindingFidelityFromLSPSQL`, scoped to def-side
- `TestEnsureCanonicalViews_SkipsEmptyTokenRows` → renamed `_SkipsEmptyDefTokenRows` (empty-ref-token filter moved up to producer boundary; LLO guarantees `refToken` non-empty)
- `TestDeadCode_InterfaceMethodAliveWhenLSPSeesRefs` migrated: writes sibling `.bindings.capnp` via new `writeBindingLogForTest` helper
- `TestFalsifiabilityA_SyntheticHarness` migrated: same helper + explicit `LoadCapnpBindings` call

## Out of scope (follow-up beads)

- **`cmd/leyline.go::loadLSPRefs`** — schema-projection content-source loader (different surface, per-symbol JSON files under `<construct>/references/`). Not routed through `v_refs`.
- **`_lsp_defs` migration** — BindingRecord doesn't cover standalone def metadata. Needs its own capnp record type or extension.
- **T8.7 `qualifier` consumption** — tracked in `mache-6c0d07` (replaces #355's projection-function naming-pattern exemption with structural metric).

## Test plan

- [x] Full `go test ./...` green: 20/20 packages
- [x] Real-LLO Falsifiability A still passes (ablation: zero new dead-flagged on capnp source)
- [x] Real-LLO Falsifiability B still passes (0% call-site discrepancy)
- [x] golangci-lint passes
- [ ] CI green
- [ ] Copilot review

Refs: `mache-6bd4d8`, gates ley-line-open T8.9.