### PR TITLE
feat(udsGraph): typed daemon-response decode + leyline-schema v0.3.0

### DIFF
--- a/cmd/uds_graph.go
+++ b/cmd/uds_graph.go
@@ -30,27 +30,22 @@ func (g *udsGraph) GetNode(id string) (*graph.Node, error) {
 		return &graph.Node{ID: "", Mode: os.ModeDir | 0o555}, nil
 	}
 
-	resp, err := g.sock.SendOp(map[string]any{
+	var resp leyline.GetNodeResponse
+	if err := g.sock.SendOpInto(map[string]any{
 		"op": "get_node",
 		"id": id,
-	})
-	if err != nil {
+	}, &resp); err != nil {
 		return nil, err
 	}
-	if ok, _ := resp["ok"].(bool); !ok {
+	if !boolVal(resp.OK) || resp.Node == nil {
 		return nil, graph.ErrNotFound
 	}
 
-	nodeData, _ := resp["node"].(map[string]any)
-	if nodeData == nil {
-		return nil, graph.ErrNotFound
-	}
-
-	kind := toInt(nodeData["kind"])
-	size := toInt64(nodeData["size"])
+	kind := int32Val(resp.Node.Kind)
+	size := int64Val(resp.Node.Size)
 
 	mode := os.FileMode(0o444)
-	if kind == graph.NodeKindDir {
+	if int(kind) == graph.NodeKindDir {
 		mode = os.ModeDir | 0o555
 	}
 
@@ -58,39 +53,37 @@ func (g *udsGraph) GetNode(id string) (*graph.Node, error) {
 		ID:   id,
 		Mode: mode,
 	}
-	if kind == graph.NodeKindFile {
+	if int(kind) == graph.NodeKindFile {
 		node.Ref = &graph.ContentRef{ContentLen: size}
 	}
-
-	// Try to get record content for ReadContent
-	if record, ok := nodeData["record"].(string); ok && record != "" {
-		node.Data = []byte(record)
+	if resp.Node.Record != nil && *resp.Node.Record != "" {
+		node.Data = []byte(*resp.Node.Record)
 	}
 
 	return node, nil
 }
 
-// listChildrenResponse fetches the daemon's `list_children` response. The
-// daemon returns `[{id, name, kind, size}, ...]` per child (single-shot
-// stats, see rs/ll-open/cli-lib/src/daemon/ops.rs::op_list_children) —
-// not bare ID strings. ListChildren and ListChildStats both consume the
-// same payload; this helper centralizes the JSON parse + error envelope
-// so the two stay in lock-step and don't misread a daemon error as an
-// empty directory.
-func (g *udsGraph) listChildrenResponse(id string) ([]map[string]any, error) {
-	resp, err := g.sock.SendOp(map[string]any{
+// listChildren issues the daemon's `list_children` op. The daemon returns
+// `[{id, name, kind, size}, ...]` per child (single-shot stats, see
+// rs/ll-open/cli-lib/src/daemon/ops.rs::op_list_children) — not bare ID
+// strings. ListChildren and ListChildStats both consume the same payload;
+// this helper centralizes the JSON decode + error envelope so the two stay
+// in lock-step and don't misread a daemon error as an empty directory.
+func (g *udsGraph) listChildren(id string) ([]leyline.Node, error) {
+	var resp leyline.ListChildrenResponse
+	if err := g.sock.SendOpInto(map[string]any{
 		"op": "list_children",
 		"id": id,
-	})
-	if err != nil {
+	}, &resp); err != nil {
 		return nil, err
 	}
 	// Daemon signals failure via {"ok": false, "error": "..."}. Match the
 	// shape SQLiteGraph uses — missing-node returns graph.ErrNotFound so
 	// readdir on a stale ID surfaces cleanly instead of looking like a
 	// successful read of an empty dir.
-	if ok, _ := resp["ok"].(bool); !ok {
-		if msg, _ := resp["error"].(string); msg != "" {
+	if !boolVal(resp.OK) {
+		msg := strVal(resp.Error)
+		if msg != "" {
 			if strings.Contains(strings.ToLower(msg), "not found") {
 				return nil, graph.ErrNotFound
 			}
@@ -98,25 +91,18 @@ func (g *udsGraph) listChildrenResponse(id string) ([]map[string]any, error) {
 		}
 		return nil, fmt.Errorf("list_children %q: daemon returned ok=false", id)
 	}
-	raw, _ := resp["children"].([]any)
-	out := make([]map[string]any, 0, len(raw))
-	for _, c := range raw {
-		if m, ok := c.(map[string]any); ok {
-			out = append(out, m)
-		}
-	}
-	return out, nil
+	return resp.Children, nil
 }
 
 func (g *udsGraph) ListChildren(id string) ([]string, error) {
 	id = graph.NormalizeID(id)
-	children, err := g.listChildrenResponse(id)
+	children, err := g.listChildren(id)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]string, 0, len(children))
-	for _, c := range children {
-		if s, ok := c["id"].(string); ok && s != "" {
+	for i := range children {
+		if s := strVal(children[i].ID); s != "" {
 			out = append(out, s)
 		}
 	}
@@ -125,20 +111,20 @@ func (g *udsGraph) ListChildren(id string) ([]string, error) {
 
 func (g *udsGraph) ListChildStats(id string) ([]graph.NodeStat, error) {
 	id = graph.NormalizeID(id)
-	children, err := g.listChildrenResponse(id)
+	children, err := g.listChildren(id)
 	if err != nil {
 		return nil, err
 	}
 	stats := make([]graph.NodeStat, 0, len(children))
-	for _, c := range children {
-		cid, _ := c["id"].(string)
+	for i := range children {
+		cid := strVal(children[i].ID)
 		if cid == "" {
 			continue
 		}
 		stats = append(stats, graph.NodeStat{
 			ID:          cid,
-			IsDir:       toInt(c["kind"]) == graph.NodeKindDir,
-			ContentSize: toInt64(c["size"]),
+			IsDir:       int(int32Val(children[i].Kind)) == graph.NodeKindDir,
+			ContentSize: int64Val(children[i].Size),
 		})
 	}
 	return stats, nil
@@ -147,38 +133,32 @@ func (g *udsGraph) ListChildStats(id string) ([]graph.NodeStat, error) {
 func (g *udsGraph) ReadContent(id string, buf []byte, offset int64) (int, error) {
 	id = graph.NormalizeID(id)
 
-	resp, err := g.sock.SendOp(map[string]any{
+	var resp leyline.ReadContentResponse
+	if err := g.sock.SendOpInto(map[string]any{
 		"op": "read_content",
 		"id": id,
-	})
-	if err != nil {
+	}, &resp); err != nil {
 		return 0, err
 	}
-	if ok, _ := resp["ok"].(bool); !ok {
+	if !boolVal(resp.OK) {
 		return 0, graph.ErrNotFound
 	}
 
-	content, _ := resp["content"].(string)
-	return graph.SliceContent([]byte(content), buf, offset), nil
+	return graph.SliceContent([]byte(strVal(resp.Content)), buf, offset), nil
 }
 
 func (g *udsGraph) GetCallers(token string) ([]*graph.Node, error) {
-	resp, err := g.sock.SendOp(map[string]any{
+	var resp leyline.FindCallersResponse
+	if err := g.sock.SendOpInto(map[string]any{
 		"op":    "find_callers",
 		"token": token,
-	})
-	if err != nil {
+	}, &resp); err != nil {
 		return nil, err
 	}
 
-	rawCallers, _ := resp["callers"].([]any)
-	nodes := make([]*graph.Node, 0, len(rawCallers))
-	for _, c := range rawCallers {
-		row, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		nodeID, _ := row["node_id"].(string)
+	nodes := make([]*graph.Node, 0, len(resp.Callers))
+	for i := range resp.Callers {
+		nodeID := strVal(resp.Callers[i].NodeID)
 		if nodeID != "" {
 			nodes = append(nodes, &graph.Node{
 				ID:   nodeID,
@@ -206,32 +186,27 @@ func (g *udsGraph) GetCallees(id string) ([]*graph.Node, error) {
 		return nil, nil
 	}
 
-	resp, err := g.sock.SendOp(map[string]any{
+	var resp leyline.FindCalleesResponse
+	if err := g.sock.SendOpInto(map[string]any{
 		"op": "find_callees",
 		"id": id,
-	})
-	if err != nil {
+	}, &resp); err != nil {
 		return nil, err
 	}
-	if ok, _ := resp["ok"].(bool); !ok {
+	if !boolVal(resp.OK) {
 		// Match the "no callees found" semantics other backends use —
 		// missing-node or empty-result is not an error condition for
 		// this query, just an empty edge set.
 		return nil, nil
 	}
 
-	rawCallees, _ := resp["callees"].([]any)
-	nodes := make([]*graph.Node, 0, len(rawCallees))
+	nodes := make([]*graph.Node, 0, len(resp.Callees))
 	// Compare in normalized form so daemon-returned "/pkg/X" matches our
-	// already-normalized input id "pkg/X" — otherwise the self-edge slip
+	// already-normalized input id "pkg/X" — otherwise the self-edge slips
 	// past and `find_callees(F)` lists F itself.
 	seen := map[string]bool{id: true}
-	for _, c := range rawCallees {
-		row, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		nodeID, _ := row["node_id"].(string)
+	for i := range resp.Callees {
+		nodeID := strVal(resp.Callees[i].NodeID)
 		if nodeID == "" {
 			continue
 		}
@@ -260,26 +235,37 @@ func (g *udsGraph) Close() error {
 
 var _ graph.Graph = (*udsGraph)(nil)
 
-// --- helpers ---
+// --- pointer-deref helpers ---
+//
+// The typed wire structs use `*T` for every field to model capnp's
+// "field is set" vs "field is unset" distinction. These helpers collapse
+// that into Go zero-values at the consumer boundary where we don't need
+// to distinguish nil from zero.
 
-func toInt(v any) int {
-	switch n := v.(type) {
-	case float64:
-		return int(n)
-	case int:
-		return n
-	default:
-		return 0
+func boolVal(p *bool) bool {
+	if p == nil {
+		return false
 	}
+	return *p
 }
 
-func toInt64(v any) int64 {
-	switch n := v.(type) {
-	case float64:
-		return int64(n)
-	case int64:
-		return n
-	default:
+func strVal(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func int32Val(p *int32) int32 {
+	if p == nil {
 		return 0
 	}
+	return *p
+}
+
+func int64Val(p *int64) int64 {
+	if p == nil {
+		return 0
+	}
+	return *p
 }

--- a/cmd/uds_graph_test.go
+++ b/cmd/uds_graph_test.go
@@ -179,6 +179,198 @@ func TestGetCallees_ResolvesViaDaemonFindCalleesOp(t *testing.T) {
 		"self-edge to /pkg/auth/Login skipped; duplicate Validate deduped")
 }
 
+// TestGetNode_DirKindNoContentRef pins the kind=dir branch of GetNode:
+// directories must NOT carry a ContentRef (they have no content to read).
+// Asserts the dir-mode bit is set and Ref stays nil. Counterpart of the
+// file-kind coverage in TestGetNode_DecodesSizeAsJSONString.
+func TestGetNode_DirKindNoContentRef(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{
+			"ok": true,
+			"node": map[string]any{
+				"id":   "/pkg",
+				"name": "pkg",
+				"kind": 1, // dir
+				"size": "0",
+			},
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	node, err := g.GetNode("/pkg")
+	require.NoError(t, err)
+	require.True(t, node.Mode.IsDir(), "kind=1 must set ModeDir")
+	require.Nil(t, node.Ref, "directories must not carry a ContentRef")
+}
+
+// TestGetNode_RecordPopulatesData pins the `record` → `node.Data` path.
+// When the daemon returns a non-empty `record` (the rendered file content
+// from SQLite), GetNode must surface it as `node.Data` so callers like
+// ReadContent can short-circuit through the in-band bytes.
+func TestGetNode_RecordPopulatesData(t *testing.T) {
+	const wantRecord = "package main\n\nfunc main() {}\n"
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{
+			"ok": true,
+			"node": map[string]any{
+				"id":     "/pkg/main.go",
+				"name":   "main.go",
+				"kind":   0,
+				"size":   "30",
+				"record": wantRecord,
+			},
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	node, err := g.GetNode("/pkg/main.go")
+	require.NoError(t, err)
+	require.Equal(t, wantRecord, string(node.Data),
+		"non-empty `record` field must populate node.Data verbatim")
+}
+
+// TestGetNode_MissingNodeIsNotFound pins the {ok:true, node:null} edge:
+// daemon ack but no node payload must surface as graph.ErrNotFound, not
+// a successful empty-node return.
+func TestGetNode_MissingNodeIsNotFound(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{"ok": true} // no `node` key
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	_, err = g.GetNode("/missing")
+	require.ErrorIs(t, err, graph.ErrNotFound,
+		"ok:true with no node payload must surface as ErrNotFound")
+}
+
+// TestReadContent_DecodesContentField pins the typed-decode round-trip
+// for the read_content op. The daemon emits `{"ok":true,"content":"..."}`;
+// the consumer must slice the returned bytes into the caller's buffer.
+// No test existed for this path before — silent regressions in the
+// content decode would not have been caught.
+func TestReadContent_DecodesContentField(t *testing.T) {
+	const wantContent = "hello mache\n"
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		if req["op"] != "read_content" {
+			return map[string]any{"ok": false, "error": "unexpected op"}
+		}
+		return map[string]any{
+			"ok":      true,
+			"content": wantContent,
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	buf := make([]byte, 64)
+	n, err := g.ReadContent("/file.txt", buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, len(wantContent), n)
+	require.Equal(t, wantContent, string(buf[:n]))
+}
+
+// TestReadContent_ErrorEnvelopeIsNotFound pins that {ok:false} on
+// read_content surfaces as graph.ErrNotFound, matching the contract
+// SQLiteGraph uses for stale node IDs.
+func TestReadContent_ErrorEnvelopeIsNotFound(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{"ok": false, "error": "node not found"}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	_, err = g.ReadContent("/stale", make([]byte, 16), 0)
+	require.ErrorIs(t, err, graph.ErrNotFound)
+}
+
+// TestGetCallers_DecodesNodeIDs pins the typed-decode round-trip for
+// find_callers. Each `callers[]` entry's `node_id` must surface as a
+// graph.Node. No test existed for this path before — the refactor
+// from map[string]any to typed Ref structs was uncovered.
+func TestGetCallers_DecodesNodeIDs(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		if req["op"] != "find_callers" {
+			return map[string]any{"ok": false, "error": "unexpected op"}
+		}
+		require.Equal(t, "Validate", req["token"], "find_callers must pass the token verbatim")
+		return map[string]any{
+			"ok": true,
+			"callers": []any{
+				map[string]any{"node_id": "/pkg/a/UseValidate", "source_id": "/pkg/a/UseValidate/source"},
+				map[string]any{"node_id": "/pkg/b/CallValidate", "source_id": "/pkg/b/CallValidate/source"},
+				// empty node_id must be skipped (defensive)
+				map[string]any{"node_id": "", "source_id": "/junk"},
+			},
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	callers, err := g.GetCallers("Validate")
+	require.NoError(t, err)
+	ids := make([]string, 0, len(callers))
+	for _, n := range callers {
+		ids = append(ids, n.ID)
+	}
+	require.ElementsMatch(t,
+		[]string{"/pkg/a/UseValidate", "/pkg/b/CallValidate"},
+		ids,
+		"GetCallers must decode node_id strings; empty entries skipped")
+}
+
+// TestListChildren_ErrorNotFoundMapping pins the daemon-error → typed-
+// error contract: an {"ok":false,"error":"... not found ..."} envelope
+// must surface as graph.ErrNotFound (case-insensitive substring match),
+// matching the SQLiteGraph contract for stale directory IDs.
+func TestListChildren_ErrorNotFoundMapping(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{"ok": false, "error": "Node Not Found in arena"}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	_, err = g.ListChildren("/stale")
+	require.ErrorIs(t, err, graph.ErrNotFound,
+		"daemon error containing 'not found' must map to graph.ErrNotFound")
+}
+
+// TestListChildren_GenericErrorPropagates pins the non-not-found error
+// path: any other error string from the daemon must propagate as a
+// generic error (with the daemon's message preserved for debugging).
+// Without this, mache would conflate all daemon errors with ErrNotFound.
+func TestListChildren_GenericErrorPropagates(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{"ok": false, "error": "arena read failed: io/timeout"}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	_, err = g.ListChildren("/x")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, graph.ErrNotFound, "non-not-found errors must not collapse to ErrNotFound")
+	require.Contains(t, err.Error(), "arena read failed: io/timeout",
+		"daemon error message must be preserved in the wrapped error")
+}
+
 // TestGetNode_DecodesSizeAsJSONString pins the bug this PR targets:
 // post-b0ea2e the daemon emits Int64 fields as quoted JSON strings (e.g.
 // `"size":"4096"`). The pre-refactor `map[string]any` + `.(float64)`

--- a/cmd/uds_graph_test.go
+++ b/cmd/uds_graph_test.go
@@ -179,6 +179,70 @@ func TestGetCallees_ResolvesViaDaemonFindCalleesOp(t *testing.T) {
 		"self-edge to /pkg/auth/Login skipped; duplicate Validate deduped")
 }
 
+// TestGetNode_DecodesSizeAsJSONString pins the bug this PR targets:
+// post-b0ea2e the daemon emits Int64 fields as quoted JSON strings (e.g.
+// `"size":"4096"`). The pre-refactor `map[string]any` + `.(float64)`
+// pattern silently zeroed every Int64 field on that wire. Typed decoding
+// with `,string` tags must round-trip the value correctly.
+//
+// Counterpart of TestListChildren_ParsesObjectsNotStrings — that one
+// covers the list_children path; this one covers get_node so any future
+// regression in the typed decoder is caught for both shapes the daemon
+// actually emits Node records in.
+func TestGetNode_DecodesSizeAsJSONString(t *testing.T) {
+	const wantSize int64 = 4096
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		if req["op"] != "get_node" {
+			return map[string]any{"ok": false, "error": "unexpected op"}
+		}
+		return map[string]any{
+			"ok": true,
+			"node": map[string]any{
+				"id":        "/pkg/foo.go",
+				"parent_id": "/pkg",
+				"name":      "foo.go",
+				"kind":      0, // file
+				"size":      "4096",
+			},
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	node, err := g.GetNode("/pkg/foo.go")
+	require.NoError(t, err)
+	require.NotNil(t, node.Ref, "file node must carry a ContentRef")
+	require.Equal(t, wantSize, node.Ref.ContentLen,
+		"Size must round-trip through the `,string` json tag")
+}
+
+// TestGetNode_RejectsBareNumericSize is the inverse guard: under the
+// post-b0ea2e wire contract sizes are quoted strings; if a (broken or
+// pre-v0.3.0) daemon emits a bare number, we want a loud error rather
+// than a silent zero. This pins the "strict decode is the failure mode"
+// design choice flagged on PR review.
+func TestGetNode_RejectsBareNumericSize(t *testing.T) {
+	sock := stubDaemon(t, func(req map[string]any) map[string]any {
+		return map[string]any{
+			"ok": true,
+			"node": map[string]any{
+				"id":   "/pkg/foo.go",
+				"kind": 0,
+				"size": 4096, // bare number — pre-b0ea2e shape
+			},
+		}
+	})
+
+	g, err := newUDSGraph(sock)
+	require.NoError(t, err)
+	defer func() { _ = g.Close() }()
+
+	_, err = g.GetNode("/pkg/foo.go")
+	require.Error(t, err, "bare numeric size must fail decode, not silently zero")
+}
+
 func TestGetCallees_EmptyResultIsNotAnError(t *testing.T) {
 	// Daemon returning {ok: false} (e.g. unknown node, no refs) should
 	// not propagate as an error — other Graph backends treat empty

--- a/cmd/uds_graph_test.go
+++ b/cmd/uds_graph_test.go
@@ -65,6 +65,9 @@ func stubDaemon(t *testing.T, handler func(map[string]any) map[string]any) strin
 // returns (rs/ll-open/cli-lib/src/daemon/ops.rs::op_list_children). The
 // old code did `c.(string)` on each entry, so every non-empty directory
 // listing came back as an empty slice.
+//
+// Size values are JSON-string-encoded to match the post-b0ea2e capnp-json
+// wire shape (Int64 emitted as quoted strings for JS Number compatibility).
 func TestListChildren_ParsesObjectsNotStrings(t *testing.T) {
 	sock := stubDaemon(t, func(req map[string]any) map[string]any {
 		if req["op"] != "list_children" {
@@ -73,8 +76,8 @@ func TestListChildren_ParsesObjectsNotStrings(t *testing.T) {
 		return map[string]any{
 			"ok": true,
 			"children": []any{
-				map[string]any{"id": "/root/a", "name": "a", "kind": 1, "size": 0},
-				map[string]any{"id": "/root/b", "name": "b", "kind": 0, "size": 42},
+				map[string]any{"id": "/root/a", "name": "a", "kind": 1, "size": "0"},
+				map[string]any{"id": "/root/b", "name": "b", "kind": 0, "size": "42"},
 			},
 		}
 	})
@@ -100,8 +103,8 @@ func TestListChildStats_SingleShotFromListChildrenResponse(t *testing.T) {
 			return map[string]any{
 				"ok": true,
 				"children": []any{
-					map[string]any{"id": "/root/dir", "name": "dir", "kind": 1, "size": 0},
-					map[string]any{"id": "/root/file.go", "name": "file.go", "kind": 0, "size": 128},
+					map[string]any{"id": "/root/dir", "name": "dir", "kind": 1, "size": "0"},
+					map[string]any{"id": "/root/file.go", "name": "file.go", "kind": 0, "size": "128"},
 				},
 			}
 		case "get_node":

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.5
 require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.2.2
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.3.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ capnproto.org/go/capnp/v3 v3.1.0-alpha.2 h1:93ISpqHf2/3WQlfrBP0tT8Dg/RQc3uq6DV36
 capnproto.org/go/capnp/v3 v3.1.0-alpha.2/go.mod h1:2vT5D2dtG8sJGEoEKU17e+j7shdaYp1Myl8X03B3hmc=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.2.2 h1:xu4YGp/SlpHGRvypix8l4LrORJ9yV7iCdTLByvoOf4U=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.2.2/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.3.0 h1:L/RHUY3nQc7nN1vIZ8gfzIZNEQhVfUGwJxoYNcX6kcY=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.3.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -258,6 +258,33 @@ func (c *SocketClient) Close() error {
 // SendOp sends a JSON request and reads the JSON response.
 // Both are line-delimited (newline-terminated JSON).
 func (c *SocketClient) SendOp(req map[string]any) (map[string]any, error) {
+	line, err := c.sendRaw(req)
+	if err != nil {
+		return nil, err
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(line, &resp); err != nil {
+		return nil, fmt.Errorf("unmarshal response: %w", err)
+	}
+	return resp, nil
+}
+
+// SendOpInto sends a JSON request and decodes the response into dest.
+// Use this for ops with typed response structs (see wire.go); SendOp's
+// map[string]any return silently zeros Int64 fields under the post-b0ea2e
+// daemon wire (capnp-json codec emits int64 as JSON strings).
+func (c *SocketClient) SendOpInto(req map[string]any, dest any) error {
+	line, err := c.sendRaw(req)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(line, dest); err != nil {
+		return fmt.Errorf("unmarshal response: %w", err)
+	}
+	return nil
+}
+
+func (c *SocketClient) sendRaw(req map[string]any) ([]byte, error) {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -272,13 +299,7 @@ func (c *SocketClient) SendOp(req map[string]any) (map[string]any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read response: %w", err)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &resp); err != nil {
-		return nil, fmt.Errorf("unmarshal response: %w", err)
-	}
-
-	return resp, nil
+	return []byte(strings.TrimSpace(line)), nil
 }
 
 // Tool invokes a named tool with the given args via the `tool` op.

--- a/internal/leyline/wire.go
+++ b/internal/leyline/wire.go
@@ -1,0 +1,71 @@
+// Typed Go structs for the daemon JSON wire protocol.
+//
+// These mirror the hand-written bindings in LLO's
+// `clients/go/leyline-schema/daemon/daemon_protocol_test.go` (PR #12
+// commit 145fcc5). When `clients/go/leyline-schema/v0.3.0` is tagged with
+// these types promoted to a shipped `daemon/types.go`, replace this file
+// with imports from that package — the shapes are byte-identical by design.
+//
+// Wire encoding note: under the b0ea2e capnp-json codec (LLO ≥ post-PR-#12),
+// 64-bit integers ride as JSON strings to avoid JS Number precision loss.
+// All Int64 / UInt64 fields carry `,string` so json.Unmarshal accepts the
+// `"123"` form. Without these tags decode silently zeros the field.
+
+package leyline
+
+// Node represents an entry in the projected graph. Used by both
+// list_children (Record omitted to keep directory listings small) and
+// get_node (Record present when the SQL record column is non-null).
+type Node struct {
+	ID       *string `json:"id"`
+	ParentID *string `json:"parent_id"`
+	Name     *string `json:"name"`
+	Kind     *int32  `json:"kind"`
+	Size     *int64  `json:"size,string"`
+	Record   *string `json:"record,omitempty"`
+}
+
+// Ref is a {node_id, source_id} pair returned by find_callers /
+// find_callees / find_defs. SourceID is the construct's source-file node.
+type Ref struct {
+	NodeID   *string `json:"node_id"`
+	SourceID *string `json:"source_id"`
+}
+
+// GetNodeResponse is the response shape for op=get_node.
+type GetNodeResponse struct {
+	OK    *bool   `json:"ok"`
+	Node  *Node   `json:"node,omitempty"`
+	Error *string `json:"error,omitempty"`
+}
+
+// ListChildrenResponse is the response shape for op=list_children.
+// Failure path carries Error; mache treats "not found" specially.
+type ListChildrenResponse struct {
+	OK       *bool   `json:"ok"`
+	Children []Node  `json:"children"`
+	Error    *string `json:"error,omitempty"`
+}
+
+// ReadContentResponse is the response shape for op=read_content.
+type ReadContentResponse struct {
+	OK      *bool   `json:"ok"`
+	Content *string `json:"content,omitempty"`
+	Error   *string `json:"error,omitempty"`
+}
+
+// FindCallersResponse is the response shape for op=find_callers.
+type FindCallersResponse struct {
+	OK      *bool   `json:"ok"`
+	Callers []Ref   `json:"callers"`
+	Error   *string `json:"error,omitempty"`
+}
+
+// FindCalleesResponse is the response shape for op=find_callees
+// (added in LLO 0.2.2). Daemon executes the JOIN against node_refs +
+// node_defs and returns the resolved construct rows.
+type FindCalleesResponse struct {
+	OK      *bool   `json:"ok"`
+	Callees []Ref   `json:"callees"`
+	Error   *string `json:"error,omitempty"`
+}

--- a/internal/leyline/wire.go
+++ b/internal/leyline/wire.go
@@ -2,14 +2,20 @@
 //
 // These mirror the hand-written bindings in LLO's
 // `clients/go/leyline-schema/daemon/daemon_protocol_test.go` (PR #12
-// commit 145fcc5). When `clients/go/leyline-schema/v0.3.0` is tagged with
-// these types promoted to a shipped `daemon/types.go`, replace this file
-// with imports from that package — the shapes are byte-identical by design.
+// commit 145fcc5). The current `leyline-schema/v0.3.0` ships those
+// mirrors in `package daemon_test` (test-only), so we cannot import
+// them directly — this file is the consumer-side declaration. If a
+// future leyline-schema release promotes the structs to a non-test
+// package, this file becomes a trivial import swap; the shapes are
+// byte-identical by design.
 //
-// Wire encoding note: under the b0ea2e capnp-json codec (LLO ≥ post-PR-#12),
+// Wire encoding note: under the b0ea2e capnp-json codec (LLO ≥ v0.3.0),
 // 64-bit integers ride as JSON strings to avoid JS Number precision loss.
 // All Int64 / UInt64 fields carry `,string` so json.Unmarshal accepts the
 // `"123"` form. Without these tags decode silently zeros the field.
+// The strict-decode is intentional: pre-b0ea2e daemons emit bare numeric
+// JSON which will surface as a UnmarshalTypeError rather than a silent
+// wrong-zero — the failure mode is loud and points at version skew.
 
 package leyline
 


### PR DESCRIPTION
## Summary

- Replace `map[string]any` consumers in `cmd/uds_graph.go` with typed Go structs that mirror `daemon.capnp`; structs live in `internal/leyline/wire.go` and match LLO PR #12's [`daemon/daemon_protocol_test.go`](https://github.com/agentic-research/ley-line-open/blob/main/clients/go/leyline-schema/daemon/daemon_protocol_test.go) byte-for-byte.
- Add `SocketClient.SendOpInto(req, &dest)` for typed-decode; existing `SendOp` retained for extension ops (sheaf_*, semantic_*) and the tool/query envelopes.
- Bump `clients/go/leyline-schema` to `v0.3.0` (PR #12 merged at `4a7006c`).

## Why

Post-b0ea2e the daemon wire codec emits Int64/UInt64 as JSON strings (capnp-json codec, JS Number precision avoidance — see [bead mache-a5ad09](rsry://mache-a5ad09) for a probe trace). Mache's existing `map[string]any` + `.(float64)` pattern **silently zeros every Int64 field** on the new wire. Typed structs with `,string` json tags decode correctly; the compiler now polices the daemon's response shape.

Tracking: [mache-a5ad09](rsry://mache-a5ad09).

## Scope, intentional limits

- Covers the 5 base ops `udsGraph` consumes: `get_node`, `list_children`, `read_content`, `find_callers`, `find_callees`.
- **`sheaf.go` / `semantic.go` float64 sites untouched.** Those are LLO extension ops not in PR #12's migration; wire shape needs a live probe before assuming change. Tracked as a separate concern per the bead.
- `wire.go` is a local mirror, not an import — LLO ships those structs as `package daemon_test` (lowercase, test-only). A follow-up could promote them to `types.go`; until then mache's local copy is the canonical consumer-side declaration. Comment at the top of `wire.go` flags this.

## Test plan

- [x] `task check` green locally (test + vet + lint + fmt + validate + docs:lint).
- [x] Fixture sizes in `cmd/uds_graph_test.go` updated to the `"0"` / `"128"` quoted-string form to match v0.3.0 wire.
- [ ] End-to-end smoke against a running v0.3.0 LLO daemon (deferred to integration; bead notes `ley-line-open-69072b` compose-recipe makes this a one-command test once it lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)