### PR TITLE
fix(leyline): public ley-line-open download + version pin [mache-9051f0]

### DIFF
--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -545,23 +545,42 @@ func (c *SocketClient) Prioritize(files []string) error {
 	return err
 }
 
-// leylineReleaseURLTemplate is the GitHub releases URL for the public
-// ley-line-open repository. The earlier private-repo URL (agentic-research/ley-line)
-// was retired when mache integrated against ley-line-open per the T8 work.
+// leylineBinaryVersion pins the ley-line-open release that mache downloads
+// when no leyline binary is found on PATH or in ~/.mache/bin/. This MUST
+// mirror the schema-client pin in go.mod:
 //
-// Pulls from `/releases/latest/download/` so installs track the latest
-// LLO release automatically. The bundle deployment path (apko + melange
-// image) ships leyline alongside mache and does not exercise this flow.
-// CI can set MACHE_NO_LEYLINE=1 to skip download entirely.
-const leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-open/releases/latest/download/%s"
+//	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.4.1
+//
+// BUMP THIS WHEN UPDATING leyline-schema in go.mod. The Go schema-client and
+// the daemon binary travel together — mache built against schema vX.Y.Z must
+// run a daemon at the same major/minor or it will mis-decode the wire format.
+//
+// Future hardening (mache-8kif): on socket connect, query the daemon's
+// `version` op and refuse to proceed if it disagrees with this constant.
+const leylineBinaryVersion = "v0.4.1"
 
-// downloadLeyline fetches the leyline binary from the latest GitHub release
-// to the specified path. Returns the path on success.
+// leylineReleaseURLTemplate is the GitHub releases URL for the public
+// ley-line-open repository. The earlier URL pointed at the private
+// agentic-research/ley-line repo (mache-9051f0) and used /releases/latest/
+// which floated against whatever the most recent LLO tag happened to be —
+// a recipe for picking up a binary that doesn't match mache's schema-client
+// pin. Both issues are fixed by pinning to ley-line-open at a specific tag.
+//
+// The bundle deployment path (apko + melange image) ships leyline alongside
+// mache and does not exercise this flow. CI can set MACHE_NO_LEYLINE=1 to
+// skip download entirely.
+//
+// First %s = version tag, second %s = asset name.
+const leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-open/releases/download/%s/%s"
+
+// downloadLeyline fetches the pinned-version leyline binary from GitHub
+// releases (see leylineBinaryVersion) to the specified path. Returns the
+// path on success.
 func downloadLeyline(destPath string) (string, error) {
 	osName := runtime.GOOS // "darwin" or "linux"
 	arch := runtime.GOARCH // "arm64" or "amd64"
 	assetName := fmt.Sprintf("leyline-%s-%s", osName, arch)
-	url := fmt.Sprintf(leylineReleaseURLTemplate, assetName)
+	url := fmt.Sprintf(leylineReleaseURLTemplate, leylineBinaryVersion, assetName)
 
 	log.Printf("downloading leyline binary from %s", url)
 
@@ -571,16 +590,19 @@ func downloadLeyline(destPath string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	// 404 = "no releases published yet on ley-line-open". This is the
-	// expected steady state until LLO cuts its first release. The error
-	// is still returned (DiscoverOrStart's caller decides what to do),
-	// but with explicit "no release available" wording so logs/UI can
-	// distinguish "not published yet" from "real download failure" and
-	// optionally degrade gracefully (e.g. fall back to CGO tree-sitter).
-	// Bundle deployments don't exercise this code path (leyline ships in
-	// the image); CI can set MACHE_NO_LEYLINE=1 to skip download entirely.
+	// 404 = "this pinned version isn't published on ley-line-open" — either
+	// the tag doesn't exist, or the per-OS/arch asset wasn't uploaded for
+	// this release. With a version-pinned URL (no more /latest/) this is
+	// almost always a mismatch between leylineBinaryVersion and the actual
+	// LLO releases page. The error is still returned (DiscoverOrStart's
+	// caller decides what to do), but with explicit "no release available"
+	// wording so logs/UI can distinguish "not published yet" from "real
+	// download failure" and optionally degrade gracefully (e.g. fall back
+	// to CGO tree-sitter). Bundle deployments don't exercise this code
+	// path (leyline ships in the image); CI can set MACHE_NO_LEYLINE=1 to
+	// skip download entirely.
 	if resp.StatusCode == http.StatusNotFound {
-		return "", fmt.Errorf("no leyline release available yet on ley-line-open (HTTP 404 from %s)", url)
+		return "", fmt.Errorf("no leyline release available at pinned version %s on ley-line-open (HTTP 404 from %s)", leylineBinaryVersion, url)
 	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("download %s: HTTP %d", url, resp.StatusCode)

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -571,7 +571,11 @@ const leylineBinaryVersion = "v0.4.1"
 // skip download entirely.
 //
 // First %s = version tag, second %s = asset name.
-const leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-open/releases/download/%s/%s"
+//
+// Declared as var (not const) so hermetic tests can swap in an httptest server
+// URL to exercise downloadLeyline without touching the network. Production
+// code never mutates this — see socket_test.go for the test-only override.
+var leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-open/releases/download/%s/%s"
 
 // downloadLeyline fetches the pinned-version leyline binary from GitHub
 // releases (see leylineBinaryVersion) to the specified path. Returns the

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
 	"os"
@@ -325,6 +326,33 @@ func TestLeylineReleaseURL_PointsAtPublicRepo(t *testing.T) {
 	if strings.Contains(leylineReleaseURLTemplate, "/ley-line/") {
 		t.Errorf("leylineReleaseURLTemplate still references the private ley-line repo: %q", leylineReleaseURLTemplate)
 	}
+}
+
+// TestLeylineReleaseURL_IncludesVersion pins the second half of the
+// mache-9051f0 fix: the auto-download URL must be version-pinned, not
+// `/releases/latest/download/`. Floating-latest is a recipe for picking
+// up a daemon binary that doesn't match mache's schema-client pin in
+// go.mod, which produces wire-format decode errors that are very hard
+// to diagnose from the consumer side. The constructed URL must:
+//   - reference the pinned version constant leylineBinaryVersion, and
+//   - NOT contain the string "/releases/latest/" — every download
+//     resolves to an exact tag.
+func TestLeylineReleaseURL_IncludesVersion(t *testing.T) {
+	// Pinned version must be a non-empty `vX.Y.Z`-shaped string.
+	require.NotEmpty(t, leylineBinaryVersion, "leylineBinaryVersion must not be empty")
+	assert.True(t, strings.HasPrefix(leylineBinaryVersion, "v"),
+		"leylineBinaryVersion must be a vX.Y.Z tag (got %q)", leylineBinaryVersion)
+
+	// The template substitutes (version, asset). Render with a stand-in
+	// asset and assert the rendered URL embeds the pinned version and
+	// does not fall back to /releases/latest/.
+	rendered := fmt.Sprintf(leylineReleaseURLTemplate, leylineBinaryVersion, "leyline-linux-amd64")
+	assert.Contains(t, rendered, leylineBinaryVersion,
+		"rendered download URL must include the pinned version (got %q)", rendered)
+	assert.NotContains(t, rendered, "/releases/latest/",
+		"rendered download URL must NOT use /releases/latest/ — floating-latest defeats the version pin (got %q)", rendered)
+	assert.Contains(t, rendered, "ley-line-open/releases/download/",
+		"rendered download URL must use the /releases/download/<tag>/ form (got %q)", rendered)
 }
 
 // TestSendOp_ConcurrentCallsDoNotInterleave is the regression guard

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -626,4 +628,96 @@ func TestSubscribe_SlowConsumerCountsAndLogsDrops(t *testing.T) {
 	assert.Positive(t, dropped, "consumer never read; SubscribeDropped() must be non-zero")
 	assert.Contains(t, logSnap(), "subscribe: dropping events (consumer behind)",
 		"first drop must emit a log line so operators see the signal before stale-cache decisions pile up")
+}
+
+// swapLeylineReleaseURLTemplate replaces leylineReleaseURLTemplate for the
+// duration of a test, restoring the original via t.Cleanup. This is the
+// hermetic-test seam for downloadLeyline — production code never mutates
+// the template, only tests do, so the global swap is safe as long as tests
+// in this file don't run downloadLeyline in parallel (they don't).
+func swapLeylineReleaseURLTemplate(t *testing.T, replacement string) {
+	t.Helper()
+	orig := leylineReleaseURLTemplate
+	leylineReleaseURLTemplate = replacement
+	t.Cleanup(func() { leylineReleaseURLTemplate = orig })
+}
+
+// TestDownloadLeyline_HappyPath exercises the 200-OK branch of
+// downloadLeyline without touching the network. It stands up an
+// httptest.Server that returns a known payload, swaps the release-URL
+// template to point at that server, then asserts the binary lands on
+// disk with the right bytes and an executable bit set. This covers the
+// assetName / URL construction lines plus the io.Copy + chmod + rename
+// path. Coverage-gate flagged the assetName line (L583) as new-prod
+// uncovered in PR #388; this test closes that gap hermetically.
+func TestDownloadLeyline_HappyPath(t *testing.T) {
+	const wantBody = "fake-leyline-binary-payload"
+
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(wantBody))
+	}))
+	t.Cleanup(srv.Close)
+
+	// Template still takes (version, asset) — keep the same %s/%s shape
+	// so the assetName Sprintf inside downloadLeyline is still exercised.
+	swapLeylineReleaseURLTemplate(t, srv.URL+"/releases/download/%s/%s")
+
+	destDir := t.TempDir()
+	destPath := filepath.Join(destDir, "leyline")
+
+	out, err := downloadLeyline(destPath)
+	require.NoError(t, err, "downloadLeyline must succeed on 200 OK")
+	require.Equal(t, destPath, out, "downloadLeyline must return the requested dest path")
+
+	// Asset name is built from runtime.GOOS/GOARCH inside downloadLeyline —
+	// the server saw a URL of the form /releases/download/<version>/leyline-<os>-<arch>.
+	// Don't pin os/arch (test runs on darwin AND linux CI); just assert the
+	// /releases/download/<version>/leyline- prefix lines up.
+	assert.Contains(t, gotPath, "/releases/download/"+leylineBinaryVersion+"/leyline-",
+		"server should have received a version-pinned, asset-name-suffixed request path (got %q)", gotPath)
+
+	// Verify file landed with the right bytes.
+	gotBytes, err := os.ReadFile(destPath)
+	require.NoError(t, err, "downloaded binary must exist on disk")
+	assert.Equal(t, wantBody, string(gotBytes), "downloaded bytes must match server payload")
+
+	// Verify the executable bit is set (chmod 0o755).
+	info, err := os.Stat(destPath)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "downloaded binary must have at least one executable bit set (got mode %v)", info.Mode())
+}
+
+// TestDownloadLeyline_NotFound exercises the 404 branch of downloadLeyline
+// without touching the network. Coverage-gate flagged the StatusNotFound
+// arm (L605) as new-prod uncovered in PR #388. The user-facing error must
+// distinguish "this pinned version isn't published" from a generic network
+// failure so operators can fix the pin (or fall back) instead of chasing
+// a transport-layer ghost.
+func TestDownloadLeyline_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	swapLeylineReleaseURLTemplate(t, srv.URL+"/releases/download/%s/%s")
+
+	destDir := t.TempDir()
+	destPath := filepath.Join(destDir, "leyline")
+
+	_, err := downloadLeyline(destPath)
+	require.Error(t, err, "downloadLeyline must return an error on HTTP 404")
+	assert.Contains(t, err.Error(), "no leyline release available",
+		"404 error must use the 'no release available' phrasing so operators can distinguish missing-pin from transport failure (got %q)", err.Error())
+	assert.Contains(t, err.Error(), leylineBinaryVersion,
+		"404 error must name the pinned version so operators know which tag to publish/repin (got %q)", err.Error())
+
+	// Negative assertion: file must NOT have been created when download
+	// failed — otherwise a stale zero-byte binary lingers and confuses
+	// subsequent runs.
+	_, statErr := os.Stat(destPath)
+	assert.True(t, os.IsNotExist(statErr),
+		"destPath must not exist after a failed download (got stat err %v)", statErr)
 }


### PR DESCRIPTION
## Summary

Closes bead `mache-9051f0`. The auto-download URL in `internal/leyline/socket.go` had two problems that together produced silent breakage on fresh-clone machines:

1. **Private repo**: URL pointed at `agentic-research/ley-line` (private). Anything without a checkout token got 404s.
2. **Floating `/releases/latest/`**: Even with the public repo, `latest` pulls whatever LLO tagged most recently — no relationship to the `leyline-schema v0.4.1` pin in `go.mod`. A daemon at the wrong schema produces wire-format decode errors that are very hard to diagnose.

## Changes

```
OLD: https://github.com/agentic-research/ley-line/releases/latest/download/leyline-{os}-{arch}
NEW: https://github.com/agentic-research/ley-line-open/releases/download/v0.4.1/leyline-{os}-{arch}
```

- New `leylineBinaryVersion = "v0.4.1"` const beside the URL template (Option A from the bead — simplest, no extra build infra). The const must mirror the `leyline-schema` pin in `go.mod`; comment block documents the bump discipline.
- URL template switched to `/releases/download/%s/%s` and `downloadLeyline` now substitutes both version and asset name.
- 404 error message updated to mention the pinned version so logs show exactly which tag was missing.
- Forward pointer to `mache-8kif` (startup version handshake with the daemon) noted in the comment as the eventual hardening.

## Files

ONE production file + ONE test file, as required:
- `internal/leyline/socket.go` — const + URL template + 404 message
- `internal/leyline/socket_test.go` — new `TestLeylineReleaseURL_IncludesVersion`; existing `TestLeylineReleaseURL_PointsAtPublicRepo` still passes unchanged (it only asserts on the repo path).

## Test plan

- [x] `go test -run 'TestLeyline|TestDownload|TestDiscover' -v ./internal/leyline/` — all pass
- [x] `task check` — gofumpt, vet, golangci-lint, full test sweep, docs lint all pass
- [x] No network calls in tests — verified by inspection (`fmt.Sprintf` only on the rendered URL)
- [x] `MACHE_NO_LEYLINE=1` short-circuit path (`TestDiscoverOrStart_NoLeylineEnv_SkipsDownload`) still gates the download as before