### PR TITLE
feat(serve): wire watcher → sheaf cascade + get_sheaf_status [mache-c11848 + mache-4a0c05]

### DIFF
--- a/cmd/all_tools_e2e_test.go
+++ b/cmd/all_tools_e2e_test.go
@@ -158,7 +158,7 @@ func TestE2E_AllMCPTools(t *testing.T) {
 	schema, err := resolveSchema("go", ".")
 	require.NoError(t, err)
 	require.NotNil(t, schema, "go preset schema must resolve")
-	g, cleanup, err := buildMaybeMultiGraph(dir, schema)
+	g, _, cleanup, err := buildMaybeMultiGraph(dir, schema)
 	require.NoError(t, err)
 	defer cleanup()
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -354,8 +354,20 @@ func cloneRepo(repoURL string) (string, func(), error) {
 }
 
 // buildServeGraph constructs a read-only Graph from the data source.
+// Returns the graph plus a *graph.SheafInvalidator wired into the file
+// watcher's onChange path. The invalidator is non-nil iff this build
+// constructed a watcher (i.e. dataSource is a directory) — file-shaped
+// sources, .db sources, and control-mode init all return a nil
+// invalidator since there's no watcher to fire it.
+//
+// The invalidator is constructed with sheaf=nil and result=nil. The
+// MCP get_communities handler swaps in both via SetCommunityResult /
+// SetSheaf after running community detection + dialing the daemon.
+// Pre-swap, the watcher's cascade attempts fall back to single-node
+// Graph.Invalidate — correct behavior, just no cross-region propagation
+// until the moat is engaged.
 // Returns the graph, a cleanup function, and any error.
-func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func(), error) {
+func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, *graph.SheafInvalidator, func(), error) {
 	noop := func() {}
 
 	// Control block path: read from ley-line arena with hot-swap.
@@ -377,9 +389,9 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func
 	if info, statErr := os.Stat(dataSource); statErr == nil && info.IsDir() &&
 		os.Getenv("MACHE_NO_LEYLINE") == "" {
 		if dbPath, dbCleanup, err := autoInvokeLeylineParse(dataSource); err == nil {
-			g, gCleanup, gerr := openDBGraph(dbPath, schema, dbCleanup)
+			g, si, gCleanup, gerr := openDBGraph(dbPath, schema, dbCleanup)
 			if gerr == nil {
-				return g, gCleanup, nil
+				return g, si, gCleanup, nil
 			}
 			log.Printf("auto-leyline: opened .db failed (%v); falling back to in-process ingest", gerr)
 			dbCleanup()
@@ -397,31 +409,57 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func
 	engine := ingest.NewEngine(schema, store)
 	if err := engine.Ingest(dataSource); err != nil {
 		resolver.Close()
-		return nil, noop, fmt.Errorf("ingestion: %w", err)
+		return nil, nil, noop, fmt.Errorf("ingestion: %w", err)
 	}
 
 	if err := store.InitRefsDB(); err != nil {
 		resolver.Close()
-		return nil, noop, fmt.Errorf("init refs db: %w", err)
+		return nil, nil, noop, fmt.Errorf("init refs db: %w", err)
 	}
 	if err := store.FlushRefs(); err != nil {
 		log.Printf("Warning: refs flush: %v", err)
 	}
 
 	// Start file watcher for incremental re-index if source is a directory.
+	// The SheafInvalidator is constructed *only* on this path — it has no
+	// purpose without a watcher to fire it. cmd/serve_handlers.go's
+	// get_communities handler later calls si.SetCommunityResult + SetSheaf
+	// to engage the cross-region cascade; until then the watcher's
+	// invalidate calls fall back to single-node Graph.Invalidate.
 	var fw *ingest.Watcher
+	var si *graph.SheafInvalidator
 	if info, statErr := os.Stat(dataSource); statErr == nil && info.IsDir() {
+		si = graph.NewSheafInvalidator(store, nil, nil)
 		onChange := func(path string) {
 			store.DeleteFileNodes(path)
 			if reErr := engine.ReIngestFile(path); reErr != nil {
 				log.Printf("watcher: re-ingest %s: %v", path, reErr)
-			} else {
-				log.Printf("watcher: re-indexed %s", path)
+				return
+			}
+			log.Printf("watcher: re-indexed %s", path)
+			// Cascade invalidation for every node touched by this file.
+			// NodesForPath is post-reingest so it reflects the new node IDs;
+			// the watcher's bookkeeping in the daemon's sheaf cache uses
+			// region IDs that depend on community membership the handler
+			// will install later — pre-install this loop is a no-op past
+			// single-node Graph.Invalidate (which DeleteFileNodes already
+			// effectively did) and that's intentional graceful degradation.
+			for _, nodeID := range store.NodesForPath(path) {
+				si.InvalidateWithCascade(nodeID, nil)
 			}
 		}
 		onDelete := func(path string) {
+			// Snapshot affected nodes BEFORE DeleteFileNodes wipes the
+			// path↔nodes bitmap — otherwise NodesForPath returns empty
+			// and the cascade has nothing to invalidate. The post-delete
+			// graph.Invalidate path is correct for local caches; the
+			// cascade is what propagates the boundary change daemon-side.
+			affected := store.NodesForPath(path)
 			store.DeleteFileNodes(path)
 			log.Printf("watcher: deleted nodes for %s", path)
+			for _, nodeID := range affected {
+				si.InvalidateWithCascade(nodeID, nil)
+			}
 		}
 		var watchErr error
 		fw, watchErr = ingest.NewWatcher(dataSource, onChange, onDelete,
@@ -433,7 +471,7 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func
 		}
 	}
 
-	return store, func() {
+	return store, si, func() {
 		if fw != nil {
 			fw.Stop()
 		}
@@ -444,21 +482,28 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, func
 
 // buildMaybeMultiGraph dispatches between single-source and composite
 // (multi-mount) construction. With no --mount flags, it's a thin
-// pass-through to buildServeGraph. With one or more --mount NAME=PATH
-// flags, it builds a CompositeGraph by calling buildServeGraph for
-// each mount path and Mount-ing the result under NAME.
+// pass-through to buildServeGraph (propagating its *SheafInvalidator).
+// With one or more --mount NAME=PATH flags, it builds a CompositeGraph
+// by calling buildServeGraph for each mount path and Mount-ing the
+// result under NAME. The composite case returns a nil *SheafInvalidator
+// — per-mount watchers each have their own invalidator captured in
+// their closures, and there's no semantically correct way to expose
+// a single composite invalidator to the MCP handler layer (each mount
+// has its own CommunityResult). Composite mounts forfeit the cascade
+// in exchange for the multi-mount feature; document for the wiring PR
+// that revisits this if a use case emerges.
 //
 // When --mount is set, the positional dataSource is rejected — the
 // caller must choose between a single source and a composite.
 //
 // Cleanup runs in reverse-mount order so child graphs are torn down
 // before any shared resources they depend on.
-func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph, func(), error) {
+func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph, *graph.SheafInvalidator, func(), error) {
 	if len(serveMounts) == 0 {
 		return buildServeGraph(dataSource, schema)
 	}
 	if dataSource != "" {
-		return nil, func() {}, fmt.Errorf("cannot use both a positional source (%q) and --mount; use one or the other", dataSource)
+		return nil, nil, func() {}, fmt.Errorf("cannot use both a positional source (%q) and --mount; use one or the other", dataSource)
 	}
 
 	composite := graph.NewCompositeGraph()
@@ -494,46 +539,51 @@ func buildMaybeMultiGraph(dataSource string, schema *api.Topology) (graph.Graph,
 		name, path, ok := strings.Cut(spec, "=")
 		if !ok || name == "" || path == "" {
 			runAll()
-			return nil, func() {}, fmt.Errorf("invalid --mount spec %q (expected NAME=PATH)", spec)
+			return nil, nil, func() {}, fmt.Errorf("invalid --mount spec %q (expected NAME=PATH)", spec)
 		}
-		g, cleanup, err := buildServeGraph(path, schema)
+		g, _, cleanup, err := buildServeGraph(path, schema)
 		if err != nil {
 			runAll()
-			return nil, func() {}, fmt.Errorf("mount %s=%s: %w", name, path, err)
+			return nil, nil, func() {}, fmt.Errorf("mount %s=%s: %w", name, path, err)
 		}
 		cleanups = append(cleanups, cleanup)
 		if err := composite.Mount(name, g); err != nil {
 			runAll()
-			return nil, func() {}, fmt.Errorf("mount %q: %w", name, err)
+			return nil, nil, func() {}, fmt.Errorf("mount %q: %w", name, err)
 		}
 		log.Printf("mounted %s -> %s", name, path)
 	}
-	return composite, runAll, nil
+	return composite, nil, runAll, nil
 }
 
 // openDBGraph opens a .db file as a SQLiteGraph after materializing virtual
 // nodes. The extra cleanup callback runs after the graph is closed (used to
 // delete an auto-generated temp .db).
-func openDBGraph(dbPath string, schema *api.Topology, extraCleanup func()) (graph.Graph, func(), error) {
+// openDBGraph returns (graph, nil, cleanup, err) — the *SheafInvalidator
+// slot is always nil here because .db sources don't run a file watcher
+// and have no need for cascade wiring (the contents are frozen at the
+// time the .db was built). Callers (e.g. buildServeGraph) propagate the
+// nil to their own returns.
+func openDBGraph(dbPath string, schema *api.Topology, extraCleanup func()) (graph.Graph, *graph.SheafInvalidator, func(), error) {
 	if extraCleanup == nil {
 		extraCleanup = func() {}
 	}
 	if err := materializeVirtuals(dbPath, schema, false); err != nil {
 		extraCleanup()
-		return nil, func() {}, fmt.Errorf("materialize virtuals: %w", err)
+		return nil, nil, func() {}, fmt.Errorf("materialize virtuals: %w", err)
 	}
 	sg, err := graph.OpenSQLiteGraph(dbPath, schema, machetmpl.Render)
 	if err != nil {
 		extraCleanup()
-		return nil, func() {}, fmt.Errorf("open sqlite graph: %w", err)
+		return nil, nil, func() {}, fmt.Errorf("open sqlite graph: %w", err)
 	}
 	sg.SetCallExtractor(pickCallExtractor(sg.DB()))
 	if err := sg.EagerScan(); err != nil {
 		_ = sg.Close()
 		extraCleanup()
-		return nil, func() {}, fmt.Errorf("scan: %w", err)
+		return nil, nil, func() {}, fmt.Errorf("scan: %w", err)
 	}
-	return sg, func() {
+	return sg, nil, func() {
 		_ = sg.Close()
 		extraCleanup()
 	}, nil
@@ -586,7 +636,12 @@ func autoInvokeLeylineParse(sourceDir string) (string, func(), error) {
 // buildControlGraph connects to the ley-line daemon over UDS.
 // The daemon owns SQLite (zero-copy via sqlite3_deserialize on the arena).
 // Mache sends structured ops, never opens SQLite directly.
-func buildControlGraph(ctrlPath string, _ *api.Topology) (graph.Graph, func(), error) {
+//
+// Returns a nil *SheafInvalidator slot: control mode reads from an
+// arena that's owned by the daemon (no mache-side watcher, no need
+// for cascade wiring — the daemon's own reparse pipeline drives the
+// freshness story in this mode).
+func buildControlGraph(ctrlPath string, _ *api.Topology) (graph.Graph, *graph.SheafInvalidator, func(), error) {
 	// The daemon socket is at <ctrl>.sock (convention)
 	sockPath := ctrlPath[:len(ctrlPath)-len(".ctrl")] + ".sock"
 
@@ -598,7 +653,7 @@ func buildControlGraph(ctrlPath string, _ *api.Topology) (graph.Graph, func(), e
 		}
 		select {
 		case <-deadline:
-			return nil, nil, fmt.Errorf("timed out waiting for daemon socket %s (30s)", sockPath)
+			return nil, nil, nil, fmt.Errorf("timed out waiting for daemon socket %s (30s)", sockPath)
 		default:
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -606,9 +661,9 @@ func buildControlGraph(ctrlPath string, _ *api.Topology) (graph.Graph, func(), e
 
 	g, err := newUDSGraph(sockPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("connect to daemon: %w", err)
+		return nil, nil, nil, fmt.Errorf("connect to daemon: %w", err)
 	}
 	log.Printf("Connected to ley-line daemon at %s", sockPath)
 
-	return g, func() { _ = g.Close() }, nil
+	return g, nil, func() { _ = g.Close() }, nil
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -386,11 +386,28 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, *gra
 	// This eliminates CGO tree-sitter at mount time. Falls back silently to
 	// the in-process Engine + SitterWalker path on any failure.
 	// Disable via MACHE_NO_LEYLINE=1.
+	//
+	// KNOWN GAP (PR #383 Copilot #4 → bead mache-6c9e1d): this path returns
+	// a NIL *SheafInvalidator because openDBGraph's .db backend is frozen
+	// at parse time — no watcher is constructed, so the file-watcher →
+	// sheaf cascade wiring is disabled in the default leyline-installed
+	// setup. Only MACHE_NO_LEYLINE=1 (in-process MemoryStore path below)
+	// currently exercises the cascade.
+	//
+	// Closing this requires either (a) flipping auto-leyline from one-
+	// shot `leyline parse` to a managed daemon that watches the source
+	// dir + reparses + emits sheaf.invalidate events that mache subscribes
+	// to (depends on mache-c14c43), or (b) building the cascade-eligible
+	// in-process store alongside the .db (wasteful double-ingest). Tracked
+	// for the followup; the current behavior is honest documented
+	// degradation — agents using auto-leyline get fast cold-start but
+	// stale results after edits until the daemon-mode rewrite ships.
 	if info, statErr := os.Stat(dataSource); statErr == nil && info.IsDir() &&
 		os.Getenv("MACHE_NO_LEYLINE") == "" {
 		if dbPath, dbCleanup, err := autoInvokeLeylineParse(dataSource); err == nil {
 			g, si, gCleanup, gerr := openDBGraph(dbPath, schema, dbCleanup)
 			if gerr == nil {
+				log.Printf("auto-leyline: serving from %s (frozen .db — sheaf cascade NOT engaged for live edits; set MACHE_NO_LEYLINE=1 for the in-process watcher path)", filepath.Base(dbPath))
 				return g, si, gCleanup, nil
 			}
 			log.Printf("auto-leyline: opened .db failed (%v); falling back to in-process ingest", gerr)
@@ -431,22 +448,33 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, *gra
 	if info, statErr := os.Stat(dataSource); statErr == nil && info.IsDir() {
 		si = graph.NewSheafInvalidator(store, nil, nil)
 		onChange := func(path string) {
+			// Snapshot PRE-edit node IDs before DeleteFileNodes wipes
+			// the path↔nodes bitmap. The new IDs (post-reingest) may
+			// differ if the edit renames/moves/removes constructs —
+			// without including the old IDs, the cascade misses
+			// regions that the old constructs occupied (PR #383
+			// Copilot #3). Union of old + new covers both: regions
+			// containing removed-or-renamed nodes get invalidated
+			// via the pre-edit IDs; regions containing the new
+			// construct names get invalidated via the post-edit IDs.
+			oldIDs := store.NodesForPath(path)
 			store.DeleteFileNodes(path)
 			if reErr := engine.ReIngestFile(path); reErr != nil {
 				log.Printf("watcher: re-ingest %s: %v", path, reErr)
+				// Still cascade the old IDs — the file's prior
+				// state is no longer valid downstream regardless
+				// of whether the re-ingest succeeded.
+				si.InvalidateNodesWithCascade(oldIDs)
 				return
 			}
 			log.Printf("watcher: re-indexed %s", path)
-			// Cascade invalidation for every node touched by this file.
-			// NodesForPath is post-reingest so it reflects the new node IDs;
-			// the watcher's bookkeeping in the daemon's sheaf cache uses
-			// region IDs that depend on community membership the handler
-			// will install later — pre-install this loop is a no-op past
-			// single-node Graph.Invalidate (which DeleteFileNodes already
-			// effectively did) and that's intentional graceful degradation.
-			for _, nodeID := range store.NodesForPath(path) {
-				si.InvalidateWithCascade(nodeID, nil)
-			}
+			newIDs := store.NodesForPath(path)
+			affected := unionStringSlices(oldIDs, newIDs)
+			// One daemon round-trip per unique region (dedupe in
+			// InvalidateNodesWithCascade). Pre-install (no sheaf,
+			// no result) this still degrades to single-node
+			// invalidates — same intentional graceful behavior.
+			si.InvalidateNodesWithCascade(affected)
 		}
 		onDelete := func(path string) {
 			// Snapshot affected nodes BEFORE DeleteFileNodes wipes the
@@ -457,9 +485,7 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, *gra
 			affected := store.NodesForPath(path)
 			store.DeleteFileNodes(path)
 			log.Printf("watcher: deleted nodes for %s", path)
-			for _, nodeID := range affected {
-				si.InvalidateWithCascade(nodeID, nil)
-			}
+			si.InvalidateNodesWithCascade(affected)
 		}
 		var watchErr error
 		fw, watchErr = ingest.NewWatcher(dataSource, onChange, onDelete,
@@ -478,6 +504,34 @@ func buildServeGraph(dataSource string, schema *api.Topology) (graph.Graph, *gra
 		_ = store.Close()
 		resolver.Close()
 	}, nil
+}
+
+// unionStringSlices returns the deduped union of a and b. Order
+// within the result is undefined. Used by the watcher's onChange to
+// build the union of pre- and post-edit node IDs so the cascade
+// hits regions containing both states (PR #383 Copilot #3).
+func unionStringSlices(a, b []string) []string {
+	if len(a) == 0 {
+		return b
+	}
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]struct{}, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	for _, s := range b {
+		if _, ok := seen[s]; !ok {
+			seen[s] = struct{}{}
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // buildMaybeMultiGraph dispatches between single-source and composite

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -907,26 +908,25 @@ func makeGetCommunitiesHandlerWithDone(g graph.Graph, pushDone chan<- struct{}) 
 			Membership:  result.Membership,
 		}
 
-		// Install the snapshot on the SheafInvalidator the file watcher
-		// holds (if any), so its next onChange fire engages the cascade
-		// instead of falling back to single-node Graph.Invalidate. This
-		// must happen on the SYNCHRONOUS path — the goroutine below
-		// also dials the daemon and pushes topology, but the watcher
-		// shouldn't have to wait on daemon discovery to start using
-		// real membership data. SetCommunityResult is mutex-guarded
-		// (TestSheafInvalidator_ConcurrentReadWrite); the watcher can
-		// safely read while we write here.
+		// Resolve the SheafInvalidator (if this graph has one) up front
+		// so the goroutine below can install state atomically once it
+		// successfully reaches the daemon.
 		//
 		// Graph backends without a watcher (control-mode lazyGraph,
 		// composite mounts) don't implement sheafInvalidatorProvider —
 		// the type-assert degrades silently, which is the documented
 		// behavior for those modes (see buildServeGraph).
+		//
+		// DELIBERATELY DEFER state install until PushTopology succeeds.
+		// Installing SetCommunityResult synchronously here (the prior
+		// shape) paired NEW membership with the OLD sheaf/topology
+		// during the dial+push window — watcher events in that window
+		// looked up regions in the new membership but sent them to a
+		// daemon that still held the prior topology. Fixed by atomic
+		// SetState below; see PR #383 Copilot #6.
 		var sip sheafInvalidatorProvider
 		if sp, ok := g.(sheafInvalidatorProvider); ok {
 			sip = sp
-			if si := sip.SheafInvalidator(); si != nil {
-				si.SetCommunityResult(snap)
-			}
 		}
 
 		go func() {
@@ -941,22 +941,42 @@ func makeGetCommunitiesHandlerWithDone(g graph.Graph, pushDone chan<- struct{}) 
 			if err != nil {
 				return
 			}
-			defer func() { _ = sock.Close() }()
+			// Track whether we handed off socket ownership to the
+			// invalidator. If we did, the SheafClient inside the
+			// invalidator owns the socket and we MUST NOT close it
+			// here — the watcher's later cascade calls reuse the
+			// connection. If we didn't hand off, close it normally
+			// to avoid leaking a socket per failed get_communities
+			// run. See PR #383 Copilot #1: the prior code deferred
+			// sock.Close() unconditionally, so the SheafClient
+			// stored on the invalidator was talking to a closed
+			// socket from the goroutine's return onward.
+			var handedOff bool
+			defer func() {
+				if !handedOff {
+					_ = sock.Close()
+				}
+			}()
+
 			sc := leyline.NewSheafClient(sock)
 			if pushErr := sc.PushTopology(snap, refs); pushErr != nil {
 				logSheafPushOnce(pushErr)
 				return
 			}
-			// PushTopology succeeded — swap the (now-live) SheafClient
-			// into the invalidator so subsequent watcher fires engage
-			// the cross-region cascade instead of falling back. This
-			// closes the consumer-side loop the mache-49bf9a audit
-			// flagged as "sketch": from here on, edits route through
-			// the daemon and the cascade output drives local cache
-			// invalidation.
+			// PushTopology succeeded — atomically swap BOTH the new
+			// CommunityResult and the new SheafClient onto the
+			// invalidator. From here on, subsequent watcher fires
+			// engage the cross-region cascade. The prior backend
+			// (if any) is returned so we can close its socket and
+			// avoid leaking one UDS connection per get_communities
+			// call across the process lifetime.
 			if sip != nil {
 				if si := sip.SheafInvalidator(); si != nil {
-					si.SetSheaf(sc)
+					prior := si.SetState(snap, sc)
+					handedOff = true
+					if closer, ok := prior.(io.Closer); ok {
+						_ = closer.Close()
+					}
 				}
 			}
 		}()

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -135,6 +135,21 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 		r.wrapHandler(makeGetOverviewHandler),
 	)
 
+	// get_sheaf_status surfaces the ley-line daemon's sheaf state to
+	// agents — generation (monotonic, advances on every cascade run),
+	// valid/total cache entries, defect score. Lets an agent decide
+	// whether a cached result is still fresh after an edit, without
+	// having to invalidate the whole world. Registered directly (no
+	// graph-registry wrapping) because the tool doesn't depend on
+	// session state; it talks to the daemon over UDS using the
+	// well-known socket path.
+	s.AddTool(
+		mcp.NewTool("get_sheaf_status",
+			mcp.WithDescription("Returns the ley-line daemon's sheaf cache state (generation counter, valid/total entries, defect score). Use to decide whether cached find_callers / find_definition / get_architecture results are still fresh after an edit. Returns {available: false, reason: ...} when the daemon is not reachable rather than erroring — safe to call periodically."),
+		),
+		makeGetSheafStatusHandler(),
+	)
+
 	s.AddTool(
 		mcp.NewTool("get_impact",
 			mcp.WithDescription("Change impact analysis: given a symbol, trace through the refs graph to show affected callers and/or callees (multi-hop BFS traversal). Use for 'what would be affected if I change X?', 'blast radius of modifying Y'."),
@@ -1283,6 +1298,57 @@ func makeGetOverviewHandler(g graph.Graph) server.ToolHandlerFunc {
 		}
 
 		data, _ := json.MarshalIndent(ov, "", "  ")
+		return mcp.NewToolResultText(string(data)), nil
+	}
+}
+
+// makeGetSheafStatusHandler returns the handler for the get_sheaf_status
+// MCP tool. The tool surfaces the daemon's sheaf cache state to agents
+// so they can decide whether cached results are still fresh.
+//
+// Design contract: the handler MUST NOT surface daemon unavailability
+// as an MCP error. Agents polling this tool would otherwise see
+// transport failures whenever the daemon is down or hasn't been
+// dialed yet. Instead, return a structured {available: false, reason:
+// "..."} response. This matches the documented graceful-degradation
+// pattern in the wider sheaf wiring (cmd/serve.go).
+//
+// DiscoverSocket (not DiscoverOrStart) is the right primitive here:
+// a status check should never trigger a daemon auto-spawn (which can
+// download the binary, take seconds, etc.).
+func makeGetSheafStatusHandler() server.ToolHandlerFunc {
+	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		unavailable := func(reason string) (*mcp.CallToolResult, error) {
+			data, _ := json.Marshal(map[string]any{
+				"available": false,
+				"reason":    reason,
+			})
+			return mcp.NewToolResultText(string(data)), nil
+		}
+
+		sockPath, err := leyline.DiscoverSocket()
+		if err != nil {
+			return unavailable("no ley-line daemon socket — set LEYLINE_SOCKET or start `leyline daemon`")
+		}
+		sock, err := leyline.DialSocket(sockPath)
+		if err != nil {
+			return unavailable(fmt.Sprintf("dial %s: %v", sockPath, err))
+		}
+		defer func() { _ = sock.Close() }()
+
+		sc := leyline.NewSheafClient(sock)
+		s, err := sc.Status()
+		if err != nil {
+			return unavailable(fmt.Sprintf("sheaf_status: %v", err))
+		}
+
+		data, _ := json.Marshal(map[string]any{
+			"available":  true,
+			"generation": s.Generation,
+			"valid":      s.Valid,
+			"total":      s.Total,
+			"defect":     s.Defect,
+		})
 		return mcp.NewToolResultText(string(data)), nil
 	}
 }

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -891,6 +891,29 @@ func makeGetCommunitiesHandlerWithDone(g graph.Graph, pushDone chan<- struct{}) 
 			Communities: snapComms,
 			Membership:  result.Membership,
 		}
+
+		// Install the snapshot on the SheafInvalidator the file watcher
+		// holds (if any), so its next onChange fire engages the cascade
+		// instead of falling back to single-node Graph.Invalidate. This
+		// must happen on the SYNCHRONOUS path — the goroutine below
+		// also dials the daemon and pushes topology, but the watcher
+		// shouldn't have to wait on daemon discovery to start using
+		// real membership data. SetCommunityResult is mutex-guarded
+		// (TestSheafInvalidator_ConcurrentReadWrite); the watcher can
+		// safely read while we write here.
+		//
+		// Graph backends without a watcher (control-mode lazyGraph,
+		// composite mounts) don't implement sheafInvalidatorProvider —
+		// the type-assert degrades silently, which is the documented
+		// behavior for those modes (see buildServeGraph).
+		var sip sheafInvalidatorProvider
+		if sp, ok := g.(sheafInvalidatorProvider); ok {
+			sip = sp
+			if si := sip.SheafInvalidator(); si != nil {
+				si.SetCommunityResult(snap)
+			}
+		}
+
 		go func() {
 			if pushDone != nil {
 				defer close(pushDone)
@@ -907,6 +930,19 @@ func makeGetCommunitiesHandlerWithDone(g graph.Graph, pushDone chan<- struct{}) 
 			sc := leyline.NewSheafClient(sock)
 			if pushErr := sc.PushTopology(snap, refs); pushErr != nil {
 				logSheafPushOnce(pushErr)
+				return
+			}
+			// PushTopology succeeded — swap the (now-live) SheafClient
+			// into the invalidator so subsequent watcher fires engage
+			// the cross-region cascade instead of falling back. This
+			// closes the consumer-side loop the mache-49bf9a audit
+			// flagged as "sketch": from here on, edits route through
+			// the daemon and the cascade output drives local cache
+			// invalidation.
+			if sip != nil {
+				if si := sip.SheafInvalidator(); si != nil {
+					si.SetSheaf(sc)
+				}
 			}
 		}()
 

--- a/cmd/serve_mount_test.go
+++ b/cmd/serve_mount_test.go
@@ -44,10 +44,13 @@ func TestBuildMaybeMultiGraph_NoMountsFallsThroughToSingleSource(t *testing.T) {
 	// MemoryStore path deterministically.
 	t.Setenv("MACHE_NO_LEYLINE", "1")
 
-	g, cleanup, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	g, si, cleanup, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
 	require.NoError(t, err)
 	defer cleanup()
 	require.NotNil(t, g)
+	// Pass-through case: invalidator propagates from buildServeGraph and
+	// is non-nil for directory sources.
+	require.NotNil(t, si, "no --mount + directory must propagate the SheafInvalidator")
 
 	// We don't assert graph contents here — that would require a
 	// non-empty topology and exercise the schema/ingest pipeline,
@@ -70,9 +73,12 @@ func TestBuildMaybeMultiGraph_MountsBuildComposite(t *testing.T) {
 	})
 	t.Setenv("MACHE_NO_LEYLINE", "1")
 
-	g, cleanup, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
+	g, si, cleanup, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
 	require.NoError(t, err)
 	defer cleanup()
+	// Composite mount mode forfeits the unified cascade — see
+	// buildMaybeMultiGraph for the design call.
+	assert.Nil(t, si, "composite mounts must return nil *SheafInvalidator")
 
 	root, err := g.GetNode("")
 	require.NoError(t, err)
@@ -94,7 +100,7 @@ func TestBuildMaybeMultiGraph_PositionalSourceWithMountErrors(t *testing.T) {
 	dir := writeSourceDir(t, "Foo")
 	withServeMounts(t, []string{"x=" + dir})
 
-	_, _, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	_, _, _, err := buildMaybeMultiGraph(dir, &api.Topology{Version: api.SchemaVersion})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot use both")
 }
@@ -114,7 +120,7 @@ func TestBuildMaybeMultiGraph_InvalidSpecErrors(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			withServeMounts(t, []string{tc.spec})
-			_, _, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
+			_, _, _, err := buildMaybeMultiGraph("", &api.Topology{Version: api.SchemaVersion})
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid --mount spec")
 		})

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -337,6 +337,24 @@ type lazyGraph struct {
 	schema       *api.Topology // retained after init for schema-aware tools
 	cleanup      func()
 	err          error
+	// sheafInv is the SheafInvalidator wired into the file watcher's
+	// onChange path (when this lazyGraph backs a directory source).
+	// Nil for control mode, .db sources, single-file sources, and
+	// composite mounts — see buildServeGraph / buildMaybeMultiGraph
+	// for the construction contract. The MCP get_communities handler
+	// calls SetCommunityResult + SetSheaf on this to engage the
+	// cross-region cascade; until then the watcher's invalidate calls
+	// fall back to single-node Graph.Invalidate.
+	sheafInv *graph.SheafInvalidator
+}
+
+// SheafInvalidator exposes the cascade-invalidator the file watcher
+// holds for this lazyGraph. Returns nil for graphs that don't have a
+// watcher (control mode, .db sources, composite mounts) — callers
+// must nil-check before use.
+func (lg *lazyGraph) SheafInvalidator() *graph.SheafInvalidator {
+	lg.init()
+	return lg.sheafInv
 }
 
 // schemaProvider exposes the Topology used during graph construction.
@@ -367,12 +385,13 @@ func (lg *lazyGraph) init() {
 
 		// --control mode: skip all source detection, read from arena.
 		if serveControl != "" {
-			g, cleanup, err := buildServeGraph("", &api.Topology{Version: api.SchemaVersion})
+			g, si, cleanup, err := buildServeGraph("", &api.Topology{Version: api.SchemaVersion})
 			if err != nil {
 				lg.err = err
 				return
 			}
 			lg.inner = g
+			lg.sheafInv = si // expected nil in control mode; stored for uniformity
 			lg.cleanup = cleanup
 			lg.schema = &api.Topology{Version: api.SchemaVersion}
 			log.Println("graph ready (arena control mode)")
@@ -449,12 +468,13 @@ func (lg *lazyGraph) init() {
 			}
 		}
 
-		g, cleanup, err := buildMaybeMultiGraph(dataSource, schema)
+		g, si, cleanup, err := buildMaybeMultiGraph(dataSource, schema)
 		if err != nil {
 			lg.err = err
 			return
 		}
 		lg.inner = g
+		lg.sheafInv = si
 		lg.schema = schema
 		lg.cleanup = cleanup
 		log.Println("graph ready")

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -689,6 +689,18 @@ type defsMapProvider interface {
 	DefsMap() map[string][]string
 }
 
+// sheafInvalidatorProvider is the subset of Graph backends that own a
+// SheafInvalidator wired into their file-watcher onChange path. The
+// get_communities handler type-asserts this to install the freshly-
+// detected CommunityResult + dialed SheafClient, which is the trigger
+// that moves the watcher's cascade calls from single-node fallback
+// into actual cross-region propagation. Backends that don't have a
+// watcher (control-mode lazyGraph, composite mounts) don't implement
+// this interface; the handler degrades silently in that case.
+type sheafInvalidatorProvider interface {
+	SheafInvalidator() *graph.SheafInvalidator
+}
+
 // defsLookuper is the cheaper alternative to defsMapProvider for the
 // common case of looking up exactly one symbol. Backends that
 // implement it avoid the O(N) snapshot copy of the full defs map

--- a/cmd/sheaf_wire_test.go
+++ b/cmd/sheaf_wire_test.go
@@ -217,19 +217,29 @@ type testGraphWithSI struct {
 
 func (t *testGraphWithSI) SheafInvalidator() *graph.SheafInvalidator { return t.si }
 
-// TestGetCommunities_PopulatesInvalidator pins the consumer-side wire
-// the audit identified as load-bearing: after the handler runs, the
-// invalidator MUST have community-result state so the watcher's next
-// fire engages the cascade instead of falling back to single-node.
-func TestGetCommunities_PopulatesInvalidator(t *testing.T) {
-	// Suppress auto-spawn; SetSheaf will see nil and the invalidator
-	// will fall back to single-node — but SetCommunityResult must still
-	// fire. This is the minimum contract the watcher cares about.
+// TestGetCommunities_PopulatesInvalidator_WithDaemon pins the consumer-
+// side wire the audit identified as load-bearing: when the handler can
+// reach the daemon AND PushTopology succeeds, the invalidator MUST be
+// populated with BOTH the new CommunityResult and the new SheafClient
+// — atomically (PR #383 Copilot #6). Pre-fix the handler did
+// SetCommunityResult sync + SetSheaf async, opening a window where
+// the watcher could pair new membership with stale sheaf state.
+//
+// We use a mock UDS daemon (sheaf_set_topology returns ok) to drive
+// PushTopology to success; LEYLINE_SOCKET steers the discovery there.
+func TestGetCommunities_PopulatesInvalidator_WithDaemon(t *testing.T) {
+	leyline.StopManaged()
+	sockPath := startMockSheafServer(t, func(req map[string]any) map[string]any {
+		// PushTopology sends sheaf_set_topology; respond with the
+		// success shape the daemon would return.
+		return map[string]any{"ok": true, "delta_zero_mode": true, "regions": 2.0, "restrictions": 1.0}
+	})
+	t.Setenv("LEYLINE_SOCKET", sockPath)
+	// Steer PATH/HOME away so DiscoverSocket finds our mock — not
+	// some leftover real daemon — and DiscoverOrStart doesn't try
+	// to auto-spawn.
 	t.Setenv("PATH", "/nonexistent-path-for-test")
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv("MACHE_NO_LEYLINE", "1")
-	t.Setenv("LEYLINE_SOCKET", "/tmp/nonexistent-leyline-test.sock")
-	leyline.StopManaged()
 
 	// Build a store with enough cross-references to produce a real
 	// CommunityResult (Louvain needs at least one community above
@@ -250,25 +260,62 @@ func TestGetCommunities_PopulatesInvalidator(t *testing.T) {
 
 	g := &testGraphWithSI{MemoryStore: store, si: si}
 
-	// Wire deterministic wait on the fire-and-forget goroutine.
 	pushDone := make(chan struct{})
 	handler := makeGetCommunitiesHandlerWithDone(g, pushDone)
 	result, err := handler(context.Background(), makeRequest(nil))
 	require.NoError(t, err)
 	require.False(t, result.IsError, "handler returned error result: %s", resultText(t, result))
 
-	// Wait for the goroutine that wraps PushTopology + (in the wired
-	// implementation) SetCommunityResult / SetSheaf to complete.
 	select {
 	case <-pushDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("get_communities goroutine did not finish within 2s")
 	}
 
-	// THE CONTRACT: the invalidator MUST now have community-result
-	// state so the watcher's next fire engages the cascade path.
+	// THE CONTRACT: when PushTopology succeeds, the invalidator is
+	// atomically populated (SetState swaps result + sheaf together).
 	assert.True(t, si.HasResult(),
-		"handler must call SetCommunityResult on the invalidator — without this the moat never engages no matter how many edits the watcher sees")
+		"handler must atomically install CommunityResult + SheafClient after PushTopology succeeds — see PR #383 Copilot #6")
+}
+
+// TestGetCommunities_NoDaemon_LeavesInvalidatorEmpty pins the
+// correctness side of PR #383 Copilot #6: when the daemon is
+// unreachable, the handler MUST NOT install CommunityResult on the
+// invalidator. Doing so would pair new membership with no sheaf
+// (or, worse, stale sheaf state from a prior call) and produce
+// cascades against a daemon that doesn't have the new topology.
+// Graceful degradation: leave the invalidator in its prior state
+// so watcher fires use the prior pair atomically.
+func TestGetCommunities_NoDaemon_LeavesInvalidatorEmpty(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	t.Setenv("LEYLINE_SOCKET", "/tmp/nonexistent-leyline-test.sock")
+	leyline.StopManaged()
+
+	store := graph.NewMemoryStore()
+	require.NoError(t, store.AddRef("a", "n1"))
+	require.NoError(t, store.AddRef("a", "n2"))
+	require.NoError(t, store.AddRef("b", "n2"))
+	require.NoError(t, store.AddRef("b", "n3"))
+
+	si := graph.NewSheafInvalidator(store, nil, nil)
+	g := &testGraphWithSI{MemoryStore: store, si: si}
+
+	pushDone := make(chan struct{})
+	handler := makeGetCommunitiesHandlerWithDone(g, pushDone)
+	result, err := handler(context.Background(), makeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+
+	select {
+	case <-pushDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not finish within 2s")
+	}
+
+	assert.False(t, si.HasResult(),
+		"with no daemon, CommunityResult must NOT be installed — would pair new membership with stale/missing sheaf and cause wrong cascades (PR #383 Copilot #6)")
 }
 
 // TestGetCommunities_NoInvalidatorWhenGraphDoesntProvide guards the

--- a/cmd/sheaf_wire_test.go
+++ b/cmd/sheaf_wire_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/agentic-research/mache/api"
 	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/leyline"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -184,4 +186,113 @@ func TestBuildServeGraph_OnDeleteAlsoFiresInvalidator(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	assert.Empty(t, store.NodesForPath(target), "onDelete must purge the file's nodes within debounce + 2s")
+}
+
+// ---------------------------------------------------------------------------
+// TDD #4 — get_communities populates the invalidator
+// ---------------------------------------------------------------------------
+//
+// Without this wiring, the watcher's InvalidateWithCascade calls
+// degrade to single-node Graph.Invalidate forever — even after the
+// MCP layer has community data that COULD enable the cascade. The
+// handler is the natural place to install it: it's the only path
+// that runs community detection AND dials the daemon, which are
+// the two prerequisites SheafInvalidator needs.
+
+// testGraphWithSI is a minimal wrapper that satisfies graph.Graph,
+// refsMapProvider (via the embedded MemoryStore), AND the
+// sheafInvalidatorProvider interface — lets unit tests stand in for
+// a lazyGraph without building the full lazy-init / session-routing
+// machinery. Embedding the concrete *graph.MemoryStore (not the
+// interface) so RefsMap/DefsMap and friends are promoted.
+type testGraphWithSI struct {
+	*graph.MemoryStore
+	si *graph.SheafInvalidator
+}
+
+func (t *testGraphWithSI) SheafInvalidator() *graph.SheafInvalidator { return t.si }
+
+// TestGetCommunities_PopulatesInvalidator pins the consumer-side wire
+// the audit identified as load-bearing: after the handler runs, the
+// invalidator MUST have community-result state so the watcher's next
+// fire engages the cascade instead of falling back to single-node.
+func TestGetCommunities_PopulatesInvalidator(t *testing.T) {
+	// Suppress auto-spawn; SetSheaf will see nil and the invalidator
+	// will fall back to single-node — but SetCommunityResult must still
+	// fire. This is the minimum contract the watcher cares about.
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	t.Setenv("LEYLINE_SOCKET", "/tmp/nonexistent-leyline-test.sock")
+	leyline.StopManaged()
+
+	// Build a store with enough cross-references to produce a real
+	// CommunityResult (Louvain needs at least one community above
+	// min_size).
+	store := graph.NewMemoryStore()
+	require.NoError(t, store.AddRef("alpha", "a1"))
+	require.NoError(t, store.AddRef("alpha", "a2"))
+	require.NoError(t, store.AddRef("alpha", "a3"))
+	require.NoError(t, store.AddRef("beta", "b1"))
+	require.NoError(t, store.AddRef("beta", "b2"))
+	require.NoError(t, store.AddRef("beta", "b3"))
+	require.NoError(t, store.AddRef("bridge", "a1"))
+	require.NoError(t, store.AddRef("bridge", "b1"))
+
+	// Wrap with an invalidator that the handler MUST populate.
+	si := graph.NewSheafInvalidator(store, nil, nil)
+	require.False(t, si.HasResult(), "precondition: invalidator starts empty")
+
+	g := &testGraphWithSI{MemoryStore: store, si: si}
+
+	// Wire deterministic wait on the fire-and-forget goroutine.
+	pushDone := make(chan struct{})
+	handler := makeGetCommunitiesHandlerWithDone(g, pushDone)
+	result, err := handler(context.Background(), makeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "handler returned error result: %s", resultText(t, result))
+
+	// Wait for the goroutine that wraps PushTopology + (in the wired
+	// implementation) SetCommunityResult / SetSheaf to complete.
+	select {
+	case <-pushDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("get_communities goroutine did not finish within 2s")
+	}
+
+	// THE CONTRACT: the invalidator MUST now have community-result
+	// state so the watcher's next fire engages the cascade path.
+	assert.True(t, si.HasResult(),
+		"handler must call SetCommunityResult on the invalidator — without this the moat never engages no matter how many edits the watcher sees")
+}
+
+// TestGetCommunities_NoInvalidatorWhenGraphDoesntProvide guards the
+// nil-receiver / missing-provider case. A graph that doesn't expose a
+// SheafInvalidator (e.g. control-mode lazyGraph, composite mounts)
+// must let the handler succeed with no state mutation — the cascade
+// just isn't available in those modes and that's documented behavior.
+func TestGetCommunities_NoInvalidatorWhenGraphDoesntProvide(t *testing.T) {
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	t.Setenv("LEYLINE_SOCKET", "/tmp/nonexistent-leyline-test.sock")
+	leyline.StopManaged()
+
+	store := graph.NewMemoryStore()
+	require.NoError(t, store.AddRef("x", "n1"))
+	require.NoError(t, store.AddRef("x", "n2"))
+
+	// store is a plain MemoryStore — does NOT implement
+	// sheafInvalidatorProvider. Handler must complete normally.
+	pushDone := make(chan struct{})
+	handler := makeGetCommunitiesHandlerWithDone(store, pushDone)
+	result, err := handler(context.Background(), makeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "handler must succeed even when graph has no invalidator")
+
+	select {
+	case <-pushDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not finish within 2s")
+	}
 }

--- a/cmd/sheaf_wire_test.go
+++ b/cmd/sheaf_wire_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TDD #2 — buildServeGraph contract: callers receive an invalidator
+// alongside the graph, or explicitly nil for modes that don't support
+// one (composite mounts, control-only / arena-backed init).
+//
+// The signature change is deliberate. Hiding the SheafInvalidator
+// behind a type assertion on MemoryStore would silently break the day
+// someone swaps the backing store — exactly the kind of regression PR
+// #380's snapshot fix taught us to lock with an explicit contract.
+
+// TestBuildServeGraph_ReturnsInvalidatorForDir asserts a non-nil
+// invalidator comes back for a real source directory — the watcher
+// is constructed in this path and needs the invalidator to wire its
+// onChange callback.
+func TestBuildServeGraph_ReturnsInvalidatorForDir(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	dir := writeSourceDir(t, "Foo")
+
+	g, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, g, "graph must be non-nil")
+	require.NotNil(t, si, "invalidator must be non-nil for directory sources")
+	assert.False(t, si.HasResult(), "fresh invalidator has no community result until get_communities runs")
+}
+
+// TestBuildServeGraph_NilInvalidatorForNonDir asserts that a
+// file-shaped source (not a directory) returns nil invalidator —
+// there's no watcher to wire so the invalidator is structurally
+// unnecessary. The contract is "you get an invalidator iff there's
+// a watcher that can fire it." Composite mounts and control-only
+// init follow the same rule.
+func TestBuildServeGraph_NilInvalidatorForNonDir(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	// Single .go file (not a dir) — ingest accepts it but no watcher fires.
+	dir := t.TempDir()
+	file := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(file, []byte("package main\nfunc Foo() {}\n"), 0o600))
+
+	g, si, cleanup, err := buildServeGraph(file, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, g)
+	assert.Nil(t, si, "single-file source has no watcher → no invalidator")
+}
+
+// TestBuildServeGraph_InvalidatorWiredIntoStore asserts that the
+// returned invalidator can actually invalidate nodes through the
+// graph it was constructed with. This is the smoke test for the
+// closure capture inside buildServeGraph — if the invalidator
+// references a different graph than the one returned, watcher
+// invalidations would silently miss.
+func TestBuildServeGraph_InvalidatorWiredIntoStore(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	dir := writeSourceDir(t, "Bar")
+
+	g, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, si)
+
+	// Without a CommunityResult and without a sheaf backend, the
+	// invalidator must still successfully call through to the graph's
+	// own Invalidate (single-node fallback). Pass an arbitrary node ID
+	// — even if the graph has never seen it, Invalidate is a no-op-safe
+	// operation on MemoryStore.
+	count := si.InvalidateWithCascade("nonexistent/node", nil)
+	assert.Equal(t, 1, count, "fallback path: single-node invalidate fires")
+
+	_ = g // graph reference held so the deferred cleanup doesn't race init
+}
+
+// TestBuildServeGraph_WatcherFiresInvalidator is the end-to-end
+// wiring assertion. It writes a file, lets the watcher debounce, and
+// confirms the watcher invoked the invalidator at least once. The
+// race-detector run also pins that the watcher goroutine and a
+// concurrent SetCommunityResult call don't trip the new mutex
+// (covered by TestSheafInvalidator_ConcurrentReadWrite at the unit
+// level, this is the integration variant).
+func TestBuildServeGraph_WatcherFiresInvalidator(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	dir := writeSourceDir(t, "Baz")
+
+	_, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, si)
+
+	// Edit the file. The watcher's debounce is 100ms by default.
+	file := filepath.Join(dir, "main.go")
+	require.NoError(t, os.WriteFile(file, []byte("package main\nfunc Baz() { _ = 1 }\n"), 0o600))
+
+	// Spin up to 2s waiting for the invalidator to record activity.
+	// The contract: the watcher onChange MUST end up routing through
+	// the invalidator we got back from buildServeGraph (not a
+	// different one, not direct store.Invalidate).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		// si.HasResult() stays false until get_communities runs —
+		// what we're really checking here is that the watcher
+		// touched the invalidator at all. Without a more direct
+		// hook we'd need to inject a mock; this test pins the wiring
+		// indirectly via the no-result/no-sheaf fallback path
+		// returning count > 0.
+		//
+		// (A subsequent test with a get_communities call + mock
+		// SheafBackend will tighten this to actually observe
+		// cascade calls — see TDD #4.)
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// For now the assertion is just: didn't panic, didn't deadlock,
+	// the invalidator survived a watcher event cycle.
+	assert.False(t, si.HasResult(), "still no community result post-edit")
+	_ = graph.NodesForPathProvider(nil) // keep the import live; provider used in next PR's wiring
+}
+
+// TestBuildServeGraph_IngestErrorReturnsNilInvalidator pins that error
+// paths return a CONSISTENT shape — no graph, no invalidator, a noop
+// cleanup, and an error. Without this, a caller that ignored the
+// invalidator value but checked err could end up with a dangling
+// non-nil invalidator pointing at a partially-constructed store.
+//
+// We trigger the ingest error by pointing at a nonexistent path; the
+// engine surfaces "no such file" while still letting the cleanup chain
+// complete (resolver.Close()).
+func TestBuildServeGraph_IngestErrorReturnsNilInvalidator(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	g, si, cleanup, err := buildServeGraph(missing, &api.Topology{Version: api.SchemaVersion})
+	require.Error(t, err, "nonexistent source must error")
+	assert.Nil(t, g, "no graph returned on error")
+	assert.Nil(t, si, "no invalidator returned on error")
+	require.NotNil(t, cleanup, "cleanup must always be non-nil so deferred callers don't nil-deref")
+	cleanup() // noop, must not panic
+}
+
+// TestBuildServeGraph_OnDeleteAlsoFiresInvalidator pins the symmetric
+// path: when a file is removed, the watcher's onDelete callback must
+// also route through the invalidator. Without this, deleted files leak
+// stale entries in downstream caches that the cascade was meant to
+// flush.
+//
+// The test creates a file, lets the initial ingest see it, deletes it,
+// then asserts the store's NodesForPath returns empty within the
+// debounce window. Pins the wiring at a black-box level — a future
+// refactor that reverts onDelete to "just DeleteFileNodes, no cascade"
+// is caught by TDD #4's cascade-coupling test below; this test pins
+// the more basic invariant that delete-events fire at all.
+func TestBuildServeGraph_OnDeleteAlsoFiresInvalidator(t *testing.T) {
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	dir := writeSourceDir(t, "Doomed")
+
+	g, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	require.NoError(t, err)
+	defer cleanup()
+	require.NotNil(t, si)
+
+	target := filepath.Join(dir, "main.go")
+	require.NoError(t, os.Remove(target))
+
+	store, ok := g.(*graph.MemoryStore)
+	require.True(t, ok, "in-process build returns a MemoryStore")
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(store.NodesForPath(target)) == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.Empty(t, store.NodesForPath(target), "onDelete must purge the file's nodes within debounce + 2s")
+}

--- a/cmd/sheaf_wire_test.go
+++ b/cmd/sheaf_wire_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -97,42 +98,111 @@ func TestBuildServeGraph_InvalidatorWiredIntoStore(t *testing.T) {
 // concurrent SetCommunityResult call don't trip the new mutex
 // (covered by TestSheafInvalidator_ConcurrentReadWrite at the unit
 // level, this is the integration variant).
+// countingSheafBackend records every Invalidate call so tests can
+// assert the watcher actually routed through the cascade path. Stand-
+// in for the real SheafClient when the test doesn't need (or want) a
+// live UDS daemon. Thread-safe — the watcher fires from a goroutine.
+type countingSheafBackend struct {
+	mu       sync.Mutex
+	calls    []int // region IDs received, in call order
+	response []int // canned cascade response
+}
+
+func (c *countingSheafBackend) Invalidate(regionID int) ([]int, error) {
+	c.mu.Lock()
+	c.calls = append(c.calls, regionID)
+	resp := c.response
+	c.mu.Unlock()
+	return resp, nil
+}
+
+func (c *countingSheafBackend) CallCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.calls)
+}
+
+func (c *countingSheafBackend) Calls() []int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]int, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+// TestBuildServeGraph_WatcherFiresInvalidator hardens the prior
+// version of this test (PR #383 Copilot #5) — the previous shape
+// slept until a deadline and asserted on `si.HasResult()` being
+// false, which would have passed even if the watcher→invalidator
+// wiring were deleted entirely.
+//
+// The hardened version installs a counting fake SheafBackend AND a
+// synthetic CommunityResult that maps the fixture's node IDs to a
+// known region. After editing the file, the test waits up to 2s for
+// the fake backend to record at least one Invalidate call. Without
+// the watcher→invalidator wiring (or with a regression that bypasses
+// the invalidator), the call count stays at 0 and the test fails.
+//
+// Also pins that the cascade is called with the *correct* region —
+// the synthetic membership puts every node from the fixture file
+// into region 42, so the only legitimate call recorded is for 42.
 func TestBuildServeGraph_WatcherFiresInvalidator(t *testing.T) {
 	t.Setenv("MACHE_NO_LEYLINE", "1")
 	dir := writeSourceDir(t, "Baz")
 
-	_, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
+	g, si, cleanup, err := buildServeGraph(dir, &api.Topology{Version: api.SchemaVersion})
 	require.NoError(t, err)
 	defer cleanup()
 	require.NotNil(t, si)
 
-	// Edit the file. The watcher's debounce is 100ms by default.
+	// Resolve the fixture's actual node IDs so the synthetic membership
+	// maps every one of them to our known region.
+	store, ok := g.(*graph.MemoryStore)
+	require.True(t, ok, "in-process build returns a MemoryStore")
 	file := filepath.Join(dir, "main.go")
+	nodeIDs := store.NodesForPath(file)
+	require.NotEmpty(t, nodeIDs, "fixture must produce at least one node after Ingest")
+
+	const knownRegion = 42
+	membership := make(map[string]int, len(nodeIDs))
+	for _, id := range nodeIDs {
+		membership[id] = knownRegion
+	}
+	cr := &graph.CommunityResult{
+		Communities: []graph.Community{{ID: knownRegion, Members: nodeIDs}},
+		Membership:  membership,
+	}
+	mock := &countingSheafBackend{response: []int{knownRegion}}
+
+	// Install state via the atomic SetState — same path the real
+	// get_communities handler uses post-PushTopology (PR #383 #6).
+	prior := si.SetState(cr, mock)
+	require.Nil(t, prior, "fresh invalidator has no prior backend")
+
+	// Edit the file. The watcher's debounce is 100ms by default.
 	require.NoError(t, os.WriteFile(file, []byte("package main\nfunc Baz() { _ = 1 }\n"), 0o600))
 
-	// Spin up to 2s waiting for the invalidator to record activity.
-	// The contract: the watcher onChange MUST end up routing through
-	// the invalidator we got back from buildServeGraph (not a
-	// different one, not direct store.Invalidate).
+	// Wait up to 2s for the cascade call to be recorded. Without
+	// the watcher→invalidator wiring this loop times out with
+	// CallCount() == 0 — that's the regression signal.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		// si.HasResult() stays false until get_communities runs —
-		// what we're really checking here is that the watcher
-		// touched the invalidator at all. Without a more direct
-		// hook we'd need to inject a mock; this test pins the wiring
-		// indirectly via the no-result/no-sheaf fallback path
-		// returning count > 0.
-		//
-		// (A subsequent test with a get_communities call + mock
-		// SheafBackend will tighten this to actually observe
-		// cascade calls — see TDD #4.)
+		if mock.CallCount() > 0 {
+			break
+		}
 		time.Sleep(50 * time.Millisecond)
 	}
 
-	// For now the assertion is just: didn't panic, didn't deadlock,
-	// the invalidator survived a watcher event cycle.
-	assert.False(t, si.HasResult(), "still no community result post-edit")
-	_ = graph.NodesForPathProvider(nil) // keep the import live; provider used in next PR's wiring
+	calls := mock.Calls()
+	require.NotEmpty(t, calls, "watcher must route the edit through SheafBackend.Invalidate within 2s — empty here means the watcher→invalidator wiring regressed")
+	// Every recorded call MUST be for the known region. Any other
+	// region ID means membership-snapshot logic regressed (e.g. the
+	// onChange path is using new IDs without including the pre-edit
+	// snapshot — but in this test old IDs == new IDs because we
+	// preserved the function name).
+	for _, region := range calls {
+		assert.Equal(t, knownRegion, region, "all cascades must hit the known region; got %v", region)
+	}
 }
 
 // TestBuildServeGraph_IngestErrorReturnsNilInvalidator pins that error

--- a/cmd/sheaf_wire_test.go
+++ b/cmd/sheaf_wire_test.go
@@ -1,15 +1,20 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
+	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/agentic-research/mache/api"
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -295,4 +300,170 @@ func TestGetCommunities_NoInvalidatorWhenGraphDoesntProvide(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fatal("goroutine did not finish within 2s")
 	}
+}
+
+// ---------------------------------------------------------------------------
+// TDD #5 — get_sheaf_status MCP tool [mache-4a0c05]
+// ---------------------------------------------------------------------------
+//
+// Surfaces the daemon's monotonic generation counter (+ defect, valid,
+// total) to agents so they can decide whether a cached result is still
+// fresh. Pre-cmd-c14c43 the agent has no signal that the cascade fired
+// at all — this tool is the missing visibility.
+
+// startMockSheafServer is a self-contained UDS server that handles a
+// single op pattern: receive line-delimited JSON, return the canned
+// response from the handler func. Mirrors the (unexported)
+// internal/leyline test helper; kept local to cmd/ so the package
+// boundary stays clean.
+func startMockSheafServer(t *testing.T, handler func(map[string]any) map[string]any) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "mache-sheaf-tool-")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	sockPath := filepath.Join(dir, "t.sock")
+
+	ln, err := net.Listen("unix", sockPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				rd := bufio.NewReader(c)
+				for {
+					line, err := rd.ReadString('\n')
+					if err != nil {
+						return
+					}
+					var req map[string]any
+					if err := json.Unmarshal([]byte(strings.TrimSpace(line)), &req); err != nil {
+						continue
+					}
+					resp := handler(req)
+					data, _ := json.Marshal(resp)
+					_, _ = c.Write(append(data, '\n'))
+				}
+			}(conn)
+		}
+	}()
+
+	return sockPath
+}
+
+// TestGetSheafStatus_ReturnsDaemonState pins the happy path: when the
+// daemon is reachable and reports sheaf state, the tool returns a JSON
+// object with the four fields agents need (generation, valid, total,
+// defect) plus an `available: true` marker.
+//
+// Uses the quoted-string generation format (the live wire shape, see
+// PR #382's parseUint64 + cmd/sheaf-wire-check) to also pin that the
+// MCP tool routes through SheafClient.Status (which knows that codec)
+// rather than parsing the response directly and silently dropping the
+// generation value.
+func TestGetSheafStatus_ReturnsDaemonState(t *testing.T) {
+	leyline.StopManaged()
+	sockPath := startMockSheafServer(t, func(req map[string]any) map[string]any {
+		assert.Equal(t, "sheaf_status", req["op"])
+		return map[string]any{
+			"generation": "42", // quoted — capnp-json Int64 shape
+			"valid":      7.0,
+			"total":      10.0,
+			"defect":     0.25,
+		}
+	})
+	t.Setenv("LEYLINE_SOCKET", sockPath)
+
+	handler := makeGetSheafStatusHandler()
+	result, err := handler(context.Background(), makeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "handler must succeed when daemon responds: %s", resultText(t, result))
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &out))
+	assert.Equal(t, true, out["available"])
+	assert.EqualValues(t, 42, out["generation"], "must parse quoted-string Int64 from the live wire format")
+	assert.EqualValues(t, 7, out["valid"])
+	assert.EqualValues(t, 10, out["total"])
+	assert.InDelta(t, 0.25, out["defect"].(float64), 0.001)
+}
+
+// TestGetSheafStatus_NoDaemonReturnsUnavailable pins the documented
+// graceful-degradation contract: when no daemon socket exists, the
+// tool returns a structured "unavailable" response, NOT an MCP error.
+// Agents calling this tool periodically (e.g. as part of a freshness
+// check) should never see a transport-level failure just because the
+// daemon happens to be down.
+func TestGetSheafStatus_NoDaemonReturnsUnavailable(t *testing.T) {
+	leyline.StopManaged()
+	// Steer LEYLINE_SOCKET + HOME away so neither the env var nor the
+	// well-known fallback resolves.
+	t.Setenv("LEYLINE_SOCKET", "/tmp/nonexistent-sheaf-status-sock")
+	t.Setenv("HOME", t.TempDir())
+
+	handler := makeGetSheafStatusHandler()
+	result, err := handler(context.Background(), makeRequest(nil))
+	require.NoError(t, err)
+	require.False(t, result.IsError, "no-daemon path must not surface as an MCP error")
+
+	var out map[string]any
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &out))
+	assert.Equal(t, false, out["available"])
+	assert.NotEmpty(t, out["reason"], "must explain why state is unavailable")
+}
+
+// TestGetSheafStatus_RegisteredInToolSet pins that the tool is wired
+// into the MCP server's tool list — without this assertion a future
+// refactor could quietly drop the registration and the moat's
+// visibility layer would silently disappear.
+func TestGetSheafStatus_RegisteredInToolSet(t *testing.T) {
+	store := graph.NewMemoryStore()
+	registry := newGraphRegistry(".", nil)
+	registry.graphs.Store(".", &lazyGraph{inner: store})
+
+	srv := mcpServerForToolListing()
+	registerMCPTools(srv, registry)
+
+	names := listRegisteredTools(t, srv)
+	assert.Contains(t, names, "get_sheaf_status",
+		"get_sheaf_status must be in the MCP tool surface — see mache-4a0c05")
+}
+
+// mcpServerForToolListing constructs a bare MCP server fit for tool
+// enumeration. Extracted so the get_sheaf_status registration test
+// doesn't drag the full multi-tenant TestRegisterMCPTools fixture.
+func mcpServerForToolListing() *server.MCPServer {
+	return server.NewMCPServer("test", "1.0.0", server.WithToolCapabilities(false))
+}
+
+// listRegisteredTools queries the server's tools/list endpoint and
+// returns the set of registered names. Mirrors the pattern in
+// TestRegisterMCPTools (cmd/serve_test.go) — kept local so the new
+// tool's regression guard is self-contained.
+func listRegisteredTools(t *testing.T, s *server.MCPServer) map[string]bool {
+	t.Helper()
+	reqJSON := json.RawMessage(`{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}`)
+	resp := s.HandleMessage(context.Background(), reqJSON)
+	respJSON, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var parsed struct {
+		Result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(respJSON, &parsed))
+
+	names := map[string]bool{}
+	for _, tool := range parsed.Result.Tools {
+		names[tool.Name] = true
+	}
+	return names
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -594,6 +595,67 @@ func (s *MemoryStore) DeleteFileNodes(filePath string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.deleteFileNodes(filePath)
+}
+
+// NodesForPath returns the IDs of every node whose origin file is filePath,
+// in deterministic order. The path is canonicalised via filepath.EvalSymlinks
+// to match the bookkeeping Ingest does. Returns an empty slice when no nodes
+// are indexed under that path.
+//
+// O(k) via the file→nodes bitmap; falls back to a full O(N) scan only when a
+// path was added before the bitmap was populated (the same fallback path
+// DeleteFileNodes uses, kept for parity).
+//
+// Used by the file-watcher → SheafInvalidator wiring (cmd/serve.go) so the
+// sheaf cascade has a node ID to look up the region for. Exposed via the
+// NodesForPathProvider interface so non-MemoryStore backends can plug in
+// without leaking *MemoryStore type assertions into serve.go.
+func (s *MemoryStore) NodesForPath(filePath string) []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	canonical := filePath
+	if realPath, err := filepath.EvalSymlinks(filePath); err == nil {
+		canonical = realPath
+	}
+
+	var ids []string
+	if bm, ok := s.fileToNodes[canonical]; ok {
+		it := bm.Iterator()
+		for it.HasNext() {
+			intID := it.Next()
+			if int(intID) < len(s.intToNodeID) {
+				nodeID := s.intToNodeID[intID]
+				if nodeID != "" {
+					ids = append(ids, nodeID)
+				}
+			}
+		}
+		sort.Strings(ids)
+		return ids
+	}
+
+	// Fallback: linear scan for paths not in the bitmap yet.
+	for id, n := range s.nodes {
+		if n.Origin != nil && n.Origin.FilePath == canonical {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// NodesForPathProvider is implemented by graph backends that can answer
+// "which node IDs originated from this file?". MemoryStore implements it;
+// other backends (SQLiteGraph, CompositeGraph) may either implement it
+// directly or compose it via type assertion on their inner store.
+//
+// Kept as a separate interface (rather than added to Graph) so consumers
+// that don't need this query — most graph readers — aren't forced to
+// implement it. Watcher-driven invalidation paths type-assert and degrade
+// gracefully when the backing store doesn't satisfy the interface.
+type NodesForPathProvider interface {
+	NodesForPath(filePath string) []string
 }
 
 // ReplaceFileNodes atomically replaces all nodes from a file with a new set.

--- a/internal/graph/sheaf_invalidate.go
+++ b/internal/graph/sheaf_invalidate.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"log"
+	"sync"
 )
 
 // SheafInvalidator wraps a Graph with sheaf-aware cascading invalidation.
@@ -12,7 +13,12 @@ import (
 // If the SheafClient is nil or the daemon is unavailable, it falls back
 // to plain Graph.Invalidate on the single node.
 type SheafInvalidator struct {
-	graph  Graph
+	graph Graph
+	// mu guards sheaf + result. The watcher goroutine calls
+	// InvalidateWithCascade while the MCP get_communities handler may
+	// concurrently call SetCommunityResult / SetSheaf. Both reads
+	// (sheaf, result) are taken under RLock; writes upgrade to Lock.
+	mu     sync.RWMutex
 	sheaf  SheafBackend
 	result *CommunityResult
 }
@@ -38,7 +44,34 @@ func NewSheafInvalidator(graph Graph, sheaf SheafBackend, result *CommunityResul
 // SetCommunityResult updates the community detection result used for lookups.
 // Call this after re-running community detection.
 func (si *SheafInvalidator) SetCommunityResult(cr *CommunityResult) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
 	si.result = cr
+}
+
+// SetSheaf swaps the sheaf backend. Pass nil to disable cascades (the
+// invalidator falls back to single-node Graph.Invalidate). Used by the
+// serve startup path to attach a SheafClient lazily — the file watcher
+// can install the invalidator before the ley-line daemon is reachable,
+// then swap in a real backend once a connection is established.
+func (si *SheafInvalidator) SetSheaf(b SheafBackend) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	si.sheaf = b
+}
+
+// HasResult reports whether the invalidator has a CommunityResult to
+// look up regions in. When false, InvalidateWithCascade degrades to
+// single-node invalidate (still correct, just no cascade). Callers
+// (e.g. the watcher) use this to decide whether to skip the lookup
+// entirely vs. fall through.
+func (si *SheafInvalidator) HasResult() bool {
+	if si == nil {
+		return false
+	}
+	si.mu.RLock()
+	defer si.mu.RUnlock()
+	return si.result != nil
 }
 
 // InvalidateWithCascade invalidates a node and, if sheaf is available,
@@ -53,13 +86,22 @@ func (si *SheafInvalidator) InvalidateWithCascade(id string, membership map[stri
 		return 0
 	}
 
+	// Take a consistent snapshot of sheaf + result under the read lock,
+	// then release it before any network I/O — sheaf.Invalidate dials
+	// the daemon and could block long enough to starve SetSheaf /
+	// SetCommunityResult writers.
+	si.mu.RLock()
+	sheaf := si.sheaf
+	storedResult := si.result
+	si.mu.RUnlock()
+
 	// Use stored membership if caller didn't provide one.
-	if membership == nil && si.result != nil {
-		membership = si.result.Membership
+	if membership == nil && storedResult != nil {
+		membership = storedResult.Membership
 	}
 
 	// If no sheaf backend or no community info, fall back to single invalidation.
-	if si.sheaf == nil || membership == nil {
+	if sheaf == nil || membership == nil {
 		si.graph.Invalidate(id)
 		return 1
 	}
@@ -71,7 +113,7 @@ func (si *SheafInvalidator) InvalidateWithCascade(id string, membership map[stri
 		return 1
 	}
 
-	affected, err := si.sheaf.Invalidate(regionID)
+	affected, err := sheaf.Invalidate(regionID)
 	if err != nil {
 		// Daemon error — log and fall back to single invalidation.
 		log.Printf("sheaf invalidate region %d: %v (falling back to single node)", regionID, err)

--- a/internal/graph/sheaf_invalidate.go
+++ b/internal/graph/sheaf_invalidate.go
@@ -54,10 +54,35 @@ func (si *SheafInvalidator) SetCommunityResult(cr *CommunityResult) {
 // serve startup path to attach a SheafClient lazily — the file watcher
 // can install the invalidator before the ley-line daemon is reachable,
 // then swap in a real backend once a connection is established.
-func (si *SheafInvalidator) SetSheaf(b SheafBackend) {
+//
+// Returns the prior backend so callers that own SheafBackend resources
+// (e.g. a SheafClient wrapping a UDS socket) can close the prior one
+// without leaking. Returns nil if no prior backend was installed.
+func (si *SheafInvalidator) SetSheaf(b SheafBackend) (prior SheafBackend) {
 	si.mu.Lock()
 	defer si.mu.Unlock()
+	prior = si.sheaf
 	si.sheaf = b
+	return prior
+}
+
+// SetState atomically swaps both the CommunityResult and SheafBackend
+// under a single Lock. Use this when both pieces are being replaced
+// together (e.g. from get_communities after PushTopology succeeds).
+// The standalone SetSheaf / SetCommunityResult paths open a window
+// where the watcher can observe new membership paired with old sheaf
+// (or vice versa) — see TestSheafInvalidator_SetState_AtomicSwap and
+// PR #383 Copilot #6 for the cascade-mismatch failure mode.
+//
+// Returns the prior backend so the caller can close it without
+// leaking. Returns nil if no prior backend was installed.
+func (si *SheafInvalidator) SetState(result *CommunityResult, sheaf SheafBackend) (prior SheafBackend) {
+	si.mu.Lock()
+	defer si.mu.Unlock()
+	prior = si.sheaf
+	si.result = result
+	si.sheaf = sheaf
+	return prior
 }
 
 // HasResult reports whether the invalidator has a CommunityResult to

--- a/internal/graph/sheaf_invalidate.go
+++ b/internal/graph/sheaf_invalidate.go
@@ -99,6 +99,116 @@ func (si *SheafInvalidator) HasResult() bool {
 	return si.result != nil
 }
 
+// InvalidateNodesWithCascade is the batched-by-region variant of
+// InvalidateWithCascade. The watcher passes every node touched by a
+// file edit; this method dedupes them to the underlying set of unique
+// region IDs and calls the daemon exactly once per unique region.
+//
+// Why this exists (PR #383 Copilot #7): the naive
+// `for _, id := range ids { InvalidateWithCascade(id) }` loop hits the
+// daemon once per node. On a large file with 50 functions all in the
+// same community, that's 50 redundant region invalidations — each
+// bumps the generation counter and re-cascades the same regions on
+// the daemon side. This method collapses that to one call per unique
+// region.
+//
+// IDs not present in membership fall back to single-node
+// Graph.Invalidate (same fallback as InvalidateWithCascade for unknown
+// nodes). When sheaf or membership is nil, the entire input falls
+// back to per-id Graph.Invalidate.
+//
+// Returns total nodes invalidated across all paths (cascades + fallbacks).
+func (si *SheafInvalidator) InvalidateNodesWithCascade(ids []string) int {
+	if si == nil || si.graph == nil || len(ids) == 0 {
+		return 0
+	}
+
+	si.mu.RLock()
+	sheaf := si.sheaf
+	storedResult := si.result
+	si.mu.RUnlock()
+
+	var membership map[string]int
+	if storedResult != nil {
+		membership = storedResult.Membership
+	}
+
+	// Degraded path: no sheaf or no membership → per-id single-node invalidate.
+	if sheaf == nil || membership == nil {
+		for _, id := range ids {
+			si.graph.Invalidate(id)
+		}
+		return len(ids)
+	}
+
+	// Split inputs: nodes that map to a region (eligible for cascade)
+	// vs. unmapped (fall back to single-node invalidate).
+	regionSet := make(map[int]struct{})
+	var unmapped []string
+	for _, id := range ids {
+		if rid, ok := membership[id]; ok {
+			regionSet[rid] = struct{}{}
+		} else {
+			unmapped = append(unmapped, id)
+		}
+	}
+
+	// If nothing maps to a region, fall back per-id.
+	if len(regionSet) == 0 {
+		for _, id := range ids {
+			si.graph.Invalidate(id)
+		}
+		return len(ids)
+	}
+
+	// Call the daemon ONCE per unique region; union the affected sets.
+	affectedSet := make(map[int]struct{})
+	for region := range regionSet {
+		affected, err := sheaf.Invalidate(region)
+		if err != nil {
+			log.Printf("sheaf invalidate region %d: %v (falling back to single node)", region, err)
+			// Best-effort: invalidate the requesting region's member
+			// nodes via the local graph so this region isn't entirely
+			// dropped, then continue with the remaining regions.
+			for nodeID, cid := range membership {
+				if cid == region {
+					si.graph.Invalidate(nodeID)
+				}
+			}
+			continue
+		}
+		for _, rid := range affected {
+			affectedSet[rid] = struct{}{}
+		}
+		// Daemon-returned cascade may be empty (no entries to
+		// invalidate); the input region itself is still stale, so
+		// include it for the local invalidation pass below.
+		affectedSet[region] = struct{}{}
+	}
+
+	// Invalidate every node in the union of affected regions exactly once.
+	invalidated := make(map[string]struct{})
+	for nodeID, cid := range membership {
+		if _, hit := affectedSet[cid]; hit {
+			if _, seen := invalidated[nodeID]; !seen {
+				si.graph.Invalidate(nodeID)
+				invalidated[nodeID] = struct{}{}
+			}
+		}
+	}
+
+	// Plus unmapped inputs (renames / new constructs not yet in the
+	// stored CommunityResult) — fall back to single-node invalidate.
+	for _, id := range unmapped {
+		if _, seen := invalidated[id]; !seen {
+			si.graph.Invalidate(id)
+			invalidated[id] = struct{}{}
+		}
+	}
+
+	return len(invalidated)
+}
+
 // InvalidateWithCascade invalidates a node and, if sheaf is available,
 // cascades the invalidation to all nodes in transitively affected regions.
 //

--- a/internal/graph/sheaf_invalidate_test.go
+++ b/internal/graph/sheaf_invalidate_test.go
@@ -1,6 +1,8 @@
 package graph
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,14 +14,29 @@ import (
 // ---------------------------------------------------------------------------
 
 type mockSheafBackend struct {
+	mu       sync.Mutex
 	calls    []int // region IDs passed to Invalidate
 	response []int // affected region IDs to return
 	err      error // error to return
 }
 
 func (m *mockSheafBackend) Invalidate(regionID int) ([]int, error) {
+	m.mu.Lock()
 	m.calls = append(m.calls, regionID)
-	return m.response, m.err
+	resp, err := m.response, m.err
+	m.mu.Unlock()
+	return resp, err
+}
+
+// Calls returns a snapshot of the recorded region IDs. Use this in
+// assertions instead of touching .calls directly so the mutex protects
+// concurrent test usage.
+func (m *mockSheafBackend) Calls() []int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]int, len(m.calls))
+	copy(out, m.calls)
+	return out
 }
 
 // ---------------------------------------------------------------------------
@@ -27,6 +44,7 @@ func (m *mockSheafBackend) Invalidate(regionID int) ([]int, error) {
 // ---------------------------------------------------------------------------
 
 type mockGraph struct {
+	mu          sync.Mutex
 	invalidated []string
 }
 
@@ -41,7 +59,28 @@ func (m *mockGraph) Act(id, action, payload string) (*ActionResult, error) {
 }
 
 func (m *mockGraph) Invalidate(id string) {
+	m.mu.Lock()
 	m.invalidated = append(m.invalidated, id)
+	m.mu.Unlock()
+}
+
+// Invalidated returns a snapshot of the recorded node IDs. Use this in
+// assertions instead of touching .invalidated directly so the mutex
+// protects concurrent test usage.
+func (m *mockGraph) Invalidated() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.invalidated))
+	copy(out, m.invalidated)
+	return out
+}
+
+// resetInvalidated clears the recorded list. Test helper for cases that
+// reset between phases (e.g. before/after a hot-swap).
+func (m *mockGraph) resetInvalidated() {
+	m.mu.Lock()
+	m.invalidated = nil
+	m.mu.Unlock()
 }
 
 // ---------------------------------------------------------------------------
@@ -335,4 +374,133 @@ func TestSheafInvalidator_WithRealCommunities(t *testing.T) {
 	for _, nid := range g.invalidated {
 		assert.Equal(t, a1Region, cr.Membership[nid])
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Hot-swap + race-safety contracts (mache-c11848)
+//
+// The watcher goroutine calls InvalidateWithCascade while MCP handlers
+// concurrently mutate the invalidator via SetCommunityResult / SetSheaf.
+// These tests pin the mutex protection added for the file-watcher wiring.
+// ---------------------------------------------------------------------------
+
+// TestSheafInvalidator_HasResult covers the "do I have membership data?"
+// accessor the watcher uses to decide whether to short-circuit a cascade
+// before even constructing the call. nil-receiver safety is the new
+// invariant — without it the cascade path on a nil invalidator would
+// nil-deref instead of cleanly degrading to "no cascade".
+func TestSheafInvalidator_HasResult(t *testing.T) {
+	var nilSi *SheafInvalidator
+	assert.False(t, nilSi.HasResult(), "nil receiver must be safe + false")
+
+	si := NewSheafInvalidator(&mockGraph{}, nil, nil)
+	assert.False(t, si.HasResult(), "fresh invalidator without result")
+
+	cr := &CommunityResult{
+		Communities: []Community{{ID: 1, Members: []string{"a"}}},
+		Membership:  map[string]int{"a": 1},
+	}
+	si.SetCommunityResult(cr)
+	assert.True(t, si.HasResult(), "after SetCommunityResult")
+}
+
+// TestSheafInvalidator_SetSheaf_Hotswap pins the contract that the
+// invalidator can be constructed before the ley-line daemon is reachable
+// — the file watcher installs it at serve startup, and the sheaf backend
+// gets swapped in later once a connection is established. Pre-swap the
+// invalidator must fall back to single-node Graph.Invalidate; post-swap
+// the cascade must engage.
+func TestSheafInvalidator_SetSheaf_Hotswap(t *testing.T) {
+	g := &mockGraph{}
+	cr := &CommunityResult{
+		Communities: []Community{
+			{ID: 1, Members: []string{"a"}},
+			{ID: 2, Members: []string{"b"}},
+		},
+		Membership: map[string]int{"a": 1, "b": 2},
+	}
+	si := NewSheafInvalidator(g, nil, cr)
+
+	// Pre-swap: no sheaf attached. Must fall back to single-node.
+	count := si.InvalidateWithCascade("a", nil)
+	assert.Equal(t, 1, count, "no sheaf → single-node")
+	assert.Equal(t, []string{"a"}, g.invalidated, "only the requested node")
+
+	// Hot-swap a sheaf backend in mid-flight.
+	mock := &mockSheafBackend{response: []int{1, 2}}
+	si.SetSheaf(mock)
+
+	g.resetInvalidated()
+	count = si.InvalidateWithCascade("a", nil)
+	assert.Equal(t, 2, count, "post-swap → full cascade")
+	assert.Equal(t, []int{1}, mock.Calls(), "sheaf called with region id")
+	assert.ElementsMatch(t, []string{"a", "b"}, g.Invalidated(), "both region members invalidated")
+
+	// Hot-swap back to nil — must return to single-node, not panic.
+	si.SetSheaf(nil)
+	g.resetInvalidated()
+	count = si.InvalidateWithCascade("a", nil)
+	assert.Equal(t, 1, count, "nil-swap → fallback")
+}
+
+// TestSheafInvalidator_ConcurrentReadWrite is the race-detector gate.
+// Without the mutex on (sheaf, result), the watcher goroutine reading
+// these fields while the MCP handler swaps them produces the same
+// kind of data race the get_communities snapshot fix (PR #380) caught
+// — it just hadn't fired yet because there was no concurrent writer.
+//
+// Run with `go test -race` to actually catch a regression. Without
+// -race this only validates that 100 concurrent calls don't panic
+// or deadlock, which is weaker but still useful as a smoke test.
+func TestSheafInvalidator_ConcurrentReadWrite(t *testing.T) {
+	g := &mockGraph{}
+	si := NewSheafInvalidator(g, nil, nil)
+
+	const (
+		readers    = 8
+		writers    = 4
+		iterations = 200
+	)
+
+	var done sync.WaitGroup
+	var readOps int64
+
+	// Reader goroutines hammer InvalidateWithCascade.
+	for i := 0; i < readers; i++ {
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			for j := 0; j < iterations; j++ {
+				si.InvalidateWithCascade("a", nil)
+				_ = si.HasResult()
+				atomic.AddInt64(&readOps, 1)
+			}
+		}()
+	}
+
+	// Writer goroutines hammer SetCommunityResult + SetSheaf.
+	for i := 0; i < writers; i++ {
+		done.Add(1)
+		go func(seed int) {
+			defer done.Done()
+			for j := 0; j < iterations; j++ {
+				cr := &CommunityResult{
+					Communities: []Community{{ID: seed, Members: []string{"a"}}},
+					Membership:  map[string]int{"a": seed},
+				}
+				si.SetCommunityResult(cr)
+				si.SetSheaf(&mockSheafBackend{response: []int{seed}})
+				// And clear them to keep the swap surface honest.
+				if j%17 == 0 {
+					si.SetSheaf(nil)
+				}
+				if j%23 == 0 {
+					si.SetCommunityResult(nil)
+				}
+			}
+		}(i + 1)
+	}
+
+	done.Wait()
+	assert.Equal(t, int64(readers*iterations), readOps, "all reads completed")
 }

--- a/internal/graph/sheaf_invalidate_test.go
+++ b/internal/graph/sheaf_invalidate_test.go
@@ -565,3 +565,88 @@ func TestSheafInvalidator_SetSheaf_ReturnsPrior(t *testing.T) {
 	assert.Same(t, b, si.SetSheaf(nil), "nil clear: returns b as prior")
 	assert.Nil(t, si.SetSheaf(nil), "no-op clear: nil prior")
 }
+
+// TestSheafInvalidator_InvalidateNodesWithCascade_DedupsByRegion pins
+// PR #383 Copilot #7: the watcher passes multiple node IDs (every
+// node touched by a file edit), but many of those nodes typically
+// share the same community/region. The naive loop of "for each id:
+// InvalidateWithCascade(id)" hits the daemon once per node, which on
+// a large file is dozens of redundant region invalidations that
+// bump the generation counter per call and re-cascade the same
+// regions.
+//
+// InvalidateNodesWithCascade collapses to ONE daemon call per
+// unique region. Verified by the fake backend's Calls() returning
+// exactly len(unique regions) entries, not len(ids).
+func TestSheafInvalidator_InvalidateNodesWithCascade_DedupsByRegion(t *testing.T) {
+	g := &mockGraph{}
+	cr := &CommunityResult{
+		Communities: []Community{
+			{ID: 1, Members: []string{"a1", "a2", "a3"}},
+			{ID: 2, Members: []string{"b1", "b2"}},
+		},
+		Membership: map[string]int{
+			"a1": 1, "a2": 1, "a3": 1,
+			"b1": 2, "b2": 2,
+		},
+	}
+	mock := &mockSheafBackend{response: []int{1, 2}}
+	si := NewSheafInvalidator(g, mock, cr)
+
+	// Call with 5 IDs spanning 2 unique regions.
+	count := si.InvalidateNodesWithCascade([]string{"a1", "a2", "a3", "b1", "b2"})
+
+	// Pin the dedupe contract: exactly 2 daemon calls (one per unique
+	// region), not 5.
+	calls := mock.Calls()
+	require.Len(t, calls, 2, "must call sheaf.Invalidate once per UNIQUE region, not once per node")
+	assert.ElementsMatch(t, []int{1, 2}, calls, "both unique regions called exactly once")
+
+	// All 5 nodes should still be invalidated (cascade union — both
+	// regions 1 and 2 returned as affected, so all members invalidated).
+	assert.Equal(t, 5, count, "all nodes in affected regions invalidated")
+	assert.ElementsMatch(t, []string{"a1", "a2", "a3", "b1", "b2"}, g.Invalidated())
+}
+
+// TestSheafInvalidator_InvalidateNodesWithCascade_FallbackPaths covers
+// the degraded cases the watcher hits before get_communities has run
+// (no sheaf, no result) and the partial case where some IDs are not
+// in the membership map (renames, new constructs).
+func TestSheafInvalidator_InvalidateNodesWithCascade_FallbackPaths(t *testing.T) {
+	t.Run("no_sheaf_no_result_single_node_per_id", func(t *testing.T) {
+		g := &mockGraph{}
+		si := NewSheafInvalidator(g, nil, nil)
+		count := si.InvalidateNodesWithCascade([]string{"x", "y", "z"})
+		assert.Equal(t, 3, count, "fallback: each id invalidates locally")
+		assert.ElementsMatch(t, []string{"x", "y", "z"}, g.Invalidated())
+	})
+
+	t.Run("ids_not_in_membership_fall_through", func(t *testing.T) {
+		g := &mockGraph{}
+		cr := &CommunityResult{
+			Communities: []Community{{ID: 1, Members: []string{"known"}}},
+			Membership:  map[string]int{"known": 1},
+		}
+		mock := &mockSheafBackend{response: []int{1}}
+		si := NewSheafInvalidator(g, mock, cr)
+
+		// One known + two unknown IDs.
+		count := si.InvalidateNodesWithCascade([]string{"known", "ghost1", "ghost2"})
+
+		// Cascade fires once for region 1 (known); ghosts fall back
+		// to single-node invalidate.
+		assert.Equal(t, []int{1}, mock.Calls(), "only the known id's region cascades")
+		// known's cascade returns region 1, which has member "known" → invalidated.
+		// ghosts are invalidated individually via the fallback path.
+		assert.ElementsMatch(t, []string{"known", "ghost1", "ghost2"}, g.Invalidated())
+		assert.Equal(t, 3, count)
+	})
+
+	t.Run("empty_input_no_op", func(t *testing.T) {
+		g := &mockGraph{}
+		si := NewSheafInvalidator(g, &mockSheafBackend{}, &CommunityResult{Membership: map[string]int{}})
+		count := si.InvalidateNodesWithCascade(nil)
+		assert.Equal(t, 0, count)
+		assert.Empty(t, g.Invalidated())
+	})
+}

--- a/internal/graph/sheaf_invalidate_test.go
+++ b/internal/graph/sheaf_invalidate_test.go
@@ -504,3 +504,64 @@ func TestSheafInvalidator_ConcurrentReadWrite(t *testing.T) {
 	done.Wait()
 	assert.Equal(t, int64(readers*iterations), readOps, "all reads completed")
 }
+
+// TestSheafInvalidator_SetState_AtomicSwap pins the contract added in
+// response to PR #383 Copilot #6: SetCommunityResult + SetSheaf as two
+// separate writes opens a window where the watcher can observe new
+// membership paired with old sheaf (or vice versa) — and route
+// invalidations through a daemon that doesn't yet have the new
+// topology. SetState swaps both under a single Lock, so the watcher
+// either sees the old pair OR the new pair, never a mismatched mix.
+//
+// Verifies the swap is atomic by serializing a sequence: SetState(A) →
+// SetState(B) → SetState(C); the watcher's snapshot is always one
+// consistent (result, sheaf) tuple — never (resultA, sheafB).
+func TestSheafInvalidator_SetState_AtomicSwap(t *testing.T) {
+	g := &mockGraph{}
+	si := NewSheafInvalidator(g, nil, nil)
+
+	crA := &CommunityResult{Membership: map[string]int{"x": 1}}
+	backendA := &mockSheafBackend{response: []int{1}}
+
+	priorA := si.SetState(crA, backendA)
+	assert.Nil(t, priorA, "first SetState returns nil prior backend")
+	assert.True(t, si.HasResult(), "result installed")
+
+	// Verify the snapshot is consistent post-SetState.
+	g.resetInvalidated()
+	si.InvalidateWithCascade("x", nil)
+	assert.Equal(t, []int{1}, backendA.Calls(), "post-SetState cascade hits backendA")
+
+	// Hot-swap to a new pair atomically.
+	crB := &CommunityResult{Membership: map[string]int{"y": 2}}
+	backendB := &mockSheafBackend{response: []int{2}}
+	priorB := si.SetState(crB, backendB)
+	assert.Same(t, backendA, priorB, "second SetState returns priorA so caller can close it")
+
+	g.resetInvalidated()
+	si.InvalidateWithCascade("y", nil)
+	assert.Equal(t, []int{2}, backendB.Calls(), "post-swap cascade hits backendB only")
+	assert.Equal(t, []int{1}, backendA.Calls(), "backendA not touched after swap")
+
+	// Clear: pass nil/nil; prior is backendB.
+	priorC := si.SetState(nil, nil)
+	assert.Same(t, backendB, priorC)
+	assert.False(t, si.HasResult(), "result cleared")
+}
+
+// TestSheafInvalidator_SetSheaf_ReturnsPrior covers the standalone
+// SetSheaf path with the same prior-backend handoff. Callers that
+// own SheafBackend resources (e.g. a SheafClient wrapping a UDS
+// socket) need this to close the prior backend without leaking.
+func TestSheafInvalidator_SetSheaf_ReturnsPrior(t *testing.T) {
+	g := &mockGraph{}
+	si := NewSheafInvalidator(g, nil, nil)
+
+	a := &mockSheafBackend{}
+	b := &mockSheafBackend{}
+
+	assert.Nil(t, si.SetSheaf(a), "initial set: no prior")
+	assert.Same(t, a, si.SetSheaf(b), "second set: returns a as prior")
+	assert.Same(t, b, si.SetSheaf(nil), "nil clear: returns b as prior")
+	assert.Nil(t, si.SetSheaf(nil), "no-op clear: nil prior")
+}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -29,9 +29,24 @@ import (
 
 // SocketClient communicates with a running ley-line daemon over its
 // Unix domain control socket ({ctrl}.sock).
+//
+// SendOp / SendOpInto are safe for concurrent use: sendMu serializes
+// the write-then-read pair so the line-delimited JSON protocol can't
+// get crossed when multiple callers (e.g. the file watcher firing
+// multiple debounce timers after a save burst) hit the same client
+// simultaneously. The protocol is request/response — interleaving
+// produces a response for the wrong caller, which the daemon can't
+// detect since there's no per-message correlation ID.
+//
+// Subscribe is the exception: once a Subscribe goroutine takes
+// ownership of the read side, ad-hoc SendOp on the same connection
+// is unsupported and will race the subscription's event reads. The
+// canonical usage is one SocketClient per role (one for ops, one
+// for subscribe).
 type SocketClient struct {
-	conn net.Conn
-	rd   *bufio.Reader
+	conn   net.Conn
+	rd     *bufio.Reader
+	sendMu sync.Mutex
 }
 
 // managed holds state for a leyline daemon subprocess auto-spawned by mache.
@@ -290,6 +305,14 @@ func (c *SocketClient) sendRaw(req map[string]any) ([]byte, error) {
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 	data = append(data, '\n')
+
+	// Serialize the write-then-read pair. Without this lock, concurrent
+	// callers interleave their writes and crossed reads on the line-
+	// delimited JSON protocol — caller A reads caller B's response and
+	// vice versa, and there's no per-message correlation ID to detect
+	// the swap. Pinned by TestSendOp_ConcurrentCallsDoNotInterleave.
+	c.sendMu.Lock()
+	defer c.sendMu.Unlock()
 
 	if _, err := c.conn.Write(data); err != nil {
 		return nil, fmt.Errorf("write: %w", err)

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -7,8 +7,13 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockServer starts a UDS server that echoes back canned responses.
@@ -318,4 +323,57 @@ func TestLeylineReleaseURL_PointsAtPublicRepo(t *testing.T) {
 	if strings.Contains(leylineReleaseURLTemplate, "/ley-line/") {
 		t.Errorf("leylineReleaseURLTemplate still references the private ley-line repo: %q", leylineReleaseURLTemplate)
 	}
+}
+
+// TestSendOp_ConcurrentCallsDoNotInterleave is the regression guard
+// for Copilot's PR #383 review: SocketClient.SendOp performs an
+// unsynchronized write-then-read on a shared connection. Without a
+// mutex, concurrent callers (e.g. the file watcher firing multiple
+// debounce timers in quick succession after a save burst) would
+// interleave requests and reads, corrupting the line-delimited
+// JSON protocol. Pinned here so a future refactor can't drop the
+// serialization without the race detector catching it.
+//
+// The mock server tags each response with the request's "id" field;
+// after N parallel SendOps, every caller must see a response whose
+// id matches its own request. Without the mutex, ids will mismatch
+// (or the read will EOF) under -race.
+func TestSendOp_ConcurrentCallsDoNotInterleave(t *testing.T) {
+	const calls = 50
+
+	sockPath := mockServer(t, func(req map[string]any) map[string]any {
+		// Echo the id so callers can verify their request matched
+		// the response they read.
+		return map[string]any{"id": req["id"], "ok": true}
+	})
+
+	sock, err := DialSocket(sockPath)
+	require.NoError(t, err)
+	defer sock.Close() //nolint:errcheck
+
+	var (
+		wg         sync.WaitGroup
+		mismatches int64
+		errs       int64
+	)
+	for i := 0; i < calls; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			resp, err := sock.SendOp(map[string]any{"op": "echo", "id": float64(id)})
+			if err != nil {
+				atomic.AddInt64(&errs, 1)
+				return
+			}
+			gotID, _ := resp["id"].(float64)
+			if int(gotID) != id {
+				atomic.AddInt64(&mismatches, 1)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	assert.Zero(t, atomic.LoadInt64(&errs), "no SendOp call should error under concurrent load")
+	assert.Zero(t, atomic.LoadInt64(&mismatches),
+		"every caller must read the response matching its own request id — mismatches mean the line-delimited protocol got crossed")
 }


### PR DESCRIPTION
## Summary

Closes the consumer-side loop the [`mache-49bf9a`](../audit/sheaf-incremental.md) audit identified as load-bearing. Before this PR, edits to files under a mache mount never reached the daemon — the watcher's `onChange` did purely local reingest, the sheaf cascade (real and gated since LLO v0.4.1, see PRs #380/#381/#382) never ran in response. After this PR, edits route through `SheafInvalidator.InvalidateWithCascade`, and `get_communities` installs the `CommunityResult` + dialed `SheafClient` that engage the cross-region cascade.

Also ships **`get_sheaf_status` MCP tool** (mache-4a0c05) — agent-facing visibility into the daemon's monotonic generation counter, the staleness signal agents need to decide whether cached results are still fresh.

**Defers:** mache-c14c43 (subscribe to `sheaf.invalidate` events from the daemon) — separate concern with its own reconnect-handling complexity. The current wiring is "mache pushes invalidations, daemon cascades, mache reads the response synchronously." Event subscribe gets us "daemon notifies mache of cascades triggered by OTHER sources" — useful when there are multiple consumers, not strictly required for the single-consumer story.

## 4 commits, all TDD

| # | Commit | Layer | Coverage |
|---|---|---|---|
| 1 | `feat(graph)`: SheafInvalidator hot-swap + NodesForPath | `internal/graph` primitives | `TestSheafInvalidator_HasResult` / `_SetSheaf_Hotswap` / `_ConcurrentReadWrite` (race-gated) |
| 2 | `feat(serve)`: wire file watcher into SheafInvalidator | `cmd/serve.go` watcher | `TestBuildServeGraph_*` × 6 (happy + nil-invalidator-for-non-dir + ingest-error + on-delete) |
| 3 | `feat(serve)`: get_communities populates invalidator | `cmd/serve_handlers.go` handler | `TestGetCommunities_PopulatesInvalidator` / `_NoInvalidatorWhenGraphDoesntProvide` |
| 4 | `feat(mcp)`: get_sheaf_status tool | new MCP tool | `TestGetSheafStatus_ReturnsDaemonState` (quoted-Int64 wire) / `_NoDaemonReturnsUnavailable` / `_RegisteredInToolSet` |

Each commit: RED test first, then implementation, then GREEN. The race-detector test (TDD #1) actually failed under `-race` against the pre-mutex draft — caught my own bug before the PR shipped.

## Design contracts

**`buildServeGraph` signature change:** now returns `(graph.Graph, *graph.SheafInvalidator, func(), error)`. The invalidator is non-nil iff this build constructed a watcher to fire it. Composite mounts forfeit the cascade (per-mount invalidators each have their own `CommunityResult`; no semantically correct unified invalidator). Control mode + .db sources + single-file sources return nil. Type system enforces the contract — no hidden type assertions on `MemoryStore` that silently break the day someone swaps backends.

**`SheafInvalidator` hot-swap:** `SetSheaf`/`SetCommunityResult` are mutex-guarded so the watcher goroutine can call `InvalidateWithCascade` while the MCP handler concurrently swaps state. Construction at serve startup happens with sheaf=nil and result=nil; `get_communities` installs both. Pre-install fallback is single-node `Graph.Invalidate`; post-install engages the cross-region cascade.

**`get_sheaf_status` graceful degradation:** never surfaces daemon unavailability as an MCP error. Returns `{available: false, reason: "..."}` so agents polling for freshness signal don't see transport failures. Uses `DiscoverSocket` (not `DiscoverOrStart`) so a status check never triggers daemon auto-spawn.

## What this unblocks

- mache-c14c43 — subscribe to `sheaf.invalidate` events (the daemon→mache notification path)
- mache-33ffb0 — pre-injection + warm-cache epic (cascade output is now a real signal)
- mache-9077ae — cost-quality bench rerun (edit→fresh-result latency is now measurable end-to-end)

## Test plan

- [x] `go test -race ./internal/graph/...` — clean (incl. 8r/4w/200i concurrent stress)
- [x] `go test -race -short ./...` — full repo clean (~3.7s validate, ~108s cmd)
- [x] All 12 new tests pass; 0 existing tests modified beyond signature-change ripples
- [x] `golangci-lint` clean
- [ ] Reviewer sanity-checks the `buildServeGraph` signature choice over the type-assert-on-MemoryStore alternative (rationale in commit 2)
- [ ] Reviewer sanity-checks the `get_sheaf_status` graceful-degradation choice (no MCP error on no-daemon)