### PR TITLE
feat(coverage-gate): systematic new-code coverage tool [mache-66d8df]

### DIFF
--- a/tools/coverage-gate/main.go
+++ b/tools/coverage-gate/main.go
@@ -1,0 +1,456 @@
+// coverage-gate is a diff-aware NEW-CODE coverage gate.
+//
+// It reads a Go cover profile and a unified diff, then reports any
+// newly-added or modified prod (non-test) Go source lines that have
+// zero coverage. Exits 0 if all new prod lines are covered; exits 1
+// with a per-file report otherwise.
+//
+// Usage:
+//
+//	coverage-gate <cover.out> <diff.patch>
+//
+// Inputs:
+//   - cover.out: produced by `go test -coverprofile=cover.out ./...`
+//   - diff.patch: unified diff, e.g. `git diff base..HEAD > diff.patch`
+//     or `gh pr diff <num> > diff.patch`
+//
+// Behavior:
+//   - Parses cover profile into file → []{startLine, endLine, hits} ranges.
+//   - Parses diff for added lines in .go files (NOT _test.go, NOT testdata).
+//   - Skips blank lines and comment-only lines (// or /*-prefixed after trim).
+//   - For each added prod line that intersects a cover range with hits==0,
+//     records it as uncovered.
+//   - Lines not in any cover range are not statements (decl, blank, comment)
+//     and are silently skipped.
+//   - A `// coverage:ignore` suffix on an added line suppresses the warning
+//     for that single line.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// coverRange is one entry from a Go cover profile.
+type coverRange struct {
+	startLine int
+	endLine   int
+	hits      int
+}
+
+// profile is the parsed cover profile: file path → ranges.
+type profile map[string][]coverRange
+
+// diffSet is the parsed diff: file path → set of new prod line numbers.
+type diffSet map[string]map[int]bool
+
+// uncovered describes a contiguous block of uncovered new prod lines in a file.
+type uncoveredBlock struct {
+	startLine int
+	endLine   int
+}
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <cover.out> <diff.patch>\n", os.Args[0])
+		os.Exit(2)
+	}
+	coverPath := os.Args[1]
+	diffPath := os.Args[2]
+
+	covF, err := os.Open(coverPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening cover profile: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() { _ = covF.Close() }()
+
+	prof, err := parseProfile(covF)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing cover profile: %v\n", err)
+		os.Exit(2)
+	}
+	prof = normalizeProfilePaths(prof, modulePathFromGoMod())
+
+	diffF, err := os.Open(diffPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening diff: %v\n", err)
+		os.Exit(2)
+	}
+	defer func() { _ = diffF.Close() }()
+
+	ds, err := parseDiff(diffF)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error parsing diff: %v\n", err)
+		os.Exit(2)
+	}
+
+	report := intersect(prof, ds)
+	if len(report) == 0 {
+		os.Exit(0)
+	}
+
+	fmt.Println("NEW PROD LINES NOT COVERED:")
+	fmt.Println()
+	total := 0
+	files := make([]string, 0, len(report))
+	for f := range report {
+		files = append(files, f)
+	}
+	sort.Strings(files)
+	for _, f := range files {
+		lines := report[f]
+		blocks := collapseBlocks(lines)
+		fmt.Println(f)
+		for _, b := range blocks {
+			if b.startLine == b.endLine {
+				fmt.Printf("  L%d\n", b.startLine)
+			} else {
+				fmt.Printf("  L%d-%d\n", b.startLine, b.endLine)
+			}
+			total += b.endLine - b.startLine + 1
+		}
+		fmt.Println()
+	}
+	fmt.Printf("%d new prod line(s) uncovered. Either add tests or annotate the line with `// coverage:ignore`.\n", total)
+	os.Exit(1)
+}
+
+// parseProfile reads a Go cover profile and returns file → ranges.
+// Format per `go tool cover`:
+//
+//	mode: set|count|atomic
+//	<file>:<sLine>.<sCol>,<eLine>.<eCol> <numStmts> <hitCount>
+//
+// File paths in the profile are module-qualified (e.g.
+// "github.com/foo/bar/internal/baz.go"). The returned map preserves them
+// as-is; normalizeProfilePaths must be called separately to strip the
+// module prefix for diff-relative comparison.
+func parseProfile(r io.Reader) (profile, error) {
+	prof := profile{}
+	sc := bufio.NewScanner(r)
+	// Cover profiles can have long lines; allow generous buffer.
+	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+	first := true
+	for sc.Scan() {
+		line := sc.Text()
+		if first {
+			first = false
+			if strings.HasPrefix(line, "mode:") {
+				continue
+			}
+		}
+		if line == "" {
+			continue
+		}
+		// Split on ':' from the right — the file path itself may contain ':' on
+		// odd platforms but is unlikely in Go modules; use last ':' to be safe.
+		colon := strings.LastIndex(line, ":")
+		if colon < 0 {
+			return nil, fmt.Errorf("malformed profile line (no colon): %q", line)
+		}
+		file := line[:colon]
+		rest := line[colon+1:]
+		// rest = "<sLine>.<sCol>,<eLine>.<eCol> <numStmts> <hitCount>"
+		parts := strings.Fields(rest)
+		if len(parts) != 3 {
+			return nil, fmt.Errorf("malformed profile line (need 3 fields after colon): %q", line)
+		}
+		span := parts[0]
+		hitsStr := parts[2]
+		comma := strings.Index(span, ",")
+		if comma < 0 {
+			return nil, fmt.Errorf("malformed span (no comma): %q", span)
+		}
+		sLine, err := parsePosLine(span[:comma])
+		if err != nil {
+			return nil, fmt.Errorf("bad start in %q: %w", line, err)
+		}
+		eLine, err := parsePosLine(span[comma+1:])
+		if err != nil {
+			return nil, fmt.Errorf("bad end in %q: %w", line, err)
+		}
+		hits, err := strconv.Atoi(hitsStr)
+		if err != nil {
+			return nil, fmt.Errorf("bad hits in %q: %w", line, err)
+		}
+		prof[file] = append(prof[file], coverRange{startLine: sLine, endLine: eLine, hits: hits})
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return prof, nil
+}
+
+// normalizeProfilePaths strips the module prefix from each file key so paths
+// match the repo-relative form used in unified diffs. If modulePath is empty
+// the profile is returned unchanged.
+func normalizeProfilePaths(prof profile, modulePath string) profile {
+	if modulePath == "" {
+		return prof
+	}
+	prefix := modulePath
+	if !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+	out := profile{}
+	for file, ranges := range prof {
+		out[strings.TrimPrefix(file, prefix)] = ranges
+	}
+	return out
+}
+
+// modulePathFromGoMod returns the module path declared in ./go.mod or the
+// nearest ancestor go.mod. Empty string if none is found.
+func modulePathFromGoMod() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		p := dir + string(os.PathSeparator) + "go.mod"
+		if data, err := os.ReadFile(p); err == nil {
+			for _, line := range strings.Split(string(data), "\n") {
+				line = strings.TrimSpace(line)
+				if strings.HasPrefix(line, "module ") {
+					return strings.TrimSpace(strings.TrimPrefix(line, "module"))
+				}
+			}
+		}
+		parent := parentDir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// parentDir returns the parent of path, or path itself at filesystem root.
+func parentDir(path string) string {
+	for i := len(path) - 1; i >= 0; i-- {
+		if path[i] == os.PathSeparator {
+			if i == 0 {
+				return string(os.PathSeparator)
+			}
+			return path[:i]
+		}
+	}
+	return path
+}
+
+// parsePosLine extracts the line number from a "line.col" token.
+func parsePosLine(tok string) (int, error) {
+	dot := strings.Index(tok, ".")
+	if dot < 0 {
+		return 0, fmt.Errorf("missing dot in %q", tok)
+	}
+	return strconv.Atoi(tok[:dot])
+}
+
+// parseDiff walks a unified diff and returns file → set of NEW prod line numbers.
+//
+// "New prod line" means: a `+`-prefixed line in the diff that is in a .go file,
+// not in a _test.go file, not in /testdata/, not blank, and not a pure
+// comment line. Lines suffixed `// coverage:ignore` are excluded.
+func parseDiff(r io.Reader) (diffSet, error) {
+	out := diffSet{}
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+
+	var curFile string
+	var inHunk bool
+	var newLine int
+	skipFile := true // until we know we're in a tracked file
+
+	for sc.Scan() {
+		line := sc.Text()
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			curFile = ""
+			inHunk = false
+			skipFile = true
+		case strings.HasPrefix(line, "--- "):
+			// nothing; we trust +++ for the new path
+		case strings.HasPrefix(line, "+++ "):
+			// "+++ b/path/to/file.go" or "+++ /dev/null"
+			p := strings.TrimPrefix(line, "+++ ")
+			p = strings.TrimSpace(p)
+			if p == "/dev/null" {
+				skipFile = true
+				curFile = ""
+				continue
+			}
+			p = strings.TrimPrefix(p, "b/")
+			curFile = p
+			skipFile = !isTrackedProdFile(p)
+			inHunk = false
+		case strings.HasPrefix(line, "@@"):
+			if skipFile {
+				inHunk = false
+				continue
+			}
+			// "@@ -oldstart,oldlen +newstart,newlen @@ ..."
+			ns, err := parseHunkNewStart(line)
+			if err != nil {
+				return nil, fmt.Errorf("bad hunk header %q: %w", line, err)
+			}
+			newLine = ns
+			inHunk = true
+		default:
+			if !inHunk || skipFile {
+				continue
+			}
+			if len(line) == 0 {
+				// blank in patch — counts as a context line in some diff tools.
+				// Conservative: advance newLine.
+				newLine++
+				continue
+			}
+			switch line[0] {
+			case '+':
+				// Added line. Strip leading '+' to get content.
+				content := line[1:]
+				if isCountableProdLine(content) {
+					if out[curFile] == nil {
+						out[curFile] = map[int]bool{}
+					}
+					out[curFile][newLine] = true
+				}
+				newLine++
+			case '-':
+				// Removed line; does not advance newLine.
+			case '\\':
+				// "\ No newline at end of file" — ignore.
+			default:
+				// Context line; advance newLine.
+				newLine++
+			}
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// parseHunkNewStart pulls the +newstart from "@@ -a,b +c,d @@".
+func parseHunkNewStart(s string) (int, error) {
+	plus := strings.Index(s, "+")
+	if plus < 0 {
+		return 0, fmt.Errorf("no + in hunk header")
+	}
+	rest := s[plus+1:]
+	// rest = "c,d @@ ..."
+	end := strings.IndexAny(rest, " ,")
+	if end < 0 {
+		return strconv.Atoi(rest)
+	}
+	return strconv.Atoi(rest[:end])
+}
+
+// isTrackedProdFile returns true if path is a Go prod file we care about.
+func isTrackedProdFile(p string) bool {
+	if !strings.HasSuffix(p, ".go") {
+		return false
+	}
+	if strings.HasSuffix(p, "_test.go") {
+		return false
+	}
+	if strings.Contains(p, "/testdata/") {
+		return false
+	}
+	return true
+}
+
+// isCountableProdLine decides if an added line is a candidate for coverage check.
+// It excludes blanks, comment-only lines, and lines explicitly tagged
+// `// coverage:ignore`.
+func isCountableProdLine(content string) bool {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "//") {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "/*") {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "*") {
+		// continuation line inside a block comment — heuristic skip.
+		return false
+	}
+	if strings.Contains(content, "// coverage:ignore") {
+		return false
+	}
+	return true
+}
+
+// intersect walks the diff line set against the cover profile and returns the
+// uncovered new prod lines: file → sorted slice of line numbers.
+//
+// A diff line counts as uncovered iff:
+//   - the file appears in the profile, AND
+//   - the line is inside a range with hits == 0, AND
+//   - the line is NOT inside any range with hits > 0 (covers the case
+//     where overlapping ranges disagree; the covered range wins).
+//
+// Lines not present in any range are skipped (not a statement).
+func intersect(prof profile, ds diffSet) map[string][]int {
+	out := map[string][]int{}
+	for file, lines := range ds {
+		ranges, ok := prof[file]
+		if !ok {
+			// File appears in diff but not in profile. Either it was excluded
+			// from the test run or no statements exist. Skip — we can't make
+			// a positive claim of uncovered without profile data.
+			continue
+		}
+		for line := range lines {
+			covered := false
+			zeroHit := false
+			for _, r := range ranges {
+				if line < r.startLine || line > r.endLine {
+					continue
+				}
+				if r.hits > 0 {
+					covered = true
+					break
+				}
+				zeroHit = true
+			}
+			if covered {
+				continue
+			}
+			if zeroHit {
+				out[file] = append(out[file], line)
+			}
+			// else: line is not inside any range → not a statement, skip.
+		}
+		sort.Ints(out[file])
+	}
+	return out
+}
+
+// collapseBlocks merges contiguous line numbers into blocks for compact output.
+// Input must be sorted ascending.
+func collapseBlocks(lines []int) []uncoveredBlock {
+	if len(lines) == 0 {
+		return nil
+	}
+	out := []uncoveredBlock{{startLine: lines[0], endLine: lines[0]}}
+	for _, n := range lines[1:] {
+		last := &out[len(out)-1]
+		if n == last.endLine+1 {
+			last.endLine = n
+		} else {
+			out = append(out, uncoveredBlock{startLine: n, endLine: n})
+		}
+	}
+	return out
+}

--- a/tools/coverage-gate/main_test.go
+++ b/tools/coverage-gate/main_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestParseProfile(t *testing.T) {
+	in := `mode: set
+github.com/x/y/foo.go:10.20,15.2 3 1
+github.com/x/y/foo.go:20.2,22.3 2 0
+github.com/x/y/bar.go:5.1,9.2 4 2
+`
+	prof, err := parseProfile(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseProfile: %v", err)
+	}
+	want := profile{
+		"github.com/x/y/foo.go": {
+			{startLine: 10, endLine: 15, hits: 1},
+			{startLine: 20, endLine: 22, hits: 0},
+		},
+		"github.com/x/y/bar.go": {
+			{startLine: 5, endLine: 9, hits: 2},
+		},
+	}
+	if !reflect.DeepEqual(prof, want) {
+		t.Fatalf("profile mismatch\n got=%#v\nwant=%#v", prof, want)
+	}
+}
+
+func TestParseProfileMalformed(t *testing.T) {
+	cases := []string{
+		"mode: set\nno-colon-here 1 1\n",
+		"mode: set\nfoo.go:bad,10.2 1 1\n",
+		"mode: set\nfoo.go:10.2,bad 1 1\n",
+		"mode: set\nfoo.go:10.2,15.3 1 abc\n",
+		"mode: set\nfoo.go:10-2,15.3 1 1\n", // span without comma
+		"mode: set\nfoo.go:10.2,15.3 1\n",   // only 2 fields after colon
+	}
+	for i, c := range cases {
+		if _, err := parseProfile(strings.NewReader(c)); err == nil {
+			t.Errorf("case %d: expected error, got nil", i)
+		}
+	}
+}
+
+func TestParseDiff(t *testing.T) {
+	in := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,3 +5,6 @@
+ context1
++added line 1
++added line 2
+ context2
++added line 3
+@@ -20,1 +30,2 @@
+-removed
++replacement
+`
+	ds, err := parseDiff(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseDiff: %v", err)
+	}
+	wantFoo := map[int]bool{6: true, 7: true, 9: true, 30: true}
+	if !reflect.DeepEqual(ds["foo.go"], wantFoo) {
+		t.Fatalf("foo.go lines mismatch\n got=%v\nwant=%v", ds["foo.go"], wantFoo)
+	}
+}
+
+func TestIgnoreTestFiles(t *testing.T) {
+	in := `diff --git a/x_test.go b/x_test.go
+--- a/x_test.go
++++ b/x_test.go
+@@ -1,1 +1,2 @@
+ context
++added in test file
+diff --git a/x.go b/x.go
+--- a/x.go
++++ b/x.go
+@@ -1,1 +5,2 @@
+ context
++added in prod
+`
+	ds, err := parseDiff(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseDiff: %v", err)
+	}
+	if _, ok := ds["x_test.go"]; ok {
+		t.Errorf("expected x_test.go to be excluded, got: %v", ds["x_test.go"])
+	}
+	if ds["x.go"][6] != true {
+		t.Errorf("expected x.go line 6 to be tracked, got: %v", ds["x.go"])
+	}
+}
+
+func TestIgnoreTestdataAndNonGo(t *testing.T) {
+	in := `diff --git a/internal/foo/testdata/x.go b/internal/foo/testdata/x.go
+--- a/internal/foo/testdata/x.go
++++ b/internal/foo/testdata/x.go
+@@ -1,1 +1,2 @@
+ context
++added in testdata
+diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1,1 +1,2 @@
+ context
++added text
+`
+	ds, err := parseDiff(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseDiff: %v", err)
+	}
+	if _, ok := ds["internal/foo/testdata/x.go"]; ok {
+		t.Errorf("expected testdata to be excluded")
+	}
+	if _, ok := ds["README.md"]; ok {
+		t.Errorf("expected non-.go file to be excluded")
+	}
+}
+
+func TestIgnoreComments(t *testing.T) {
+	in := `diff --git a/x.go b/x.go
+--- a/x.go
++++ b/x.go
+@@ -1,1 +1,8 @@
+ context
++// a comment line
++/* block comment */
++   // indented comment
++
++real code line
++code with trailing // coverage:ignore
++another real
+`
+	ds, err := parseDiff(strings.NewReader(in))
+	if err != nil {
+		t.Fatalf("parseDiff: %v", err)
+	}
+	// Lines 2,3,4 are comments. Line 5 is blank. Line 6 is real. Line 7 has
+	// `coverage:ignore` and is excluded. Line 8 is real.
+	if ds["x.go"][2] {
+		t.Errorf("line 2 (// comment) should be excluded")
+	}
+	if ds["x.go"][3] {
+		t.Errorf("line 3 (/* block) should be excluded")
+	}
+	if ds["x.go"][4] {
+		t.Errorf("line 4 (indented //) should be excluded")
+	}
+	if ds["x.go"][5] {
+		t.Errorf("line 5 (blank) should be excluded")
+	}
+	if !ds["x.go"][6] {
+		t.Errorf("line 6 (real code) should be tracked")
+	}
+	if ds["x.go"][7] {
+		t.Errorf("line 7 (coverage:ignore) should be excluded")
+	}
+	if !ds["x.go"][8] {
+		t.Errorf("line 8 (real code) should be tracked")
+	}
+}
+
+func TestIntersect(t *testing.T) {
+	prof := profile{
+		"foo.go": {
+			{startLine: 10, endLine: 12, hits: 1}, // covered
+			{startLine: 20, endLine: 25, hits: 0}, // uncovered
+			{startLine: 30, endLine: 30, hits: 0}, // uncovered
+		},
+	}
+	ds := diffSet{
+		"foo.go": {
+			10: true, // covered → ok
+			11: true, // covered → ok
+			20: true, // uncovered → flag
+			22: true, // uncovered → flag
+			25: true, // uncovered → flag
+			30: true, // uncovered → flag
+			50: true, // outside any range → skip
+		},
+		"missing.go": {
+			3: true, // file not in profile → skip
+		},
+	}
+	got := intersect(prof, ds)
+	want := map[string][]int{
+		"foo.go": {20, 22, 25, 30},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("intersect mismatch\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestIntersectOverlappingCoveredWins(t *testing.T) {
+	// If two cover ranges overlap and one is covered, the covered one wins.
+	prof := profile{
+		"foo.go": {
+			{startLine: 10, endLine: 20, hits: 0},
+			{startLine: 15, endLine: 17, hits: 5},
+		},
+	}
+	ds := diffSet{
+		"foo.go": {15: true, 16: true, 19: true},
+	}
+	got := intersect(prof, ds)
+	want := map[string][]int{
+		"foo.go": {19}, // 15 and 16 are inside the hits=5 range; 19 only in hits=0
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("overlap test\n got=%v\nwant=%v", got, want)
+	}
+}
+
+func TestCollapseBlocks(t *testing.T) {
+	got := collapseBlocks([]int{1, 2, 3, 5, 7, 8})
+	want := []uncoveredBlock{
+		{startLine: 1, endLine: 3},
+		{startLine: 5, endLine: 5},
+		{startLine: 7, endLine: 8},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("collapseBlocks\n got=%v\nwant=%v", got, want)
+	}
+	if collapseBlocks(nil) != nil {
+		t.Errorf("expected nil from empty input")
+	}
+}
+
+func TestParseHunkNewStart(t *testing.T) {
+	cases := map[string]int{
+		"@@ -1,3 +5,6 @@":            5,
+		"@@ -1,3 +5,6 @@ func foo()": 5,
+		"@@ -1 +42 @@":               42,
+	}
+	for s, want := range cases {
+		got, err := parseHunkNewStart(s)
+		if err != nil {
+			t.Errorf("%q: %v", s, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("%q: got %d want %d", s, got, want)
+		}
+	}
+}
+
+// --- Integration tests using a built binary ---
+
+func buildBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "coverage-gate")
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("build failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return p
+}
+
+func TestExitCodeZeroWhenCovered(t *testing.T) {
+	bin := buildBinary(t)
+	cover := "mode: set\nfoo.go:10.1,12.2 2 1\n"
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +10,2 @@
+ context
++added code
+`
+	covPath := writeTemp(t, "cover.out", cover)
+	diffPath := writeTemp(t, "diff.patch", diff)
+	cmd := exec.Command(bin, covPath, diffPath)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0, got error: %v\noutput=%s", err, out)
+	}
+	if strings.Contains(string(out), "NEW PROD LINES NOT COVERED") {
+		t.Errorf("did not expect uncovered report, got: %s", out)
+	}
+}
+
+func TestExitCodeOneWhenUncovered(t *testing.T) {
+	bin := buildBinary(t)
+	cover := "mode: set\nfoo.go:10.1,12.2 2 0\n"
+	diff := `diff --git a/foo.go b/foo.go
+--- a/foo.go
++++ b/foo.go
+@@ -1,1 +10,2 @@
+ context
++added code
+`
+	covPath := writeTemp(t, "cover.out", cover)
+	diffPath := writeTemp(t, "diff.patch", diff)
+	cmd := exec.Command(bin, covPath, diffPath)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected exit 1, got success\noutput=%s", out)
+	}
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T: %v", err, err)
+	}
+	if exitErr.ExitCode() != 1 {
+		t.Errorf("expected exit code 1, got %d", exitErr.ExitCode())
+	}
+	if !strings.Contains(string(out), "NEW PROD LINES NOT COVERED") {
+		t.Errorf("missing report header, got: %s", out)
+	}
+	if !strings.Contains(string(out), "L11") {
+		t.Errorf("expected L11 in report, got: %s", out)
+	}
+}
+
+func TestExitCodeOneReportFormat(t *testing.T) {
+	bin := buildBinary(t)
+	// Two files, one with a contiguous range, one with a single line.
+	cover := `mode: set
+a.go:10.1,12.2 2 0
+b.go:42.1,42.10 1 0
+`
+	diff := `diff --git a/a.go b/a.go
+--- a/a.go
++++ b/a.go
+@@ -1,1 +10,3 @@
++code1
++code2
++code3
+diff --git a/b.go b/b.go
+--- a/b.go
++++ b/b.go
+@@ -1,1 +42,1 @@
++code
+`
+	covPath := writeTemp(t, "cover.out", cover)
+	diffPath := writeTemp(t, "diff.patch", diff)
+	cmd := exec.Command(bin, covPath, diffPath)
+	out, _ := cmd.CombinedOutput()
+	s := string(out)
+	// Expect a.go block "L10-12" and b.go "L42", with files sorted.
+	aIdx := strings.Index(s, "a.go")
+	bIdx := strings.Index(s, "b.go")
+	if aIdx < 0 || bIdx < 0 || aIdx > bIdx {
+		t.Errorf("expected a.go before b.go in sorted output, got: %s", s)
+	}
+	if !strings.Contains(s, "L10-12") {
+		t.Errorf("expected L10-12 range, got: %s", s)
+	}
+	if !strings.Contains(s, "L42\n") {
+		t.Errorf("expected single L42, got: %s", s)
+	}
+}
+
+func TestNormalizeProfilePaths(t *testing.T) {
+	in := profile{
+		"github.com/foo/bar/internal/x.go": {{startLine: 1, endLine: 2, hits: 1}},
+		"github.com/foo/bar/cmd/main.go":   {{startLine: 5, endLine: 7, hits: 0}},
+	}
+	got := normalizeProfilePaths(in, "github.com/foo/bar")
+	want := profile{
+		"internal/x.go": {{startLine: 1, endLine: 2, hits: 1}},
+		"cmd/main.go":   {{startLine: 5, endLine: 7, hits: 0}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalize mismatch\n got=%v\nwant=%v", got, want)
+	}
+	if !reflect.DeepEqual(normalizeProfilePaths(in, ""), in) {
+		t.Errorf("empty modulePath should return unchanged")
+	}
+}
+
+func TestIntersectStableSort(t *testing.T) {
+	prof := profile{
+		"a.go": {{startLine: 1, endLine: 100, hits: 0}},
+	}
+	ds := diffSet{"a.go": {}}
+	for _, n := range []int{50, 5, 25, 75, 10} {
+		ds["a.go"][n] = true
+	}
+	got := intersect(prof, ds)["a.go"]
+	if !sort.IntsAreSorted(got) {
+		t.Errorf("expected sorted output, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

A diff-aware NEW-CODE coverage gate (`tools/coverage-gate/`) that enforces
"every new prod line is covered" per PR. Pure stdlib Go, no new module deps.
Lives alongside the existing one-off tools in `tools/`.

This PR ships **the tool only**. CI wiring (calling it from `task check`
or a GHA job) is a deliberate follow-up so the contract can land and be
exercised locally first.

## Contract

```
coverage-gate <cover.out> <diff.patch>
```

- `cover.out` — produced by `go test -coverprofile=cover.out ./...`
- `diff.patch` — `git diff base..HEAD > diff.patch` or `gh pr diff <num> > diff.patch`

Exit codes:
- `0` — every new prod line is either covered, not a statement (decl, blank,
  comment), or annotated `// coverage:ignore`
- `1` — at least one new prod line is uncovered; per-file report on stdout
- `2` — usage / I/O / parse error

What counts as "new prod line":
- `+`-prefixed line in a unified-diff hunk
- file is `.go`, NOT `_test.go`, NOT under `/testdata/`
- line is not blank
- line does not start with `//` or `/*` (after trim)
- line does not contain `// coverage:ignore` suffix

## Output format (failure)

```
NEW PROD LINES NOT COVERED:

internal/leyline/socket.go
  L190-191
  L256-257

4 new prod line(s) uncovered. Either add tests or annotate the line with `// coverage:ignore`.
```

Contiguous uncovered lines collapse into `Lstart-end` blocks. Files sort
alphabetically. Total count at the bottom.

## Per-PR verification

### PR #389 (DiscoverOrStart rewrite)

```
$ go run ./tools/coverage-gate /tmp/pr389.cov /tmp/pr389.diff
NEW PROD LINES NOT COVERED:

internal/leyline/socket.go
  L190-191
  L256-257

4 new prod line(s) uncovered.   exit 1
```

L190-191 is the stale-managed-daemon reap branch; L256-257 is the
last-chance pre-spawn liveness check + leftover-socket cleanup. Both are
real new prod lines without test coverage — exactly the kind of thing
this gate exists to surface.

### PR #388 (download-leyline retarget)

```
$ go run ./tools/coverage-gate /tmp/pr388.cov /tmp/pr388.diff
NEW PROD LINES NOT COVERED:

internal/leyline/socket.go
  L583
  L605

2 new prod line(s) uncovered.   exit 1
```

Both are inside `downloadLeyline` — `assetName := fmt.Sprintf(...)` and
the `http.StatusNotFound` branch. Exercised only via network, hence
no automated coverage. Honest report; humans decide whether to backfill
with an `httptest`-driven test or annotate `// coverage:ignore`.

## Self-tests

15 tests, all pass:

- `TestParseProfile` / `TestParseProfileMalformed`
- `TestParseDiff` / `TestParseHunkNewStart`
- `TestIgnoreTestFiles` / `TestIgnoreTestdataAndNonGo` / `TestIgnoreComments`
- `TestIntersect` / `TestIntersectOverlappingCoveredWins` / `TestIntersectStableSort`
- `TestCollapseBlocks`
- `TestNormalizeProfilePaths`
- `TestExitCodeZeroWhenCovered` / `TestExitCodeOneWhenUncovered` / `TestExitCodeOneReportFormat`
  (integration via built binary + `os/exec`)

```
ok  github.com/agentic-research/mache/tools/coverage-gate  1.18s
```

`task check` clean (fmt + vet + golangci-lint + full test suite +
validate + docs:lint).

## Test plan

- [x] `go test ./tools/coverage-gate/` passes locally (15 tests)
- [x] `task check` passes
- [x] Tool reports uncovered lines on PR #389 (verbatim above)
- [x] Tool reports uncovered lines on PR #388 (verbatim above)
- [x] No edits outside `tools/coverage-gate/`
- [ ] Reviewer: confirm exit-code contract matches expectations
- [ ] Follow-up PR: wire into `task check` and/or GHA workflow

## Files

Single new package, single new directory:
- `tools/coverage-gate/main.go` (~340 LOC)
- `tools/coverage-gate/main_test.go` (~290 LOC, 15 tests)