### PR TITLE
feat(ingest): self-contained ASTWalker↔SitterWalker parity gate + 1:1 CI gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,16 @@ repos:
         language: system
         files: (go\.mod|go\.sum)$
         pass_filenames: false
+
+      # Pre-PUSH gate (not commit): run the SAME non-mutating CI-equivalent
+      # gate CI runs, so a push that CI would reject fails locally first.
+      # `task ci` is the single source of truth (Taskfile) — this hook never
+      # re-implements the commands, it just invokes the task. Install once with:
+      #   pre-commit install --hook-type pre-push
+      - id: task-ci
+        name: task ci (1:1 with CI — full gate before push)
+        entry: task ci
+        language: system
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -152,7 +152,12 @@ tasks:
       - go test -v -run 'TestEngine_IngestTreeSitter_Go' ./internal/ingest/
 
   parity:
-    desc: Run ASTWalker ↔ SitterWalker parity tests (requires leyline on PATH)
+    desc: ASTWalker↔SitterWalker byte-level projection parity — self-contained (no leyline), always runs
+    cmds:
+      - go test -run 'TestASTQueryParity' ./internal/ingest/
+
+  parity:conformance:
+    desc: "Axis-2: parity vs real leyline-produced _ast (requires leyline on PATH; skips otherwise)"
     cmds:
       - go test -tags leyline -v -run 'TestASTParity' ./internal/ingest/
 
@@ -402,9 +407,29 @@ tasks:
         echo "server.json is up to date"
 
   check:
-    desc: Run all checks (fmt, vet, lint, test, validate, docs:lint, server.json drift)
+    desc: "Dev gate (mutating: fmt -w, lint --fix). For the non-mutating 1:1-with-CI gate use `task ci`."
     cmds:
       - task: fmt
+      - task: vet
+      - task: lint
+      - task: parity
+      - task: test
+      - task: validate
+      - task: docs:lint
+      - task: gen:server-json:check
+
+  ci:
+    # SINGLE SOURCE OF TRUTH for the merge gate. CI workflows AND the pre-push
+    # git hook (.pre-commit-config.yaml, stages: [pre-push]) invoke THIS — never
+    # re-implement the underlying commands, so local == CI by construction
+    # (the principle from the version single-sourcing work). Non-mutating:
+    # fmt:check verifies instead of rewriting, so a dirty tree fails the gate
+    # instead of being silently fixed. `task test` already runs the parity gate
+    # (TestASTQueryParity); `parity` is listed first for fast, named signal.
+    desc: Non-mutating CI-equivalent gate — run this (or let the pre-push hook) to be 1:1 with CI before pushing
+    cmds:
+      - task: parity
+      - task: fmt:check
       - task: vet
       - task: lint
       - task: test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -407,7 +407,7 @@ tasks:
         echo "server.json is up to date"
 
   check:
-    desc: "Dev gate (mutating: fmt -w, lint --fix). For the non-mutating 1:1-with-CI gate use `task ci`."
+    desc: "Dev gate (mutating: `fmt` rewrites files with -w). For the non-mutating 1:1-with-CI gate use `task ci`."
     cmds:
       - task: fmt
       - task: vet
@@ -419,12 +419,15 @@ tasks:
       - task: gen:server-json:check
 
   ci:
-    # SINGLE SOURCE OF TRUTH for the merge gate. CI workflows AND the pre-push
-    # git hook (.pre-commit-config.yaml, stages: [pre-push]) invoke THIS — never
-    # re-implement the underlying commands, so local == CI by construction
-    # (the principle from the version single-sourcing work). Non-mutating:
-    # fmt:check verifies instead of rewriting, so a dirty tree fails the gate
-    # instead of being silently fixed. `task test` already runs the parity gate
+    # The pre-push git hook (.pre-commit-config.yaml, stages: [pre-push]) invokes
+    # THIS, so a push CI would reject fails locally first. CI itself currently runs
+    # the same underlying task targets as separate jobs (task test/vet/fmt:check +
+    # the golangci-lint action) rather than this single `task ci` call — the dedup
+    # is at the TASK level: both sides invoke the same task definitions and never
+    # re-implement the commands inline (the principle from the version
+    # single-sourcing work). Folding CI onto one `task ci` invocation is a
+    # follow-up. Non-mutating: fmt:check verifies instead of rewriting, so a dirty
+    # tree fails the gate. `task test` already runs the parity gate
     # (TestASTQueryParity); `parity` is listed first for fast, named signal.
     desc: Non-mutating CI-equivalent gate — run this (or let the pre-push hook) to be 1:1 with CI before pushing
     cmds:

--- a/internal/ingest/ast_query_parity_test.go
+++ b/internal/ingest/ast_query_parity_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -37,7 +38,8 @@ import (
 //
 // Node IDs are "/"-joined paths; each segment is "<kind>_<perKindIndex>" so
 // stripNumericSuffix recovers the tree-sitter kind and depth == segment count.
-// The root node is skipped: its named children become top-level (parent_id="").
+// The root node IS emitted (parent_id=""), so top-level selectors like
+// `(source_file ...) @scope` match it (see the emit(root, ...) call below).
 // source_id is filepath.Base(sourceFile) to match the engine's ASTRoot wiring
 // (engine_treesitter.go: SourceID = filepath.Base(result.job.path)).
 func sitterToASTDB(tb testing.TB, dbPath, sourceFile, langName string, src []byte) *sql.DB {
@@ -94,6 +96,11 @@ func sitterToASTDB(tb testing.TB, dbPath, sourceFile, langName string, src []byt
 		(node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
 	require.NoError(tb, err)
+	// Cleanup on early require failure: Rollback is a no-op after a successful
+	// Commit; closing the prepared statements releases their handles.
+	defer func() { _ = tx.Rollback() }()
+	defer func() { _ = insNode.Close() }()
+	defer func() { _ = insAST.Close() }()
 
 	// Emit every named node, INCLUDING the root (e.g. source_file) — the schema's
 	// top-level selector matches it: `(source_file (package_clause ...)) @scope`.
@@ -146,6 +153,11 @@ func readAllContent(tb testing.TB, g graph.Graph, id string) []byte {
 			out = append(out, buf[:n]...)
 			off += int64(n)
 		}
+		// A gating test must not swallow read errors: a non-EOF error would
+		// otherwise masquerade as truncated/empty content and produce false parity.
+		if err != nil && err != io.EOF {
+			tb.Fatalf("ReadContent(%q) at offset %d: %v", id, off, err)
+		}
 		if err != nil || n == 0 || n < len(buf) {
 			break
 		}
@@ -163,7 +175,7 @@ func collectTree(tb testing.TB, g graph.Graph) []string {
 		queue = queue[1:]
 		children, err := g.ListChildren(id)
 		if err != nil {
-			continue
+			tb.Fatalf("ListChildren(%q): %v", id, err) // gating test: fail fast on traversal errors
 		}
 		for _, c := range children {
 			all = append(all, c)
@@ -175,8 +187,10 @@ func collectTree(tb testing.TB, g graph.Graph) []string {
 }
 
 // assertProjectionParity asserts the two projected graphs are byte-identical
-// from a consumer's vantage: same node set, same children per node, same
-// rendered content bytes, and same callers/callees per node.
+// from a consumer's vantage: same node set, same children per node, and same
+// rendered content bytes. (Cross-file callers/callees parity is intentionally
+// out of scope for this single-file gate — it can't witness inter-file edges;
+// tracked as gate expansion on mache-1166aa.)
 func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 	t.Helper()
 
@@ -188,8 +202,10 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 	}
 
 	for _, id := range wantNodes {
-		wc, _ := want.ListChildren(id)
-		gc, _ := got.ListChildren(id)
+		wc, werr := want.ListChildren(id)
+		gc, gerr := got.ListChildren(id)
+		require.NoErrorf(t, werr, "ListChildren(%q) on want", id)
+		require.NoErrorf(t, gerr, "ListChildren(%q) on got", id)
 		sort.Strings(wc)
 		sort.Strings(gc)
 		assert.Equalf(t, wc, gc, "children of %q must match", id)

--- a/internal/ingest/ast_query_parity_test.go
+++ b/internal/ingest/ast_query_parity_test.go
@@ -1,0 +1,287 @@
+package ingest
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	_ "modernc.org/sqlite"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/lang"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Axis-1 parity: ASTWalker (pure-Go, _ast tables) must produce a BYTE-IDENTICAL
+// projected graph to SitterWalker (CGO tree-sitter) for the same source — when
+// both consume the SAME parse tree. The _ast db here is emitted from mache's
+// own tree-sitter parse (sitterToASTDB), so this gate runs in normal CGO CI with
+// NO leyline binary dependency. It isolates exactly one variable: the query
+// engine. The leyline-coupled axis-2 gate lives in ast_parity_test.go.
+//
+// This is the load-bearing invariant for every step of mache-36d961 (CGO removal):
+// each time a path is ASTWalker-ified, this gate proves the projected output did
+// not drift by a single byte.
+
+// sitterToASTDB parses src with mache's own tree-sitter grammar and emits the
+// exact _ast/_source/nodes schema ASTWalker consumes (the same shape
+// ast_walker_bench_test.go hand-builds, and that `leyline parse` produces).
+//
+// Node IDs are "/"-joined paths; each segment is "<kind>_<perKindIndex>" so
+// stripNumericSuffix recovers the tree-sitter kind and depth == segment count.
+// The root node is skipped: its named children become top-level (parent_id="").
+// source_id is filepath.Base(sourceFile) to match the engine's ASTRoot wiring
+// (engine_treesitter.go: SourceID = filepath.Base(result.job.path)).
+func sitterToASTDB(tb testing.TB, dbPath, sourceFile, langName string, src []byte) *sql.DB {
+	tb.Helper()
+
+	l := lang.ForName(langName)
+	require.NotNil(tb, l, "unknown language %q", langName)
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(l.Grammar())
+	tree, err := parser.ParseCtx(context.Background(), nil, src)
+	require.NoError(tb, err)
+	defer tree.Close()
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(tb, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL, record_id TEXT, record JSON,
+			source_file TEXT
+		);
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL, start_byte INTEGER NOT NULL,
+			end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE INDEX idx_ast_source ON _ast(source_id);
+		CREATE INDEX idx_ast_kind_source ON _ast(node_kind, source_id);
+		CREATE INDEX idx_parent_name ON nodes(parent_id, name);
+		CREATE TABLE _source (
+			id TEXT PRIMARY KEY, language TEXT NOT NULL,
+			content BLOB NOT NULL, path TEXT
+		);
+	`)
+	require.NoError(tb, err)
+
+	sourceID := filepath.Base(sourceFile)
+	_, err = db.Exec("INSERT INTO _source (id, language, content, path) VALUES (?, ?, ?, NULL)",
+		sourceID, langName, src)
+	require.NoError(tb, err)
+
+	tx, err := db.Begin()
+	require.NoError(tb, err)
+
+	insNode, err := tx.Prepare(`INSERT INTO nodes (id, parent_id, name, kind, mtime, record, source_file)
+		VALUES (?, ?, ?, ?, 0, ?, ?)`)
+	require.NoError(tb, err)
+	insAST, err := tx.Prepare(`INSERT INTO _ast
+		(node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+	require.NoError(tb, err)
+
+	// Emit every named node, INCLUDING the root (e.g. source_file) — the schema's
+	// top-level selector matches it: `(source_file (package_clause ...)) @scope`.
+	// IDs are "<kind>_<perKindIndex>" path segments; depth == segment count.
+	var emit func(n *sitter.Node, id, parentID string)
+	emit = func(n *sitter.Node, id, parentID string) {
+		hasNamedKids := n.NamedChildCount() > 0
+		kindInt := 0 // leaf ("file")
+		record := "" // leaf text comes from the record column
+		if hasNamedKids {
+			kindInt = 1 // interior ("dir")
+		} else {
+			record = string(src[n.StartByte():n.EndByte()])
+		}
+
+		sp, ep := n.StartPoint(), n.EndPoint()
+		_, err := insNode.Exec(id, parentID, n.Type(), kindInt, record, sourceID)
+		require.NoError(tb, err)
+		_, err = insAST.Exec(id, sourceID, n.Type(),
+			int(n.StartByte()), int(n.EndByte()),
+			int(sp.Row), int(sp.Column), int(ep.Row), int(ep.Column))
+		require.NoError(tb, err)
+
+		counts := map[string]int{}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			c := n.NamedChild(i)
+			seg := fmt.Sprintf("%s_%d", c.Type(), counts[c.Type()])
+			counts[c.Type()]++
+			emit(c, id+"/"+seg, id)
+		}
+	}
+	root := tree.RootNode()
+	emit(root, fmt.Sprintf("%s_0", root.Type()), "")
+
+	require.NoError(tb, tx.Commit())
+	return db
+}
+
+// readAllContent reads the entire rendered content of a node via the Graph
+// ReadContent(offset) contract, so the comparison sees exactly what an NFS/MCP
+// consumer would read byte-for-byte.
+func readAllContent(tb testing.TB, g graph.Graph, id string) []byte {
+	tb.Helper()
+	var out []byte
+	buf := make([]byte, 64*1024)
+	var off int64
+	for {
+		n, err := g.ReadContent(id, buf, off)
+		if n > 0 {
+			out = append(out, buf[:n]...)
+			off += int64(n)
+		}
+		if err != nil || n == 0 || n < len(buf) {
+			break
+		}
+	}
+	return out
+}
+
+// collectTree returns every node ID reachable from the root, sorted.
+func collectTree(tb testing.TB, g graph.Graph) []string {
+	tb.Helper()
+	var all []string
+	queue := []string{""}
+	for len(queue) > 0 {
+		id := queue[0]
+		queue = queue[1:]
+		children, err := g.ListChildren(id)
+		if err != nil {
+			continue
+		}
+		for _, c := range children {
+			all = append(all, c)
+			queue = append(queue, c)
+		}
+	}
+	sort.Strings(all)
+	return all
+}
+
+// assertProjectionParity asserts the two projected graphs are byte-identical
+// from a consumer's vantage: same node set, same children per node, same
+// rendered content bytes, and same callers/callees per node.
+func assertProjectionParity(t *testing.T, want, got graph.Graph) {
+	t.Helper()
+
+	wantNodes := collectTree(t, want)
+	gotNodes := collectTree(t, got)
+	if !assert.Equal(t, wantNodes, gotNodes, "node set must match") {
+		logTreeDiff(t, wantNodes, gotNodes)
+		return // content/children comparison is meaningless once the tree diverges
+	}
+
+	for _, id := range wantNodes {
+		wc, _ := want.ListChildren(id)
+		gc, _ := got.ListChildren(id)
+		sort.Strings(wc)
+		sort.Strings(gc)
+		assert.Equalf(t, wc, gc, "children of %q must match", id)
+
+		assert.Equalf(t, readAllContent(t, want, id), readAllContent(t, got, id),
+			"rendered content of %q must be byte-identical", id)
+	}
+}
+
+func logTreeDiff(t *testing.T, want, got []string) {
+	t.Helper()
+	wset := map[string]bool{}
+	for _, w := range want {
+		wset[w] = true
+	}
+	gset := map[string]bool{}
+	for _, g := range got {
+		gset[g] = true
+	}
+	n := 0
+	for _, w := range want {
+		if !gset[w] && n < 15 {
+			t.Logf("  SITTER only: %s", w)
+			n++
+		}
+	}
+	for _, g := range got {
+		if !wset[g] && n < 30 {
+			t.Logf("  AST    only: %s", g)
+			n++
+		}
+	}
+}
+
+func loadParitySchema(t *testing.T, path string) api.Topology {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal(data, &schema))
+	return schema
+}
+
+// runQueryParity ingests the same source through SitterWalker (CGO) and
+// ASTWalker (over an emitted _ast db) and asserts byte-level projection parity.
+func runQueryParity(t *testing.T, schemaPath, langName, sourceFile string, src []byte) {
+	t.Helper()
+	schema := loadParitySchema(t, schemaPath)
+
+	srcDir := t.TempDir()
+	srcPath := filepath.Join(srcDir, sourceFile)
+	require.NoError(t, os.MkdirAll(filepath.Dir(srcPath), 0o755))
+	require.NoError(t, os.WriteFile(srcPath, src, 0o644))
+
+	// SitterWalker path (CGO, parses live)
+	sitterStore := graph.NewMemoryStore()
+	require.NoError(t, NewEngine(&schema, sitterStore).Ingest(srcPath))
+
+	// ASTWalker path (pure-Go query over a _ast db emitted from the SAME parse)
+	db := sitterToASTDB(t, filepath.Join(t.TempDir(), "ast.db"), sourceFile, langName, src)
+	defer func() { _ = db.Close() }()
+	astStore := graph.NewMemoryStore()
+	astEngine := NewEngine(&schema, astStore)
+	astEngine.SetASTWalker(NewASTWalker(db))
+	require.NoError(t, astEngine.Ingest(srcPath))
+
+	assertProjectionParity(t, sitterStore, astStore)
+}
+
+func TestASTQueryParity_Go(t *testing.T) {
+	runQueryParity(t, "../../examples/go-schema.json", "go", "example.go", []byte(`package demo
+
+import "fmt"
+
+const MaxRetries = 3
+
+var DefaultName = "world"
+
+type Greeter struct {
+	Name string
+}
+
+func Hello() string {
+	return "hello"
+}
+
+func (g *Greeter) Greet() string {
+	return "Hi, " + g.Name
+}
+
+func Caller() {
+	fmt.Println(Hello())
+}
+`))
+}

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -97,6 +97,24 @@ func (w *ASTWalker) Query(root any, selector string) ([]Match, error) {
 		captureRanges := make(map[string][2]int)
 		missingRequired := false
 
+		// Resolve the @scope node. It may be an inner node, e.g.
+		// `(type_declaration (type_spec ...) @scope)` binds @scope to type_spec,
+		// not the outer match — so the scope text excludes the `type ` keyword.
+		// Use it for the scope source text and the match byte range (write-back
+		// origin), mirroring SitterWalker.
+		scopeForText := scopeNode
+		if pattern.scopeKind != "" && pattern.scopeKind != pattern.outerKind {
+			if sn, err := w.findChildByKindAST(ar.DB, scopeNode.id, pattern.scopeKind, ar.SourceID, pattern.scopeAncestry); err == nil && sn != nil {
+				scopeForText = *sn
+			}
+		}
+		// Inject the scope node's source text as "scope", mirroring SitterWalker —
+		// so leaf templates like {{.scope}} (the most common source-leaf template)
+		// render the construct's source instead of "<no value>".
+		if source != nil && scopeForText.startByte < scopeForText.endByte && scopeForText.endByte <= len(source) {
+			values["scope"] = string(source[scopeForText.startByte:scopeForText.endByte])
+		}
+
 		// Resolve captures from children (searches descendants, not just direct children).
 		// parseSelector strips @scope captures before they reach pattern.captures,
 		// so the explicit "scope" guard below is defensive — it can't be exercised
@@ -177,8 +195,8 @@ func (w *ASTWalker) Query(root any, selector string) ([]Match, error) {
 				SourceID:     ar.SourceID,
 				ParentPrefix: scopeNode.id,
 			},
-			startByte: scopeNode.startByte,
-			endByte:   scopeNode.endByte,
+			startByte: scopeForText.startByte,
+			endByte:   scopeForText.endByte,
 		}
 		matches = append(matches, m)
 	}

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -191,9 +191,12 @@ func (w *ASTWalker) Query(root any, selector string) ([]Match, error) {
 			values:        values,
 			captureRanges: captureRanges,
 			ctx: ASTRoot{
-				DB:           ar.DB,
-				SourceID:     ar.SourceID,
-				ParentPrefix: scopeNode.id,
+				DB:       ar.DB,
+				SourceID: ar.SourceID,
+				// Scope nested schema-child queries to the resolved @scope node
+				// (which may be an inner node like type_spec), mirroring
+				// SitterWalker.Context() returning the captured scope node.
+				ParentPrefix: scopeForText.id,
 			},
 			startByte: scopeForText.startByte,
 			endByte:   scopeForText.endByte,

--- a/internal/ingest/ast_walker_selector.go
+++ b/internal/ingest/ast_walker_selector.go
@@ -15,6 +15,14 @@ type selectorPattern struct {
 	predicates    []selectorPredicate      // #eq? filters
 	matchPreds    []selectorMatchPredicate // #match? regex filters
 	notMatchPreds []selectorMatchPredicate // #not-match? negated regex filters
+
+	// scopeKind/scopeAncestry locate the @scope node when it is NOT the outer
+	// match node — e.g. `(type_declaration (type_spec ...) @scope)` binds @scope
+	// to the inner type_spec. Empty scopeKind (or scopeKind == outerKind) means
+	// @scope is the outer node. Used to resolve the construct's source text and
+	// write-back byte range to the correct node (parity with SitterWalker).
+	scopeKind     string
+	scopeAncestry []string
 }
 
 type selectorCapture struct {
@@ -271,7 +279,14 @@ func parseSExprNode(tokens []string, pos int, ancestorKinds []string, pattern *s
 	if pos < len(tokens) && strings.HasPrefix(tokens[pos], "@") {
 		capName := tokens[pos][1:]
 		pos++
-		if capName != "scope" && capName != "" {
+		if capName == "scope" {
+			// Record where @scope sits. nodeKind is the @scope node; ancestorKinds[0]
+			// is always the outerKind, so the intermediate path from outer→scope is
+			// ancestryFromKinds(ancestorKinds). For @scope on the outer node both are
+			// the outer (scopeKind == outerKind), handled as a no-op in Query.
+			pattern.scopeKind = nodeKind
+			pattern.scopeAncestry = ancestryFromKinds(ancestorKinds)
+		} else if capName != "" {
 			pattern.captures = append(pattern.captures, selectorCapture{
 				kind:     nodeKind,
 				name:     capName,


### PR DESCRIPTION
## What

Lands the **characterization net** for ADR-0012 CGO removal: a byte-level projection parity gate proving `ASTWalker` (pure-Go) and `SitterWalker` (CGO) produce identical projections — *and* the single-source `task ci` gate + pre-push hook so local == CI.

### Parity gate (`TestASTQueryParity`, `internal/ingest/ast_query_parity_test.go`)
- `sitterToASTDB` emits an `_ast`/`_source`/`nodes` db from mache's **own** tree-sitter parse, so both walkers see the **same parse tree** — isolating the query engine as the only variable (axis-1). No `leyline` binary; runs in normal CI.
- `assertProjectionParity` asserts byte-identical projection: node set, children per node, and `ReadContent` bytes.

### Real bug it caught (fixed here)
`@scope` on an **inner** node — `(type_declaration (type_spec …) @scope)` — was mis-resolved to the outer match, so the type's `source` leaf rendered `type Greeter struct{…}` instead of `Greeter struct{…}`, and the write-back byte origin was wrong. Fix: `selectorPattern` records `scopeKind`/`scopeAncestry`; `Query` resolves the real `@scope` node.

### Single-source gate (Taskfile = source of truth)
- `task parity` → the self-contained gate (always-on). Leyline axis-2 → `task parity:conformance`.
- new **`task ci`** → non-mutating CI-equivalent gate, composed from existing tasks (no command duplication).
- `.pre-commit-config.yaml` gains a **pre-push** hook running `task ci` → a push CI would reject fails locally first. One-time: `pre-commit install --hook-type pre-push`.

## Why
Per ADR-0012 the plan is to delete SitterWalker once ASTWalker reaches parity. There was **no byte-parity gate** proving that, and the ASTWalker ingestion path was untested (`// coverage:ignore`). This gate is the prerequisite for safe CGO removal (epic `mache-36d961`).

## Scope / follow-ups (tracked)
This is axis-1 single-file parity. Per math-friend review, the gate must still grow to a congruence over the multi-file ref graph (callers/callees), node attributes, doc-comments, write-back, FCA — tracked on `mache-1166aa`. Sequenced refactor: `mache-33cd7e` (widen interface) → `mache-33de70` (conditional parse) → … under decade `mache-pure-go-arena`.

Refs `mache-33b53c` (S1, closed), `mache-1166aa`, `mache-36d961`, ADR-0012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)