### PR TITLE
feat(coverage-gate): handle dissimilarity-index headers [mache-301daf]

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -292,6 +292,24 @@ tasks:
     cmds:
       - bash scripts/docs-lint.sh
 
+  coverage-gate:
+    desc: Run the diff-aware NEW-CODE coverage gate against the current branch
+    vars:
+      # Override BASE=<ref> on the command line for non-default base branches
+      # (e.g. `task coverage-gate BASE=origin/feat/godfile-decomposition`).
+      BASE: '{{.BASE | default "origin/main"}}'
+      DIFF: /tmp/.coverage-gate.diff
+      COV: /tmp/.coverage-gate.cov
+    cmds:
+      # IMPORTANT: -B5% -M5% -C5% are required for rename/copy/break-rewrite
+      # detection to fire — plain `git diff` does not emit `similarity index`
+      # or `dissimilarity index` headers, so the gate's -rename-threshold
+      # logic becomes a no-op. See tools/coverage-gate/main.go package
+      # docstring for full rationale.
+      - git diff -B5% -M5% -C5% {{.BASE}}...HEAD > {{.DIFF}}
+      - go test -coverprofile={{.COV}} ./...
+      - go run ./tools/coverage-gate {{.COV}} {{.DIFF}}
+
   check:
     desc: Run all checks (fmt, vet, lint, test, validate, docs:lint)
     cmds:

--- a/tools/coverage-gate/main.go
+++ b/tools/coverage-gate/main.go
@@ -19,8 +19,11 @@
 //     carries a `similarity index N%` header (emitted by `git diff -M`
 //     or `git diff -C`), and N is >= threshold, the block's `+` lines
 //     are treated as a pure move and excluded from the new-lines set.
-//     0 = treat any detected rename/copy as not-new; 100 = require an
-//     exact-content move.
+//     A `dissimilarity index N%` header (emitted by `git diff -B` for
+//     in-place rewrites) is mapped to similarity (100 - N)% and uses the
+//     same threshold.
+//     0 = treat any detected rename/copy/rewrite as not-new; 100 = require
+//     an exact-content move.
 //
 // Behavior:
 //   - Parses cover profile into file → []{startLine, endLine, hits} ranges.
@@ -34,6 +37,9 @@
 //     for that single line.
 //   - Pure-move refactors detected via `similarity index` headers (see
 //     -rename-threshold) are excluded.
+//   - In-place rewrites flagged via `dissimilarity index N%` are mapped
+//     to similarity (100 - N)% and excluded when that value is at or
+//     above -rename-threshold.
 package main
 
 import (
@@ -97,8 +103,9 @@ func run(progName string, args []string, stdout, stderr io.Writer) int {
 		defaultRenameThreshold,
 		"similarity percentage (0..100) at or above which a `diff --git` block "+
 			"tagged with `similarity index N%` is treated as a pure move and its "+
-			"added lines are excluded; 0 = exclude any detected rename, 100 = "+
-			"require exact-content match",
+			"added lines are excluded; `dissimilarity index N%` headers are "+
+			"mapped to similarity (100 - N)%; 0 = exclude any detected rename or "+
+			"rewrite, 100 = require exact-content match",
 	)
 	fs.Usage = func() {
 		_, _ = fmt.Fprintf(stderr, "usage: %s [-rename-threshold N] <cover.out> <diff.patch>\n", progName)
@@ -327,7 +334,16 @@ func parseDiff(r io.Reader) (diffSet, error) {
 // threshold. When a `diff --git` block carries a `similarity index N%`
 // header AND N >= renameThreshold, the block's `+` lines are excluded
 // from the result entirely (they're a pure move / copy, not new code).
-// Blocks WITHOUT a similarity header behave exactly as a non-rename diff.
+//
+// `dissimilarity index N%` headers (emitted by `git diff -B` when a file
+// has been rewritten in place — N% of the file changed) are mapped to
+// similarity (100 - N)% and use the same threshold. So at the default
+// threshold (50), `dissimilarity index 30%` → similarity 70% → block
+// excluded; `dissimilarity index 80%` → similarity 20% → block flagged
+// as new code; `dissimilarity index 50%` → similarity 50% → excluded
+// (boundary is inclusive, matching the rename case).
+//
+// Blocks WITHOUT either header behave exactly as a non-rename diff.
 // See defaultRenameThreshold for the CLI default.
 func parseDiffWithRenames(r io.Reader, renameThreshold int) (diffSet, error) {
 	out := diffSet{}
@@ -360,9 +376,17 @@ func parseDiffWithRenames(r io.Reader, renameThreshold int) (diffSet, error) {
 				skipBlock = true
 			}
 		case strings.HasPrefix(line, "dissimilarity index "):
-			// "dissimilarity index N%" — emitted with `--irreversible-delete`
-			// and a few other modes. Conservative: do NOT skip the block;
-			// fall through to the normal +/- handling below.
+			// "dissimilarity index N%" — emitted by `git diff -B` for
+			// in-place rewrites where N% of the file CHANGED. We map this
+			// to similarity (100 - N)% and apply the same threshold: at
+			// default threshold 50, dissimilarity 30% → similarity 70%
+			// (excluded as a near-move); dissimilarity 80% → similarity
+			// 20% (still flagged as new). Mirrors the similarity branch
+			// above to keep block-state semantics uniform.
+			n, ok := parseDissimilarityPercent(line)
+			if ok && (100-n) >= renameThreshold {
+				skipBlock = true
+			}
 		case strings.HasPrefix(line, "--- "):
 			// nothing; we trust +++ for the new path
 		case strings.HasPrefix(line, "+++ "):
@@ -437,6 +461,25 @@ func parseDiffWithRenames(r io.Reader, renameThreshold int) (diffSet, error) {
 // similarity info", which keeps behavior backwards-compatible.
 func parseSimilarityPercent(line string) (int, bool) {
 	rest := strings.TrimPrefix(line, "similarity index ")
+	rest = strings.TrimSpace(rest)
+	rest = strings.TrimSuffix(rest, "%")
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// parseDissimilarityPercent extracts N from `dissimilarity index N%`.
+// Returns (0, false) on malformed input — caller treats a parse failure
+// as "no dissimilarity info" and the block falls through to normal
+// new-code handling, which is the conservative choice.
+//
+// Callers should map the returned N to similarity (100 - N)% before
+// applying any rename threshold; this function intentionally does NOT
+// perform that translation so the parser layer stays purely lexical.
+func parseDissimilarityPercent(line string) (int, bool) {
+	rest := strings.TrimPrefix(line, "dissimilarity index ")
 	rest = strings.TrimSpace(rest)
 	rest = strings.TrimSuffix(rest, "%")
 	n, err := strconv.Atoi(rest)

--- a/tools/coverage-gate/main.go
+++ b/tools/coverage-gate/main.go
@@ -14,6 +14,18 @@
 //   - diff.patch: unified diff, e.g. `git diff base..HEAD > diff.patch`
 //     or `gh pr diff <num> > diff.patch`
 //
+// IMPORTANT — generating the diff:
+//
+// For best results, generate the diff with `git diff -B5% -M5% -C5%`
+// which surfaces both rename (similarity index) and break-rewrite
+// (dissimilarity index) hunks. Plain `git diff` or `gh pr diff` will
+// not produce these headers, so renames look like delete+create and
+// heavy in-place rewrites look like a full new file — which means the
+// -rename-threshold flag and the dissimilarity-index handling below are
+// effectively dead unless you pass `-B` / `-M` / `-C` when capturing the
+// diff. The `task coverage-gate` target in Taskfile.yml uses the
+// recommended invocation; copy from there if running by hand.
+//
 // Flags:
 //   - -rename-threshold N (0..100, default 50): when a `diff --git` block
 //     carries a `similarity index N%` header (emitted by `git diff -M`
@@ -109,6 +121,12 @@ func run(progName string, args []string, stdout, stderr io.Writer) int {
 	)
 	fs.Usage = func() {
 		_, _ = fmt.Fprintf(stderr, "usage: %s [-rename-threshold N] <cover.out> <diff.patch>\n", progName)
+		_, _ = fmt.Fprintf(stderr, "\n")
+		_, _ = fmt.Fprintf(stderr, "Generate the diff with `git diff -B5%% -M5%% -C5%% base..HEAD > diff.patch`\n")
+		_, _ = fmt.Fprintf(stderr, "so similarity index (rename/copy) and dissimilarity index (break-rewrite)\n")
+		_, _ = fmt.Fprintf(stderr, "headers are emitted — plain `git diff` / `gh pr diff` will not produce them\n")
+		_, _ = fmt.Fprintf(stderr, "and the rename-threshold flag becomes a no-op.\n")
+		_, _ = fmt.Fprintf(stderr, "\n")
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
@@ -457,8 +475,10 @@ func parseDiffWithRenames(r io.Reader, renameThreshold int) (diffSet, error) {
 }
 
 // parseSimilarityPercent extracts N from `similarity index N%`. Returns
-// (0, false) on malformed input — caller treats a parse failure as "no
-// similarity info", which keeps behavior backwards-compatible.
+// (0, false) on malformed OR out-of-range input — caller treats a parse
+// failure as "no similarity info", which keeps behavior backwards-
+// compatible AND prevents adversarial values (negative, >100) from
+// silently muting the gate. Range check: N must be in [0,100].
 func parseSimilarityPercent(line string) (int, bool) {
 	rest := strings.TrimPrefix(line, "similarity index ")
 	rest = strings.TrimSpace(rest)
@@ -467,13 +487,21 @@ func parseSimilarityPercent(line string) (int, bool) {
 	if err != nil {
 		return 0, false
 	}
+	if n < 0 || n > 100 {
+		return 0, false
+	}
 	return n, true
 }
 
 // parseDissimilarityPercent extracts N from `dissimilarity index N%`.
-// Returns (0, false) on malformed input — caller treats a parse failure
-// as "no dissimilarity info" and the block falls through to normal
-// new-code handling, which is the conservative choice.
+// Returns (0, false) on malformed OR out-of-range input — caller treats
+// a parse failure as "no dissimilarity info" and the block falls through
+// to normal new-code handling, which is the conservative choice (flag,
+// don't skip). The range check exists because without it a malicious or
+// malformed `dissimilarity index -5%` would compute (100 - (-5)) = 105
+// in the caller's similarity comparison, which silently mutes the gate
+// on ANY threshold value — exactly the wrong failure mode. Range:
+// N must be in [0,100].
 //
 // Callers should map the returned N to similarity (100 - N)% before
 // applying any rename threshold; this function intentionally does NOT
@@ -484,6 +512,9 @@ func parseDissimilarityPercent(line string) (int, bool) {
 	rest = strings.TrimSuffix(rest, "%")
 	n, err := strconv.Atoi(rest)
 	if err != nil {
+		return 0, false
+	}
+	if n < 0 || n > 100 {
 		return 0, false
 	}
 	return n, true

--- a/tools/coverage-gate/main_test.go
+++ b/tools/coverage-gate/main_test.go
@@ -1077,6 +1077,166 @@ func TestRun_UnknownFlagRejected(t *testing.T) {
 	}
 }
 
+// --- Dissimilarity detection tests ---
+//
+// `git diff -B` emits `dissimilarity index N%` for in-place rewrites
+// (no rename, just heavy content turnover — N% of the file CHANGED).
+// We map that to similarity (100 - N)% and reuse the rename threshold:
+//
+//   dissimilarity 30%  → similarity 70%  → excluded at threshold 50
+//   dissimilarity 80%  → similarity 20%  → flagged at threshold 50
+//   dissimilarity 50%  → similarity 50%  → excluded (inclusive boundary)
+//
+// This was driven by bead mache-301daf: the /evolve sqlite_graph
+// decomposition (PR #396, 1598 → 547 LOC) emitted `dissimilarity index
+// 62%` for internal/graph/sqlite_graph.go and the coverage-gate flagged
+// 110 lines as new — false positive, since they were uncovered before
+// the refactor too. The fix is conservative: at default threshold 50,
+// `dissimilarity 62%` (= similarity 38%) is STILL flagged. The reviewer
+// opts in by lowering -rename-threshold for heavy-rewrite PRs.
+
+func TestParseDiff_DissimilarityIndexHighExcluded(t *testing.T) {
+	// dissimilarity 30% → similarity 70%. At threshold 50, the block is
+	// classified as a near-move and the `+` lines must be excluded.
+	in := `diff --git a/x.go b/x.go
+dissimilarity index 30%
+--- a/x.go
++++ b/x.go
+@@ -1,3 +1,3 @@
++rewritten line 1
++rewritten line 2
++rewritten line 3
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	if got, ok := ds["x.go"]; ok && len(got) > 0 {
+		t.Errorf("expected NO lines flagged for dissimilarity 30%% "+
+			"(= similarity 70%%) at threshold 50, got: %v", got)
+	}
+}
+
+func TestParseDiff_DissimilarityIndexLowFlagged(t *testing.T) {
+	// dissimilarity 80% → similarity 20%. At threshold 50, the block is
+	// NOT a near-move and the `+` lines must still appear in the diff set.
+	in := `diff --git a/x.go b/x.go
+dissimilarity index 80%
+--- a/x.go
++++ b/x.go
+@@ -1,1 +1,3 @@
+ context
++rewritten line 1
++rewritten line 2
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	if !ds["x.go"][2] {
+		t.Errorf("expected x.go L2 tracked for dissimilarity 80%% "+
+			"(= similarity 20%%) at threshold 50, got: %v", ds["x.go"])
+	}
+	if !ds["x.go"][3] {
+		t.Errorf("expected x.go L3 tracked, got: %v", ds["x.go"])
+	}
+}
+
+func TestParseDiff_DissimilarityIndexBoundary(t *testing.T) {
+	// dissimilarity 50% → similarity 50%. Inclusive boundary: at
+	// threshold 50, similarity 50 satisfies `>= threshold`, so the
+	// block is excluded — matching the rename case (similarity 50% at
+	// threshold 50 is also excluded).
+	in := `diff --git a/x.go b/x.go
+dissimilarity index 50%
+--- a/x.go
++++ b/x.go
+@@ -1,2 +1,3 @@
+ context
++boundary line 1
++boundary line 2
+`
+	ds, err := parseDiffWithRenames(strings.NewReader(in), 50)
+	if err != nil {
+		t.Fatalf("parseDiffWithRenames: %v", err)
+	}
+	if got, ok := ds["x.go"]; ok && len(got) > 0 {
+		t.Errorf("expected NO lines flagged at the inclusive boundary "+
+			"(dissimilarity 50%% = similarity 50%%, threshold 50), got: %v", got)
+	}
+}
+
+func TestRunDissimilarity_RealWorldRegression(t *testing.T) {
+	// Synthesizes a diff modelled on the sqlite_graph decomposition
+	// (bead mache-301daf): `dissimilarity index 62%` with uncovered
+	// added lines that look like real Go code so isCountableProdLine
+	// accepts them.
+	//
+	// At threshold 50 (default) — dissimilarity 62% maps to similarity
+	// 38%, BELOW threshold, so the block is flagged. Gate trips.
+	// At threshold 30 — similarity 38% is at/above 30, so the block is
+	// excluded. Gate exits 0.
+	cover := "mode: set\ninternal/graph/sqlite_graph.go:10.1,12.2 2 0\n"
+	diff := `diff --git a/internal/graph/sqlite_graph.go b/internal/graph/sqlite_graph.go
+dissimilarity index 62%
+--- a/internal/graph/sqlite_graph.go
++++ b/internal/graph/sqlite_graph.go
+@@ -1,1 +10,3 @@
+ context
++func newSomething() *Foo { return &Foo{} }
++func anotherUncoveredFunc() error { return nil }
+`
+
+	// (1) Threshold 50 (default): block stays in, gate trips.
+	covPath := writeTemp(t, "cover.out", cover)
+	diffPath := writeTemp(t, "diff.patch", diff)
+	var stdout, stderr bytes.Buffer
+	code := run("coverage-gate", []string{covPath, diffPath}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit 1 at threshold 50 on dissimilarity 62%%, "+
+			"got %d (stdout=%q stderr=%q)", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "internal/graph/sqlite_graph.go") {
+		t.Errorf("expected sqlite_graph.go in report at threshold 50, got: %q",
+			stdout.String())
+	}
+
+	// (2) Threshold 30: similarity 38% >= 30, block excluded, gate clean.
+	stdout.Reset()
+	stderr.Reset()
+	code = run("coverage-gate",
+		[]string{"-rename-threshold", "30", covPath, diffPath},
+		&stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("expected exit 0 at threshold 30 on dissimilarity 62%% "+
+			"(= similarity 38%%), got %d (stdout=%q stderr=%q)",
+			code, stdout.String(), stderr.String())
+	}
+}
+
+func TestParseDissimilarityPercent(t *testing.T) {
+	// Direct unit test of the helper, mirroring TestParseSimilarityPercent.
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		"dissimilarity index 100%": {100, true},
+		"dissimilarity index 62%":  {62, true},
+		"dissimilarity index 50%":  {50, true},
+		"dissimilarity index 0%":   {0, true},
+		"dissimilarity index abc%": {0, false},
+		"dissimilarity index ":     {0, false},
+	}
+	for in, exp := range cases {
+		got, ok := parseDissimilarityPercent(in)
+		if ok != exp.ok || got != exp.want {
+			t.Errorf("parseDissimilarityPercent(%q) = (%d,%v), want (%d,%v)",
+				in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
 func TestRun_RenameThresholdPropagates(t *testing.T) {
 	// End-to-end through run(): a 100%-similarity rename block with
 	// zero coverage on the destination file must NOT trigger the gate

--- a/tools/coverage-gate/main_test.go
+++ b/tools/coverage-gate/main_test.go
@@ -1167,10 +1167,17 @@ dissimilarity index 50%
 }
 
 func TestRunDissimilarity_RealWorldRegression(t *testing.T) {
-	// Synthesizes a diff modelled on the sqlite_graph decomposition
-	// (bead mache-301daf): `dissimilarity index 62%` with uncovered
-	// added lines that look like real Go code so isCountableProdLine
-	// accepts them.
+	// Synthesized to mirror the `dissimilarity 62%` case observed when
+	// running `git diff -B5% origin/feat/godfile-decomposition..HEAD` on
+	// the sqlite_graph decomposition commit (0825449). We synthesize
+	// rather than shell out to `git diff` because the test must run in
+	// CI containers that may not have the worktree's full history (and
+	// reaching for the git binary from a Go unit test is a brittle
+	// dependency anyway). The synthetic diff shape — one `diff --git`
+	// block with `dissimilarity index 62%` followed by Go-shaped `+`
+	// lines — exercises exactly the same parseDiffWithRenames code path
+	// the real `git diff -B` output triggers; only the byte content of
+	// the additions is different.
 	//
 	// At threshold 50 (default) — dissimilarity 62% maps to similarity
 	// 38%, BELOW threshold, so the block is flagged. Gate trips.
@@ -1232,6 +1239,73 @@ func TestParseDissimilarityPercent(t *testing.T) {
 		got, ok := parseDissimilarityPercent(in)
 		if ok != exp.ok || got != exp.want {
 			t.Errorf("parseDissimilarityPercent(%q) = (%d,%v), want (%d,%v)",
+				in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestParseDissimilarityPercent_OutOfRange(t *testing.T) {
+	// Pins the range check in parseDissimilarityPercent. Without it,
+	// `dissimilarity index -5%` would compute (100 - (-5)) = 105 in the
+	// caller's similarity comparison, which is `>=` any threshold value
+	// — silently muting the gate. Equivalently, `dissimilarity index
+	// 101%` would compute (100 - 101) = -1, which is never `>=` a valid
+	// threshold but still represents nonsense input. Both must be
+	// rejected (parse-not-skip), making the caller fall through to
+	// "no dissimilarity info" and treat the block as normal new code.
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		// Negative — the original vulnerability.
+		"dissimilarity index -5%": {0, false},
+		// Above 100.
+		"dissimilarity index 101%":   {0, false},
+		"dissimilarity index 9999%":  {0, false},
+		"dissimilarity index 12345%": {0, false},
+		// In-range values stay accepted (regression check on the
+		// existing happy paths now that range check is in place).
+		"dissimilarity index 0%":   {0, true},
+		"dissimilarity index 100%": {100, true},
+		// Negative zero — strconv.Atoi accepts "-0" as 0, which passes
+		// the range check (0 is in [0,100]). Document the choice: we
+		// allow it because it's semantically equivalent to "0%" and
+		// neither value is adversarial — the gate just treats the block
+		// as "100% similarity" (fully unchanged), which is a no-op.
+		"dissimilarity index -0%": {0, true},
+	}
+	for in, exp := range cases {
+		got, ok := parseDissimilarityPercent(in)
+		if ok != exp.ok || got != exp.want {
+			t.Errorf("parseDissimilarityPercent(%q) = (%d,%v), want (%d,%v)",
+				in, got, ok, exp.want, exp.ok)
+		}
+	}
+}
+
+func TestParseSimilarityPercent_OutOfRange(t *testing.T) {
+	// Mirrors TestParseDissimilarityPercent_OutOfRange — same range
+	// check on the similarity parser. A `similarity index 105%` would
+	// be accepted as 105 without this check; while no current threshold
+	// path is broken by that (105 >= 50 just means "always exclude",
+	// the same as 100 already does), keeping both parsers symmetric
+	// avoids surprises if future code tightens or inverts the
+	// comparison.
+	cases := map[string]struct {
+		want int
+		ok   bool
+	}{
+		"similarity index -5%":   {0, false},
+		"similarity index 101%":  {0, false},
+		"similarity index 9999%": {0, false},
+		"similarity index 0%":    {0, true},
+		"similarity index 100%":  {100, true},
+		"similarity index -0%":   {0, true},
+	}
+	for in, exp := range cases {
+		got, ok := parseSimilarityPercent(in)
+		if ok != exp.ok || got != exp.want {
+			t.Errorf("parseSimilarityPercent(%q) = (%d,%v), want (%d,%v)",
 				in, got, ok, exp.want, exp.ok)
 		}
 	}


### PR DESCRIPTION
## Summary

- Extends `parseDiffWithRenames` to recognize `dissimilarity index N%` headers (emitted by `git diff -B` for in-place rewrites) and maps them to similarity `(100 - N)%` so the existing `-rename-threshold` flag applies uniformly to both renames and rewrites.
- Conservative default: at threshold 50, only blocks with `dissimilarity <= 50%` (similarity >= 50%) are excluded. Heavy rewrites still trip the gate unless the reviewer opts in by lowering the threshold.

## Motivation

PR #391 (bead `mache-e256f5`) added `similarity index` parsing for rename/copy hunks but did not handle `dissimilarity index N%`, which `git diff -B` emits for in-place rewrites where `N%` of the file CHANGED. The `/evolve` `sqlite_graph` decomposition (PR #396, commit `0825449`) surfaced the gap: 1598 -> 547 LOC, `dissimilarity index 62%`, 110 lines flagged as new even though every one was uncovered before the refactor too. The skeptic verified the false positive.

## Before / After on the sqlite_graph commit

`git diff -B5% -M5% -C5% 0825449^..0825449` includes:

```
diff --git a/internal/graph/sqlite_graph.go b/internal/graph/sqlite_graph.go
dissimilarity index 62%
```

Running the gate against the package's coverage profile:

| threshold | lines flagged | block treatment |
|-----------|---------------|-----------------|
| 50 (default) | 110 | sqlite_graph.go rewrite still in (similarity 38% < 50) |
| 30 | 6 | rewrite excluded (38% >= 30); 6 lines remain in sqlite_graph_scan.go which is a 21%-similarity COPY |
| 0 | 0 | all similarity-tagged blocks excluded |

Note: at threshold 50 the count is the same as before this change — the conservative default is preserved. The user opts in by passing `-rename-threshold 30` for known-decomposition PRs.

## Conservative choice

The bead deliberately avoids default-including dissimilarity blocks. `dissimilarity 62%` (= similarity 38%) is below the default threshold 50, so the rewrite is STILL flagged by default. This means existing PRs are not silently rubber-stamped — the reviewer has to make an explicit choice to trust the rewrite by lowering the threshold.

## Test plan

- [x] `go test -race -count=10 ./tools/coverage-gate/` — pass (9.3s)
- [x] `task check` — exit 0
- [x] Gate self-check on this PR's diff (`go run ./tools/coverage-gate cg.cov pr.diff`) — exit 0 (new code fully exercised by the 5 new tests; coverage 99.2%)
- [x] Five new tests added:
  - `TestParseDiff_DissimilarityIndexHighExcluded` — dissimilarity 30% (= sim 70%) at threshold 50 -> excluded
  - `TestParseDiff_DissimilarityIndexLowFlagged` — dissimilarity 80% (= sim 20%) at threshold 50 -> flagged
  - `TestParseDiff_DissimilarityIndexBoundary` — dissimilarity 50% (= sim 50%) at threshold 50 -> excluded (inclusive)
  - `TestRunDissimilarity_RealWorldRegression` — synthesizes the sqlite_graph case; verifies threshold 50 flags + threshold 30 clean
  - `TestParseDissimilarityPercent` — direct unit test of the helper mirroring `TestParseSimilarityPercent`

## Constraints

- Stage-by-path commit (`tools/coverage-gate/main.go`, `tools/coverage-gate/main_test.go`); no `git add -A`.
- Pure stdlib; no new go.mod deps.
- No co-author line.