### PR TITLE
test: skip dead_code perf gate under -race

### DIFF
--- a/cmd/all_tools_self_test.go
+++ b/cmd/all_tools_self_test.go
@@ -410,6 +410,14 @@ func TestFindSmells_DeadCode_PerfGate_MacheOnMache(t *testing.T) {
 	if testing.Short() {
 		t.Skip("perf gate; rerun without -short")
 	}
+	if raceEnabled {
+		// Race detector instruments every SQLite vtab read; measured
+		// wall-clock is 10-20× the un-instrumented value (PR #409
+		// integration matrix: 83s under -race vs ~3.5s without).
+		// Any fixed-anchor baseline is meaningless under -race —
+		// you're measuring synchronization overhead, not the rule.
+		t.Skip("perf gate disabled under -race; race detector skews SQLite timings beyond any meaningful baseline")
+	}
 
 	t.Setenv("MACHE_NO_LEYLINE", "1")
 	testfixtures.RequireTier(t, "medium")

--- a/cmd/race_norace.go
+++ b/cmd/race_norace.go
@@ -1,0 +1,10 @@
+//go:build !race
+
+package cmd
+
+// raceEnabled is true when the binary was built with `go test -race` /
+// `go build -race`. The companion file race_race.go provides the
+// true-valued variant. Perf-bearing tests use this to skip themselves
+// under the race detector, where SQLite-heavy workloads run 10-20×
+// slower and any fixed wall-clock baseline is meaningless.
+const raceEnabled = false

--- a/cmd/race_race.go
+++ b/cmd/race_race.go
@@ -1,0 +1,5 @@
+//go:build race
+
+package cmd
+
+const raceEnabled = true


### PR DESCRIPTION
## Why

The integration matrix runs \`go test -tags boltdb -race ...\`. Race-instrumented SQLite vtab reads are 10-20× slower than uninstrumented, so the fixed-anchor baseline (3539 ms anchored to GH-hosted macOS, see ADR-0019 D.6) is meaningless under \`-race\`.

PR #409 hit **82.98s** on macos-integration after the LFS unblock — that's not a regression, it's the race detector tax on the SQLite-heavy alive-CTE the dead_code rule runs. \`-race\` measures synchronization overhead, not the rule's algorithm; comparing to a non-race baseline is comparing apples to bicycles.

## What

- Two tiny build-tagged files (\`cmd/race_norace.go\` + \`cmd/race_race.go\`) export a package-private \`raceEnabled bool\` constant — canonical Go idiom.
- \`TestFindSmells_DeadCode_PerfGate_MacheOnMache\` skips with an explanatory message when \`raceEnabled\` is true.

## Test plan
- [x] \`go test -race -run TestFindSmells_DeadCode_PerfGate ./cmd/\` → SKIP with explanatory message
- [x] \`go test -run TestFindSmells_DeadCode_PerfGate ./cmd/\` → PASS at 160.6ms (well inside the 4423ms ceiling)
- [ ] CI matrix (test + integration on both Ubuntu and macOS) all green

## Follow-up
Once this lands, \`@dependabot rebase\` on #409 picks up the fix and unblocks the last open PR.