### PR TITLE
[mache-802d2b] feat(server-json): mcpregistry + cloister groups + drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,26 @@ jobs:
       - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9
         with:
           version: latest
+
+  server-json-drift:
+    # Self-maintaining MCP Registry surface — fails the build if the
+    # committed server.json drifts from what tools/server-json-gen
+    # would emit today. Mirrors the discipline ley-line-open ships
+    # under bead `ley-line-open-f10abb`. See bead `mache-802d2b`.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          lfs: true
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install Task
+        env:
+          GOTOOLCHAIN: auto
+        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
+
+      - name: server.json drift check
+        run: task gen:server-json:check

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -333,8 +333,35 @@ tasks:
       - go run ./tools/fixtures-rebaseline --key {{.key}} --fixture {{.fixture}} --wall-ms {{.wall_ms}} --justification "{{.justification}}"
     silent: false
 
+  gen:server-json:
+    desc: |
+      Regenerate server.json from internal/mcpregistry (ToolRegistry +
+      CloisterGroups). Self-maintaining MCP Registry surface
+      (bead mache-802d2b). Run before committing any change to the MCP
+      tool surface or cloister-group partitioning.
+    cmds:
+      - go run ./tools/server-json-gen/ > server.json
+      - echo "regenerated server.json"
+
+  gen:server-json:check:
+    desc: |
+      Verify the committed server.json matches what server-json-gen
+      would emit today. CI invariant — fails the build on drift. Same
+      discipline ley-line-open uses for its server.json.
+    cmds:
+      - |
+        EXPECTED="$(go run ./tools/server-json-gen/)"
+        ACTUAL="$(cat server.json)"
+        if [ "$EXPECTED" != "$ACTUAL" ]; then
+          echo "server.json is stale — run 'task gen:server-json' and commit"
+          echo "--- diff ---"
+          diff <(echo "$EXPECTED") <(echo "$ACTUAL") || true
+          exit 1
+        fi
+        echo "server.json is up to date"
+
   check:
-    desc: Run all checks (fmt, vet, lint, test, validate, docs:lint)
+    desc: Run all checks (fmt, vet, lint, test, validate, docs:lint, server.json drift)
     cmds:
       - task: fmt
       - task: vet
@@ -342,6 +369,7 @@ tasks:
       - task: test
       - task: validate
       - task: docs:lint
+      - task: gen:server-json:check
 
   # ────────────────────────────────────────────────────────────────
   # Portable cache (bead mache-aeb262)

--- a/cmd/serve_handlers_test.go
+++ b/cmd/serve_handlers_test.go
@@ -1,0 +1,64 @@
+package cmd
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/mcpregistry"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRegisterMCPToolsMatchesMcpRegistry is the drift gate between
+// cmd/serve_handlers.go (the runtime registration) and
+// internal/mcpregistry.ToolRegistry() (the canonical list consumed by
+// tools/server-json-gen).
+//
+// The two lists MUST stay in lock-step: every tool registered with the
+// mcp-go server must appear in the registry, and every name in the
+// registry must be registered. Adding a tool in one place without the
+// other is the failure mode this gate exists to catch.
+//
+// See bead `mache-802d2b` — the Phase 4b rollout depends on a stable
+// server.json artifact, and a hand-maintained parallel list would rot
+// silently.
+func TestRegisterMCPToolsMatchesMcpRegistry(t *testing.T) {
+	// Use a tiny in-memory graph fixture — registerMCPTools needs a
+	// graphRegistry but only to wire handler closures; tools/list
+	// doesn't invoke any of them.
+	store := graph.NewMemoryStore()
+	registry := newGraphRegistry(".", nil)
+	registry.graphs.Store(".", &lazyGraph{inner: store})
+
+	s := server.NewMCPServer("test", "1.0.0", server.WithToolCapabilities(false))
+	registerMCPTools(s, registry)
+
+	registered := listRegisteredTools(t, s)
+
+	expected := map[string]bool{}
+	for _, tool := range mcpregistry.ToolRegistry() {
+		expected[tool.Name] = true
+	}
+
+	// Symmetric difference reporting — easier to read on failure than
+	// "expected X but got Y" of one direction at a time.
+	var missingFromHandlers, missingFromRegistry []string
+	for name := range expected {
+		if !registered[name] {
+			missingFromHandlers = append(missingFromHandlers, name)
+		}
+	}
+	for name := range registered {
+		if !expected[name] {
+			missingFromRegistry = append(missingFromRegistry, name)
+		}
+	}
+	sort.Strings(missingFromHandlers)
+	sort.Strings(missingFromRegistry)
+
+	assert.Empty(t, missingFromHandlers,
+		"tools in internal/mcpregistry but NOT registered in cmd/serve_handlers.go — add s.AddTool() calls for them")
+	assert.Empty(t, missingFromRegistry,
+		"tools registered in cmd/serve_handlers.go but NOT in internal/mcpregistry — add them to ToolRegistry() and claim them in a cloister group")
+}

--- a/internal/mcpregistry/registry.go
+++ b/internal/mcpregistry/registry.go
@@ -1,0 +1,178 @@
+// Package mcpregistry is the single source of truth for the names of the
+// MCP tools mache exposes and their partitioning into cloister-resolver
+// backend groups.
+//
+// Two consumers depend on this package:
+//
+//   - cmd/serve_handlers.go registers each tool with the mark3labs/mcp-go
+//     server. A drift test (registry_drift_test.go) compares the names
+//     here against the names registered there so adding a tool in one
+//     place without the other fails CI.
+//
+//   - tools/server-json-gen emits server.json at the repo root. The
+//     `_meta.art.cloister/v1.groups[]` block in that artifact is
+//     generated from CloisterGroups(); the wire contract is the same
+//     one ley-line-open ships under bead `ley-line-open-f10abb`.
+//
+// Coverage policy: every tool returned by ToolRegistry() MUST appear in
+// exactly one group's UpstreamNames. The generator and a unit test both
+// enforce this.
+//
+// See bead `mache-802d2b` for the Phase 4b cloister/mache rollout.
+package mcpregistry
+
+// Tool is a static description of one MCP tool name mache exposes.
+// Only the name is canonical here — full descriptions and JSON schemas
+// stay co-located with the handler registration in cmd/serve_handlers.go.
+// This package owns the *partitioning* into cloister groups, not the
+// per-tool schema.
+type Tool struct {
+	// Name is the bare tool name on the wire (no `mache_` prefix). The
+	// cloister-side router rewrites between the advertised prefix
+	// (`mache_*`) and the bare upstream name per the
+	// cloister/cloister-spec/mcp-tool/v1 contract.
+	Name string
+
+	// RequiresLeyLineOpen marks tools whose backend reads tables only
+	// produced by ley-line-open's enrichment passes (_ast, _lsp_*,
+	// _embeddings). Surfaced in server.json's
+	// `io.github.agentic-research.mache/tools` block; informational
+	// only — the cloister wire ignores it.
+	RequiresLeyLineOpen bool
+}
+
+// ToolRegistry returns the canonical, ordered list of MCP tools mache
+// exposes over its `mache serve` MCP transports. Order is the wire
+// order shown to clients in tools/list and the array order in
+// server.json's tool listings — keep additions stable.
+//
+// When adding a tool: add an entry here, register it in
+// cmd/serve_handlers.go, claim it in CloisterGroups(), and run
+// `task gen:server-json` to regenerate server.json. The drift gate
+// (`task gen:server-json:check`) and the coverage test both refuse to
+// pass with a missing entry.
+func ToolRegistry() []Tool {
+	return []Tool{
+		{Name: "list_directory"},
+		{Name: "read_file"},
+		{Name: "find_callers"},
+		{Name: "find_callees"},
+		{Name: "search"},
+		{Name: "semantic_search", RequiresLeyLineOpen: true},
+		{Name: "get_communities"},
+		{Name: "find_definition"},
+		{Name: "get_type_info", RequiresLeyLineOpen: true},
+		{Name: "get_diagnostics", RequiresLeyLineOpen: true},
+		{Name: "get_overview"},
+		{Name: "get_sheaf_status"},
+		{Name: "get_impact"},
+		{Name: "get_architecture"},
+		{Name: "get_diagram"},
+		{Name: "write_file"},
+		{Name: "resolve_ref"},
+		{Name: "find_smells"},
+	}
+}
+
+// CloisterGroupDecl is one entry in the
+// `_meta.art.cloister/v1.groups[]` block emitted into server.json.
+// Mirrors the wire shape described in
+// cloister/cloister-spec/mcp-tool/v1/wire/meta-groups.md.
+type CloisterGroupDecl struct {
+	// Name is the operator-facing group identifier (also a routable
+	// backend name on the cloister side). Must be non-empty.
+	Name string
+
+	// AdvertisedPrefix is the prefix cloister advertises this group's
+	// tools under to its downstream clients. Mache's tools all reach
+	// cloister under the `mache_` prefix today (see cloister's
+	// cluster.toml `handlesPrefix = "mache_"` declaration), so every
+	// group uses the same `mache_` prefix unless a future bundle
+	// re-partitions.
+	AdvertisedPrefix string
+
+	// UpstreamNames are the bare tool names this group claims, in
+	// stable wire order. Must be non-empty and every entry must
+	// correspond to a Name in ToolRegistry().
+	UpstreamNames []string
+}
+
+// CloisterGroups partitions ToolRegistry() into operator-facing
+// cloister backend groups. The split mirrors mache's own functional
+// surface: navigation (browse + summarize), callgraph (refs/defs/impact),
+// lsp (LSP-enriched tools needing ley-line-open), lifecycle (daemon
+// status), linter (find_smells), and mutate (write_file).
+//
+// Every tool in ToolRegistry() must appear in exactly one group; the
+// generator (tools/server-json-gen) and the coverage unit test both
+// enforce this.
+func CloisterGroups() []CloisterGroupDecl {
+	return []CloisterGroupDecl{
+		// Navigation — browsing the projected tree, top-down
+		// orientation, and quotient-graph views. All read-side.
+		{
+			Name:             "navigation",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames: []string{
+				"list_directory",
+				"read_file",
+				"get_overview",
+				"get_architecture",
+				"get_diagram",
+				"get_communities",
+			},
+		},
+		// Callgraph — symbol-centric queries (defs/refs/impact) and
+		// pattern search. The bread-and-butter code-intelligence
+		// surface.
+		{
+			Name:             "callgraph",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames: []string{
+				"find_callers",
+				"find_callees",
+				"find_definition",
+				"get_impact",
+				"search",
+				"resolve_ref",
+			},
+		},
+		// LSP — tools that read LSP enrichment tables produced by
+		// ley-line-open. Separate group so a deployment without LLO
+		// can route this backend to a stub or 503 it explicitly.
+		{
+			Name:             "lsp",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames: []string{
+				"get_type_info",
+				"get_diagnostics",
+				"semantic_search",
+			},
+		},
+		// Lifecycle — daemon status surface. Single-tool group; lives
+		// on its own so a probe wired to it can be cheap and never
+		// fall through to the heavier handlers.
+		{
+			Name:             "lifecycle",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames:    []string{"get_sheaf_status"},
+		},
+		// Linter — structural code-smell rules over the parsed AST.
+		// Its own group because find_smells has substantially
+		// different cost characteristics (runs SQL over _ast) than
+		// the navigation/callgraph reads.
+		{
+			Name:             "linter",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames:    []string{"find_smells"},
+		},
+		// Mutate — the write-back surface. Isolated so a policy can
+		// allow reads and deny writes by routing this group to a
+		// 403-only backend without touching the others.
+		{
+			Name:             "mutate",
+			AdvertisedPrefix: "mache_",
+			UpstreamNames:    []string{"write_file"},
+		},
+	}
+}

--- a/internal/mcpregistry/registry_test.go
+++ b/internal/mcpregistry/registry_test.go
@@ -1,0 +1,82 @@
+package mcpregistry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolRegistryNamesAreUniqueAndNonEmpty pins the basic invariants:
+// every entry has a non-empty name and no name repeats.
+func TestToolRegistryNamesAreUniqueAndNonEmpty(t *testing.T) {
+	seen := map[string]struct{}{}
+	for _, tool := range ToolRegistry() {
+		require.NotEmpty(t, tool.Name, "tool name must be non-empty")
+		_, dup := seen[tool.Name]
+		require.False(t, dup, "duplicate tool name: %q", tool.Name)
+		seen[tool.Name] = struct{}{}
+	}
+}
+
+// TestCloisterGroupsCoverEveryRegisteredToolExactlyOnce is the coverage
+// policy from bead `mache-802d2b`: every tool returned by
+// ToolRegistry() MUST appear in exactly one group's UpstreamNames.
+// Adding a tool without claiming it in CloisterGroups() fails CI here
+// (and at server-json-gen runtime); removing a tool without pruning its
+// group entry fails here too.
+func TestCloisterGroupsCoverEveryRegisteredToolExactlyOnce(t *testing.T) {
+	registered := map[string]struct{}{}
+	for _, tool := range ToolRegistry() {
+		registered[tool.Name] = struct{}{}
+	}
+
+	// Build owner map: tool -> list of groups that claim it.
+	owner := map[string][]string{}
+	groupNames := map[string]struct{}{}
+	for _, g := range CloisterGroups() {
+		require.NotEmpty(t, g.Name, "group `name` must be non-empty")
+		require.NotEmpty(t, g.UpstreamNames,
+			"group %q has empty UpstreamNames — spec violation", g.Name)
+		_, dupGroup := groupNames[g.Name]
+		require.False(t, dupGroup, "duplicate cloister group name: %q", g.Name)
+		groupNames[g.Name] = struct{}{}
+
+		for _, tool := range g.UpstreamNames {
+			owner[tool] = append(owner[tool], g.Name)
+		}
+	}
+
+	// Every registered tool is claimed.
+	for tool := range registered {
+		_, ok := owner[tool]
+		assert.True(t, ok,
+			"tool %q is in ToolRegistry() but no cloister group claims it",
+			tool)
+	}
+
+	// Every claim points to a real tool; no tool is claimed by more
+	// than one group.
+	for tool, names := range owner {
+		_, real := registered[tool]
+		assert.True(t, real,
+			"group claim %q is not in ToolRegistry()", tool)
+		assert.Len(t, names, 1,
+			"tool %q claimed by multiple groups: %v", tool, names)
+	}
+}
+
+// TestCloisterGroupAdvertisedPrefixIsMachePrefix sanity-checks that
+// every group advertises its tools under the `mache_` prefix — that's
+// the prefix cloister's `[[routes.mcp.backends]]` declaration assigns
+// to this upstream (handlesPrefix = "mache_", stripPrefix = "mache_").
+// A future bundle could in principle split mache across multiple
+// prefixes, but the current cloister wiring assumes one prefix per
+// upstream — keep the invariant load-bearing until that changes.
+func TestCloisterGroupAdvertisedPrefixIsMachePrefix(t *testing.T) {
+	for _, g := range CloisterGroups() {
+		assert.Equal(t, "mache_", g.AdvertisedPrefix,
+			"group %q advertises under %q; cloister wiring expects mache_",
+			g.Name, g.AdvertisedPrefix)
+	}
+}

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.agentic-research/mache",
   "title": "mache",
-  "description": "Project structured data (JSON, SQLite, source code) as a filesystem driven by declarative JSON schemas. Exposes MCP tools for code intelligence: find_callers, find_definition, get_impact, get_architecture, find_smells, search, and 11 others.",
+  "description": "Project source trees, SQLite, and JSON as a structured filesystem with MCP code-intelligence tools.",
   "version": "0.8.0",
   "repository": {
     "url": "https://github.com/agentic-research/mache",
@@ -25,12 +25,21 @@
     "io.github.agentic-research.mache/transports": {
       "stdio": {
         "command": "mache",
-        "args": ["serve", "--stdio", "<source-path>"],
+        "args": [
+          "serve",
+          "--stdio",
+          "<source-path>"
+        ],
         "note": "Per-client subprocess. Use for editor integrations that own the daemon lifecycle. See .mcp.json at repo root for a Claude Code template."
       },
       "streamable-http": {
         "command": "mache",
-        "args": ["serve", "--http", ":7532", "<source-path>"],
+        "args": [
+          "serve",
+          "--http",
+          ":7532",
+          "<source-path>"
+        ],
         "note": "Recommended for shared use — one daemon across all clients avoids per-client FD leaks."
       }
     },
@@ -38,18 +47,19 @@
       "standalone": [
         "list_directory",
         "read_file",
-        "search",
         "find_callers",
         "find_callees",
+        "search",
+        "get_communities",
         "find_definition",
         "get_overview",
+        "get_sheaf_status",
         "get_impact",
         "get_architecture",
         "get_diagram",
-        "get_communities",
-        "find_smells",
+        "write_file",
         "resolve_ref",
-        "write_file"
+        "find_smells"
       ],
       "requires-ley-line-open": [
         "semantic_search",
@@ -68,6 +78,64 @@
       "db-files": ".db files produced by `mache build` or `leyline parse` open instantly via SQLiteGraph (pure-Go path)",
       "json": "JSON corpora ingest via JSONPath walker (see examples/nvd-schema.json)",
       "sqlite": "arbitrary SQLite via templated schemas (see examples/mcp-schema.json)"
+    },
+    "art.cloister/v1": {
+      "groups": [
+        {
+          "name": "navigation",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "list_directory",
+            "read_file",
+            "get_overview",
+            "get_architecture",
+            "get_diagram",
+            "get_communities"
+          ]
+        },
+        {
+          "name": "callgraph",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "find_callers",
+            "find_callees",
+            "find_definition",
+            "get_impact",
+            "search",
+            "resolve_ref"
+          ]
+        },
+        {
+          "name": "lsp",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "get_type_info",
+            "get_diagnostics",
+            "semantic_search"
+          ]
+        },
+        {
+          "name": "lifecycle",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "get_sheaf_status"
+          ]
+        },
+        {
+          "name": "linter",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "find_smells"
+          ]
+        },
+        {
+          "name": "mutate",
+          "advertisedPrefix": "mache_",
+          "upstreamNames": [
+            "write_file"
+          ]
+        }
+      ]
     }
   }
 }

--- a/tools/server-json-gen/main.go
+++ b/tools/server-json-gen/main.go
@@ -1,0 +1,412 @@
+// server-json-gen emits mache's server.json artifact byte-stably from
+// internal/mcpregistry — the same self-maintaining MCP Registry surface
+// pattern ley-line-open ships under bead `ley-line-open-f10abb`.
+//
+// The Taskfile entries `gen:server-json` and `gen:server-json:check`
+// regenerate and diff the committed artifact at the repo root; the CI
+// workflow fails on drift. See bead `mache-802d2b` for rationale.
+//
+// # Coverage policy
+//
+// Every tool returned by mcpregistry.ToolRegistry() MUST appear in
+// exactly one group's UpstreamNames. The generator enforces this at
+// runtime — partial coverage exits non-zero with a message naming the
+// orphan tool(s). The matching unit test
+// (internal/mcpregistry.TestCloisterGroupsCoverEveryRegisteredToolExactlyOnce)
+// enforces the same invariant at `task test` time so this gate is a
+// belt-and-braces backstop, not the only check.
+//
+// # Reproducibility
+//
+// Two consecutive runs MUST produce byte-identical output. Field order
+// is fixed by the struct definitions; array order matches the
+// registry / groups declaration order; no map iteration leaks into the
+// rendered artifact (every container is a slice or an ordered helper).
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/agentic-research/mache/internal/mcpregistry"
+)
+
+// schemaURL pins the MCP Registry schema version mache's server.json
+// declares against. Bump when the registry ships a new dated schema
+// and the wire shape needs to follow.
+const schemaURL = "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json"
+
+// serverName is the canonical registry-facing identifier for this
+// server. Matches the GitHub <owner>/<repo> shape registries dispatch
+// on.
+const serverName = "io.github.agentic-research/mache"
+
+// serverTitle is the display name shown in registry listings.
+const serverTitle = "mache"
+
+// serverDescription opens the registry listing. The MCP Registry
+// schema 2025-12-11 caps `description` at 100 chars — the long pitch
+// the previously hand-maintained server.json carried was actually
+// schema-invalid; this rewrite fits the cap while keeping the
+// elevator-pitch shape. The richer marketing copy lives in
+// README.md / GETTING-STARTED.md.
+const serverDescription = "Project source trees, SQLite, and JSON as a structured filesystem with MCP code-intelligence tools."
+
+// serverVersion is the mache release version stamped into server.json.
+// Kept in lock-step with melange.yaml's `version:` field and the OCI
+// image tag — those three move together at release time, by hand for
+// now. A future change can thread the constant out of a single source
+// (e.g. a `VERSION` file the build also reads).
+const serverVersion = "0.8.0"
+
+// repositoryURL + repositorySource describe where the source lives.
+const (
+	repositoryURL    = "https://github.com/agentic-research/mache"
+	repositorySource = "github"
+)
+
+// websiteURL surfaces the operator-facing "how do I run this?" doc.
+const websiteURL = "https://github.com/agentic-research/mache/blob/main/GETTING-STARTED.md"
+
+// defaultHTTPPort is the default streamable-http port mache serves
+// under. Surfaced in the `remotes[]` entry's variable defaults and
+// hard-coded into the transport `args` so the registry listing is a
+// drop-in copy.
+const defaultHTTPPort = "7532"
+
+// minLeyLineOpenVersion declares the minimum LLO release whose
+// enrichment tables mache reads. Bumped in lock-step with LLO's
+// substrate / wire-format changes that touch _ast / _lsp_* schemas.
+const minLeyLineOpenVersion = "0.4.5"
+
+// serverDoc is the top-level server.json envelope. Field order is
+// load-bearing — encoding/json's struct-field ordering is the contract
+// for byte-stable output, and downstream tools that diff this file
+// rely on a predictable shape.
+type serverDoc struct {
+	Schema      string         `json:"$schema"`
+	Name        string         `json:"name"`
+	Title       string         `json:"title"`
+	Description string         `json:"description"`
+	Version     string         `json:"version"`
+	Repository  repository     `json:"repository"`
+	WebsiteURL  string         `json:"websiteUrl"`
+	Remotes     []remote       `json:"remotes"`
+	Meta        *orderedObject `json:"_meta"`
+}
+
+type repository struct {
+	URL    string `json:"url"`
+	Source string `json:"source"`
+}
+
+type remote struct {
+	Type      string                       `json:"type"`
+	URL       string                       `json:"url"`
+	Variables map[string]remoteVarTemplate `json:"variables"`
+}
+
+type remoteVarTemplate struct {
+	Description string `json:"description"`
+	Default     string `json:"default"`
+}
+
+type transportEntry struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+	Note    string   `json:"note"`
+}
+
+type toolSplit struct {
+	Standalone          []string `json:"standalone"`
+	RequiresLeyLineOpen []string `json:"requires-ley-line-open"`
+}
+
+type optionalDep struct {
+	Purpose        string `json:"purpose"`
+	MinimumVersion string `json:"minimum-version"`
+}
+
+type sourceAcceptance struct {
+	Directories string `json:"directories"`
+	DBFiles     string `json:"db-files"`
+	JSON        string `json:"json"`
+	SQLite      string `json:"sqlite"`
+}
+
+type artCloisterV1 struct {
+	Groups []groupOut `json:"groups"`
+}
+
+type groupOut struct {
+	Name             string   `json:"name"`
+	AdvertisedPrefix string   `json:"advertisedPrefix"`
+	UpstreamNames    []string `json:"upstreamNames"`
+}
+
+// orderedObject preserves the insertion order of nested _meta entries
+// when MarshalJSON serializes them. Go maps don't preserve insertion
+// order and the encoding/json package walks struct fields in declared
+// order but maps in (sorted) key order — which means
+// `_meta.io.github.agentic-research.mache/...` keys would land in
+// alphabetical order, not the order chosen here. Use orderedObject
+// when key order matters; otherwise rely on struct-field ordering.
+type orderedObject struct {
+	keys   []string
+	values map[string]any
+}
+
+func newOrderedObject() *orderedObject {
+	return &orderedObject{values: map[string]any{}}
+}
+
+func (o *orderedObject) set(key string, value any) {
+	if _, exists := o.values[key]; !exists {
+		o.keys = append(o.keys, key)
+	}
+	o.values[key] = value
+}
+
+// MarshalJSON renders the object with its insertion-order keys, using
+// each value's normal serialization. We hand-build the buffer rather
+// than calling json.Marshal on a map because that would re-sort keys.
+//
+// HTML escaping is disabled on the inner encoder for consistency with
+// the top-level encoder in main() — otherwise embedded values
+// containing `<` (e.g. the transport `<source-path>` placeholder)
+// would render as `<` here and as the raw character in the
+// outer doc, producing inconsistent output. Encoder.Encode appends a
+// trailing newline; we strip it before splicing each value in.
+func (o *orderedObject) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range o.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyJSON, err := encodeNoHTML(key)
+		if err != nil {
+			return nil, fmt.Errorf("marshal key %q: %w", key, err)
+		}
+		buf.Write(keyJSON)
+		buf.WriteByte(':')
+		valJSON, err := encodeNoHTML(o.values[key])
+		if err != nil {
+			return nil, fmt.Errorf("marshal value for %q: %w", key, err)
+		}
+		buf.Write(valJSON)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// encodeNoHTML mirrors json.Marshal but with HTMLEscape disabled so
+// raw `<`, `>`, `&` characters survive into the output. The trailing
+// newline json.Encoder appends is trimmed.
+func encodeNoHTML(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	out := buf.Bytes()
+	// Encoder.Encode appends a single '\n'. Strip it so the bytes
+	// splice into a larger JSON value cleanly.
+	if n := len(out); n > 0 && out[n-1] == '\n' {
+		out = out[:n-1]
+	}
+	return out, nil
+}
+
+// buildDoc assembles the full server.json document from the canonical
+// registry. Validation lives here — partial cloister-group coverage
+// or duplicate claims abort with a descriptive error so a stale
+// regen never lands.
+func buildDoc() (*serverDoc, error) {
+	groupsDecl := mcpregistry.CloisterGroups()
+	registry := mcpregistry.ToolRegistry()
+
+	if err := validateCoverage(registry, groupsDecl); err != nil {
+		return nil, err
+	}
+
+	// Convert internal types to the wire shape. Both lists preserve
+	// their source order so regens diff cleanly.
+	groups := make([]groupOut, 0, len(groupsDecl))
+	for _, g := range groupsDecl {
+		names := make([]string, len(g.UpstreamNames))
+		copy(names, g.UpstreamNames)
+		groups = append(groups, groupOut{
+			Name:             g.Name,
+			AdvertisedPrefix: g.AdvertisedPrefix,
+			UpstreamNames:    names,
+		})
+	}
+
+	// Standalone vs requires-ley-line-open split mirrors the existing
+	// hand-maintained block. Drive it from the registry's
+	// RequiresLeyLineOpen field so it can't drift from the truth.
+	var standalone, llo []string
+	for _, tool := range registry {
+		if tool.RequiresLeyLineOpen {
+			llo = append(llo, tool.Name)
+		} else {
+			standalone = append(standalone, tool.Name)
+		}
+	}
+
+	meta := newOrderedObject()
+	meta.set("io.github.agentic-research.mache/transports", buildTransports())
+	meta.set("io.github.agentic-research.mache/tools", toolSplit{
+		Standalone:          standalone,
+		RequiresLeyLineOpen: llo,
+	})
+	meta.set("io.github.agentic-research.mache/optional-deps", buildOptionalDeps())
+	meta.set("io.github.agentic-research.mache/source-acceptance", sourceAcceptance{
+		Directories: "any tree containing source files — auto-detects language preset (Go, Rust, Python, TypeScript, ...)",
+		DBFiles:     ".db files produced by `mache build` or `leyline parse` open instantly via SQLiteGraph (pure-Go path)",
+		JSON:        "JSON corpora ingest via JSONPath walker (see examples/nvd-schema.json)",
+		SQLite:      "arbitrary SQLite via templated schemas (see examples/mcp-schema.json)",
+	})
+	meta.set("art.cloister/v1", artCloisterV1{Groups: groups})
+
+	doc := &serverDoc{
+		Schema:      schemaURL,
+		Name:        serverName,
+		Title:       serverTitle,
+		Description: serverDescription,
+		Version:     serverVersion,
+		Repository: repository{
+			URL:    repositoryURL,
+			Source: repositorySource,
+		},
+		WebsiteURL: websiteURL,
+		Remotes: []remote{
+			{
+				Type: "streamable-http",
+				URL:  "http://localhost:{port}/mcp",
+				Variables: map[string]remoteVarTemplate{
+					"port": {
+						Description: fmt.Sprintf("Port where `mache serve --http :PORT` is listening (default %s)", defaultHTTPPort),
+						Default:     defaultHTTPPort,
+					},
+				},
+			},
+		},
+		Meta: meta,
+	}
+	return doc, nil
+}
+
+func buildTransports() *orderedObject {
+	transports := newOrderedObject()
+	transports.set("stdio", transportEntry{
+		Command: "mache",
+		Args:    []string{"serve", "--stdio", "<source-path>"},
+		Note:    "Per-client subprocess. Use for editor integrations that own the daemon lifecycle. See .mcp.json at repo root for a Claude Code template.",
+	})
+	transports.set("streamable-http", transportEntry{
+		Command: "mache",
+		Args:    []string{"serve", "--http", ":" + defaultHTTPPort, "<source-path>"},
+		Note:    "Recommended for shared use — one daemon across all clients avoids per-client FD leaks.",
+	})
+	return transports
+}
+
+func buildOptionalDeps() *orderedObject {
+	deps := newOrderedObject()
+	deps.set("io.github.agentic-research/ley-line-open", optionalDep{
+		Purpose:        "Provides _ast / _lsp_* / _embeddings tables consumed by semantic_search, get_type_info, get_diagnostics, and the AST-backed find_smells rules.",
+		MinimumVersion: minLeyLineOpenVersion,
+	})
+	return deps
+}
+
+// validateCoverage enforces the bead `mache-802d2b` policy: every tool
+// in ToolRegistry() must appear in exactly one cloister group, every
+// group claim must point to a real registered tool, and every group
+// must have a non-empty name + non-empty claim list.
+func validateCoverage(registry []mcpregistry.Tool, groups []mcpregistry.CloisterGroupDecl) error {
+	registered := map[string]struct{}{}
+	for _, tool := range registry {
+		registered[tool.Name] = struct{}{}
+	}
+
+	owner := map[string][]string{}
+	for _, g := range groups {
+		if g.Name == "" {
+			return fmt.Errorf("cloister group has empty `name` — spec violation")
+		}
+		if len(g.UpstreamNames) == 0 {
+			return fmt.Errorf("cloister group %q has empty UpstreamNames — spec violation", g.Name)
+		}
+		for _, tool := range g.UpstreamNames {
+			owner[tool] = append(owner[tool], g.Name)
+		}
+	}
+
+	var orphans []string
+	for tool := range registered {
+		if _, ok := owner[tool]; !ok {
+			orphans = append(orphans, tool)
+		}
+	}
+	sort.Strings(orphans)
+	if len(orphans) > 0 {
+		return fmt.Errorf("%d tool(s) in ToolRegistry() are not claimed by any cloister group: %v",
+			len(orphans), orphans)
+	}
+
+	var ghosts []string
+	var overclaimed []string
+	for tool, names := range owner {
+		if _, real := registered[tool]; !real {
+			ghosts = append(ghosts, tool)
+		}
+		if len(names) > 1 {
+			overclaimed = append(overclaimed, fmt.Sprintf("%s -> %v", tool, names))
+		}
+	}
+	sort.Strings(ghosts)
+	sort.Strings(overclaimed)
+	if len(ghosts) > 0 {
+		return fmt.Errorf("%d cloister group claim(s) reference tools not in ToolRegistry(): %v",
+			len(ghosts), ghosts)
+	}
+	if len(overclaimed) > 0 {
+		return fmt.Errorf("tools claimed by multiple cloister groups: %v", overclaimed)
+	}
+	return nil
+}
+
+func main() {
+	doc, err := buildDoc()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "server-json-gen: %v\n", err)
+		os.Exit(1)
+	}
+
+	// json.Encoder with HTML escaping disabled keeps `<source-path>`
+	// readable in the output (Go's default would render `<` as
+	// `<`, which is valid JSON but human-hostile). Indent matches
+	// the existing committed shape: two spaces, trailing newline.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(doc); err != nil {
+		fmt.Fprintf(os.Stderr, "server-json-gen: encode: %v\n", err)
+		os.Exit(1)
+	}
+
+	// json.Encoder.Encode appends its own trailing newline, so the
+	// buffer already ends with one — no extra append needed.
+	if _, err := os.Stdout.Write(buf.Bytes()); err != nil {
+		fmt.Fprintf(os.Stderr, "server-json-gen: write: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4b cross-repo work — ships mache's `server.json` with `_meta.art.cloister/v1.groups[]` per cloister's MCP tool composition model (ADR-0026). Sibling to `ley-line-open-f10abb` pattern shipped 2026-05-19.

- `internal/mcpregistry/registry.go` — single source of truth for tool surface + cloister-group partitioning (18 tools across 6 groups)
- `tools/server-json-gen/main.go` — Go generator, byte-stable output, schema 2025-12-11
- `cmd/serve_handlers_test.go` — drift gate (diffs `tools/list` vs registry)
- `server.json` regenerated at root, schema-validated
- `Taskfile.yml` + `.github/workflows/ci.yml` — CI drift gate wired

## Groups (18 tools / 6 groups)

| Group | Count | Tools |
|---|---|---|
| navigation | 6 | list_directory, read_file, get_overview, get_architecture, get_diagram, get_communities |
| callgraph | 6 | find_callers, find_callees, find_definition, get_impact, search, resolve_ref |
| lsp | 3 | get_type_info, get_diagnostics, semantic_search (require LLO) |
| lifecycle | 1 | get_sheaf_status |
| linter | 1 | find_smells |
| mutate | 1 | write_file |

## Verification

- Schema validates against MCP Registry 2025-12-11
- 18/18 tools covered by exactly one group
- Two consecutive generator runs produce byte-identical output
- Drift gate fails on manual edit, passes on regen
- All existing gates green (go vet, golangci-lint, gofumpt, go test ./cmd/)

## Notes

- Description shortened to 99 chars (schema's 100-char cap; was 241)
- Version hardcoded `0.8.0` in generator (matches melange.yaml + image tag); a `VERSION` file would close this loop cleanly — flagging
- 6 functional groups not 1 — gives cloister-side policy clean levers (e.g. deny `mutate`, 503 `lsp` when LLO is down)
- Existing `_meta.io.github.agentic-research.mache/*` blocks preserved alongside the new `art.cloister/v1` block (load-bearing for non-cloister consumers)

## Test plan

- [x] go vet / golangci-lint / gofumpt clean
- [x] `task gen:server-json:check` passes; fails on manual edit
- [x] schema validation against MCP Registry 2025-12-11
- [x] coverage invariants enforced in mcpregistry tests
- [x] new `TestRegisterMCPToolsMatchesMcpRegistry` drift test passes
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)