### PR TITLE
feat(cmd): pprof CPU + heap capture per MCP tool (mache-6b6da6 phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ tools/KNOWN_ISSUES.md
 
 # E2E tool-profile harness output (mache-6b6da6)
 /.e2e/
+
+# Playwright MCP scratch (used for inspecting flamegraph SVGs)
+/.playwright-mcp/
+/architecture-heap-rendered.png
+/flamegraph-architecture-heap.png

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,9 +143,13 @@ tasks:
       # Per-tool .cpu.pprof + .heap.pprof land in .e2e/pprof/.
       # Total runtime ~3-8s depending on iteration count.
       #
-      # Open with `go tool pprof .e2e/pprof/<tool>.cpu.pprof`
-      # or `go tool pprof -svg .e2e/pprof/<tool>.heap.pprof`
-      # to render a flamegraph.
+      # Open with `go tool pprof .e2e/pprof/<tool>.cpu.pprof` for
+      # the interactive REPL, or `go tool pprof -svg <profile>` to
+      # render a CALL GRAPH (not a flamegraph — pprof's -svg emits
+      # a graph, not a flame view). Phase 3 will add a separate
+      # task for true flamegraphs via brendangregg/flamegraph.pl
+      # or `go tool pprof -http=:0` (which serves a flamegraph
+      # view alongside the call graph).
       - mkdir -p {{.ROOT_DIR}}/.e2e/pprof
       - E2E_PROFILE_OUT={{.ROOT_DIR}}/.e2e/tool-profile.json E2E_CAPTURE_PPROF=1 go test -v -run 'TestE2E_AllMCPTools' ./cmd/
       - echo "manifest -> .e2e/tool-profile.json"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -144,16 +144,125 @@ tasks:
       # Total runtime ~3-8s depending on iteration count.
       #
       # Open with `go tool pprof .e2e/pprof/<tool>.cpu.pprof` for
-      # the interactive REPL, or `go tool pprof -svg <profile>` to
-      # render a CALL GRAPH (not a flamegraph — pprof's -svg emits
-      # a graph, not a flame view). Phase 3 will add a separate
-      # task for true flamegraphs via brendangregg/flamegraph.pl
-      # or `go tool pprof -http=:0` (which serves a flamegraph
-      # view alongside the call graph).
+      # the interactive REPL, or run `task flamegraphs` to render
+      # SVG flamegraphs (real flamegraphs, not call graphs — needs
+      # brendangregg's FlameGraph scripts on PATH; the task checks
+      # for them and prints install instructions if missing).
       - mkdir -p {{.ROOT_DIR}}/.e2e/pprof
       - E2E_PROFILE_OUT={{.ROOT_DIR}}/.e2e/tool-profile.json E2E_CAPTURE_PPROF=1 go test -v -run 'TestE2E_AllMCPTools' ./cmd/
       - echo "manifest -> .e2e/tool-profile.json"
       - echo "pprof    -> .e2e/pprof/*.{cpu,heap}.pprof"
+      - echo "next     -> task flamegraphs"
+
+  flamegraphs:
+    desc: Render SVG flamegraphs from .e2e/pprof/*.pprof (mache-6b6da6 phase 3)
+    cmds:
+      # Real flamegraphs via brendangregg/FlameGraph scripts.
+      # `pprof -svg` emits a call graph, not a flamegraph (Copilot
+      # caught this on PR #361). The standard tool for static
+      # flamegraph SVGs is brendangregg/FlameGraph; not vendored
+      # here because it's CDDL+GPL perl into an Apache 2.0 Go
+      # project — license fragmentation isn't worth the convenience.
+      #
+      # Install:
+      #   macOS:  brew install flamegraph
+      #   Linux:  git clone https://github.com/brendangregg/FlameGraph
+      #           and add the dir to PATH
+      #
+      # Pipeline per profile:
+      #   go tool pprof -raw <profile>
+      #     | stackcollapse-go.pl    # collapse Go stacks
+      #     | flamegraph.pl --title  # render SVG
+      #     > <tool>.<kind>.svg
+      - cmd: |
+          if ! command -v flamegraph.pl >/dev/null 2>&1 || ! command -v stackcollapse-go.pl >/dev/null 2>&1; then
+            echo "flamegraph.pl + stackcollapse-go.pl required — install via:"
+            echo "  macOS: brew install flamegraph"
+            echo "  Linux: git clone https://github.com/brendangregg/FlameGraph && add to PATH"
+            exit 1
+          fi
+      - cmd: |
+          if [ ! -d {{.ROOT_DIR}}/.e2e/pprof ]; then
+            echo "no pprof artifacts in .e2e/pprof/ — run 'task profile-tools-pprof' first"
+            exit 1
+          fi
+      - cmd: |
+          cd {{.ROOT_DIR}}/.e2e/pprof
+          # CPU profiles: pprof -raw → stackcollapse-go.pl
+          # → flamegraph.pl. Some tools have 0 CPU samples (their
+          # 500-iteration loop completed under the 10ms sampler
+          # tick); skip those quietly with a placeholder note in
+          # the SVG so INDEX.md stays consistent.
+          for prof in *.cpu.pprof; do
+            [ -f "$prof" ] || continue
+            tool=$(basename "$prof" .cpu.pprof)
+            collapsed=$(go tool pprof -raw "$prof" 2>/dev/null | stackcollapse-go.pl 2>/dev/null)
+            if [ -z "$collapsed" ]; then
+              echo "<svg xmlns='http://www.w3.org/2000/svg'><text y='20'>$tool: no CPU samples (tool too fast for 100Hz sampler at this iteration count)</text></svg>" > "$tool.cpu.svg"
+              continue
+            fi
+            echo "$collapsed" \
+              | flamegraph.pl --title="$tool CPU" --colors=go \
+              > "$tool.cpu.svg"
+          done
+          # Heap profiles use a baseline + diff to filter out
+          # init-time allocation noise (jsonschema, sqlite,
+          # tree-sitter package init dominate the cumulative view
+          # otherwise — see Image #2 reading on PR #361). Each
+          # tool has two snapshots: <tool>.heap.baseline.pprof
+          # captured before the iteration loop, <tool>.heap.pprof
+          # captured after.
+          #
+          # Use `-alloc_space -base=baseline` to surface BYTES
+          # ALLOCATED DURING THE LOOP (column 2 of the 4-column
+          # heap raw format). `-inuse_space` would show "live at
+          # snapshot but not live at baseline" which is near-zero
+          # for short loops where allocs get GC'd before the
+          # second snapshot — the real signal is alloc_space.
+          #
+          # Pprof's raw still emits the 4-column format even with
+          # the -alloc_space filter; sed drops cols 3-4 so
+          # stackcollapse-go.pl's 2-column regex matches.
+          for prof in *.heap.pprof; do
+            [ -f "$prof" ] || continue
+            # Skip the baseline files — only iterate the AFTER snapshots.
+            case "$prof" in *.heap.baseline.pprof) continue ;; esac
+            tool=$(basename "$prof" .heap.pprof)
+            baseline="$tool.heap.baseline.pprof"
+            if [ ! -f "$baseline" ]; then
+              echo "<svg xmlns='http://www.w3.org/2000/svg'><text y='20'>$tool: missing baseline; cannot compute heap delta</text></svg>" > "$tool.heap.svg"
+              continue
+            fi
+            collapsed=$(
+              go tool pprof -alloc_space -base="$baseline" -raw "$prof" 2>/dev/null \
+                | sed -E 's/^( *[0-9]+ +[0-9]+) +[0-9]+ +[0-9]+:/\1:/' \
+                | stackcollapse-go.pl 2>/dev/null
+            )
+            if [ -z "$collapsed" ]; then
+              echo "<svg xmlns='http://www.w3.org/2000/svg'><text y='20'>$tool: no heap delta (loop allocations were fully GC'd)</text></svg>" > "$tool.heap.svg"
+              continue
+            fi
+            echo "$collapsed" \
+              | flamegraph.pl --title="$tool heap delta (alloc_space, baseline-subtracted)" --colors=mem --countname=bytes \
+              > "$tool.heap.svg"
+          done
+      - cmd: |
+          cd {{.ROOT_DIR}}/.e2e
+          {
+            echo "# E2E tool flamegraphs"
+            echo ""
+            echo "Generated by \`task flamegraphs\` from .e2e/pprof/*.pprof artifacts."
+            echo "See [tool-profile.json](tool-profile.json) for the per-tool manifest."
+            echo ""
+            echo "| Tool | CPU | Heap | Profile |"
+            echo "|------|-----|------|---------|"
+            for prof in pprof/*.cpu.pprof; do
+              tool=$(basename "$prof" .cpu.pprof)
+              echo "| $tool | [cpu.svg](pprof/$tool.cpu.svg) | [heap.svg](pprof/$tool.heap.svg) | [pprof](pprof/$tool.cpu.pprof) |"
+            done
+          } > INDEX.md
+      - echo "flamegraphs -> .e2e/pprof/*.{cpu,heap}.svg"
+      - echo "index       -> .e2e/INDEX.md"
 
   fuzz-gen:
     desc: Generate a new "Fuzz-Mutate-Repair" task by breaking a target

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,9 +123,9 @@ tasks:
     desc: E2E harness — exercise every MCP tool, emit per-tool latency/alloc manifest (mache-6b6da6)
     cmds:
       # E2E_PROFILE_OUT controls manifest emission; the test always
-      # logs a summary table to stdout regardless. Phase 1 captures
-      # latency + alloc deltas; phase 2 will add pprof CPU/heap and
-      # SVG flamegraphs.
+      # logs a summary table to stdout regardless. Latency + alloc
+      # only; rerun with `task profile-tools-pprof` to also capture
+      # pprof CPU/heap artifacts.
       #
       # Use absolute path because `go test ./cmd/` runs with cwd
       # set to cmd/, not the project root — relative paths land
@@ -133,6 +133,23 @@ tasks:
       - mkdir -p {{.ROOT_DIR}}/.e2e
       - E2E_PROFILE_OUT={{.ROOT_DIR}}/.e2e/tool-profile.json go test -v -run 'TestE2E_AllMCPTools' ./cmd/
       - echo "manifest -> .e2e/tool-profile.json"
+
+  profile-tools-pprof:
+    desc: E2E harness with per-tool pprof CPU + heap capture (mache-6b6da6 phase 2)
+    cmds:
+      # Adds pprof capture: each tool runs through E2E_CPU_ITERATIONS
+      # calls under runtime/pprof.StartCPUProfile (default 500 to
+      # cross the 100Hz sampler threshold) plus a heap snapshot.
+      # Per-tool .cpu.pprof + .heap.pprof land in .e2e/pprof/.
+      # Total runtime ~3-8s depending on iteration count.
+      #
+      # Open with `go tool pprof .e2e/pprof/<tool>.cpu.pprof`
+      # or `go tool pprof -svg .e2e/pprof/<tool>.heap.pprof`
+      # to render a flamegraph.
+      - mkdir -p {{.ROOT_DIR}}/.e2e/pprof
+      - E2E_PROFILE_OUT={{.ROOT_DIR}}/.e2e/tool-profile.json E2E_CAPTURE_PPROF=1 go test -v -run 'TestE2E_AllMCPTools' ./cmd/
+      - echo "manifest -> .e2e/tool-profile.json"
+      - echo "pprof    -> .e2e/pprof/*.{cpu,heap}.pprof"
 
   fuzz-gen:
     desc: Generate a new "Fuzz-Mutate-Repair" task by breaking a target

--- a/cmd/all_tools_e2e_test.go
+++ b/cmd/all_tools_e2e_test.go
@@ -58,18 +58,26 @@ type toolProfile struct {
 	Reason   string `json:"reason,omitempty"`    // when Status != ok
 	BodySize int    `json:"body_size,omitempty"` // bytes, ok-status only
 	// Optional pprof artifacts (phase 2). Empty string when capture
-	// is disabled (E2E_CAPTURE_PPROF unset). Path is relative to
-	// the test's cwd at run time; the manifest writer leaves it as
-	// emitted so consumers (flamegraph step, dashboards) can resolve
-	// against ROOT_DIR or the manifest's parent.
+	// is disabled (E2E_CAPTURE_PPROF unset).
+	//
+	// Recorded as ABSOLUTE paths because E2E_PPROF_DIR / the
+	// manifest-sibling default both resolve to absolute. Manifests
+	// are therefore not portable across machines as-is — consumers
+	// running on a different host should resolve via the manifest's
+	// parent directory and the trailing `<name>.{cpu,heap}.pprof`
+	// filename. Phase 4 may switch to manifest-relative when
+	// regression-detection consumes baseline manifests; keeping
+	// absolute for phase 2 since flamegraph generation runs on the
+	// same host that produced the profiles.
 	CPUProfile  string `json:"cpu_profile,omitempty"`
 	HeapProfile string `json:"heap_profile,omitempty"`
 	// CPUIterations is the count of handler calls run under the
 	// CPU profile boundary. Single-call profiles are too short for
 	// the runtime sampler (~100Hz, 10ms tick) to record meaningful
 	// stacks, so the harness loops K times inside one profile to
-	// give the sampler something to chew on. K defaults to 50 and
-	// is overridable via E2E_CPU_ITERATIONS.
+	// give the sampler something to chew on. K defaults to 500 (see
+	// readPprofOpts for why) and is overridable via
+	// E2E_CPU_ITERATIONS.
 	CPUIterations int `json:"cpu_iterations,omitempty"`
 }
 
@@ -98,7 +106,14 @@ func readPprofOpts(t *testing.T) pprofOpts {
 			dir = t.TempDir()
 		}
 	}
-	require.NoError(t, os.MkdirAll(dir, 0o755))
+	// Match capturePprof's best-effort posture: if the dir can't
+	// be created, log and disable capture rather than failing the
+	// whole harness. Phase-1 latency/alloc capture still runs and
+	// the manifest still emits — pprof is a bonus, not a gate.
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("pprof: could not create dir %s: %v (capture disabled for this run)", dir, err)
+		return pprofOpts{}
+	}
 
 	// Default iterations: 500. Mache's tools complete in <1ms each
 	// (phase 1 baseline), and the runtime CPU sampler runs at
@@ -306,6 +321,20 @@ func capturePprof(t *testing.T, name string, h server.ToolHandlerFunc, args map[
 		t.Logf("pprof: StartCPUProfile %s: %v", name, err)
 		return
 	}
+	// Defer StopCPUProfile so it runs even if a handler panics
+	// during the iteration loop. Go's testing framework recovers
+	// panics and continues running other tests; without this
+	// defer, profiling stays enabled and the next tool's
+	// StartCPUProfile fails with "already profiling", cascading
+	// the failure across the whole harness.
+	//
+	// The explicit StopCPUProfile() below the loop runs on the
+	// happy path and tightens the CPU profile boundary to just
+	// the iterations (excludes the GC+heap-write tail). The defer
+	// is then a no-op on the happy path and the panic-safety
+	// fallback otherwise.
+	defer pprof.StopCPUProfile()
+
 	for i := 0; i < opts.iterations; i++ {
 		// Ignore result/error: the canonical call above already
 		// recorded ok-status. Iterations exist to give the sampler

--- a/cmd/all_tools_e2e_test.go
+++ b/cmd/all_tools_e2e_test.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -55,6 +57,69 @@ type toolProfile struct {
 	Status   string `json:"status"`              // ok | tool_error | skipped
 	Reason   string `json:"reason,omitempty"`    // when Status != ok
 	BodySize int    `json:"body_size,omitempty"` // bytes, ok-status only
+	// Optional pprof artifacts (phase 2). Empty string when capture
+	// is disabled (E2E_CAPTURE_PPROF unset). Path is relative to
+	// the test's cwd at run time; the manifest writer leaves it as
+	// emitted so consumers (flamegraph step, dashboards) can resolve
+	// against ROOT_DIR or the manifest's parent.
+	CPUProfile  string `json:"cpu_profile,omitempty"`
+	HeapProfile string `json:"heap_profile,omitempty"`
+	// CPUIterations is the count of handler calls run under the
+	// CPU profile boundary. Single-call profiles are too short for
+	// the runtime sampler (~100Hz, 10ms tick) to record meaningful
+	// stacks, so the harness loops K times inside one profile to
+	// give the sampler something to chew on. K defaults to 50 and
+	// is overridable via E2E_CPU_ITERATIONS.
+	CPUIterations int `json:"cpu_iterations,omitempty"`
+}
+
+// pprofOpts is the per-test-run pprof capture configuration.
+// Empty .dir means "do not capture pprof" — phase 1 default.
+type pprofOpts struct {
+	dir        string // .e2e/ or whatever; empty disables capture
+	iterations int    // CPU profile loop count (heap is single-shot)
+}
+
+// readPprofOpts parses the env-var-driven pprof config. Returns
+// zero-value opts (no capture) when E2E_CAPTURE_PPROF is unset.
+func readPprofOpts(t *testing.T) pprofOpts {
+	t.Helper()
+	if os.Getenv("E2E_CAPTURE_PPROF") != "1" {
+		return pprofOpts{}
+	}
+	dir := os.Getenv("E2E_PPROF_DIR")
+	if dir == "" {
+		// Default to a sibling of the manifest, or to a tempdir if
+		// neither is set. Prefer co-locating with the manifest so
+		// `task profile-tools` ends up with one tidy output dir.
+		if mf := os.Getenv("E2E_PROFILE_OUT"); mf != "" {
+			dir = filepath.Join(filepath.Dir(mf), "pprof")
+		} else {
+			dir = t.TempDir()
+		}
+	}
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+
+	// Default iterations: 500. Mache's tools complete in <1ms each
+	// (phase 1 baseline), and the runtime CPU sampler runs at
+	// ~100Hz (10ms tick). Below ~200 iterations the CPU profile
+	// records zero samples — the loop exits before any tick.
+	// 500 × ~1ms ≈ 500ms per tool, so a full pprof run takes
+	// ~8s for the 16-tool surface. Heap profiling has no
+	// equivalent sampling-rate constraint and is meaningful at
+	// any iteration count; CPU is the dimensioning concern.
+	//
+	// On larger fixtures with slower tools, lower iterations work;
+	// users can tune via E2E_CPU_ITERATIONS.
+	iterations := 500
+	if v := os.Getenv("E2E_CPU_ITERATIONS"); v != "" {
+		n, err := strconv.Atoi(v)
+		require.NoError(t, err, "E2E_CPU_ITERATIONS must be int")
+		require.Positive(t, n, "E2E_CPU_ITERATIONS must be > 0")
+		iterations = n
+	}
+	t.Logf("pprof capture enabled: dir=%s cpu_iterations=%d", dir, iterations)
+	return pprofOpts{dir: dir, iterations: iterations}
 }
 
 // TestE2E_AllMCPTools is the harness. See file header.
@@ -114,9 +179,10 @@ func TestE2E_AllMCPTools(t *testing.T) {
 		// is the right fit. Phase 1 pins the read surface.
 	}
 
+	opts := readPprofOpts(t)
 	profiles := make([]toolProfile, 0, len(invocations))
 	for _, inv := range invocations {
-		profiles = append(profiles, profileTool(t, inv.name, inv.handler(g), inv.args))
+		profiles = append(profiles, profileTool(t, inv.name, inv.handler(g), inv.args, opts))
 	}
 
 	printProfileSummary(t, profiles)
@@ -153,7 +219,15 @@ func TestE2E_AllMCPTools(t *testing.T) {
 // profileTool calls one tool handler and records latency + alloc
 // deltas. Forces a GC before the call so the alloc delta reflects
 // only the tool's work, not the previous tool's still-live objects.
-func profileTool(t *testing.T, name string, h server.ToolHandlerFunc, args map[string]any) toolProfile {
+//
+// When opts.dir is set, additionally captures CPU + heap pprof
+// artifacts. The latency/alloc measurement still comes from a
+// single canonical call so the manifest numbers are comparable
+// run-over-run regardless of pprof being on. The CPU profile is
+// captured over a separate K-iteration loop because single-call
+// profiles are too short for the runtime sampler (~100Hz tick) to
+// record meaningful stacks.
+func profileTool(t *testing.T, name string, h server.ToolHandlerFunc, args map[string]any, opts pprofOpts) toolProfile {
 	t.Helper()
 	var startMem, endMem runtime.MemStats
 	runtime.GC()
@@ -197,7 +271,67 @@ func profileTool(t *testing.T, name string, h server.ToolHandlerFunc, args map[s
 		p.Status = "ok"
 		p.BodySize = len(resultText(t, res))
 	}
+
+	// Phase 2: optional pprof capture. Skip on tools that errored
+	// or were skipped — profiling an LSP-tool that immediately
+	// returns "no _lsp_* table" is profile noise, not signal.
+	if opts.dir != "" && p.Status == "ok" {
+		capturePprof(t, name, h, args, opts, &p)
+	}
 	return p
+}
+
+// capturePprof writes <name>.cpu.pprof + <name>.heap.pprof under
+// opts.dir. CPU profile spans a K-iteration loop; heap is a single
+// snapshot taken after the loop. Sets p.CPUProfile / p.HeapProfile
+// paths on the toolProfile so the manifest links them.
+//
+// Errors are logged via t.Logf but don't fail the test — the
+// harness's primary job is the latency/alloc measurement; pprof
+// is a bonus. A slot machine I/O failure shouldn't break the
+// observability story.
+func capturePprof(t *testing.T, name string, h server.ToolHandlerFunc, args map[string]any, opts pprofOpts, p *toolProfile) {
+	t.Helper()
+
+	// CPU profile over K iterations.
+	cpuPath := filepath.Join(opts.dir, name+".cpu.pprof")
+	cpuFile, err := os.Create(cpuPath)
+	if err != nil {
+		t.Logf("pprof: could not create %s: %v", cpuPath, err)
+		return
+	}
+	defer func() { _ = cpuFile.Close() }()
+
+	if err := pprof.StartCPUProfile(cpuFile); err != nil {
+		t.Logf("pprof: StartCPUProfile %s: %v", name, err)
+		return
+	}
+	for i := 0; i < opts.iterations; i++ {
+		// Ignore result/error: the canonical call above already
+		// recorded ok-status. Iterations exist to give the sampler
+		// enough work to record stacks.
+		_, _ = h(context.Background(), makeRequest(args))
+	}
+	pprof.StopCPUProfile()
+	p.CPUProfile = cpuPath
+	p.CPUIterations = opts.iterations
+
+	// Heap snapshot after the loop. GC first so the snapshot
+	// reflects steady-state allocations rather than interim
+	// garbage from the iteration loop.
+	runtime.GC()
+	heapPath := filepath.Join(opts.dir, name+".heap.pprof")
+	heapFile, err := os.Create(heapPath)
+	if err != nil {
+		t.Logf("pprof: could not create %s: %v", heapPath, err)
+		return
+	}
+	defer func() { _ = heapFile.Close() }()
+	if err := pprof.WriteHeapProfile(heapFile); err != nil {
+		t.Logf("pprof: WriteHeapProfile %s: %v", name, err)
+		return
+	}
+	p.HeapProfile = heapPath
 }
 
 // printProfileSummary emits a human-readable table to test output.

--- a/cmd/all_tools_e2e_test.go
+++ b/cmd/all_tools_e2e_test.go
@@ -296,17 +296,40 @@ func profileTool(t *testing.T, name string, h server.ToolHandlerFunc, args map[s
 	return p
 }
 
-// capturePprof writes <name>.cpu.pprof + <name>.heap.pprof under
-// opts.dir. CPU profile spans a K-iteration loop; heap is a single
-// snapshot taken after the loop. Sets p.CPUProfile / p.HeapProfile
-// paths on the toolProfile so the manifest links them.
+// capturePprof writes:
+//
+//   - <name>.cpu.pprof — CPU profile over the iteration loop
+//   - <name>.heap.baseline.pprof — heap snapshot BEFORE the loop
+//   - <name>.heap.pprof — heap snapshot AFTER the loop
+//
+// The two heap snapshots let consumers (the flamegraphs task, any
+// regression detector) compute the delta via `pprof -base=baseline`.
+// Without that, heap profiles show cumulative allocation since
+// process start — dominated by init-time noise (jsonschema, sqlite,
+// tree-sitter package init) that buries the actual per-tool signal.
+//
+// Sets p.CPUProfile / p.HeapProfile (the AFTER snapshot) on the
+// toolProfile. The baseline path is derived from HeapProfile by
+// the consumer (sibling .heap.baseline.pprof file).
 //
 // Errors are logged via t.Logf but don't fail the test — the
 // harness's primary job is the latency/alloc measurement; pprof
-// is a bonus. A slot machine I/O failure shouldn't break the
-// observability story.
+// is a bonus. An I/O failure shouldn't break the observability
+// story.
 func capturePprof(t *testing.T, name string, h server.ToolHandlerFunc, args map[string]any, opts pprofOpts, p *toolProfile) {
 	t.Helper()
+
+	// Baseline heap snapshot BEFORE the iteration loop. GC first
+	// so the snapshot reflects steady-state live allocations
+	// rather than pending garbage from previous tools.
+	runtime.GC()
+	baselinePath := filepath.Join(opts.dir, name+".heap.baseline.pprof")
+	if baselineFile, err := os.Create(baselinePath); err == nil {
+		_ = pprof.WriteHeapProfile(baselineFile)
+		_ = baselineFile.Close()
+	} else {
+		t.Logf("pprof: could not create %s: %v", baselinePath, err)
+	}
 
 	// CPU profile over K iterations.
 	cpuPath := filepath.Join(opts.dir, name+".cpu.pprof")


### PR DESCRIPTION
## Summary

Phase 2 of `mache-6b6da6` — extends the e2e tool harness from #360 to optionally capture `runtime/pprof` CPU + heap per tool. Gated on `E2E_CAPTURE_PPROF=1`; phase 1's latency/alloc path is unchanged when the env var is unset.

## What lands

`cmd/all_tools_e2e_test.go`:
- `toolProfile` gains `CPUProfile`, `HeapProfile`, `CPUIterations` fields (`omitempty`)
- `pprofOpts` + `readPprofOpts(t)` parse `E2E_CAPTURE_PPROF`, `E2E_PPROF_DIR`, `E2E_CPU_ITERATIONS`
- `capturePprof()` runs the handler in a K-iteration loop under `pprof.StartCPUProfile`, then snapshots heap via `pprof.WriteHeapProfile`
- Skipped on tools that errored / were skipped (profiling "no _ast table" is noise)
- Latency/alloc measurement still uses single canonical call → manifest numbers stay comparable across runs

`Taskfile.yml`:
- New `task profile-tools-pprof` runs the harness with capture enabled
- Phase 1 `task profile-tools` unchanged (latency/alloc only)

## Why 500 iterations default

Mache's tools complete in <1ms each. The CPU sampler runs at ~100Hz (10ms tick). Below ~200 iterations the CPU profile records **zero samples** — loop exits before any tick. 500 × ~1ms ≈ 500ms per tool yields ~30ms of samples (~14% duty cycle), enough for flamegraphs to find dominant stacks. Heap has no equivalent constraint.

Override via `E2E_CPU_ITERATIONS=N` for slower fixtures or deeper traces.

## Sample outputs

CPU profile (`get_architecture`):
```
Duration: 200ms, Total samples = 30ms (14.83%)
Showing nodes accounting for 30ms, 100% of 30ms total
      flat  flat%   sum%        cum   cum%
      20ms 66.67% 66.67%  20ms 66.67%  runtime.kevent
      10ms 33.33%   100%  10ms 33.33%  runtime.add (inline)
```

Heap profile (`get_architecture`):
```
File: cmd.test
Type: inuse_space
Showing top 5 nodes out of 35
 2051.25kB 40.03% 40.03%  2051.25kB 40.03%  runtime.mallocgc
 1024.03kB 19.99% 60.02%  1024.03kB 19.99%  strings.Fields
  512.38kB 10.00% 70.02%  1024.41kB 19.99%  jsonschema/v6.newSchema
  512.07kB  9.99% 80.01%   512.07kB  9.99%  hclsyntax.init.0
  512.03kB  9.99% 90.01%   512.03kB  9.99%  fmt.Sprintf
```

Heap is immediately actionable. CPU is dominated by background `runtime.kevent` (file watcher started by `buildMaybeMultiGraph` runs concurrently); phase 3 will apply `-focus=<handler>` to filter to tool-specific stacks.

## What's next (Phase 3)

- SVG flamegraph generation via `go tool pprof -svg` per tool
- `INDEX.md` linking tools → profiles → flamegraphs
- `-focus` filter for background-noise filtering

## Test plan

- [x] `task profile-tools` (no env vars) — phase 1 path unchanged, ~0.6s
- [x] `task profile-tools-pprof` produces 32 pprof files (16 tools × CPU + heap), ~3s total
- [x] Manifest links profiles via `cpu_profile` / `heap_profile` fields
- [x] `go tool pprof -top` reads both profile types successfully
- [x] Full `go test ./...` 20/20 green
- [x] golangci-lint passes
- [ ] CI green
- [ ] Copilot review

Refs: `mache-6b6da6` phase 2, builds on phase 1 (#360).