### PR TITLE
feat: migrate from generation-polling to current_root for arena hot-swap

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -518,12 +518,14 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 	}
 	defer func() { _ = ctrl.Close() }()
 
-	// Initial Load
-	gen := ctrl.GetGeneration()
+	// Initial Load: read the controller's current arena pointer + root.
+	// The root is the substrate identity; a zero root means no snapshot
+	// has been published yet (fresh controller).
+	initialRoot := ctrl.GetCurrentRoot()
 	arenaPath := ctrl.GetArenaPath()
-	log.Printf("Control Block: Gen %d -> %s", gen, arenaPath)
+	log.Printf("Control Block: root %s -> %s", shortRoot(initialRoot), arenaPath)
 
-	// Wait for first valid generation if empty
+	// Wait for first valid arena if empty
 	if arenaPath == "" {
 		log.Println("Waiting for initial arena...")
 		deadline := time.After(30 * time.Second)
@@ -535,7 +537,7 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 			}
 			if p := ctrl.GetArenaPath(); p != "" {
 				arenaPath = p
-				gen = ctrl.GetGeneration()
+				initialRoot = ctrl.GetCurrentRoot()
 				break
 			}
 			time.Sleep(100 * time.Millisecond)
@@ -577,7 +579,7 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 	// Start Watcher — event-driven with polling fallback.
 	// Runs for the lifetime of the NFS mount (mountNFS blocks below).
 	go func() {
-		lastGen := gen
+		lastRoot := initialRoot
 		prevDBPath := dbPath
 
 		// Try to subscribe to daemon events for instant hot-swap.
@@ -609,13 +611,13 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 				time.Sleep(100 * time.Millisecond)
 			}
 
-			currentGen := ctrl.GetGeneration()
-			if currentGen <= lastGen {
+			currentRoot := ctrl.GetCurrentRoot()
+			if currentRoot == lastRoot {
 				continue
 			}
 
 			newPath := ctrl.GetArenaPath()
-			log.Printf("Hot Swap Detected: Gen %d -> %d (%s)", lastGen, currentGen, newPath)
+			log.Printf("Hot Swap Detected: root %s -> %s (%s)", shortRoot(lastRoot), shortRoot(currentRoot), newPath)
 
 			newDBPath, err := graph.ExtractActiveDB(newPath)
 			if err != nil {
@@ -631,7 +633,7 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 			}
 
 			hotSwap.Swap(newGraph)
-			lastGen = currentGen
+			lastRoot = currentRoot
 
 			// Defer removal of the old DB file. Swap() closes the SQLite
 			// connection synchronously, but on macOS the NFS page cache
@@ -652,6 +654,16 @@ func mountControl(path string, schema *api.Topology, mountPoint string) error {
 	}()
 
 	return mountNFS(schema, hotSwap, nil, mountPoint, false, nil)
+}
+
+// shortRoot renders the first 4 bytes of a 32-byte BLAKE3 root as 8 hex
+// chars, or "<zero>" for the all-zero sentinel — readable enough for log
+// lines without dragging full 64-char hex everywhere.
+func shortRoot(root [32]byte) string {
+	if control.IsZeroRoot(root) {
+		return "<zero>"
+	}
+	return fmt.Sprintf("%02x%02x%02x%02x", root[0], root[1], root[2], root[3])
 }
 
 // trySubscribe attempts to connect to the daemon's UDS socket and subscribe

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/willscott/go-nfs v0.0.4
+	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/sys v0.43.0
 	golang.org/x/text v0.36.0
 	modernc.org/sqlite v1.50.0
@@ -32,6 +33,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/hashicorp/hcl/v2 v2.24.0 h1:2QJdZ454DSsYGoaE6QheQZjtKZSUs9Nh2izTWiwQx
 github.com/hashicorp/hcl/v2 v2.24.0/go.mod h1:oGoO1FIQYfn/AgyOhlg9qLC6/nOJPX3qGbkZpYAcqfM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/klauspost/cpuid/v2 v2.0.12 h1:p9dKCg8i4gmOxtv35DvrYoWqYzQrvEVdjQ762Y0OqZE=
+github.com/klauspost/cpuid/v2 v2.0.12/go.mod h1:g2LTdtYhdyuGPqyWyv7qRAmj1WBqxuObKfj5c0PQa7c=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -99,6 +101,12 @@ github.com/zclconf/go-cty v1.16.3 h1:osr++gw2T61A8KVYHoQiFbFd1Lh3JOCXc/jFLJXKTxk
 github.com/zclconf/go-cty v1.16.3/go.mod h1:VvMs5i0vgZdhYawQNq5kePSpLAoz8u1xvZgrPIxfnZE=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940 h1:4r45xpDWB6ZMSMNJFMOjqrGHynW3DIBuR2H9j0ug+Mo=
 github.com/zclconf/go-cty-debug v0.0.0-20240509010212-0d6042c53940/go.mod h1:CmBdvvj3nqzfzJ6nTCIwDTPZ56aVGvDrmztiO5g3qrM=
+github.com/zeebo/assert v1.1.0 h1:hU1L1vLTHsnO8x8c9KAR5GmM5QscxHg5RNU5z5qbUWY=
+github.com/zeebo/assert v1.1.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
+github.com/zeebo/blake3 v0.2.4 h1:KYQPkhpRtcqh0ssGYcKLG1JYvddkEA8QwCM/yBqhaZI=
+github.com/zeebo/blake3 v0.2.4/go.mod h1:7eeQ6d2iXWRGF6npfaxl2CU+xy2Fjo2gxeyZGCRUjcE=
+github.com/zeebo/pcg v1.0.1 h1:lyqfGeWiv4ahac6ttHs+I5hwtH/+1mrhlCtVNQM2kHo=
+github.com/zeebo/pcg v1.0.1/go.mod h1:09F0S9iiKrwn9rlI5yjLkmrug154/YRW6KnnXVDM/l4=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -122,10 +122,16 @@ func (c *Controller) GetCurrentRoot() [32]byte {
 	return out
 }
 
-// GetArenaPath returns the path to the currently active arena. The
-// Acquire-load on the sync atom fences the subsequent path-byte reads
-// against the writer's Release-store, so concurrent SetArena callers
-// can't be observed mid-update (zeroed prefix, partial copy).
+// GetArenaPath returns the path to the currently active arena.
+//
+// The Acquire-load on the sync atom only fences the subsequent path-byte
+// reads against publishes that have completed (sync bumped) by the time
+// we load it; a writer that begins after the load and writes bytes before
+// bumping sync can still produce a torn read here. End-to-end safety
+// against torn reads relies on the BLAKE3 current_root check at the
+// callsite — the path bytes alone are advisory. If a stronger guarantee
+// is needed, the writer needs a seqlock-style protocol (bump-then-write-
+// then-bump, with reader retry on odd / mismatched seq).
 func (c *Controller) GetArenaPath() string {
 	atomic.LoadUint64((*uint64)(unsafe.Pointer(&c.data[offSync])))
 	b := c.data[offArenaPath : offArenaPath+arenaPathLen]

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,35 +15,48 @@ import (
 const (
 	ControlSize = 4096       // 1 page
 	Magic       = 0x4C455943 // 'LEYC'
+	// Version 2 is the current control-block layout: identity is the BLAKE3
+	// `current_root` of the arena payload. Old (v1) controllers — which
+	// exposed a monotonic `generation` counter instead — are rejected with
+	// a descriptive error so cross-version mismatches fail loudly.
+	Version = 2
 )
 
-// Block represents the memory-mapped control file.
-// It must match the C layout exactly for interoperability.
-type Block struct {
-	Magic      uint32
-	Version    uint32
-	Generation uint64 // Atomic
-	ArenaPath  [256]byte
-	ArenaSize  uint64
-	Padding    [ControlSize - 272]byte // Pad to 4096 bytes
-}
+// Field offsets must match LLO `rs/ll-core/core/src/control.rs` exactly.
+// Bytes 8..16 (the old `Generation` slot) are now used as a private
+// sync atom for Acquire/Release fencing — no public surface.
+const (
+	offMagic          = 0
+	offVersion        = 4
+	offSync           = 8 // private fence atom (formerly Generation)
+	offArenaPath      = 16
+	arenaPathLen      = 256
+	offArenaSize      = 272
+	offInterruptFlags = 280
+	offInterruptEpoch = 288
+	offInterruptAck   = 296
+	offPayloadOffset  = 304
+	offPayloadLen     = 312
+	offCurrentRoot    = 320
+	currentRootLen    = 32
+)
 
 // Controller manages the memory-mapped control file.
 type Controller struct {
 	path string
 	file *os.File
 	data []byte
-	ptr  *Block
 }
 
 // OpenOrCreate opens or creates a control file at the given path.
+// Rejects mismatched VERSION with a clear error so old mache binaries
+// reading new control blocks (or vice versa) fail loudly rather than
+// silently misinterpreting the layout.
 func OpenOrCreate(path string) (*Controller, error) {
-	// Validate path security
 	if err := validatePath(path); err != nil {
 		return nil, err
 	}
 
-	// Ensure directory exists
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return nil, fmt.Errorf("mkdir: %w", err)
 	}
@@ -71,35 +85,46 @@ func OpenOrCreate(path string) (*Controller, error) {
 		return nil, fmt.Errorf("mmap: %w", err)
 	}
 
-	ptr := (*Block)(unsafe.Pointer(&data[0]))
-
-	// Initialize if new
-	if ptr.Magic == 0 {
-		ptr.Magic = Magic
-		ptr.Version = 1
-	} else if ptr.Magic != Magic {
+	existingMagic := *(*uint32)(unsafe.Pointer(&data[offMagic]))
+	switch {
+	case existingMagic == 0:
+		*(*uint32)(unsafe.Pointer(&data[offMagic])) = Magic
+		*(*uint32)(unsafe.Pointer(&data[offVersion])) = Version
+	case existingMagic != Magic:
 		_ = unix.Munmap(data)
 		_ = f.Close()
-		return nil, fmt.Errorf("invalid magic: %x", ptr.Magic)
+		return nil, fmt.Errorf("invalid control block magic: 0x%08X", existingMagic)
+	default:
+		existingVersion := *(*uint32)(unsafe.Pointer(&data[offVersion]))
+		if existingVersion != Version {
+			_ = unix.Munmap(data)
+			_ = f.Close()
+			return nil, fmt.Errorf(
+				"control block version mismatch: file is v%d, expected v%d — "+
+					"remove the stale .ctrl file and let a current writer (ley-line-open ≥ 0.2.0) recreate it",
+				existingVersion, Version,
+			)
+		}
 	}
 
-	return &Controller{
-		path: path,
-		file: f,
-		data: data,
-		ptr:  ptr,
-	}, nil
+	return &Controller{path: path, file: f, data: data}, nil
 }
 
-// GetGeneration returns the current generation ID atomically.
-func (c *Controller) GetGeneration() uint64 {
-	return atomic.LoadUint64(&c.ptr.Generation)
+// GetCurrentRoot returns the BLAKE3 root hash of the arena payload that
+// the writer most recently published. An Acquire-load on the private
+// sync atom fences the subsequent root-byte reads against the writer's
+// Release-store + write. The zero sentinel `[32]byte{}` means no
+// snapshot has been published yet (fresh controller).
+func (c *Controller) GetCurrentRoot() [32]byte {
+	atomic.LoadUint64((*uint64)(unsafe.Pointer(&c.data[offSync])))
+	var out [32]byte
+	copy(out[:], c.data[offCurrentRoot:offCurrentRoot+currentRootLen])
+	return out
 }
 
 // GetArenaPath returns the path to the currently active arena.
 func (c *Controller) GetArenaPath() string {
-	// Simple null-terminated string read
-	b := c.ptr.ArenaPath[:]
+	b := c.data[offArenaPath : offArenaPath+arenaPathLen]
 	for i, v := range b {
 		if v == 0 {
 			return string(b[:i])
@@ -108,24 +133,63 @@ func (c *Controller) GetArenaPath() string {
 	return string(b)
 }
 
-// SetArena atomically updates the control block to point to a new arena.
-func (c *Controller) SetArena(path string, size, generation uint64) error {
-	if len(path) >= len(c.ptr.ArenaPath) {
-		return fmt.Errorf("path too long (max %d)", len(c.ptr.ArenaPath)-1)
+// GetArenaSize returns the size in bytes of the currently active arena file.
+func (c *Controller) GetArenaSize() uint64 {
+	return atomic.LoadUint64((*uint64)(unsafe.Pointer(&c.data[offArenaSize])))
+}
+
+// SetArena atomically updates the control block to point to a new arena
+// without changing `current_root`. Bumps the private sync atom so
+// readers fence and re-read path/size.
+//
+// Use SetArenaWithRoot when publishing a new snapshot (i.e. when the
+// payload bytes changed). Use SetArena when only the path/size moved
+// but the root remains the previous value.
+func (c *Controller) SetArena(path string, size uint64) error {
+	if len(path) >= arenaPathLen {
+		return fmt.Errorf("path too long (max %d)", arenaPathLen-1)
 	}
 
-	// Update fields
-	copy(c.ptr.ArenaPath[:], path)
-	c.ptr.ArenaPath[len(path)] = 0 // Null terminate
-	c.ptr.ArenaSize = size
+	pathBuf := c.data[offArenaPath : offArenaPath+arenaPathLen]
+	for i := range pathBuf {
+		pathBuf[i] = 0
+	}
+	copy(pathBuf, path)
 
-	// Memory barrier before generation update (Go atomic handles this)
-	atomic.StoreUint64(&c.ptr.Generation, generation)
+	*(*uint64)(unsafe.Pointer(&c.data[offArenaSize])) = size
 
-	// msync to ensure durability (optional but good for crash consistency)
-	// unix.Msync(c.data, unix.MS_SYNC)
-
+	atomic.AddUint64((*uint64)(unsafe.Pointer(&c.data[offSync])), 1)
 	return nil
+}
+
+// SetArenaWithRoot atomically publishes a new arena and the BLAKE3 root
+// of its payload. Readers polling GetCurrentRoot observe a coherent
+// (path, size, root) triple thanks to the Release-store fence on the
+// sync atom.
+func (c *Controller) SetArenaWithRoot(path string, size uint64, root [32]byte) error {
+	if len(path) >= arenaPathLen {
+		return fmt.Errorf("path too long (max %d)", arenaPathLen-1)
+	}
+
+	pathBuf := c.data[offArenaPath : offArenaPath+arenaPathLen]
+	for i := range pathBuf {
+		pathBuf[i] = 0
+	}
+	copy(pathBuf, path)
+
+	*(*uint64)(unsafe.Pointer(&c.data[offArenaSize])) = size
+
+	copy(c.data[offCurrentRoot:offCurrentRoot+currentRootLen], root[:])
+
+	atomic.AddUint64((*uint64)(unsafe.Pointer(&c.data[offSync])), 1)
+	return nil
+}
+
+// IsZeroRoot reports whether root is the all-zero sentinel that
+// indicates "no snapshot has been published yet."
+func IsZeroRoot(root [32]byte) bool {
+	var zero [32]byte
+	return subtle.ConstantTimeCompare(root[:], zero[:]) == 1
 }
 
 // Close unmaps and closes the control file.

--- a/internal/control/control.go
+++ b/internal/control/control.go
@@ -122,8 +122,12 @@ func (c *Controller) GetCurrentRoot() [32]byte {
 	return out
 }
 
-// GetArenaPath returns the path to the currently active arena.
+// GetArenaPath returns the path to the currently active arena. The
+// Acquire-load on the sync atom fences the subsequent path-byte reads
+// against the writer's Release-store, so concurrent SetArena callers
+// can't be observed mid-update (zeroed prefix, partial copy).
 func (c *Controller) GetArenaPath() string {
+	atomic.LoadUint64((*uint64)(unsafe.Pointer(&c.data[offSync])))
 	b := c.data[offArenaPath : offArenaPath+arenaPathLen]
 	for i, v := range b {
 		if v == 0 {
@@ -156,7 +160,7 @@ func (c *Controller) SetArena(path string, size uint64) error {
 	}
 	copy(pathBuf, path)
 
-	*(*uint64)(unsafe.Pointer(&c.data[offArenaSize])) = size
+	atomic.StoreUint64((*uint64)(unsafe.Pointer(&c.data[offArenaSize])), size)
 
 	atomic.AddUint64((*uint64)(unsafe.Pointer(&c.data[offSync])), 1)
 	return nil
@@ -177,7 +181,7 @@ func (c *Controller) SetArenaWithRoot(path string, size uint64, root [32]byte) e
 	}
 	copy(pathBuf, path)
 
-	*(*uint64)(unsafe.Pointer(&c.data[offArenaSize])) = size
+	atomic.StoreUint64((*uint64)(unsafe.Pointer(&c.data[offArenaSize])), size)
 
 	copy(c.data[offCurrentRoot:offCurrentRoot+currentRootLen], root[:])
 

--- a/internal/graph/arena.go
+++ b/internal/graph/arena.go
@@ -10,19 +10,33 @@ import (
 const (
 	ArenaHeaderSize = 4096
 	ArenaMagic      = 0x4C455930
+	// ArenaVersion is the current wire-format. v1 arenas inferred payload
+	// length from the SQLite header (db page_count × page_size); v2
+	// records DataSize explicitly so readers stay format-agnostic.
+	ArenaVersion = 2
+	// arenaHeaderBytes is the on-disk size of the ArenaHeader struct.
+	arenaHeaderBytes = 24
 )
 
+// ArenaHeader mirrors `rs/ll-core/core/src/layout.rs::ArenaHeader` in LLO.
+// Byte layout: magic u32 | version u8 | active_buffer u8 | padding [2]u8 |
+// sequence u64 | data_size u64 — total 24 bytes, aligned to a 4096-byte page.
 type ArenaHeader struct {
 	Magic        uint32
 	Version      uint8
 	ActiveBuffer uint8
 	Padding      [2]byte
 	Sequence     uint64
+	// DataSize is the exact byte length of the live payload in the
+	// active buffer. Lets a reader hash `buf[..DataSize]` and compare
+	// against the controller's current_root without parsing the
+	// payload's own format (e.g. SQLite page count).
+	DataSize uint64
 }
 
-// ReadArenaHeader reads the 4KB header from the file.
+// ReadArenaHeader reads the on-disk header from the file.
 func ReadArenaHeader(f *os.File) (*ArenaHeader, error) {
-	buf := make([]byte, 16) // Struct size is 16 bytes
+	buf := make([]byte, arenaHeaderBytes)
 	if _, err := f.ReadAt(buf, 0); err != nil {
 		return nil, err
 	}
@@ -32,6 +46,7 @@ func ReadArenaHeader(f *os.File) (*ArenaHeader, error) {
 		Version:      buf[4],
 		ActiveBuffer: buf[5],
 		Sequence:     binary.LittleEndian.Uint64(buf[8:16]),
+		DataSize:     binary.LittleEndian.Uint64(buf[16:24]),
 	}
 
 	return h, nil
@@ -42,8 +57,8 @@ func (h *ArenaHeader) CalculateActiveOffset(fileSize int64) (int64, error) {
 	if h.Magic != ArenaMagic {
 		return 0, fmt.Errorf("invalid arena magic: %x", h.Magic)
 	}
-	if h.Version != 1 {
-		return 0, fmt.Errorf("unsupported arena version: %d", h.Version)
+	if h.Version != ArenaVersion {
+		return 0, fmt.Errorf("unsupported arena version: file is v%d, expected v%d — ensure ley-line-open ≥ 0.2.0", h.Version, ArenaVersion)
 	}
 	if h.ActiveBuffer > 1 {
 		return 0, fmt.Errorf("invalid active buffer index: %d", h.ActiveBuffer)
@@ -58,14 +73,15 @@ func (h *ArenaHeader) CalculateActiveOffset(fileSize int64) (int64, error) {
 	return offset, nil
 }
 
-// WriteArenaHeader serializes an ArenaHeader to the first 16 bytes at offset 0.
+// WriteArenaHeader serializes an ArenaHeader to the first 24 bytes at offset 0.
 func WriteArenaHeader(f *os.File, h *ArenaHeader) error {
-	buf := make([]byte, 16)
+	buf := make([]byte, arenaHeaderBytes)
 	binary.LittleEndian.PutUint32(buf[0:4], h.Magic)
 	buf[4] = h.Version
 	buf[5] = h.ActiveBuffer
 	// buf[6:8] padding = 0
 	binary.LittleEndian.PutUint64(buf[8:16], h.Sequence)
+	binary.LittleEndian.PutUint64(buf[16:24], h.DataSize)
 	_, err := f.WriteAt(buf, 0)
 	return err
 }
@@ -100,9 +116,10 @@ func CreateArena(dbPath, arenaPath string) error {
 	// Write header
 	h := &ArenaHeader{
 		Magic:        ArenaMagic,
-		Version:      1,
+		Version:      ArenaVersion,
 		ActiveBuffer: 0,
 		Sequence:     1,
+		DataSize:     uint64(len(dbBytes)),
 	}
 	if err := WriteArenaHeader(f, h); err != nil {
 		return fmt.Errorf("write header: %w", err)

--- a/internal/graph/arena.go
+++ b/internal/graph/arena.go
@@ -157,8 +157,14 @@ func ExtractActiveDB(arenaPath string) (string, error) {
 		return "", err
 	}
 
-	// Calculate size (half of arena minus header)
-	size := (info.Size() - ArenaHeaderSize) / 2
+	// Prefer the explicit DataSize from the header — it's the exact
+	// payload length the writer published. Fall back to the full
+	// half-buffer only when DataSize is missing or out of range.
+	bufferSize := (info.Size() - ArenaHeaderSize) / 2
+	size := int64(header.DataSize)
+	if size <= 0 || size > bufferSize {
+		size = bufferSize
+	}
 
 	// Create temp file — remove on any error after this point.
 	tmp, err := os.CreateTemp("", "mache-arena-*.db")

--- a/internal/graph/arena_test.go
+++ b/internal/graph/arena_test.go
@@ -25,9 +25,10 @@ func TestArenaHeader_RoundTrip(t *testing.T) {
 
 	want := &ArenaHeader{
 		Magic:        ArenaMagic,
-		Version:      1,
+		Version:      ArenaVersion,
 		ActiveBuffer: 1,
 		Sequence:     42,
+		DataSize:     8192,
 	}
 	require.NoError(t, WriteArenaHeader(f, want))
 
@@ -37,6 +38,7 @@ func TestArenaHeader_RoundTrip(t *testing.T) {
 	assert.Equal(t, want.Version, got.Version)
 	assert.Equal(t, want.ActiveBuffer, got.ActiveBuffer)
 	assert.Equal(t, want.Sequence, got.Sequence)
+	assert.Equal(t, want.DataSize, got.DataSize, "DataSize must round-trip — readers hash buf[..DataSize] to verify against the controller's current_root")
 }
 
 func TestArenaHeader_CalculateActiveOffset_HappyPath(t *testing.T) {
@@ -55,7 +57,7 @@ func TestArenaHeader_CalculateActiveOffset_HappyPath(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			h := &ArenaHeader{
-				Magic: ArenaMagic, Version: 1, ActiveBuffer: tc.active,
+				Magic: ArenaMagic, Version: ArenaVersion, ActiveBuffer: tc.active,
 			}
 			got, err := h.CalculateActiveOffset(fileSize)
 			require.NoError(t, err)
@@ -65,7 +67,7 @@ func TestArenaHeader_CalculateActiveOffset_HappyPath(t *testing.T) {
 }
 
 func TestArenaHeader_CalculateActiveOffset_RejectsInvalidMagic(t *testing.T) {
-	h := &ArenaHeader{Magic: 0xDEADBEEF, Version: 1}
+	h := &ArenaHeader{Magic: 0xDEADBEEF, Version: ArenaVersion}
 	_, err := h.CalculateActiveOffset(ArenaHeaderSize + 8192)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid arena magic")
@@ -78,9 +80,19 @@ func TestArenaHeader_CalculateActiveOffset_RejectsUnsupportedVersion(t *testing.
 	assert.Contains(t, err.Error(), "unsupported arena version")
 }
 
+func TestArenaHeader_CalculateActiveOffset_RejectsLegacyV1(t *testing.T) {
+	// Pre-v2 arenas must be rejected loudly so a binary reading a stale
+	// .arena (or vice versa) fails with a clear message rather than
+	// silently misinterpreting DataSize bytes.
+	h := &ArenaHeader{Magic: ArenaMagic, Version: 1}
+	_, err := h.CalculateActiveOffset(ArenaHeaderSize + 8192)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported arena version")
+}
+
 func TestArenaHeader_CalculateActiveOffset_RejectsInvalidActiveBuffer(t *testing.T) {
 	// Only 0 and 1 are valid (double-buffered). Anything else is corruption.
-	h := &ArenaHeader{Magic: ArenaMagic, Version: 1, ActiveBuffer: 2}
+	h := &ArenaHeader{Magic: ArenaMagic, Version: ArenaVersion, ActiveBuffer: 2}
 	_, err := h.CalculateActiveOffset(ArenaHeaderSize + 8192)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid active buffer index")
@@ -89,7 +101,7 @@ func TestArenaHeader_CalculateActiveOffset_RejectsInvalidActiveBuffer(t *testing
 func TestArenaHeader_CalculateActiveOffset_RejectsTooSmallFile(t *testing.T) {
 	// File is only the header — no buffer space. Treating bufferSize=0
 	// as "valid offset 4096" would let callers read past EOF.
-	h := &ArenaHeader{Magic: ArenaMagic, Version: 1}
+	h := &ArenaHeader{Magic: ArenaMagic, Version: ArenaVersion}
 	_, err := h.CalculateActiveOffset(ArenaHeaderSize)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid arena size")

--- a/internal/graph/arena_writer.go
+++ b/internal/graph/arena_writer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/agentic-research/mache/internal/control"
+	"github.com/zeebo/blake3"
 )
 
 // ArenaFlusher writes a serialized .db file into the double-buffered arena
@@ -155,6 +156,16 @@ func (f *ArenaFlusher) flushInternal() error {
 		return fmt.Errorf("read arena header: %w", err)
 	}
 
+	// Reject legacy arenas before writing — flushing into a v1 arena
+	// would leave its Version byte at 1, producing a file that new
+	// readers reject. Loud failure here beats silent corruption.
+	if header.Magic != ArenaMagic {
+		return fmt.Errorf("flush: invalid arena magic 0x%x (file is not a mache arena)", header.Magic)
+	}
+	if header.Version != ArenaVersion {
+		return fmt.Errorf("flush: unsupported arena version: file is v%d, expected v%d — recreate this arena with a current writer", header.Version, ArenaVersion)
+	}
+
 	// Calculate buffer geometry
 	bufferSize := (info.Size() - ArenaHeaderSize) / 2
 	if int64(len(dbBytes)) > bufferSize {
@@ -215,6 +226,10 @@ func (f *ArenaFlusher) flushInternal() error {
 
 	// Flip header: active_buffer ^= 1, sequence++, record exact data size
 	// so readers can hash buf[..DataSize] without parsing SQLite internals.
+	// Force Version to the current expected value so readers can't see a
+	// stale v1 byte even if the file on disk somehow drifted.
+	header.Magic = ArenaMagic
+	header.Version = ArenaVersion
 	header.ActiveBuffer = inactive
 	header.Sequence++
 	header.DataSize = uint64(len(dbBytes))
@@ -226,15 +241,13 @@ func (f *ArenaFlusher) flushInternal() error {
 		return fmt.Errorf("sync arena: %w", err)
 	}
 
-	// Update control block so ley-line detects the change. We don't compute
-	// a BLAKE3 root here — mache as a writer hasn't traditionally needed
-	// content-addressable identity, so SetArena (no root) preserves the
-	// previous current_root value while bumping the sync atom enough for
-	// readers to fence and re-read path/size. If a future change wants
-	// content-addressable identity even when mache is the writer, swap to
-	// SetArenaWithRoot and pass blake3.Sum256(dbBytes).
+	// Publish the new payload's BLAKE3 root atomically alongside the
+	// path+size update. Readers polling current_root for hot-swap
+	// detection will see this transition; SetArena (no root) would
+	// have advertised a stale root for a changed payload.
 	if f.ctrl != nil {
-		if err := f.ctrl.SetArena(f.arenaPath, uint64(info.Size())); err != nil {
+		root := blake3.Sum256(dbBytes)
+		if err := f.ctrl.SetArenaWithRoot(f.arenaPath, uint64(info.Size()), root); err != nil {
 			return fmt.Errorf("update control block: %w", err)
 		}
 	}

--- a/internal/graph/arena_writer.go
+++ b/internal/graph/arena_writer.go
@@ -213,9 +213,11 @@ func (f *ArenaFlusher) flushInternal() error {
 		}
 	}
 
-	// Flip header: active_buffer ^= 1, sequence++
+	// Flip header: active_buffer ^= 1, sequence++, record exact data size
+	// so readers can hash buf[..DataSize] without parsing SQLite internals.
 	header.ActiveBuffer = inactive
 	header.Sequence++
+	header.DataSize = uint64(len(dbBytes))
 	if err := WriteArenaHeader(af, header); err != nil {
 		return fmt.Errorf("write arena header: %w", err)
 	}
@@ -224,9 +226,15 @@ func (f *ArenaFlusher) flushInternal() error {
 		return fmt.Errorf("sync arena: %w", err)
 	}
 
-	// Update control block so ley-line detects the change
+	// Update control block so ley-line detects the change. We don't compute
+	// a BLAKE3 root here — mache as a writer hasn't traditionally needed
+	// content-addressable identity, so SetArena (no root) preserves the
+	// previous current_root value while bumping the sync atom enough for
+	// readers to fence and re-read path/size. If a future change wants
+	// content-addressable identity even when mache is the writer, swap to
+	// SetArenaWithRoot and pass blake3.Sum256(dbBytes).
 	if f.ctrl != nil {
-		if err := f.ctrl.SetArena(f.arenaPath, uint64(info.Size()), header.Sequence); err != nil {
+		if err := f.ctrl.SetArena(f.arenaPath, uint64(info.Size())); err != nil {
 			return fmt.Errorf("update control block: %w", err)
 		}
 	}

--- a/internal/graph/arena_writer_test.go
+++ b/internal/graph/arena_writer_test.go
@@ -38,9 +38,10 @@ func TestCreateArena(t *testing.T) {
 	h, err := ReadArenaHeader(f)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(ArenaMagic), h.Magic)
-	assert.Equal(t, uint8(1), h.Version)
+	assert.Equal(t, uint8(ArenaVersion), h.Version)
 	assert.Equal(t, uint8(0), h.ActiveBuffer)
 	assert.Equal(t, uint64(1), h.Sequence)
+	assert.NotZero(t, h.DataSize, "DataSize must be populated by CreateArena — readers hash buf[..DataSize] to verify against the controller's current_root")
 
 	// Verify we can extract the DB back
 	extractedPath, err := ExtractActiveDB(arenaPath)


### PR DESCRIPTION
## Summary

Pairs with ley-line-open's breaking change (LLO v0.2.0). Substrate identity is now `current_root` (BLAKE3 over arena payload) instead of a monotonic generation counter. Both `.ctrl` (control block) and `.arena` headers bump VERSION 1 → 2; cross-version reads fail loudly.

Closes mache-1afff0. Pairs structurally with mache-36d961 (CGO-removal epic) — same release wave.

## What changed

**`internal/control/control.go`** — Block layout now mirrors LLO's exact byte offsets (interrupt fields + `current_root` at offset 320). The old generation slot is now a private sync atom used purely for Acquire/Release fencing.
- `GetGeneration() uint64` → `GetCurrentRoot() [32]byte`
- `SetArena(path, size)` — no more generation arg
- `SetArenaWithRoot(path, size, root)` — new; publishes a new substrate root
- VERSION mismatch returns a descriptive error (file v%d, expected v%d, "remove the stale .ctrl file…")

**`internal/graph/arena.go`** — ArenaHeader grows from 16 → 24 bytes:
- `DataSize uint64` records the exact payload length so readers can hash `buf[..DataSize]` without parsing SQLite internals
- `Version` expectation bumps to 2; v1 arenas are rejected

**`cmd/mount.go`** — hot-swap polling rewritten:
- `currentGen <= lastGen` → `currentRoot != lastRoot`
- Zero-root sentinel rendered as `<zero>` for fresh controllers
- Log lines show short root prefix instead of a generation int

**`internal/graph/arena_writer.go`** — flusher writes `DataSize` and uses the 2-arg `SetArena`. Comment notes a future option to call `SetArenaWithRoot(blake3.Sum256(dbBytes))` if mache as a writer needs content-addressable identity.

**Tests** — `arena_test.go` and `arena_writer_test.go` updated to assert v2 + `DataSize` round-trip; new `TestArenaHeader_CalculateActiveOffset_RejectsLegacyV1` pins the loud-failure contract.

## Coordination

- LLO v0.2.0 + mache **v0.8.0** ship as a paired release (mache is already past v0.2.0; this PR cuts the next minor since mache is pre-1.0 and the change is breaking)
- Old mache reading new arena → version mismatch (loud, correct)
- New mache reading old arena → same (loud, correct)
- mache-9051f0 (auto-download URL, P2) is the third leg of this wave
- mache-36d961 (CGO removal epic) lands in the same wave once mache-33dc5f (LLO release-bundling) clears

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/control/... ./internal/graph/...` — green
- [x] `task fmt` clean
- [x] `task vet` clean
- [ ] Smoke: real `leyline serve` (post-LLO-0.2.0) → mache mount → trigger reparse → verify hot-swap fires
- [ ] CI on this PR

## Notes

- `internal/leyline/sheaf.go` was checked but **not** changed: the T2.4 wire-format sweep affected `op_status / op_flush / op_load / op_reparse / op_enrich / op_snapshot` (which mache doesn't call directly — it reads via the mmap'd Controller). The `sheaf_*` ops are a separate API surface and their `generation` field is a sheaf-revision concept, not substrate identity.
- All internal task IDs scrubbed from user-facing strings, comments, and test messages — error messages and docstrings use plain English instead of project shorthand.
