### PR TITLE
feat(coverage-gate): rename detection [mache-e256f5]

### DIFF
--- a/tools/coverage-gate/main.go
+++ b/tools/coverage-gate/main.go
@@ -7,12 +7,20 @@
 //
 // Usage:
 //
-//	coverage-gate <cover.out> <diff.patch>
+//	coverage-gate [-rename-threshold N] <cover.out> <diff.patch>
 //
 // Inputs:
 //   - cover.out: produced by `go test -coverprofile=cover.out ./...`
 //   - diff.patch: unified diff, e.g. `git diff base..HEAD > diff.patch`
 //     or `gh pr diff <num> > diff.patch`
+//
+// Flags:
+//   - -rename-threshold N (0..100, default 50): when a `diff --git` block
+//     carries a `similarity index N%` header (emitted by `git diff -M`
+//     or `git diff -C`), and N is >= threshold, the block's `+` lines
+//     are treated as a pure move and excluded from the new-lines set.
+//     0 = treat any detected rename/copy as not-new; 100 = require an
+//     exact-content move.
 //
 // Behavior:
 //   - Parses cover profile into file → []{startLine, endLine, hits} ranges.
@@ -24,10 +32,13 @@
 //     and are silently skipped.
 //   - A `// coverage:ignore` suffix on an added line suppresses the warning
 //     for that single line.
+//   - Pure-move refactors detected via `similarity index` headers (see
+//     -rename-threshold) are excluded.
 package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"os"
@@ -35,6 +46,11 @@ import (
 	"strconv"
 	"strings"
 )
+
+// defaultRenameThreshold is the default similarity percentage at or above
+// which a `diff --git` block tagged with `similarity index N%` is treated
+// as a pure move and its added lines are excluded from the new-lines set.
+const defaultRenameThreshold = 50
 
 // coverRange is one entry from a Go cover profile.
 type coverRange struct {
@@ -74,12 +90,35 @@ func main() { // coverage:ignore
 // name (i.e. os.Args[1:]). stdout receives the report; stderr receives
 // usage and error messages.
 func run(progName string, args []string, stdout, stderr io.Writer) int {
-	if len(args) != 2 {
-		_, _ = fmt.Fprintf(stderr, "usage: %s <cover.out> <diff.patch>\n", progName)
+	fs := flag.NewFlagSet(progName, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	renameThreshold := fs.Int(
+		"rename-threshold",
+		defaultRenameThreshold,
+		"similarity percentage (0..100) at or above which a `diff --git` block "+
+			"tagged with `similarity index N%` is treated as a pure move and its "+
+			"added lines are excluded; 0 = exclude any detected rename, 100 = "+
+			"require exact-content match",
+	)
+	fs.Usage = func() {
+		_, _ = fmt.Fprintf(stderr, "usage: %s [-rename-threshold N] <cover.out> <diff.patch>\n", progName)
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		// flag already wrote a message to stderr via SetOutput.
 		return 2
 	}
-	coverPath := args[0]
-	diffPath := args[1]
+	if *renameThreshold < 0 || *renameThreshold > 100 {
+		_, _ = fmt.Fprintf(stderr, "error: -rename-threshold must be in [0,100], got %d\n", *renameThreshold)
+		return 2
+	}
+	rest := fs.Args()
+	if len(rest) != 2 {
+		fs.Usage()
+		return 2
+	}
+	coverPath := rest[0]
+	diffPath := rest[1]
 
 	covF, err := os.Open(coverPath)
 	if err != nil {
@@ -102,7 +141,7 @@ func run(progName string, args []string, stdout, stderr io.Writer) int {
 	}
 	defer func() { _ = diffF.Close() }()
 
-	ds, err := parseDiff(diffF)
+	ds, err := parseDiffWithRenames(diffF, *renameThreshold)
 	if err != nil {
 		_, _ = fmt.Fprintf(stderr, "error parsing diff: %v\n", err)
 		return 2
@@ -275,7 +314,22 @@ func parsePosLine(tok string) (int, error) {
 // "New prod line" means: a `+`-prefixed line in the diff that is in a .go file,
 // not in a _test.go file, not in /testdata/, not blank, and not a pure
 // comment line. Lines suffixed `// coverage:ignore` are excluded.
+//
+// This is a thin wrapper that delegates to parseDiffWithRenames with the
+// default rename threshold. Diffs without `similarity index` headers (the
+// common case) behave identically regardless of the threshold value, so
+// existing call sites need no changes.
 func parseDiff(r io.Reader) (diffSet, error) {
+	return parseDiffWithRenames(r, defaultRenameThreshold)
+}
+
+// parseDiffWithRenames is parseDiff with an explicit rename-similarity
+// threshold. When a `diff --git` block carries a `similarity index N%`
+// header AND N >= renameThreshold, the block's `+` lines are excluded
+// from the result entirely (they're a pure move / copy, not new code).
+// Blocks WITHOUT a similarity header behave exactly as a non-rename diff.
+// See defaultRenameThreshold for the CLI default.
+func parseDiffWithRenames(r io.Reader, renameThreshold int) (diffSet, error) {
 	out := diffSet{}
 	sc := bufio.NewScanner(r)
 	sc.Buffer(make([]byte, 1024*1024), 16*1024*1024)
@@ -283,15 +337,32 @@ func parseDiff(r io.Reader) (diffSet, error) {
 	var curFile string
 	var inHunk bool
 	var newLine int
-	skipFile := true // until we know we're in a tracked file
+	skipFile := true   // until we know we're in a tracked file
+	skipBlock := false // set when the current `diff --git` block is a pure rename
 
 	for sc.Scan() {
 		line := sc.Text()
 		switch {
 		case strings.HasPrefix(line, "diff --git "):
+			// New block — reset all per-block state. similarity / rename /
+			// copy headers (if any) appear BEFORE --- / +++, so we can
+			// detect them on subsequent iterations and toggle skipBlock
+			// before any `+` lines are seen.
 			curFile = ""
 			inHunk = false
 			skipFile = true
+			skipBlock = false
+		case strings.HasPrefix(line, "similarity index "):
+			// "similarity index N%" — git's rename/copy detector emits this
+			// before the rename-from / rename-to / --- / +++ lines.
+			n, ok := parseSimilarityPercent(line)
+			if ok && n >= renameThreshold {
+				skipBlock = true
+			}
+		case strings.HasPrefix(line, "dissimilarity index "):
+			// "dissimilarity index N%" — emitted with `--irreversible-delete`
+			// and a few other modes. Conservative: do NOT skip the block;
+			// fall through to the normal +/- handling below.
 		case strings.HasPrefix(line, "--- "):
 			// nothing; we trust +++ for the new path
 		case strings.HasPrefix(line, "+++ "):
@@ -333,7 +404,12 @@ func parseDiff(r io.Reader) (diffSet, error) {
 			case '+':
 				// Added line. Strip leading '+' to get content.
 				content := line[1:]
-				if isCountableProdLine(content) {
+				// skipBlock: this `diff --git` block is a pure-move
+				// rename/copy at or above the similarity threshold. The
+				// `+` lines are the moved content, not new code. We
+				// still ADVANCE newLine so subsequent context-line
+				// counting stays correct, but we do NOT add to out.
+				if !skipBlock && isCountableProdLine(content) {
 					if out[curFile] == nil {
 						out[curFile] = map[int]bool{}
 					}
@@ -354,6 +430,20 @@ func parseDiff(r io.Reader) (diffSet, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// parseSimilarityPercent extracts N from `similarity index N%`. Returns
+// (0, false) on malformed input — caller treats a parse failure as "no
+// similarity info", which keeps behavior backwards-compatible.
+func parseSimilarityPercent(line string) (int, bool) {
+	rest := strings.TrimPrefix(line, "similarity index ")
+	rest = strings.TrimSpace(rest)
+	rest = strings.TrimSuffix(rest, "%")
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 // parseHunkNewStart pulls the +newstart from "@@ -a,b +c,d @@".

--- a/tools/coverage-gate/main_test.go
+++ b/tools/coverage-gate/main_test.go
@@ -1055,6 +1055,28 @@ func TestRun_InvalidRenameThreshold(t *testing.T) {
 	}
 }
 
+func TestRun_UnknownFlagRejected(t *testing.T) {
+	// FlagSet.Parse() errors on unknown flags. The current behavior is
+	// exit 2 with flag's own usage message on stderr — verify this path
+	// is exercised by the existing run() error handling, not bypassed.
+	// This pins the L107-110 branch (fs.Parse error → return 2) that's
+	// distinct from the threshold-range branch (L111-113) covered by
+	// TestRun_InvalidRenameThreshold above.
+	covPath := writeTemp(t, "cover.out", "mode: set\n")
+	diffPath := writeTemp(t, "diff.patch", "")
+	var stdout, stderr bytes.Buffer
+	code := run("coverage-gate",
+		[]string{"-totally-unknown-flag", covPath, diffPath},
+		&stdout, &stderr,
+	)
+	if code != 2 {
+		t.Errorf("expected exit 2 on unknown flag, got %d (stderr=%q)", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "totally-unknown-flag") {
+		t.Errorf("expected stderr to identify the offending flag, got %q", stderr.String())
+	}
+}
+
 func TestRun_RenameThresholdPropagates(t *testing.T) {
 	// End-to-end through run(): a 100%-similarity rename block with
 	// zero coverage on the destination file must NOT trigger the gate

--- a/tools/coverage-gate/main_test.go
+++ b/tools/coverage-gate/main_test.go
@@ -785,3 +785,336 @@ func TestRun_ErrorOnMalformedDiff(t *testing.T) {
 		t.Errorf("expected 'error parsing diff' in stderr, got: %q", stderr.String())
 	}
 }
+
+// --- Rename / similarity detection tests ---
+//
+// `git diff -M` and `git diff -C` emit per-block headers like:
+//
+//	diff --git a/old.go b/new.go
+//	similarity index 80%
+//	rename from old.go
+//	rename to new.go
+//	--- a/old.go
+//	+++ b/new.go
+//	@@ ... @@
+//	 <context>
+//	+<moved line>
+//
+// When similarity is at or above -rename-threshold, the `+` lines are
+// not new code — they're the moved-byte portion of a refactor. These
+// tests pin the threshold semantics and lock down regression behavior
+// for the godfile-decomposition campaign that surfaced bead mache-e256f5.
+
+func TestParseDiff_RenameHunkExcludesAllLines(t *testing.T) {
+	// similarity 100% — every `+` line in the rename block is a pure
+	// move. Even with zero coverage we must NOT flag anything.
+	in := `diff --git a/old.go b/new.go
+similarity index 100%
+rename from old.go
+rename to new.go
+--- a/old.go
++++ b/new.go
+@@ -1,3 +1,3 @@
++moved line 1
++moved line 2
++moved line 3
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	if got, ok := ds["new.go"]; ok && len(got) > 0 {
+		t.Errorf("expected NO lines flagged for 100%% rename, got: %v", got)
+	}
+}
+
+func TestParseDiff_RenameHunkBelowThresholdCountsAsNew(t *testing.T) {
+	// similarity 30%, threshold default 50 — block is NOT treated as a
+	// pure move; `+` lines must still appear in the diff set.
+	in := `diff --git a/old.go b/new.go
+similarity index 30%
+rename from old.go
+rename to new.go
+--- a/old.go
++++ b/new.go
+@@ -1,1 +1,3 @@
+ context
++new line 1
++new line 2
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	// new.go line 2 and 3 (after the context line at 1) should be tracked.
+	if !ds["new.go"][2] {
+		t.Errorf("expected new.go L2 tracked (similarity 30 < threshold 50), got: %v", ds["new.go"])
+	}
+	if !ds["new.go"][3] {
+		t.Errorf("expected new.go L3 tracked, got: %v", ds["new.go"])
+	}
+}
+
+func TestParseDiff_RenameHunkWithEditsCountsEdits(t *testing.T) {
+	// similarity 80% — overall a rename, BUT the hunk shows 1 context +
+	// 1 deletion + 1 addition (the edit). Because the whole block is
+	// classified as a move at or above threshold, the `+` (the edit)
+	// is excluded too. This documents the current model: per-BLOCK
+	// classification, not per-line. A future refinement could try to
+	// distinguish "moved" vs "edited" `+` lines, but git itself doesn't
+	// give us that granularity without recomputing similarity.
+	in := `diff --git a/old.go b/new.go
+similarity index 80%
+rename from old.go
+rename to new.go
+--- a/old.go
++++ b/new.go
+@@ -1,2 +1,2 @@
+ unchanged context
+-removed original
++added replacement
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	if got, ok := ds["new.go"]; ok && len(got) > 0 {
+		t.Errorf("expected NO lines flagged when block-level similarity (80%%) "+
+			"is at/above threshold (50%%); got: %v", got)
+	}
+
+	// Same diff, threshold raised to 90 — now the block IS treated as
+	// new code, and the `+ added replacement` line at L2 must be flagged.
+	ds2, err := parseDiffWithRenames(strings.NewReader(in), 90)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames (strict): %v", err)
+	}
+	if !ds2["new.go"][2] {
+		t.Errorf("with threshold 90, expected new.go L2 (the edit) tracked, got: %v", ds2["new.go"])
+	}
+}
+
+func TestRenameDetection_GodfileServeHandlersWIP(t *testing.T) {
+	// End-to-end regression on the WIP godfile-serve-handlers worktree.
+	//
+	// What the godfile diff actually looks like with `git diff -B5% -M5%
+	// -C5%`:
+	//
+	//   - 7 per-tool files were copy-detected by git (similarities
+	//     5-16%) — their `+` lines were already eliminated by git's
+	//     own preprocessing; the blocks contain only `-` deletions.
+	//   - 3 per-tool files (find_callers, get_sheaf_status,
+	//     semantic_search) are net-new (`new file mode`, `--- /dev/null`)
+	//     — git could not associate them with serve_handlers.go at the
+	//     5% threshold, so they show as pure additions with no
+	//     similarity header.
+	//   - serve_handlers.go has a normal in-place diff (most of its
+	//     content was removed in this WIP commit).
+	//
+	// The bead's "185 → ~0" claim was the baseline-without-flags vs the
+	// theoretical-perfect-detection. The reality after git's heuristics
+	// is closer to ~76 lines flagged before this change. This test
+	// pins the two properties this change actually delivers:
+	//
+	//   1. At threshold 50 (the default), the flagged-line count is
+	//      strictly less than OR equal to the count at threshold 101+
+	//      (effectively-disabled) — we never INCREASE false positives.
+	//   2. When we synthesize a high-similarity rename hunk on top of
+	//      the godfile diff, the count drops at threshold 50. This
+	//      proves rename detection fires when given a real opportunity.
+	//
+	// The WIP branch lives at /private/tmp/mache-worktrees/godfile-serve-handlers
+	// — if the path is missing (e.g. CI on a fresh checkout) we skip
+	// rather than fail.
+	const godfilePath = "/private/tmp/mache-worktrees/godfile-serve-handlers"
+	if _, err := os.Stat(godfilePath); err != nil {
+		t.Skipf("godfile-serve-handlers worktree not present at %s — skipping live regression test", godfilePath)
+	}
+	cmd := exec.Command("git",
+		"-C", godfilePath,
+		"diff", "-B5%", "-M5%", "-C5%", "origin/main..HEAD",
+	)
+	diffBytes, err := cmd.Output()
+	if err != nil {
+		t.Skipf("git diff failed for godfile worktree (%v); skipping", err)
+	}
+	if len(diffBytes) == 0 {
+		t.Skipf("godfile diff is empty; nothing to regress against")
+	}
+
+	// (1) No-regression: default threshold ≤ strict threshold.
+	dsDefault, err := parseDiffWithRenames(bytes.NewReader(diffBytes), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames (default): %v", err)
+	}
+	dsStrict, err := parseDiffWithRenames(bytes.NewReader(diffBytes), 100)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames (strict): %v", err)
+	}
+	defaultTotal := 0
+	for _, lines := range dsDefault {
+		defaultTotal += len(lines)
+	}
+	strictTotal := 0
+	for _, lines := range dsStrict {
+		strictTotal += len(lines)
+	}
+	if defaultTotal > strictTotal {
+		t.Errorf("rename detection regressed: default threshold flagged MORE "+
+			"lines than strict. default=%d strict=%d files(default)=%v",
+			defaultTotal, strictTotal, summarizeDiffSet(dsDefault))
+	}
+	t.Logf("godfile-serve-handlers WIP diff: default(50)=%d, strict(100)=%d",
+		defaultTotal, strictTotal)
+
+	// (2) Concatenate a synthesized high-similarity rename hunk to the
+	// real diff. parseDiff should drop the synthesized `+` lines at
+	// threshold 50 but NOT at threshold 100.
+	const synth = `
+diff --git a/_synth_old.go b/_synth_new.go
+similarity index 95%
+rename from _synth_old.go
+rename to _synth_new.go
+--- a/_synth_old.go
++++ b/_synth_new.go
+@@ -1,3 +1,3 @@
++synth line 1
++synth line 2
++synth line 3
+`
+	combined := append([]byte{}, diffBytes...)
+	combined = append(combined, synth...)
+
+	dsCombinedRelaxed, err := parseDiffWithRenames(bytes.NewReader(combined), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames (combined,relaxed): %v", err)
+	}
+	dsCombinedStrict, err := parseDiffWithRenames(bytes.NewReader(combined), 100)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames (combined,strict): %v", err)
+	}
+	if got := len(dsCombinedRelaxed["_synth_new.go"]); got != 0 {
+		t.Errorf("synth rename at 95%% similarity should be EXCLUDED at "+
+			"threshold 50, got %d flagged: %v",
+			got, dsCombinedRelaxed["_synth_new.go"])
+	}
+	if got := len(dsCombinedStrict["_synth_new.go"]); got != 3 {
+		t.Errorf("synth rename at 95%% similarity should be INCLUDED at "+
+			"threshold 100, got %d flagged (want 3): %v",
+			got, dsCombinedStrict["_synth_new.go"])
+	}
+}
+
+// summarizeDiffSet produces a compact per-file count summary for test failures.
+func summarizeDiffSet(ds diffSet) map[string]int {
+	out := make(map[string]int, len(ds))
+	for f, lines := range ds {
+		out[f] = len(lines)
+	}
+	return out
+}
+
+func TestParseSimilarityPercent(t *testing.T) {
+	// Direct unit test of the helper for completeness.
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		"similarity index 100%": {100, true},
+		"similarity index 50%":  {50, true},
+		"similarity index 0%":   {0, true},
+		"similarity index 7%":   {7, true},
+		"similarity index abc%": {0, false},
+		"similarity index ":     {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseSimilarityPercent(in)
+		if ok != exp.ok || got != exp.want {
+			t.Errorf("parseSimilarityPercent(%q) = (%d,%v), want (%d,%v)",
+				in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestRun_InvalidRenameThreshold(t *testing.T) {
+	covPath := writeTemp(t, "cover.out", "mode: set\n")
+	diffPath := writeTemp(t, "diff.patch", "")
+	for _, bad := range []string{"-1", "101", "9999"} {
+		var stdout, stderr bytes.Buffer
+		code := run("coverage-gate",
+			[]string{"-rename-threshold", bad, covPath, diffPath},
+			&stdout, &stderr,
+		)
+		if code != 2 {
+			t.Errorf("threshold %q: expected exit 2, got %d (stderr=%q)", bad, code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "rename-threshold") {
+			t.Errorf("threshold %q: expected stderr to mention rename-threshold, got %q",
+				bad, stderr.String())
+		}
+	}
+}
+
+func TestRun_RenameThresholdPropagates(t *testing.T) {
+	// End-to-end through run(): a 100%-similarity rename block with
+	// zero coverage on the destination file must NOT trigger the gate
+	// at threshold 50, but MUST trigger at threshold 101.
+	cover := "mode: set\nnew.go:1.1,3.10 3 0\n"
+	diff := `diff --git a/old.go b/new.go
+similarity index 100%
+rename from old.go
+rename to new.go
+--- a/old.go
++++ b/new.go
+@@ -1,3 +1,3 @@
++moved line 1
++moved line 2
++moved line 3
+`
+	covPath := writeTemp(t, "cover.out", cover)
+	diffPath := writeTemp(t, "diff.patch", diff)
+
+	// Default threshold (50) — 100%% similarity excludes the block.
+	var stdout, stderr bytes.Buffer
+	code := run("coverage-gate", []string{covPath, diffPath}, &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("expected exit 0 with default threshold on 100%% rename, got %d (stdout=%q stderr=%q)",
+			code, stdout.String(), stderr.String())
+	}
+
+	// Strict threshold (101) — no rename ever matches, gate trips.
+	stdout.Reset()
+	stderr.Reset()
+	code = run("coverage-gate",
+		[]string{"-rename-threshold", "101"},
+		&stdout, &stderr,
+	)
+	// 101 is out of range; expect exit 2 (validation error).
+	if code != 2 {
+		t.Errorf("expected exit 2 on out-of-range threshold 101, got %d (stderr=%q)", code, stderr.String())
+	}
+
+	// Threshold 100 (boundary inclusive) — still excluded.
+	stdout.Reset()
+	stderr.Reset()
+	code = run("coverage-gate",
+		[]string{"-rename-threshold", "100", covPath, diffPath},
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Errorf("expected exit 0 with threshold=100 on 100%% rename, got %d (stdout=%q)",
+			code, stdout.String())
+	}
+
+	// Threshold 0 — every similarity-tagged block is excluded.
+	stdout.Reset()
+	stderr.Reset()
+	code = run("coverage-gate",
+		[]string{"-rename-threshold", "0", covPath, diffPath},
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Errorf("expected exit 0 with threshold=0, got %d (stdout=%q)",
+			code, stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary

Adds `-rename-threshold N` (default 50, range 0..100) to `tools/coverage-gate`.
When a `diff --git` block carries a `similarity index N%` header (emitted by
`git diff -M` / `git diff -C`) and `N >= threshold`, the block's `+` lines
are excluded from the new-lines set entirely — they represent a move/copy,
not new code.

Closes bead `mache-e256f5`. The bead was surfaced by the `feat/evolve-coverage-trunk`
wave-6b god-file split attempt on `cmd/serve_handlers.go` (1374 → 182 LOC):
mechanical decomposition was being flagged as 100% new code because
`parseDiff` ignored git's similarity metadata.

## Demo on the WIP godfile-serve-handlers diff

```
cd /private/tmp/mache-worktrees/godfile-serve-handlers
git diff -B5% -M5% -C5% origin/main..HEAD > /tmp/godfile.diff
go test -coverprofile=/tmp/godfile.cov ./...
cd /private/tmp/mache-worktrees/mache-e256f5
go run ./tools/coverage-gate -rename-threshold 50  /tmp/godfile.cov /tmp/godfile.diff  → 76 lines uncovered
go run ./tools/coverage-gate -rename-threshold 100 /tmp/godfile.cov /tmp/godfile.diff  → 76 lines uncovered
```

In this particular diff `git -C5%` already preprocessed the copy blocks
to contain only `-` deletions (similarities are 5-16%), so the remaining
flagged lines (76) are **genuinely new code** in net-new files that git
could not associate with the original (`find_callers`, `get_sheaf_status`,
`semantic_search`), plus `serve_handlers.go` residual edits and the
`coverage-gate` tool itself. The new mechanism is exercised at higher
similarities via a synthesized 95% rename hunk in the regression test.

The original bead claimed "185 → ~0" — that baseline was the **plain**
`git diff` (216 lines actually, no `-M`/`-C` preprocessing). Documented
in the test comment for posterity.

## New tests (7 added, 0 modified)

- `TestParseDiff_RenameHunkExcludesAllLines` — 100% similarity, zero coverage, NO lines flagged
- `TestParseDiff_RenameHunkBelowThresholdCountsAsNew` — 30% similarity, default threshold 50, lines tracked
- `TestParseDiff_RenameHunkWithEditsCountsEdits` — 80% similarity excludes the edit too (per-BLOCK decision); threshold 90 flips it back
- `TestRenameDetection_GodfileServeHandlersWIP` — live regression on the WIP worktree; skips if absent; synthesizes a 95% rename to prove end-to-end firing
- `TestParseSimilarityPercent` — helper unit
- `TestRun_InvalidRenameThreshold` — flag validation (-1, 101, 9999 → exit 2)
- `TestRun_RenameThresholdPropagates` — end-to-end through `run()` covering 0 / 100 / out-of-range boundaries

Total: 34 → 41 tests, all passing under `go test -race -count=10`.

## Backwards compatibility

- Public API `parseDiff(r io.Reader)` preserved unchanged — delegates to new `parseDiffWithRenames(r, defaultRenameThreshold)`. All 34 existing tests are untouched.
- Diffs without similarity headers (the common case) behave identically regardless of threshold.

## Why

See `mache-e256f5`: the godfile decomposition campaign was running into 185+ false-positive coverage-gate flags every time mechanical-move work was attempted, eroding the gate's signal-to-noise ratio. This change makes the gate distinguish moves from new code at the same granularity git itself does.

## Test plan

- [x] `go test -race -count=10 ./tools/coverage-gate/` passes
- [x] `task check` passes (full CI-equivalent)
- [x] Demo against the godfile-serve-handlers WIP worktree
- [x] No `go.mod` changes (pure stdlib)