### PR TITLE
[mache-ec1a06] feat(smell_rules): Severity+Tags schema + CLI gate flags + 3 drift_doc_* placeholder rules (ADR-0018 PR 1-3 bundle)

### DIFF
--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,103 +38,176 @@ var (
 	findSmellsLimit     int
 	findSmellsMinMetric int64
 	findSmellsFormat    string
+	findSmellsFailOn    string
+	findSmellsTags      string
 )
+
+// exitFunc is the process-exit hook the CLI uses after RunE returns a
+// non-zero code. Production points it at os.Exit; tests override it to
+// capture the code without crashing the test binary. Keeping it as a
+// package var (rather than weaving t.Cleanup hooks through every test)
+// matches the cobra-CLI convention used elsewhere in this package.
+var exitFunc = os.Exit
 
 var findSmellsCmd = &cobra.Command{
 	Use:   "find-smells",
 	Short: "Run structural code-smell rules against a mache or leyline-built SQLite database",
 	Long: `Runs the same rule registry that powers the find_smells MCP tool, but as a
 CLI for non-MCP consumers (CI, scripts, GitHub Actions). With no --rule
-argument it lists registered rules; otherwise it executes the named rule.
+argument it lists registered rules; otherwise it executes the named rule
+(or every rule whose ID matches the glob pattern).
 
 Output formats:
   --format=json (default)  machine-readable, same shape as the MCP tool
   --format=md              human-readable markdown summary
+  --format=ci              one-line-per-finding "file:line:col: severity: msg [rule-id]"
+                           (gh / ripgrep / vale convention)
+
+Rule selection:
+  --rule=ID                exact match (legacy)
+  --rule='drift_doc_*'     filepath.Match glob; runs every matching rule
+  --tags=docs,security     filter the registry to rules whose Tags contain
+                           ANY of the listed values (set union). Composes
+                           with --rule glob.
+
+Gate decision (ADR-0018, pylint precedent):
+  --fail-on=none           never exits non-zero on findings (legacy default)
+  --fail-on=warn           exit 1 if any finding's rule resolves to warn or error
+  --fail-on=error (default) exit 1 only on findings from rules with Severity=error
 
 Exit codes:
-  0  success — regardless of how many findings the rule produced
+  0  success — no findings exceeded the --fail-on threshold
+  1  findings exceeded --fail-on threshold (new in ADR-0018 PR 2)
   2  pre-flight failed (missing tables on the active backend)
-  3  unknown rule
+  3  unknown rule (no matches from --rule glob + --tags filter)
   4  database open / query error
 
-This tool is observability, not a gate. It never exits non-zero on findings.`,
+The historical observability contract ("never exits non-zero on findings") is
+preserved with --fail-on=none, and is the de-facto default for every rule that
+ships at Severity=warn (which is every rule today) when --fail-on=error.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Discovery mode: no rule -> dump the listing. No db required.
-		if findSmellsRule == "" {
-			return renderListing(cmd.OutOrStdout(), findSmellsFormat)
+		code, err := runFindSmells(cmd, args)
+		// On success (code 0), return any benign render error directly so
+		// cobra surfaces it via its normal channel. On non-zero, the
+		// error has already been printed to stderr inside runFindSmells;
+		// short-circuit via exitFunc so the process exit code reflects
+		// the failure mode (2 = pre-flight, 3 = unknown rule, 4 = db,
+		// 1 = gate fired). Tests swap exitFunc to capture the code.
+		if code != 0 {
+			exitFunc(code)
 		}
+		return err
+	},
+}
 
-		// Running a rule requires a db. SQLite would silently create
-		// missing files on Open, so existence-check first to give a
-		// clear error rather than running the rule against an empty
-		// auto-created file.
-		if findSmellsDBPath == "" {
-			return fmt.Errorf("--db PATH is required when --rule is set")
-		}
-		if _, err := os.Stat(findSmellsDBPath); err != nil {
-			return cliExit(4, fmt.Errorf("db file: %w", err))
-		}
-		db, err := sql.Open("sqlite", findSmellsDBPath)
-		if err != nil {
-			return cliExit(4, fmt.Errorf("open db: %w", err))
-		}
-		defer func() { _ = db.Close() }()
-		if err := db.Ping(); err != nil {
-			return cliExit(4, fmt.Errorf("ping db: %w", err))
-		}
-		// SetMaxOpenConns(1) pins all queries to a single connection so
-		// the TEMP _capnp_binding_refs table created by ensureCanonicalViews
-		// + LoadCapnpBindings stays visible to subsequent queries.
-		// modernc/sqlite spreads queries across the pool by default,
-		// which would put the TEMP-table population on a connection
-		// the rule SELECT never sees.
-		db.SetMaxOpenConns(1)
-		qg := &dbQuerier{db: db, path: findSmellsDBPath}
+// runFindSmells is the testable core: it returns the intended process
+// exit code plus any cobra-surfaceable error, instead of calling
+// os.Exit directly. This lets tests assert exit semantics (especially
+// the new --fail-on gate behavior) without crashing the test binary.
+//
+// Production flow:
+//
+//	RunE -> runFindSmells -> (code, err) -> exitFunc(code) on non-zero
+//
+// Error printing for non-zero codes still happens here (mirroring the
+// old cliExit), so cobra doesn't double-print.
+func runFindSmells(cmd *cobra.Command, _ []string) (int, error) {
+	// Discovery mode: no rule glob -> dump the listing. No db required.
+	// Tags filter is intentionally NOT applied to discovery — listing
+	// is meant to show every registered rule so an agent can decide
+	// which tags to pass.
+	if findSmellsRule == "" {
+		return 0, renderListing(cmd.OutOrStdout(), findSmellsFormat)
+	}
 
-		var rule *SmellRule
-		for i := range smellRegistry {
-			if smellRegistry[i].ID == findSmellsRule {
-				rule = &smellRegistry[i]
-				break
-			}
-		}
-		if rule == nil {
-			return cliExit(3, fmt.Errorf(
-				"unknown rule %q — available: %s — run with no --rule for full descriptions",
-				findSmellsRule, strings.Join(allRuleIDs(), ", "),
-			))
-		}
+	// Validate --fail-on early so a typo surfaces before we open the db.
+	if !validFailOn(findSmellsFailOn) {
+		return printAndCode(4, fmt.Errorf(
+			"invalid --fail-on=%q; must be one of: none, warn, error", findSmellsFailOn,
+		))
+	}
 
+	// Resolve rule selection: glob + tags filter against the registry.
+	// allRuleIDs() returns alphabetical; matchRules preserves registry
+	// order so multiple-match runs are deterministic.
+	tagSet := parseTags(findSmellsTags)
+	matched, err := matchRules(findSmellsRule, tagSet)
+	if err != nil {
+		return printAndCode(3, fmt.Errorf(
+			"invalid --rule glob %q: %w", findSmellsRule, err,
+		))
+	}
+	if len(matched) == 0 {
+		return printAndCode(3, fmt.Errorf(
+			"no rules match --rule=%q --tags=%q — available: %s — run with no --rule for full descriptions",
+			findSmellsRule, findSmellsTags, strings.Join(allRuleIDs(), ", "),
+		))
+	}
+
+	// Running rules requires a db. SQLite would silently create
+	// missing files on Open, so existence-check first to give a
+	// clear error rather than running against an empty auto-created file.
+	if findSmellsDBPath == "" {
+		return 0, fmt.Errorf("--db PATH is required when --rule is set")
+	}
+	if _, err := os.Stat(findSmellsDBPath); err != nil {
+		return printAndCode(4, fmt.Errorf("db file: %w", err))
+	}
+	db, err := sql.Open("sqlite", findSmellsDBPath)
+	if err != nil {
+		return printAndCode(4, fmt.Errorf("open db: %w", err))
+	}
+	defer func() { _ = db.Close() }()
+	if err := db.Ping(); err != nil {
+		return printAndCode(4, fmt.Errorf("ping db: %w", err))
+	}
+	// SetMaxOpenConns(1) pins all queries to a single connection so
+	// the TEMP _capnp_binding_refs table created by ensureCanonicalViews
+	// + LoadCapnpBindings stays visible to subsequent queries.
+	// modernc/sqlite spreads queries across the pool by default,
+	// which would put the TEMP-table population on a connection
+	// the rule SELECT never sees.
+	db.SetMaxOpenConns(1)
+	qg := &dbQuerier{db: db, path: findSmellsDBPath}
+
+	// Mirror the MCP handler's threshold-default semantics. If
+	// the caller passed --min-metric explicitly, that value wins
+	// (including 0 for "show me everything sorted"). If the flag
+	// wasn't set, fall back to rule.DefaultMinMetric per rule.
+	minMetricChanged := cmd.Flags().Changed("min-metric")
+
+	// Run every matched rule and concatenate results. Each finding
+	// already carries its RuleID so downstream consumers can split
+	// by rule. Output is one envelope per rule in JSON/MD modes; CI
+	// mode interleaves lines (per the gh/ripgrep convention).
+	results := make([]ruleRunResult, 0, len(matched))
+
+	for _, rule := range matched {
 		// Pre-flight required tables, same shape as the MCP handler.
-		if missing, err := missingTables(qg, rule.Requires); err != nil {
-			return cliExit(4, fmt.Errorf("pre-flight: %w", err))
+		if missing, mErr := missingTables(qg, rule.Requires); mErr != nil {
+			return printAndCode(4, fmt.Errorf("pre-flight: %w", mErr))
 		} else if len(missing) > 0 {
 			backendNote := ""
 			if backend := queryBuildBackend(qg); backend != "" {
 				backendNote = fmt.Sprintf(" (built with backend=%q)", backend)
 			}
-			return cliExit(2, fmt.Errorf(
+			return printAndCode(2, fmt.Errorf(
 				"rule %q requires SQL tables [%s] which aren't present in %s%s — "+
 					"_ast / _source / _imports / _lsp* come from ley-line-open's `leyline parse`; "+
 					"node_defs / node_refs / nodes come from both standalone mache and LLO; "+
 					"see docs/ARCHITECTURE.md#interplay-with-ley-line-open for the full capability matrix",
-				findSmellsRule, strings.Join(missing, ", "), findSmellsDBPath, backendNote,
+				rule.ID, strings.Join(missing, ", "), findSmellsDBPath, backendNote,
 			))
 		}
 
-		findings, err := runSmellRule(qg, rule, findSmellsSourceID, findSmellsLimit)
-		if err != nil {
-			return cliExit(4, fmt.Errorf("rule %q: %w", findSmellsRule, err))
+		findings, rErr := runSmellRule(qg, rule, findSmellsSourceID, findSmellsLimit)
+		if rErr != nil {
+			return printAndCode(4, fmt.Errorf("rule %q: %w", rule.ID, rErr))
 		}
 
-		// Mirror the MCP handler's threshold-default semantics. If
-		// the caller passed --min-metric explicitly, that value wins
-		// (including 0 for "show me everything sorted"). If the flag
-		// wasn't set, fall back to rule.DefaultMinMetric so CLI and
-		// MCP consumers see the same default set.
 		minMetric := findSmellsMinMetric
-		if !cmd.Flags().Changed("min-metric") {
+		if !minMetricChanged {
 			minMetric = rule.DefaultMinMetric
 		}
 		if minMetric > 0 {
@@ -146,19 +220,152 @@ This tool is observability, not a gate. It never exits non-zero on findings.`,
 			findings = filtered
 		}
 		populateSnippets(qg, findings)
+		results = append(results, ruleRunResult{rule: rule, findings: findings})
+	}
 
-		return renderFindings(cmd.OutOrStdout(), rule.ID, findings, findSmellsFormat)
-	},
+	// Render — CI format streams lines across all rules; JSON/MD emit
+	// one envelope per rule so the legacy single-rule shape is preserved
+	// when the matcher returned exactly one match.
+	if findSmellsFormat == "ci" {
+		for _, r := range results {
+			if err := renderFindingsCI(cmd.OutOrStdout(), r.rule, r.findings); err != nil {
+				return 0, err
+			}
+		}
+	} else {
+		for _, r := range results {
+			if err := renderFindings(cmd.OutOrStdout(), r.rule.ID, r.findings, findSmellsFormat); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	// Gate decision (ADR-0018). --fail-on=none preserves the legacy
+	// observability contract; warn fails on warn-or-error findings;
+	// error fails only on findings from rules opted-in via
+	// Severity=error. Today every shipped rule is warn, so the
+	// effective default behavior with --fail-on=error is "exit 0".
+	exitCode := gateDecision(findSmellsFailOn, results)
+	return exitCode, nil
 }
 
-// cliExit wraps an error with a specific exit code so callers can
-// distinguish pre-flight failures from real errors. Cobra's RunE only
-// supports a single err return, so we set the process exit code via
-// os.Exit at the call site.
-func cliExit(code int, err error) error {
+// printAndCode mirrors the historical cliExit side effect (write the
+// error to stderr) but returns the intended exit code instead of
+// calling os.Exit, so tests can assert it.
+func printAndCode(code int, err error) (int, error) {
 	fmt.Fprintln(os.Stderr, err)
-	os.Exit(code)
-	return err // unreachable
+	return code, nil
+}
+
+// validFailOn returns true for the three permitted --fail-on values.
+// Anything else is a typo; surfacing it as exit 4 (DB-error class)
+// keeps the unknown-rule code (3) reserved for rule-resolution failures.
+func validFailOn(s string) bool {
+	switch s {
+	case "none", "warn", "error":
+		return true
+	}
+	return false
+}
+
+// parseTags splits the comma-separated --tags value into a lookup set.
+// Empty / whitespace tokens are dropped so `--tags=,foo,` behaves like
+// `--tags=foo`.
+func parseTags(csv string) map[string]struct{} {
+	if csv == "" {
+		return nil
+	}
+	out := make(map[string]struct{})
+	for _, t := range strings.Split(csv, ",") {
+		t = strings.TrimSpace(t)
+		if t != "" {
+			out[t] = struct{}{}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// matchRules resolves a --rule pattern (exact ID or glob) intersected
+// with the --tags filter to the concrete subset of smellRegistry rules
+// that should run. The pattern is matched via filepath.Match, which
+// supports `*`, `?`, and `[...]`. A pattern without metacharacters
+// behaves as exact-match (same as the legacy code path).
+//
+// Tags semantics are union (match-any): a rule passes when ANY of its
+// Tags is in the requested set. Empty tagSet disables the filter.
+//
+// Registry order is preserved so multi-match output is deterministic
+// across runs.
+func matchRules(pattern string, tagSet map[string]struct{}) ([]*SmellRule, error) {
+	// Eagerly validate the pattern so a typo like '[' surfaces here,
+	// not deep inside the loop where filepath.Match would return
+	// ErrBadPattern repeatedly.
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		return nil, err
+	}
+	var out []*SmellRule
+	for i := range smellRegistry {
+		r := &smellRegistry[i]
+		ok, _ := filepath.Match(pattern, r.ID)
+		if !ok {
+			continue
+		}
+		if len(tagSet) > 0 && !hasAnyTag(r.Tags, tagSet) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// hasAnyTag implements the union-semantics tag filter: returns true
+// if the rule carries at least one of the requested tags.
+func hasAnyTag(ruleTags []string, want map[string]struct{}) bool {
+	for _, t := range ruleTags {
+		if _, ok := want[t]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ruleRunResult bundles one rule with the findings it produced for the
+// current invocation. Package-level (not anonymous) so gateDecision can
+// take a typed slice — anonymous structs don't share identity across
+// function boundaries.
+type ruleRunResult struct {
+	rule     *SmellRule
+	findings []smellFinding
+}
+
+// gateDecision implements --fail-on per ADR-0018. Returns 1 when any
+// finding belongs to a rule whose Effective() severity crosses the
+// requested threshold; 0 otherwise. --fail-on=none always returns 0
+// (the legacy observability contract).
+func gateDecision(failOn string, results []ruleRunResult) int {
+	if failOn == "none" {
+		return 0
+	}
+	for _, r := range results {
+		if len(r.findings) == 0 {
+			continue
+		}
+		sev := r.rule.Effective()
+		switch failOn {
+		case "warn":
+			if sev == SeverityWarn || sev == SeverityError {
+				return 1
+			}
+		case "error":
+			if sev == SeverityError {
+				return 1
+			}
+		}
+	}
+	return 0
 }
 
 func renderListing(w io.Writer, format string) error {
@@ -239,16 +446,61 @@ func renderFindings(w io.Writer, ruleID string, findings []smellFinding, format 
 	return enc.Encode(resp)
 }
 
+// renderFindingsCI emits one line per finding in the gh/ripgrep/vale
+// convention: `<source_id>:<line>:<column>: <severity>: <message> [<rule-id>]`.
+// The message is the rule's Description, normalized (newlines -> spaces,
+// truncated to ~120 chars) so editors can parse the line cleanly.
+// Severity is the rule's Effective() value so the on-the-wire shape
+// reflects the gate decision the consumer would see.
+func renderFindingsCI(w io.Writer, rule *SmellRule, findings []smellFinding) error {
+	sev := string(rule.Effective())
+	msg := truncateOneLine(rule.Description, 120)
+	for _, f := range findings {
+		if _, err := fmt.Fprintf(w, "%s:%d:%d: %s: %s [%s]\n",
+			f.SourceID, f.Line, f.Column, sev, msg, rule.ID,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// truncateOneLine collapses newlines/tabs/CRs to single spaces and
+// truncates at maxLen with an ellipsis, so a multiline rule description
+// renders cleanly on the CI format's one-line shape. The cap is fuzzy
+// (gh/vale don't enforce a hard limit) but ~120 keeps lines reviewable
+// in a terminal without horizontal scroll on most setups.
+func truncateOneLine(s string, maxLen int) string {
+	s = strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)
+	// Collapse runs of spaces so the output stays compact.
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	s = strings.TrimSpace(s)
+	if len(s) > maxLen {
+		// Reserve 3 chars for the ellipsis so the total length stays
+		// within maxLen for downstream parsers that buffer line-by-line.
+		if maxLen > 3 {
+			s = s[:maxLen-3] + "..."
+		} else {
+			s = s[:maxLen]
+		}
+	}
+	return s
+}
+
 func escapePipes(s string) string {
 	return strings.ReplaceAll(s, "|", `\|`)
 }
 
 func init() {
 	findSmellsCmd.Flags().StringVar(&findSmellsDBPath, "db", "", "path to the SQLite database (mache-built or leyline-built) — required")
-	findSmellsCmd.Flags().StringVar(&findSmellsRule, "rule", "", "rule ID to run; omit to list available rules")
+	findSmellsCmd.Flags().StringVar(&findSmellsRule, "rule", "", "rule ID or glob (e.g. 'drift_doc_*'); omit to list available rules")
 	findSmellsCmd.Flags().StringVar(&findSmellsSourceID, "source-id", "", "scope rule to a single source file path")
-	findSmellsCmd.Flags().IntVar(&findSmellsLimit, "limit", 200, "cap result count")
+	findSmellsCmd.Flags().IntVar(&findSmellsLimit, "limit", 200, "cap result count per rule")
 	findSmellsCmd.Flags().Int64Var(&findSmellsMinMetric, "min-metric", 0, "drop findings whose metric is below this threshold")
-	findSmellsCmd.Flags().StringVar(&findSmellsFormat, "format", "json", "output format: json or md")
+	findSmellsCmd.Flags().StringVar(&findSmellsFormat, "format", "json", "output format: json, md, or ci")
+	findSmellsCmd.Flags().StringVar(&findSmellsFailOn, "fail-on", "error", "exit non-zero when findings reach severity: none | warn | error (ADR-0018)")
+	findSmellsCmd.Flags().StringVar(&findSmellsTags, "tags", "", "comma-separated tags; runs rules whose Tags contain ANY of these values (set union)")
 	rootCmd.AddCommand(findSmellsCmd)
 }

--- a/cmd/find_smells_cli_test.go
+++ b/cmd/find_smells_cli_test.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -239,12 +241,358 @@ func TestFindSmellsCLI_ExplicitMinMetricLowersThreshold(t *testing.T) {
 	assert.ElementsMatch(t, []string{"big", "mid"}, gotIDs)
 }
 
+// captureExit installs a no-op exitFunc that records the exit code into
+// the returned int pointer instead of terminating the test binary. The
+// snapshot.restore() registered earlier will put the real os.Exit back
+// when the test finishes. Tests check `*code` to assert exit semantics.
+func captureExit(t *testing.T) *int {
+	t.Helper()
+	code := -1
+	exitFunc = func(c int) { code = c }
+	return &code
+}
+
+// registerTestRule appends a SmellRule to smellRegistry and registers a
+// t.Cleanup to slice it back off. The rule's SQL just selects rows from
+// the test fixture so we get deterministic findings without standing
+// up a full _ast graph. The pre-flight check requires only `nodes`,
+// which writeSmellCLIFixture creates.
+func registerTestRule(t *testing.T, rule SmellRule) {
+	t.Helper()
+	smellRegistry = append(smellRegistry, rule)
+	t.Cleanup(func() {
+		// Strip the trailing entry we just added. Other tests that mutate
+		// the registry use snapshotSmellRegistry — these new tests
+		// surgically pop the last N entries so they compose with that
+		// helper without ordering hazards.
+		for i := len(smellRegistry) - 1; i >= 0; i-- {
+			if smellRegistry[i].ID == rule.ID {
+				smellRegistry = append(smellRegistry[:i], smellRegistry[i+1:]...)
+				return
+			}
+		}
+	})
+}
+
+// testRuleQuery emits one row per node so a fixture's three seeded
+// nodes produce three findings. The `%s` is the scope clause splice
+// every rule requires; the leading "AND 1=1 %s" keeps the splice valid
+// whether scope is empty or `AND ... = ?`.
+const testRuleQuery = `
+	SELECT n.id AS source_id,
+	       n.id AS node_id,
+	       0 AS start_byte, 0 AS end_byte,
+	       0 AS start_row, 0 AS start_col,
+	       0 AS metric
+	FROM nodes n
+	WHERE 1=1 %s
+	ORDER BY n.id
+`
+
+// TestFindSmellsCLI_FailOn_None_NeverFails pins the observability-contract
+// escape hatch: `--fail-on=none` MUST exit 0 even when findings exist.
+// This is the only setting that preserves the pre-ADR-0018 documented
+// behavior, so any change to the default-semantic path that breaks this
+// is a contract regression.
+func TestFindSmellsCLI_FailOn_None_NeverFails(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+	code := captureExit(t)
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "dead_code",
+		"--format", "json",
+		"--fail-on", "none",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	assert.Equal(t, -1, *code, "exitFunc must not be called when --fail-on=none")
+	assert.Contains(t, buf.String(), "pkg/Dead",
+		"finding output must still be emitted; --fail-on=none mutes the gate, not the rule")
+}
+
+// TestFindSmellsCLI_FailOn_Warn_FailsOnWarnRule asserts that
+// --fail-on=warn escalates a default-severity (warn) rule's findings
+// into a non-zero exit. This is the clippy `-D warnings` analogue —
+// CI opt-in to treat warnings as fatal.
+func TestFindSmellsCLI_FailOn_Warn_FailsOnWarnRule(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+	code := captureExit(t)
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "dead_code", // default Severity ("") => warn
+		"--format", "json",
+		"--fail-on", "warn",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	assert.Equal(t, 1, *code,
+		"--fail-on=warn must exit 1 when a warn-severity rule emits findings")
+}
+
+// TestFindSmellsCLI_FailOn_Error_OnlyFailsOnErrorRule pins the default
+// --fail-on=error semantics: warn-severity rules pass even with
+// findings, but a rule explicitly marked Severity=error fails the gate.
+// This is the contract that lets the default be `error` without
+// silently breaking the observability promise — every shipped rule
+// today is warn-severity, so the default behavior is "no gate" until
+// a rule author opts in.
+func TestFindSmellsCLI_FailOn_Error_OnlyFailsOnErrorRule(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+
+	// Warn rule: default --fail-on=error must NOT escalate.
+	t.Run("warn rule passes the default error gate", func(t *testing.T) {
+		saved := saveCLIFlags()
+		defer saved.restore()
+		code := captureExit(t)
+
+		var buf bytes.Buffer
+		findSmellsCmd.SetOut(&buf)
+		findSmellsCmd.SetErr(&buf)
+		require.NoError(t, findSmellsCmd.ParseFlags([]string{
+			"--db", dbPath,
+			"--rule", "dead_code",
+			"--format", "json",
+			"--fail-on", "error",
+		}))
+		require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+		assert.Equal(t, -1, *code,
+			"warn-severity rules must NOT trigger --fail-on=error (default observability contract)")
+	})
+
+	// Error rule: same default --fail-on=error MUST escalate.
+	t.Run("error-severity rule trips the default error gate", func(t *testing.T) {
+		saved := saveCLIFlags()
+		defer saved.restore()
+		code := captureExit(t)
+
+		registerTestRule(t, SmellRule{
+			ID:          "test_error_rule",
+			Description: "Test-only error-severity rule for --fail-on=error coverage.",
+			Severity:    SeverityError,
+			Requires:    []string{"nodes"},
+			Query:       testRuleQuery,
+		})
+
+		var buf bytes.Buffer
+		findSmellsCmd.SetOut(&buf)
+		findSmellsCmd.SetErr(&buf)
+		require.NoError(t, findSmellsCmd.ParseFlags([]string{
+			"--db", dbPath,
+			"--rule", "test_error_rule",
+			"--format", "json",
+			"--fail-on", "error",
+		}))
+		require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+		assert.Equal(t, 1, *code,
+			"--fail-on=error MUST exit 1 when an error-severity rule emits findings")
+	})
+}
+
+// TestFindSmellsCLI_Rule_GlobMatchesMultiple pins the glob extension
+// (ADR-0018): `--rule='test_*'` runs every rule whose ID matches,
+// not just the first registry hit. The output for both rules must
+// appear so a downstream consumer (CI script, GHA) sees both rule IDs.
+func TestFindSmellsCLI_Rule_GlobMatchesMultiple(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+	captureExit(t) // findings would not gate; warn rules + default fail-on=error
+
+	registerTestRule(t, SmellRule{
+		ID:          "test_a",
+		Description: "Test rule A for glob coverage.",
+		Requires:    []string{"nodes"},
+		Query:       testRuleQuery,
+	})
+	registerTestRule(t, SmellRule{
+		ID:          "test_b",
+		Description: "Test rule B for glob coverage.",
+		Requires:    []string{"nodes"},
+		Query:       testRuleQuery,
+	})
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "test_*",
+		"--format", "json",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	out := buf.String()
+	// JSON renderer emits one envelope per rule; both rule IDs must surface.
+	assert.Contains(t, out, `"rule": "test_a"`,
+		"glob test_* must match test_a")
+	assert.Contains(t, out, `"rule": "test_b"`,
+		"glob test_* must also match test_b (not just the first hit)")
+}
+
+// TestFindSmellsCLI_Rule_GlobMatchesNone_Exit3 pins the
+// no-match error path: when the glob (and tags) filter produces zero
+// rules, exit 3 fires and the message includes the glob so the user
+// can debug their pattern.
+func TestFindSmellsCLI_Rule_GlobMatchesNone_Exit3(t *testing.T) {
+	saved := saveCLIFlags()
+	defer saved.restore()
+	code := captureExit(t)
+
+	// stderr capture — the printAndCode error goes to os.Stderr, not
+	// cmd.ErrOrStderr, so we redirect the package var. (Cobra's
+	// SetErr doesn't intercept os.Stderr writes.)
+	stderr := captureStderr(t)
+	defer stderr.restore()
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", "/dev/null", // never reached; matcher fails first
+		"--rule", "no_such_*",
+		"--format", "json",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	assert.Equal(t, 3, *code, "unmatched --rule glob must exit 3")
+	got := stderr.read()
+	assert.Contains(t, got, "no_such_*",
+		"exit 3 message must name the glob so the failure is debuggable")
+}
+
+// TestFindSmellsCLI_Tags_FiltersToMatchingRules pins that --tags
+// filters the registry via set-union semantics on rule.Tags. Two test
+// rules with disjoint tags; --tags=docs picks only the docs-tagged one.
+func TestFindSmellsCLI_Tags_FiltersToMatchingRules(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+	captureExit(t)
+
+	registerTestRule(t, SmellRule{
+		ID:          "test_foo",
+		Description: "Test rule tagged docs.",
+		Tags:        []string{"docs"},
+		Requires:    []string{"nodes"},
+		Query:       testRuleQuery,
+	})
+	registerTestRule(t, SmellRule{
+		ID:          "test_bar",
+		Description: "Test rule tagged security.",
+		Tags:        []string{"security"},
+		Requires:    []string{"nodes"},
+		Query:       testRuleQuery,
+	})
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "test_*",
+		"--tags", "docs",
+		"--format", "json",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	out := buf.String()
+	assert.Contains(t, out, `"rule": "test_foo"`,
+		"--tags=docs must run the docs-tagged rule")
+	assert.NotContains(t, out, `"rule": "test_bar"`,
+		"--tags=docs must NOT run the security-tagged rule (union, not catch-all)")
+}
+
+// TestFindSmellsCLI_Format_CI_OutputShape pins the `--format=ci` line
+// shape: `<source_id>:<line>:<column>: <severity>: <message> [<rule-id>]`.
+// One assertion per emitted finding so the test catches both shape
+// drift AND missing-finding regressions.
+func TestFindSmellsCLI_Format_CI_OutputShape(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t)
+	saved := saveCLIFlags()
+	defer saved.restore()
+	captureExit(t)
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	require.NoError(t, findSmellsCmd.ParseFlags([]string{
+		"--db", dbPath,
+		"--rule", "dead_code",
+		"--format", "ci",
+	}))
+	require.NoError(t, findSmellsCmd.RunE(findSmellsCmd, nil))
+
+	out := strings.TrimSpace(buf.String())
+	require.NotEmpty(t, out, "CI format must produce at least one finding line")
+
+	// Pattern: file:line:col: severity: message [rule-id]
+	// - file: greedy non-colon-or-space match (dead_code fixture uses
+	//   plain filenames like "dead.go")
+	// - severity: one of off/warn/error (warn for dead_code today)
+	// - message: anything non-greedy up to the trailing [rule-id]
+	pat := regexp.MustCompile(`^[^\s:]+:\d+:\d+: (off|warn|error): .+ \[[a-z_][a-z0-9_]*\]$`)
+	for i, line := range strings.Split(out, "\n") {
+		assert.Regexp(t, pat, line,
+			"CI line %d does not match `<source_id>:<line>:<col>: <severity>: <msg> [<rule-id>]`: %q", i, line)
+	}
+}
+
+// captureStderr swaps os.Stderr for a pipe so tests can read what
+// printAndCode wrote (the unknown-rule error message). Restored via
+// the returned struct's .restore(). Kept here (not in the snapshot)
+// because not every test needs it.
+type stderrCapture struct {
+	orig *os.File
+	r, w *os.File
+}
+
+func captureStderr(t *testing.T) *stderrCapture {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stderr
+	os.Stderr = w
+	return &stderrCapture{orig: orig, r: r, w: w}
+}
+
+func (s *stderrCapture) read() string {
+	_ = s.w.Close()
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(s.r)
+	return buf.String()
+}
+
+func (s *stderrCapture) restore() {
+	// Close pipe ends in case read() wasn't called (e.g. test aborted
+	// before assertion). Best-effort — both writes after Close are
+	// no-ops on a closed *os.File.
+	_ = s.w.Close()
+	_ = s.r.Close()
+	os.Stderr = s.orig
+}
+
 // cliFlagSnapshot lets tests mutate the package-level flag vars without
-// leaking state across tests (cobra binds them globally).
+// leaking state across tests (cobra binds them globally). Extended in
+// ADR-0018 PR 2 to cover --fail-on / --tags and the exitFunc override.
 type cliFlagSnapshot struct {
-	rule, db, sourceID, format string
-	limit                      int
-	minMetric                  int64
+	rule, db, sourceID, format, failOn, tags string
+	limit                                    int
+	minMetric                                int64
+	exitFunc                                 func(int)
 }
 
 func saveCLIFlags() cliFlagSnapshot {
@@ -253,8 +601,11 @@ func saveCLIFlags() cliFlagSnapshot {
 		db:        findSmellsDBPath,
 		sourceID:  findSmellsSourceID,
 		format:    findSmellsFormat,
+		failOn:    findSmellsFailOn,
+		tags:      findSmellsTags,
 		limit:     findSmellsLimit,
 		minMetric: findSmellsMinMetric,
+		exitFunc:  exitFunc,
 	}
 }
 
@@ -263,6 +614,9 @@ func (s cliFlagSnapshot) restore() {
 	findSmellsDBPath = s.db
 	findSmellsSourceID = s.sourceID
 	findSmellsFormat = s.format
+	findSmellsFailOn = s.failOn
+	findSmellsTags = s.tags
 	findSmellsLimit = s.limit
 	findSmellsMinMetric = s.minMetric
+	exitFunc = s.exitFunc
 }

--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -140,15 +140,20 @@ func rulesListing() any {
 		Description      string   `json:"description"`
 		Requires         []string `json:"requires,omitempty"`
 		DefaultMinMetric int64    `json:"default_min_metric,omitempty"`
+		Severity         Severity `json:"severity"` // always emitted; "warn" when rule omits the field
+		Tags             []string `json:"tags,omitempty"`
 	}
 	out := make([]ruleSummary, 0, len(smellRegistry))
-	for _, r := range smellRegistry {
+	for i := range smellRegistry {
+		r := &smellRegistry[i]
 		out = append(out, ruleSummary{
 			ID:               r.ID,
 			Languages:        r.Languages,
 			Description:      r.Description,
 			Requires:         r.Requires,
 			DefaultMinMetric: r.DefaultMinMetric,
+			Severity:         r.Effective(),
+			Tags:             r.Tags,
 		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -3051,3 +3051,191 @@ func TestFindSmells_MinMetricFilters(t *testing.T) {
 	assert.Equal(t, "c.go", filtered.Findings[0].SourceID)
 	assert.Equal(t, int64(5000), filtered.Findings[0].Metric)
 }
+
+// ---------------------------------------------------------------------------
+// drift_doc_* rules (ADR-0018 PR 3) — v1 placeholder contract tests.
+//
+// Each of the three rules below ships in the registry today with a
+// no-op SQL query (returns zero rows). The tests pin:
+//
+//   1. _Registered: the registry actually carries the rule with the
+//      expected metadata (ID, Languages, Severity, Tags, Requires).
+//   2. _ListingExposesIt: the MCP rules-listing surface emits the rule
+//      with severity + tags so PR 2's `--rule 'drift_doc_*'` glob and
+//      future agent discovery have something to match.
+//   3. _PlaceholderQueryReturnsZeroFindings: invoking the rule today
+//      runs cleanly (pre-flight passes, SQL executes) and returns zero
+//      findings. This pins the v1 placeholder contract — the follow-up
+//      bead implementing the firing logic will replace this assertion
+//      with a "fires on the seeded drift, doesn't fire on the seeded
+//      clean case" pair once the preprocessor / host-side validator /
+//      TOML loader lands.
+// ---------------------------------------------------------------------------
+
+// findRegisteredRule is a tiny helper for the placeholder tests below.
+// Returns the rule by ID or fails the test loudly so the assertion that
+// follows can use the pointer without nil-guards.
+func findRegisteredRule(t *testing.T, id string) *SmellRule {
+	t.Helper()
+	for i := range smellRegistry {
+		if smellRegistry[i].ID == id {
+			return &smellRegistry[i]
+		}
+	}
+	t.Fatalf("rule %q not registered in smellRegistry", id)
+	return nil
+}
+
+// driftRuleSummary is the JSON shape the rules-listing surface emits
+// for each rule. Mirrors the inline ruleSummary type in
+// serve_find_smells.go rulesListing() — kept local to the tests so a
+// shape drift in the production type is caught by these unmarshal calls
+// rather than silently coerced.
+type driftRuleSummary struct {
+	ID          string   `json:"id"`
+	Languages   []string `json:"languages"`
+	Description string   `json:"description"`
+	Requires    []string `json:"requires"`
+	Severity    string   `json:"severity"`
+	Tags        []string `json:"tags"`
+}
+
+// listingFor finds a rule in the rules-listing handler output by ID.
+// Calls the handler with no rule (discovery mode), unmarshals, and
+// returns the entry. Fails the test if the rule is absent.
+func listingFor(t *testing.T, id string) driftRuleSummary {
+	t.Helper()
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Rules []driftRuleSummary `json:"rules"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	for _, r := range resp.Rules {
+		if r.ID == id {
+			return r
+		}
+	}
+	t.Fatalf("rule %q absent from rules listing", id)
+	return driftRuleSummary{}
+}
+
+// runPlaceholderRule invokes the find_smells handler against the rule
+// and returns the decoded response. Verifies the call did not error
+// (placeholder SQL must execute cleanly against the seedSmellAST
+// fixture) and that the rule echoed back matches the request.
+func runPlaceholderRule(t *testing.T, id string) (int, []smellFinding) {
+	t.Helper()
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": id,
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "placeholder rule %q must execute cleanly: %s", id, resultText(t, res))
+
+	var resp struct {
+		Rule     string         `json:"rule"`
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, id, resp.Rule)
+	return resp.Total, resp.Findings
+}
+
+// --- drift_doc_dead_symbol_reference -------------------------------
+
+func TestFindSmells_DriftDocDeadSymbolReference_Registered(t *testing.T) {
+	r := findRegisteredRule(t, "drift_doc_dead_symbol_reference")
+	assert.Equal(t, []string{"markdown"}, r.Languages)
+	assert.Equal(t, SeverityWarn, r.Effective(),
+		"placeholder rules default to warn — observability tier per ADR-0018")
+	assert.Equal(t, []string{"docs", "drift"}, r.Tags)
+	assert.ElementsMatch(t, []string{"nodes", "node_defs"}, r.Requires,
+		"rule reads nodes (markdown content) + node_defs (symbol ground truth)")
+	assert.Equal(t, "COALESCE(md.source_file, '')", r.ScopeColumn,
+		"scope column matches the alias the real query will use once the preprocessor lands")
+	assert.NotEmpty(t, r.Description)
+}
+
+func TestFindSmells_DriftDocDeadSymbolReference_ListingExposesIt(t *testing.T) {
+	entry := listingFor(t, "drift_doc_dead_symbol_reference")
+	assert.Equal(t, []string{"markdown"}, entry.Languages)
+	assert.Equal(t, string(SeverityWarn), entry.Severity,
+		"listing must emit severity so PR 2's --fail-on flag can reason about gating")
+	assert.Equal(t, []string{"docs", "drift"}, entry.Tags,
+		"listing must emit tags so PR 2's --rule glob (drift_doc_*) and future --tags filter work")
+	assert.ElementsMatch(t, []string{"nodes", "node_defs"}, entry.Requires)
+}
+
+func TestFindSmells_DriftDocDeadSymbolReference_PlaceholderQueryReturnsZeroFindings(t *testing.T) {
+	total, findings := runPlaceholderRule(t, "drift_doc_dead_symbol_reference")
+	assert.Zero(t, total,
+		"v1 placeholder returns zero findings; follow-up bead under mache-e1b6c8 will replace this once the preprocessor lands")
+	assert.Empty(t, findings)
+}
+
+// --- drift_doc_broken_internal_link --------------------------------
+
+func TestFindSmells_DriftDocBrokenInternalLink_Registered(t *testing.T) {
+	r := findRegisteredRule(t, "drift_doc_broken_internal_link")
+	assert.Equal(t, []string{"markdown"}, r.Languages)
+	assert.Equal(t, SeverityWarn, r.Effective())
+	assert.Equal(t, []string{"docs", "drift", "links"}, r.Tags)
+	assert.ElementsMatch(t, []string{"nodes"}, r.Requires,
+		"link-target validation needs the markdown content (nodes); filesystem stat happens host-side")
+	assert.Equal(t, "COALESCE(md.source_file, '')", r.ScopeColumn)
+	assert.NotEmpty(t, r.Description)
+}
+
+func TestFindSmells_DriftDocBrokenInternalLink_ListingExposesIt(t *testing.T) {
+	entry := listingFor(t, "drift_doc_broken_internal_link")
+	assert.Equal(t, []string{"markdown"}, entry.Languages)
+	assert.Equal(t, string(SeverityWarn), entry.Severity)
+	assert.Equal(t, []string{"docs", "drift", "links"}, entry.Tags)
+	assert.ElementsMatch(t, []string{"nodes"}, entry.Requires)
+}
+
+func TestFindSmells_DriftDocBrokenInternalLink_PlaceholderQueryReturnsZeroFindings(t *testing.T) {
+	total, findings := runPlaceholderRule(t, "drift_doc_broken_internal_link")
+	assert.Zero(t, total,
+		"v1 placeholder returns zero findings; follow-up bead under mache-e1b6c8 will replace this once host-side filesystem validation lands")
+	assert.Empty(t, findings)
+}
+
+// --- drift_doc_outdated_count --------------------------------------
+
+func TestFindSmells_DriftDocOutdatedCount_Registered(t *testing.T) {
+	r := findRegisteredRule(t, "drift_doc_outdated_count")
+	assert.Equal(t, []string{"markdown"}, r.Languages)
+	assert.Equal(t, SeverityWarn, r.Effective())
+	assert.Equal(t, []string{"docs", "drift", "counts"}, r.Tags)
+	assert.ElementsMatch(t, []string{"nodes"}, r.Requires,
+		"ground-truth queries from .mache/drift-counts.toml execute against the wider DB; this rule needs only the markdown content (nodes)")
+	assert.Equal(t, "COALESCE(md.source_file, '')", r.ScopeColumn)
+	assert.NotEmpty(t, r.Description)
+}
+
+func TestFindSmells_DriftDocOutdatedCount_ListingExposesIt(t *testing.T) {
+	entry := listingFor(t, "drift_doc_outdated_count")
+	assert.Equal(t, []string{"markdown"}, entry.Languages)
+	assert.Equal(t, string(SeverityWarn), entry.Severity)
+	assert.Equal(t, []string{"docs", "drift", "counts"}, entry.Tags)
+	assert.ElementsMatch(t, []string{"nodes"}, entry.Requires)
+}
+
+func TestFindSmells_DriftDocOutdatedCount_PlaceholderQueryReturnsZeroFindings(t *testing.T) {
+	total, findings := runPlaceholderRule(t, "drift_doc_outdated_count")
+	assert.Zero(t, total,
+		"v1 placeholder returns zero findings; follow-up bead under mache-e1b6c8 will replace this once the TOML loader + claim extractor land")
+	assert.Empty(t, findings)
+}

--- a/cmd/smell_rules.go
+++ b/cmd/smell_rules.go
@@ -760,4 +760,114 @@ var smellRegistry = []SmellRule{
 			ORDER BY metric DESC, src.source_id
 		`,
 	},
+	// drift_doc_* rules — v1 placeholders per ADR-0018 (PR 3 of the
+	// migration path). The rule METADATA ships now so:
+	//
+	//   1. `mache find_smells` (no rule) surfaces them in the listing
+	//      — discovery surface is complete.
+	//   2. PR 2's `--rule 'drift_doc_*'` glob has something to match —
+	//      the CLI feature can be exercised end-to-end against real
+	//      registry entries instead of an empty set.
+	//   3. PR 4's pre-commit hook can wire the rule pack today without
+	//      waiting on the actual firing logic.
+	//
+	// Each rule's QUERY is intentionally a no-op (WHERE 1=0). The real
+	// firing logic for each has an honest dependency on additional
+	// plumbing — a markdown-token preprocessor, host-side filesystem
+	// validation, and a TOML config loader respectively — none of which
+	// belongs in PR 3's scope. Each rule has a follow-up bead filed
+	// against ADR-0018 (mache-e1b6c8) + the schema bead (mache-ec1a06).
+	//
+	// The placeholder Query shape — seven canonical columns wrapped in
+	// WHERE 1=0 — keeps these rules wired through the existing
+	// runSmellRule machinery without special-casing. They return zero
+	// findings, but every other code path (listing, severity, tags,
+	// requires pre-flight) treats them exactly like any other rule.
+	{
+		ID:        "drift_doc_dead_symbol_reference",
+		Languages: []string{"markdown"},
+		Description: "v1 placeholder (ADR-0018 PR 3). Spec: every backtick-fenced token `Foo` or `pkg.Bar` " +
+			"in markdown should refer to a real symbol defined in node_defs; a missing definition " +
+			"signals the doc has drifted from the code (renamed/removed function/type still " +
+			"referenced in docs). Current implementation: no findings — the firing logic requires " +
+			"a backtick-token preprocessor (either a derived _doc_tokens view populated by the " +
+			"markdown ingestion path, or a SQLite regex extension) which is tracked as a separate " +
+			"follow-up bead under mache-e1b6c8. The rule appears in the listing today so PR 2's " +
+			"--rule 'drift_doc_*' glob has something to match and PR 4's pre-commit hook can wire " +
+			"the rule pack ahead of the firing logic landing.",
+		Severity:    SeverityWarn,
+		Tags:        []string{"docs", "drift"},
+		Requires:    []string{"nodes", "node_defs"},
+		ScopeColumn: "COALESCE(md.source_file, '')",
+		Query: `
+			-- Placeholder: returns zero rows. Real implementation needs
+			-- a derived view of backtick-fenced tokens extracted from
+			-- markdown source. Follow-up bead under mache-e1b6c8.
+			SELECT '' AS source_id, '' AS node_id,
+			       0 AS start_byte, 0 AS end_byte,
+			       0 AS start_row, 0 AS start_col,
+			       0 AS metric
+			WHERE 1=0
+			%s
+		`,
+	},
+	{
+		ID:        "drift_doc_broken_internal_link",
+		Languages: []string{"markdown"},
+		Description: "v1 placeholder (ADR-0018 PR 3). Spec: every markdown internal link " +
+			"`[text](relative/path)` should resolve to an existing file on disk (external URLs — " +
+			"http/https/mailto — are skipped). Catches doc reorganizations that left stale links. " +
+			"Current implementation: no findings — SQL cannot stat the filesystem, so the firing " +
+			"logic requires a host-side post-processing step in runSmellRule that checks each " +
+			"candidate link's path on disk. That's a small refactor tracked as a separate " +
+			"follow-up bead under mache-e1b6c8. The rule appears in the listing today so PR 2's " +
+			"--rule 'drift_doc_*' glob has something to match and PR 4's pre-commit hook can wire " +
+			"the rule pack ahead of the firing logic landing.",
+		Severity:    SeverityWarn,
+		Tags:        []string{"docs", "drift", "links"},
+		Requires:    []string{"nodes"},
+		ScopeColumn: "COALESCE(md.source_file, '')",
+		Query: `
+			-- Placeholder: returns zero rows. Real implementation needs
+			-- host-side filesystem stat for each markdown link target;
+			-- pure SQL cannot do this. Follow-up bead under mache-e1b6c8.
+			SELECT '' AS source_id, '' AS node_id,
+			       0 AS start_byte, 0 AS end_byte,
+			       0 AS start_row, 0 AS start_col,
+			       0 AS metric
+			WHERE 1=0
+			%s
+		`,
+	},
+	{
+		ID:        "drift_doc_outdated_count",
+		Languages: []string{"markdown"},
+		Description: "v1 placeholder (ADR-0018 PR 3). Spec: numeric claims in markdown like " +
+			"'supports 28 languages' or '17 MCP tools' should match a SQL ground-truth query the " +
+			"repo author provides in .mache/drift-counts.toml (the schema is sketched in ADR-0018 " +
+			"Open Question 2). Generalizes the cloister-style narrow-lint pattern already " +
+			"implemented in bash as check #4 in scripts/docs-lint.sh for language-count claims. " +
+			"Current implementation: no findings — the firing logic needs a TOML loader, a regex " +
+			"extractor for '(\\d+) (tools|languages|rules)' patterns in markdown, and a per-claim " +
+			"SQL execution loop. Those three pieces are tracked as a separate follow-up bead " +
+			"under mache-e1b6c8. The rule appears in the listing today so PR 2's " +
+			"--rule 'drift_doc_*' glob has something to match and PR 4's pre-commit hook can wire " +
+			"the rule pack ahead of the firing logic landing.",
+		Severity:    SeverityWarn,
+		Tags:        []string{"docs", "drift", "counts"},
+		Requires:    []string{"nodes"},
+		ScopeColumn: "COALESCE(md.source_file, '')",
+		Query: `
+			-- Placeholder: returns zero rows. Real implementation needs
+			-- a .mache/drift-counts.toml loader, a regex extractor for
+			-- numeric claims in markdown, and a per-claim SQL execution
+			-- loop. Follow-up bead under mache-e1b6c8.
+			SELECT '' AS source_id, '' AS node_id,
+			       0 AS start_byte, 0 AS end_byte,
+			       0 AS start_row, 0 AS start_col,
+			       0 AS metric
+			WHERE 1=0
+			%s
+		`,
+	},
 }

--- a/cmd/smell_rules.go
+++ b/cmd/smell_rules.go
@@ -53,6 +53,53 @@ type SmellRule struct {
 	// default and see everything; any non-zero min_metric also
 	// overrides.
 	DefaultMinMetric int64
+	// Severity controls whether a finding from this rule is fatal to
+	// the gate. Three tiers per ESLint precedent (off/warn/error) —
+	// see ADR-0018 and bead mache-ec1a06 for the prior-art rationale.
+	//
+	//   - "off"   — rule defined but never produces findings; useful
+	//     for shipping a rule in a pack that's disabled for now
+	//   - "warn"  — emits findings, exit 0 (observability default)
+	//   - "error" — emits findings, exit 1 (rule author asserts this
+	//     drift must not ship)
+	//
+	// Default ("") is treated as "warn" — preserves the existing
+	// observability contract for all rules that haven't opted in.
+	// Gate decision is made at CLI invocation via --fail-on (pylint
+	// precedent): rule says what's true, gate decides whether truth
+	// is fatal.
+	Severity Severity
+	// Tags is a free-form classification used for CLI selection via
+	// --tags=foo,bar. Per ADR-0018 + research, NOT a closed enum:
+	// stages (pre-commit, ci) emerge as CLI profiles from
+	// (--tags × --fail-on) combinations, not from a fixed schema.
+	// Cap at 3-5 tags per rule to avoid the clippy-group explosion;
+	// expand the vocabulary deliberately, not reactively.
+	Tags []string
+}
+
+// Severity is one of off / warn / error. ESLint precedent (string
+// names, no numeric aliases). See mache-ec1a06 for the prior-art
+// rationale across ruff/pylint/eslint/clippy/semgrep.
+type Severity string
+
+const (
+	SeverityOff   Severity = "off"
+	SeverityWarn  Severity = "warn"
+	SeverityError Severity = "error"
+)
+
+// Effective returns the resolved severity, treating the zero value
+// ("") as warn — the default for any rule that hasn't opted in.
+// Callers asking "is this rule fatal" should always go through
+// Effective() rather than reading Severity directly.
+func (r *SmellRule) Effective() Severity {
+	switch r.Severity {
+	case SeverityOff, SeverityError:
+		return r.Severity
+	default:
+		return SeverityWarn
+	}
 }
 
 // smellRegistry holds the registered rules. Built-ins below; external

--- a/cmd/smell_rules_test.go
+++ b/cmd/smell_rules_test.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestSmellRule_Severity_Effective pins the zero-value behavior of
+// SmellRule.Severity: an unset field MUST resolve to SeverityWarn so
+// the schema addition (mache-ec1a06) doesn't silently flip existing
+// rules from observability to gating mode.
+//
+// All currently-shipped rules omit Severity, so this is the
+// load-bearing default. If it ever changes, every existing rule
+// quietly becomes a candidate for --fail-on=warn promotion in CI —
+// the kind of contract-change-by-default we explicitly avoided per
+// ADR-0018.
+func TestSmellRule_Severity_Effective(t *testing.T) {
+	cases := []struct {
+		name string
+		in   Severity
+		want Severity
+	}{
+		{"zero value defaults to warn", Severity(""), SeverityWarn},
+		{"explicit off stays off", SeverityOff, SeverityOff},
+		{"explicit warn stays warn", SeverityWarn, SeverityWarn},
+		{"explicit error stays error", SeverityError, SeverityError},
+		{"unknown string defaults to warn (defensive)", Severity("debug"), SeverityWarn},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := SmellRule{Severity: tc.in}
+			assert.Equal(t, tc.want, r.Effective())
+		})
+	}
+}
+
+// TestSmellRule_AllRegisteredRulesHaveDefaultableSeverity pins that
+// every built-in rule's Severity field resolves to a known value via
+// Effective(). Catches accidental misuse of the string type (e.g. a
+// future contributor typing "ERROR" instead of "error" — Effective
+// will silently treat it as warn, which is correct fail-soft behavior
+// but worth flagging via this test so the test name documents intent.
+func TestSmellRule_AllRegisteredRulesHaveDefaultableSeverity(t *testing.T) {
+	for i := range smellRegistry {
+		r := &smellRegistry[i]
+		t.Run(r.ID, func(t *testing.T) {
+			got := r.Effective()
+			assert.Contains(t, []Severity{SeverityOff, SeverityWarn, SeverityError}, got,
+				"rule %q effective severity must be one of the canonical three; got %q (raw=%q)",
+				r.ID, got, r.Severity)
+		})
+	}
+}
+
+// TestSmellRule_Tags_NoExplosion enforces the cap from research +
+// ADR-0018: rules should carry 3-5 tags at most. Beyond that we're
+// recreating clippy's `restriction` group failure mode where rules
+// accumulate orthogonal classifications that confuse selection.
+//
+// This is a soft cap — the test allows up to 5 and warns visibly
+// past that, but doesn't fail the build until 8+. Adjust if the
+// cap proves wrong in practice.
+func TestSmellRule_Tags_NoExplosion(t *testing.T) {
+	const softCap = 5
+	const hardCap = 8
+	for i := range smellRegistry {
+		r := &smellRegistry[i]
+		if len(r.Tags) > softCap {
+			t.Logf("rule %q has %d tags (soft cap %d); consider consolidating",
+				r.ID, len(r.Tags), softCap)
+		}
+		if len(r.Tags) > hardCap {
+			t.Errorf("rule %q has %d tags (hard cap %d) — taxonomy is exploding (see mache-ec1a06)",
+				r.ID, len(r.Tags), hardCap)
+		}
+	}
+}

--- a/docs/adr/0018-doc-drift-as-executable-specs.md
+++ b/docs/adr/0018-doc-drift-as-executable-specs.md
@@ -1,9 +1,17 @@
 # ADR-0018: Doc-Drift Detection as Executable Specs (find_smells First-Class Workflow)
 
 Date: 2026-05-19
-Status: Proposed
+Status: Accepted (vocabulary amended post-merge per `mache-ec1a06`)
 Bead: `mache-e1b6c8`
-Pairs with: `mache-96341d` (rule categorization), `mache-966e22` (external rule pack distribution), `mache-9e03df` (viper+TOML config — *bead, not yet shipped*)
+Pairs with: `mache-96341d` (rule categorization), `mache-966e22` (external rule pack distribution), `mache-9e03df` (viper+TOML config — *bead, not yet shipped*), `mache-ec1a06` (severity+tags vocabulary, prior-art research)
+
+> **Amendment 2026-05-19 (`mache-ec1a06`):** Prior-art research across ruff/pylint/eslint/clippy/semgrep (full report: `/tmp/prior-art-rule-classification.md`) refined the schema before implementation. Two changes from the original draft:
+>
+> - **Severity vocabulary:** `block | warn | info` → **`off | warn | error`** (ESLint precedent, three-tier near-universal). `block` was bespoke; `error` aligns with every existing 2026 linter. `info` was non-actionable; `off` matches clippy's `allow` and lets a rule ship-disabled in a pack.
+> - **`Stages []string` field dropped.** None of the 5 surveyed tools puts stages on the rule. Replaced with **`Tags []string`** (free-form, capped at 3-5) — stages emerge as CLI profiles from `(--tags × --fail-on)` combinations at invocation, not from a frozen enum baked into the schema. Same agent-native local/CI symmetry, more flexible.
+> - **`--fail-on` default** is `error` (not the original `never`). Observability contract is preserved by construction because new rules default to `Severity = "warn"` — no rule ships at error severity unless the author opts in. CI escalates via `--fail-on=warn` (clippy `-D warnings` idiom).
+>
+> The rest of the ADR (PR roadmap, scope, deferred federation, SDD framing) stands as-is. The implementation PRs ship the amended vocabulary.
 
 ## Context
 


### PR DESCRIPTION
## Summary

Implements ADR-0018 PR 1–3 in a single bundle. Three commits, one bead, three logical changes — bundled because they're tightly coupled (PR 2 + PR 3 depend on PR 1's schema, and dogfooding the gate requires all three).

## What ships

### PR 1 (commit `6c0c780`) — `SmellRule` schema

- `Severity Severity` field (`off | warn | error` per ESLint precedent)
- `Tags []string` field (free-form, capped 3-5 per rule)
- `Effective()` method: zero value → `warn` (preserves existing observability contract; all 11 pre-existing rules keep current behavior)
- Listing payload (`rulesListing`) now emits `severity` + `tags` so MCP/CLI consumers see them

### PR 2 (commit `f297db1`) — CLI gate flags

- `--fail-on=<none|warn|error>` (default `error`) — exit-code gate, decoupled from rule severity (pylint precedent)
- `--rule` supports `filepath.Match` globs (e.g. `'drift_doc_*'`); runs every match
- `--format=ci` — `file:line:col: severity: msg [rule-id]` lines (gh / ripgrep / vale convention)
- `--tags=tag1,tag2` — union filter against `SmellRule.Tags`; composes with `--rule`
- Refactored `cliExit` → `runFindSmells(cmd, args) (int, error)` + `exitFunc` hook so tests capture exit codes without crashing the test binary

### PR 3 (commit `b5f4ddc`) — placeholder doc-drift rules

- `drift_doc_dead_symbol_reference` — markdown backtick-fenced tokens vs `node_defs`
- `drift_doc_broken_internal_link` — markdown internal links vs filesystem
- `drift_doc_outdated_count` — markdown numeric claims vs SQL ground-truth queries

All three ship as registered metadata with `WHERE 1=0` placeholder queries so they appear in `mache find_smells --list` and PR 2's `--rule 'drift_doc_*'` glob has something to match. Honest-degradation: each rule has a real plumbing dependency that exceeded PR 3 scope; tracking as follow-up beads:
- `mache-fa12b3` — backtick-token extraction (preprocessor or SQL regex)
- `mache-fa569a` — host-side filesystem link validation
- `mache-faacf3` — `.mache/drift-counts.toml` parser + per-claim SQL execution

## Why this scope

ADR-0018 (PR #402) framed doc-drift as **spec-driven development applied to maintenance** — existing prose docs ARE the spec; rules turn claims into executable verifications. This PR ships the substrate (schema + CLI gate) and visible placeholders. Subsequent PRs (via the follow-up beads) implement the actual firing logic.

The schema decisions (Severity vocabulary, Tags vs Stages) follow prior-art research (`mache-ec1a06`) across ruff/pylint/eslint/clippy/semgrep. ADR-0018 was amended in-place (PR 1 commit) with the vocabulary pivots from the original draft.

## Tests

- 10 new tests in `cmd/smell_rules_test.go` (Severity/Tags schema)
- 7 new tests in `cmd/find_smells_cli_test.go` (CLI flags + gate)
- 9 new tests in `cmd/serve_find_smells_test.go` (3 per drift rule: registered, listing-exposed, placeholder returns 0)
- All passing: `go test -count=1 -short ./cmd/ ./internal/graph/` exits 0 (≈100s)

## Subagent provenance

This PR was assembled via the `/evolve` pattern:

1. Prior-art research subagent → `/tmp/prior-art-rule-classification.md` (informs schema)
2. PR 1 (schema) implemented inline (small)
3. PR 2 (CLI) dispatched as worktree-isolated subagent (`agent-ab59be19e61f5a7dc`) → commit `6a2ec51`
4. PR 3 (rules) dispatched as worktree-isolated subagent (`agent-aeb262f10019c5933`) → commit `b5f4ddc`
5. Synthesis: cherry-pick both onto `feat/drift-rules-implementation`; verify; push.

## Beads

Closes: `mache-ec1a06` (schema decision)
Progress on: `mache-e1b6c8` (ADR-0018 rollout — placeholder rules ship; follow-ups remain via `mache-fa12b3`, `mache-fa569a`, `mache-faacf3`)
Pairs with: `mache-96341d` (categories — Severity addresses value-axis), `mache-966e22` (rule pack distribution)

## Test plan

- [x] Full `go test -short ./cmd/...` passes on the branch
- [ ] CI green
- [ ] Reviewer agrees with the schema vocabulary (Severity = off|warn|error; Tags free-form)