### PR TITLE
ci: LFS tripwire — fail PRs that re-introduce filter=lfs

### DIFF
--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -1,0 +1,61 @@
+# LFS tripwire — fails any PR that re-introduces Git LFS tracking.
+#
+# Background (bead mache-608c5a): 2026-06-17 the org's LFS budget silently
+# exhausted. The only LFS-tracked file was `internal/treesitter/elixir/parser.c`
+# (~13MB). Every `actions/checkout` started failing with "This repository
+# exceeded its LFS budget"; main was red from the last merged commit until
+# PR #419 migrated the file out of LFS. The failure was non-obvious — it
+# died inside checkout step, not in our code.
+#
+# This guard catches the regression: any PR adding a `filter=lfs` line to
+# `.gitattributes` fails fast with a loud, actionable error. The full
+# budget-monitoring story (calling the GitHub LFS billing API on a weekly
+# schedule) needs org-billing perms we don't have here; this lightweight
+# guard covers the actual failure mode we've observed.
+
+name: lfs-guard
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .gitattributes
+
+permissions:
+  contents: read
+
+jobs:
+  no-new-lfs:
+    name: assert .gitattributes adds no filter=lfs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          # Explicit `lfs: false` so this job can run even when the org
+          # quota is exhausted — the failure mode we're trying to detect.
+          lfs: false
+
+      - name: Check for filter=lfs in .gitattributes
+        run: |
+          set -euo pipefail
+          if [ ! -f .gitattributes ]; then
+            echo "No .gitattributes file — nothing to check."
+            exit 0
+          fi
+          if grep -qE 'filter=lfs' .gitattributes; then
+            echo "::error file=.gitattributes::Git LFS pattern detected in .gitattributes."
+            echo ""
+            echo "This repository deliberately does NOT use Git LFS — see bead"
+            echo "mache-608c5a + PR #419 for the prior incident (LFS budget"
+            echo "exhaustion silently bricked CI for ~4 weeks)."
+            echo ""
+            echo "If you genuinely need LFS, get explicit signoff (and a budget"
+            echo "monitor in place) BEFORE merging. Otherwise, commit the file"
+            echo "as a regular blob — GitHub allows up to 100MB per file."
+            echo ""
+            echo "Offending lines in .gitattributes:"
+            grep -nE 'filter=lfs' .gitattributes || true
+            exit 1
+          fi
+          echo "OK — no filter=lfs lines in .gitattributes."


### PR DESCRIPTION
## Why

2026-06-17 the agentic-research org's LFS budget silently exhausted. The only LFS-tracked file was \`internal/treesitter/elixir/parser.c\` (~13MB). Every \`actions/checkout\` started failing with "This repository exceeded its LFS budget" — main was red from the last merged commit until PR #419 migrated the file out of LFS. The failure was non-obvious: it died in the checkout step, not in our code, so the symptom (every CI check failing) looked unrelated to the cause.

We deliberately don't use LFS anymore. This PR adds a tripwire so the next time someone tries to re-introduce it, they fail fast with a loud, actionable error instead of silently bricking CI.

## What

\`.github/workflows/lfs-guard.yml\` — runs only on PRs that touch \`.gitattributes\` (paths filter, so it's free for everyone else). Greps for \`filter=lfs\` lines; fails with an annotated error linking back to the prior incident if any are found.

Notable: \`lfs: false\` on the checkout step so this job can still run when the org quota IS exhausted (the failure mode it's detecting).

## What this PR does NOT cover

The richer story (weekly GitHub LFS billing API check) needs org-admin billing scope that standard GH Actions doesn't have. Filed as a future extension on the bead. This guard covers the failure mode we actually observed.

## Test plan
- [x] Workflow lints OK locally
- [ ] CI passes on this PR (no .gitattributes change → workflow doesn't fire; other workflows green)
- [ ] Future PR adding a stray \`filter=lfs\` line will fail this check (not tested here; will validate organically)

Closes bead \`mache-608c5a\`.