### PR TITLE
chore(release): drop vestigial ley-line FFI link — no octo-sts, no sudo, no fuse_t dep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,11 @@ permissions: {}
 env:
   TAG: ${{ inputs.tag || github.event.client_payload.tag || github.ref_name }}
   # The ley-line-open release carrying the FFI staticlib + header that mache
-  # links against. Keep aligned with internal/leyline.leylineBinaryVersion.
-  LEYLINE_OPEN_VERSION: v0.4.6
+  # links against at build time. This is the build-time linker source and may
+  # legitimately differ from the runtime daemon pin (leylineBinaryVersion):
+  # v0.4.7 is the first LLO release to ship the libleyline_fs-*.a staticlibs
+  # for all three platforms (v0.4.6's darwin-arm64 lib failed to build).
+  LEYLINE_OPEN_VERSION: v0.4.7
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: Release
 
 # Build mache binaries linked against the ley-line FFI artifacts and
-# publish a GitHub release. The FFI library still comes from the private
-# `agentic-research/ley-line` repo (downloaded via the octo-sts OIDC
-# exchange below); the public `ley-line-open` repo carries the schemas
-# + daemon, not the linker artifacts. When ley-line-open ships the FFI
-# binaries, this workflow should switch its scope and download.
+# publish a GitHub release. The FFI library + header now come from the
+# PUBLIC `agentic-research/ley-line-open` repo (release LEYLINE_OPEN_VERSION),
+# fetched with the default GITHUB_TOKEN — no octo-sts / private-repo access.
+# LLO publishes `libleyline_fs-<os>-<arch>.a` + `leyline_fs.h` as of
+# ley-line-open-c33b9a. Bump LEYLINE_OPEN_VERSION when adopting a newer LLO.
 # Golden path: use `task` commands, never raw go/cargo.
 
 on:
@@ -24,6 +24,9 @@ permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.event.client_payload.tag || github.ref_name }}
+  # The ley-line-open release carrying the FFI staticlib + header that mache
+  # links against. Keep aligned with internal/leyline.leylineBinaryVersion.
+  LEYLINE_OPEN_VERSION: v0.4.6
 
 jobs:
   build:
@@ -46,8 +49,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     permissions:
+      # id-token (octo-sts) no longer needed — LLO artifacts are public.
       contents: read
-      id-token: write
 
     steps:
       - name: Checkout mache
@@ -69,20 +72,17 @@ jobs:
           GOTOOLCHAIN: auto
         run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
 
-      - name: Exchange OIDC → GitHub token (octo-sts)
-        id: octo-sts
-        uses: octo-sts/action@f603d3be9d8dd9871a265776e625a27b00effe05 # v1.1.1
-        with:
-          scope: agentic-research/ley-line
-          identity: mache-release
-
-      - name: Download ley-line release artifacts
+      - name: Download ley-line-open FFI artifacts (public)
         env:
-          GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LEYLINE_LIB: ${{ matrix.leyline-lib }}
         run: |
+          # Public LLO release — plain GITHUB_TOKEN, no octo-sts. LEYLINE_LIB
+          # comes from the matrix via env (never interpolated into the shell).
           mkdir -p leyline-artifacts
-          gh release download --repo agentic-research/ley-line \
-            -p '${{ matrix.leyline-lib }}' \
+          gh release download "$LEYLINE_OPEN_VERSION" \
+            --repo agentic-research/ley-line-open \
+            -p "$LEYLINE_LIB" \
             -p 'leyline_fs.h' \
             -D leyline-artifacts/
 
@@ -103,9 +103,10 @@ jobs:
         run: |
           GIT_COMMIT=$(git rev-parse --short HEAD)
           BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          # Version is NOT injected — it is single-sourced from the embedded
+          # internal/buildinfo (version.txt). Only Commit/Date come via ldflags.
           go build \
             -ldflags "-s -w \
-              -X github.com/agentic-research/mache/cmd.Version=${TAG} \
               -X github.com/agentic-research/mache/cmd.Commit=${GIT_COMMIT} \
               -X github.com/agentic-research/mache/cmd.Date=${BUILD_DATE}" \
             -o ${{ matrix.artifact }} .
@@ -125,8 +126,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      # contents: write to publish the release; no OIDC consumer here.
       contents: write
-      id-token: write
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,15 @@
 name: Release
 
-# Build mache binaries linked against the ley-line FFI artifacts and
-# publish a GitHub release. The FFI library + header now come from the
-# PUBLIC `agentic-research/ley-line-open` repo (release LEYLINE_OPEN_VERSION),
-# fetched with the default GITHUB_TOKEN — no octo-sts / private-repo access.
-# LLO publishes `libleyline_fs-<os>-<arch>.a` + `leyline_fs.h` as of
-# ley-line-open-c33b9a. Bump LEYLINE_OPEN_VERSION when adopting a newer LLO.
-# Golden path: use `task` commands, never raw go/cargo.
+# Build mache binaries and publish a GitHub release.
+#
+# mache links NO external C libraries. CGO is enabled solely for the
+# tree-sitter grammars, which carry their own #cgo directives over vendored
+# parser.c. The leyline integration in released binaries is the pure-Go UDS
+# daemon client (internal/leyline); the cgo FFI client
+# (internal/leyline/client.go) is `//go:build leyline` and is NOT compiled
+# here, so the released binary pulls zero symbols from libleyline_fs and
+# needs no fuse headers/framework. Net effect: no privileged access (sudo),
+# no fuse_t runtime dependency — the binary runs on any host.
 
 on:
   push:
@@ -24,12 +27,6 @@ permissions: {}
 
 env:
   TAG: ${{ inputs.tag || github.event.client_payload.tag || github.ref_name }}
-  # The ley-line-open release carrying the FFI staticlib + header that mache
-  # links against at build time. This is the build-time linker source and may
-  # legitimately differ from the runtime daemon pin (leylineBinaryVersion):
-  # v0.4.7 is the first LLO release to ship the libleyline_fs-*.a staticlibs
-  # for all three platforms (v0.4.6's darwin-arm64 lib failed to build).
-  LEYLINE_OPEN_VERSION: v0.4.7
 
 jobs:
   build:
@@ -39,20 +36,13 @@ jobs:
         include:
           - os: macos-latest
             artifact: mache-darwin-arm64
-            leyline-lib: libleyline_fs-darwin-arm64.a
-            fuse_setup: brew install --cask fuse-t
           - os: ubuntu-latest
             artifact: mache-linux-amd64
-            leyline-lib: libleyline_fs-linux-amd64.a
-            fuse_setup: sudo apt-get update && sudo apt-get install -y libfuse-dev
           - os: ubuntu-24.04-arm
             artifact: mache-linux-arm64
-            leyline-lib: libleyline_fs-linux-arm64.a
-            fuse_setup: sudo apt-get update && sudo apt-get install -y libfuse-dev
 
     runs-on: ${{ matrix.os }}
     permissions:
-      # id-token (octo-sts) no longer needed — LLO artifacts are public.
       contents: read
 
     steps:
@@ -66,48 +56,16 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install FUSE
-        run: ${{ matrix.fuse_setup }}
-
-      - name: Install Task
-        # See ci.yml — go install bypasses GitHub's release CDN.
-        env:
-          GOTOOLCHAIN: auto
-        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
-
-      - name: Download ley-line-open FFI artifacts (public)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          LEYLINE_LIB: ${{ matrix.leyline-lib }}
-        run: |
-          # Public LLO release — plain GITHUB_TOKEN, no octo-sts. LEYLINE_LIB
-          # comes from the matrix via env (never interpolated into the shell).
-          mkdir -p leyline-artifacts
-          gh release download "$LEYLINE_OPEN_VERSION" \
-            --repo agentic-research/ley-line-open \
-            -p "$LEYLINE_LIB" \
-            -p 'leyline_fs.h' \
-            -D leyline-artifacts/
-
-      - name: Build mache (linked against ley-line)
+      - name: Build mache
+        # CGO on for the tree-sitter grammars only (they carry their own #cgo
+        # directives). No external libs, no FUSE, no sudo. Version is
+        # single-sourced from embedded internal/buildinfo; only Commit/Date
+        # come via ldflags.
         env:
           CGO_ENABLED: '1'
-          CGO_CFLAGS: >-
-            ${{ runner.os == 'macOS'
-              && '-I/Library/Frameworks/fuse_t.framework/Versions/Current/Headers'
-              || '' }}
-            -I${{ github.workspace }}/leyline-artifacts
-          CGO_LDFLAGS: >-
-            ${{ runner.os == 'macOS'
-              && '-F/Library/Frameworks -framework fuse_t -Wl,-rpath,/Library/Frameworks'
-              || '' }}
-            ${{ github.workspace }}/leyline-artifacts/${{ matrix.leyline-lib }}
-            -lm -ldl -lpthread
         run: |
           GIT_COMMIT=$(git rev-parse --short HEAD)
           BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
-          # Version is NOT injected — it is single-sourced from the embedded
-          # internal/buildinfo (version.txt). Only Commit/Date come via ldflags.
           go build \
             -ldflags "-s -w \
               -X github.com/agentic-research/mache/cmd.Commit=${GIT_COMMIT} \


### PR DESCRIPTION
Pre-v0.9.0 release fix. Originally scoped to repoint the FFI download from private ley-line → public ley-line-open. A **fresh-eyes review during validation** found a deeper truth that makes that moot: **the FFI link is vestigial.**

## What the validation found (all reproduced locally, zero sudo)

- `internal/leyline/client.go` — the only cgo consumer of `libleyline_fs` — is `//go:build leyline`, and the release **never passes `-tags leyline`**.
- Built the release exactly as CI does (with the v0.4.7 `.a` + `-framework fuse_t`): `nm` shows the binary pulls **0** `leyline_fs` symbols. The `.a` is dead weight.
- The binary's *only* `fuse_t` dependency came from the explicit `-framework fuse_t` flag — which bought nothing but **made `mache` fail to start on any host without fuse_t installed.**
- mache's cgo FFI surface is arena/query only (`leyline_open`, `leyline_get_node`, …) — **no FUSE/mount functions exist in it at all.** The one real cgo need is the tree-sitter grammars (own `#cgo` directives), which want only `CGO_ENABLED=1`.

## Change

Strip the entire FFI/fuse/sudo machinery from the release:
- ❌ LLO FFI download + `LEYLINE_OPEN_VERSION` (octo-sts was already removed)
- ❌ `Install FUSE` step + `fuse_setup` matrix → **no more `sudo apt-get` / `brew --cask`**
- ❌ `-framework fuse_t` + `libleyline_fs.a` in `CGO_LDFLAGS` → **no fuse_t runtime dep; runs on any host**
- ❌ unused `Install Task` step (the build is raw `go build`)
- ✅ keep `CGO_ENABLED=1` for tree-sitter

**Net: no privileged access on any runner, no external-repo dependency, smaller link.**

## Verification

`CGO_ENABLED=1 go build … -o mache .` → `mache version 0.9.0` (buildinfo single-source works); `otool -L` shows **no fuse_t dependency**. Reproduced on darwin-arm64; Linux uses the system gcc already on the runner.

## Notes

- The original goal (publish v0.9.0 binaries off a clean, sudo-free release) is met — and better, since there's no LLO build-time coupling at all.
- ley-line-open#68/#70 + the `v0.4.7` release (FFI staticlibs) remain a legitimate LLO improvement for anyone building `-tags leyline`; they're simply not needed by mache's released binaries.
- If we ever want released mache to *use* the embedded FFI query path, that's a separate, deliberate `-tags leyline` change (and would then warrant a `--no-default-features` staticlib so it stays sudo-free).

Tracks: `mache-55d3e1`