### PR TITLE
docs(plugin): add authoring-schemas + authoring-smell-rules skills

### DIFF
--- a/plugin/skills/authoring-schemas/SKILL.md
+++ b/plugin/skills/authoring-schemas/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: authoring-schemas
+description: Author a mache projection schema (Topology→Node→Leaf) that maps structured data or source code into a filesystem/graph. Use when creating or debugging a *-schema.json for a new data source (SQLite/JSON) or a new source language. Covers both dialects — tree-sitter S-expression selectors for code, and JSONPath selectors for data — the gotchas (@scope on inner nodes, nested $[*], _parent traversal, the .db vs JSON-walker capability split), and how to validate the result.
+allowed-tools: Read,Glob,Grep,Edit,Write,Bash(go test *),Bash(task *),Bash(jq *),mcp__mache__*
+argument-hint: '<new-schema-name> [source: db|json|code] [example-to-copy]'
+version: 0.1.0
+author: ART Ecosystem (mache)
+---
+
+<!-- Provenance: mache beads mache-442fd9, mache-1094a2. Reference impl: examples/{go,nvd,kev}-schema.json. The @scope-inner gotcha is mache-33b53c. -->
+
+# /mache:authoring-schemas — Write a mache projection schema
+
+A mache schema (`api/schema.go`) projects data into a tree: **`Topology` → `Node` (dirs) → `Leaf` (files)**. There are **two dialects** and the first decision is which you're in:
+
+| Source                        | Walker                  | Selector dialect                                               | Path                             |
+| ----------------------------- | ----------------------- | -------------------------------------------------------------- | -------------------------------- |
+| **source code** (.go, .py, …) | tree-sitter / ASTWalker | tree-sitter S-expressions: `(kind field: (child) @cap) @scope` | `examples/go-schema.json`        |
+| **data** (.db, .json)         | JSONPath (ojg)          | JSONPath: `$`, `$[*]`, `$.item.field[*]`                       | `examples/{nvd,kev}-schema.json` |
+
+Start by copying the closest example and editing — never write from scratch.
+
+## Schema shape (the fields that matter)
+
+```
+Topology { version, table?, nodes[], file_sets?, diagrams? }
+  Node   { name, selector?, refs?, language?, children[], files[], skip_self_match? }
+  Leaf   { name, content_template, content_source?, attributes? }
+```
+
+- **`name`** is a Go text/template rendered against the match — it can be a literal (`functions`), a field (`{{.name}}`), or a computed expression (`{{replace .item.X ":" " "}}`). Computed names become directory names.
+- **`selector`** picks matches. `$` is the wildcard "everything at this level" (used for grouping dirs like `functions/`, `types/`).
+- **`content_template`** renders a leaf's bytes. The `source` leaf conventionally uses `{{.scope}}` — the matched construct's full source text.
+- **`refs`** are template strings; each rendered token calls `AddRef(token, nodeID)` → powers `callers/`.
+
+## Tree-sitter dialect (source code) — gotchas
+
+- Pattern: `(outer_kind field: (child_kind) @capture) @scope`. The `@scope` node becomes the projected construct; `@capture`s become template values.
+- **`@scope` can be an INNER node**, not the outer match: `(type_declaration (type_spec name: (type_identifier) @name) @scope)` binds scope to `type_spec`, so `{{.scope}}` is `Greeter struct{…}` *without* the `type ` keyword. (This was a real ASTWalker bug — mache-33b53c.) If your `source` leaf includes a leading keyword it shouldn't, your `@scope` is on the wrong node.
+- **Ancestry = id-path depth.** A nested capture's depth must match the real named-node nesting; that's how ASTWalker resolves it (`matchAncestry`). Write the selector to mirror the actual tree-sitter named structure.
+- Predicates: `#eq?`, `#match?`, `#not-match?` are supported by ASTWalker. `#not-eq?`, `#any-eq?`, `#is?` are NOT (fall back to CGO SitterWalker) — avoid them.
+
+## JSONPath dialect (data) — the full toolbox
+
+The data dialect is richer than the examples suggest (see the venturi trivy schema for a worked maximal example):
+
+- **Nested array iteration**: `$[*]`, then deeper `$.item.X.FixedIn[*]`.
+- **Computed directory names** via template funcs: `{{replace .item.Namespace ":" " "}}`.
+- **`_parent` ancestor traversal** in templates: `{{._parent._parent.item.Name}}` — pull a value from a grandparent match (e.g. a leaf name from two levels up).
+- **Inline JSON content**: `{{dict "Field" .Version "Status" 0 | json}}` builds a JSON object as the file body.
+- **Multi-root / multi-view**: multiple top-level `nodes[]` project the *same* data different ways (one tree by namespace, another flat by name).
+
+**Template funcs available**: `json, first, slice, dig, dict, lookup, default, replace, lower, upper, title, split, join, unquote, hasPrefix, hasSuffix, trimPrefix, trimSuffix`.
+
+## ⚠ The capability split (.db fast path vs JSON-walker)
+
+`.db` sources go through **SQLiteGraph** (zero-copy, `json_extract` in SQL) which **cannot iterate nested arrays** (`$.item.remotes[*]`). The richer JSONPath features (nested `$[*]`, deep `_parent`) work on the **JSON-walker/MemoryStore** path (ingesting JSON), not the `.db` fast path. **Rule of thumb: keep `.db` schemas flat; reserve nested iteration / `_parent` for JSON ingestion.** If a `.db` schema silently produces empty dirs, you've hit this — flatten it or pre-flatten the data (see `tools/mcp-fetch` for the normalize-then-flat pattern).
+
+## Procedure
+
+1. **Pick the dialect** (code vs data) and copy the nearest `examples/*.json`.
+1. **Sketch the tree** top-down: root grouping nodes (`$` selectors) → construct nodes (real selectors) → `source`/detail leaves.
+1. **For data on `.db`:** verify every selector is flat (no nested `[*]`). For deep structure, ingest JSON instead.
+1. **Validate** — this is non-negotiable:
+   - source schema → `task parity` (the ASTWalker↔SitterWalker byte gate) and mount + `mcp__mache__list_directory` to eyeball the tree.
+   - data schema → `task validate` (SQLite fixtures) or mount the real `.db` and inspect.
+1. **Check `callers/`** if you added `refs` — mount and read a `callers/` dir to confirm tokens resolve.
+
+## Red flags
+
+- `source` leaf shows a leading keyword (`type `, `func `) it shouldn't → `@scope` is on the wrong (outer) node.
+- `.db` schema yields empty dirs → nested-array selector on the SQLiteGraph path; flatten.
+- A capture never resolves → ancestry depth in the selector doesn't match the real named-node nesting.
+- Using `#not-eq?`/`#is?` → unsupported by ASTWalker; rewrite with `#eq?`/`#match?`.
+
+## Definition of done
+
+The schema mounts, the projected tree matches intent under `list_directory`, `task parity`/`task validate` is green, and (if `refs` were used) `callers/` resolves.

--- a/plugin/skills/authoring-schemas/SKILL.md
+++ b/plugin/skills/authoring-schemas/SKILL.md
@@ -38,7 +38,7 @@ Topology { version, table?, nodes[], file_sets?, diagrams? }
 - Pattern: `(outer_kind field: (child_kind) @capture) @scope`. The `@scope` node becomes the projected construct; `@capture`s become template values.
 - **`@scope` can be an INNER node**, not the outer match: `(type_declaration (type_spec name: (type_identifier) @name) @scope)` binds scope to `type_spec`, so `{{.scope}}` is `Greeter struct{…}` *without* the `type ` keyword. (This was a real ASTWalker bug — mache-33b53c.) If your `source` leaf includes a leading keyword it shouldn't, your `@scope` is on the wrong node.
 - **Ancestry = id-path depth.** A nested capture's depth must match the real named-node nesting; that's how ASTWalker resolves it (`matchAncestry`). Write the selector to mirror the actual tree-sitter named structure.
-- Predicates: `#eq?`, `#match?`, `#not-match?` are supported by ASTWalker. `#not-eq?`, `#any-eq?`, `#is?` are NOT (fall back to CGO SitterWalker) — avoid them.
+- Predicates: `#eq?`, `#match?`, `#not-match?` are supported by ASTWalker. `#not-eq?`, `#any-eq?`, `#is?`, `#is-not?` are NOT (the parser rejects them; they fall back to CGO SitterWalker) — avoid them.
 
 ## JSONPath dialect (data) — the full toolbox
 

--- a/plugin/skills/authoring-smell-rules/SKILL.md
+++ b/plugin/skills/authoring-smell-rules/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: authoring-smell-rules
+description: Add a find_smells rule to mache — a SQL query over the projected code graph that surfaces a code smell (duplication, complexity, dead code, drift). Use when adding or debugging a SmellRule in cmd/smell_rules.go or an external $MACHE_SMELL_RULES_DIR rule. Covers the SmellRule struct, the standalone-vs-_ast table capability split, severity/polarity, tags, and the adversarial-fixture test discipline.
+allowed-tools: Read,Glob,Grep,Edit,Write,Bash(go test *),Bash(task *),Bash(./mache *),mcp__mache__find_smells,mcp__mache__search
+argument-hint: <rule_id> [language] [must-hold|must-not-hold]
+version: 0.1.0
+author: ART Ecosystem (mache)
+---
+
+<!-- Provenance: mache beads mache-444483, mache-187b22, mache-185791, mache-c7421e (polarity), mache-96341d (allowlist), ADR-0018. Engine: cmd/smell_rules.go, cmd/smell_findings.go. -->
+
+# /mache:authoring-smell-rules — Add a find_smells rule
+
+A smell rule is a **SQL query over mache's projected graph tables** plus metadata. Rules live in `smellRegistry` in `cmd/smell_rules.go` (built-ins) or in `$MACHE_SMELL_RULES_DIR` (external, appended at init). Each rule is one `SmellRule`:
+
+```go
+SmellRule{
+    ID:          "magic_int_in_comparison", // stable; the MCP/CLI argument
+    Languages:   []string{"go"},            // match _source.language; empty = any
+    Description:  "...",                     // shown in the rules listing
+    Requires:    []string{"_ast", "nodes"}, // tables the query reads (capability gate)
+    ScopeColumn: "lit.source_id",            // SQL expr compared to source_id; "" disables scoping
+    Query: `SELECT source_id, node_id, start_byte, end_byte, start_row, start_col, <metric> AS metric
+            FROM ... WHERE ... %s`,          // %s = optional injected scope clause
+    DefaultMinMetric: 10,                    // threshold when caller omits min_metric (0 = return all)
+    Severity:    SeverityWarn,               // off | warn | error
+    Tags:        []string{"complexity"},     // free-form; CLI --tags selection (cap 3-5)
+}
+```
+
+### The query contract
+
+Return columns **in this order**: `source_id, node_id, start_byte, end_byte, start_row, start_col, metric`. The `%s` placeholder receives the scope clause (so a rule can be run against one file). `metric` drives sorting (desc) and `min_metric` filtering — use `0 AS metric` for non-metric rules.
+
+## ⚠ The capability split (`Requires`) — get this right
+
+What tables exist depends on who built the `.db`:
+
+- **standalone mache** emits: `nodes`, `node_refs`, `node_defs`.
+- **ley-line-open–built `.db`** additionally has: `_ast`, `_source`, `_imports`, `_lsp*`.
+
+A rule that `Requires: ["_ast"]` silently can't run on a standalone build — 4 of the 9 built-ins (complexity, long_function, long_file, magic_int) are `_ast`-only for exactly this reason (ADR-0012). **Prefer `nodes`/`node_defs`/`node_refs` if you want the rule to run everywhere; only reach for `_ast`/`_source` when the smell genuinely needs syntax.** List every table the query reads in `Requires` so agents can tell upfront whether it'll run.
+
+## Polarity — must-NOT-hold vs must-hold
+
+Most rules are **must-not-hold**: a match IS the smell (duplicate def, magic int, dead code). Some are **must-hold** invariants where ABSENCE is the smell (mache-c7421e) — those are inverted: the query finds violations of a property that should always be true. Decide polarity first; it changes whether your `WHERE` selects the bad thing or the missing-good thing.
+
+## Severity & gating (ADR-0018)
+
+- `off` — defined but emits nothing (ship-disabled in a pack).
+- `warn` — emits findings, exit 0 (observability default; the zero value).
+- `error` — emits findings, exit 1 (author asserts this drift must not ship).
+  The rule states *what's true*; the **gate decides whether truth is fatal** at CLI via `--fail-on` / `--tags`. Don't encode CI-vs-precommit in the rule — that emerges from `(--tags × --fail-on)` profiles.
+
+## Procedure
+
+1. **Find prior art.** `grep -n 'ID:' cmd/smell_rules.go` — copy the closest rule (e.g. the two newest: divergent-default dups `mache-187b22`, task-usage drift `mache-185791`).
+1. **Write the query** against the minimal table set; verify column order; put the scope clause as trailing `%s`.
+1. **Set metadata**: `Requires` (every table touched), `Severity`, 1–3 `Tags`, `DefaultMinMetric` if metric-bearing.
+1. **TEST with adversarial fixtures** (non-negotiable, \[[feedback_happy_path_not_enough]\]): a fixture that SHOULD trip the rule AND one that should NOT (boundary). Assert counts on both. A rule with only a happy-path test is not done.
+1. **Run it**: `./mache find_smells --rule <id> <db>` (or `mcp__mache__find_smells`), and `task smells` for the self-scan.
+1. **Document the trade-offs** in `Description` — exclusions, why certain categories are skipped (see the dup-defs rule for the gold-standard exclusion rationale).
+
+## Red flags
+
+- Query reads `_ast` but `Requires` omits it → silently empty on standalone builds.
+- Wrong column count/order → findings render garbage or crash `smell_findings.go`.
+- Only a happy-path fixture → false confidence; add the negative/boundary case.
+- A long tail of trivial low-metric rows → set `DefaultMinMetric`.
+- More than ~5 tags → clippy-group explosion; trim.
+
+## Definition of done
+
+Rule registered, query returns the 7-column contract, `Requires` lists every table, severity/tags set, **both positive and negative fixtures pass**, and `./mache find_smells --rule <id>` produces the expected findings on a real `.db`.
+
+> If this rule feels like it wants to be its own tool/action (SARIF, GH code-scanning), that's tracked separately — `mache-445887`.

--- a/plugin/skills/authoring-smell-rules/SKILL.md
+++ b/plugin/skills/authoring-smell-rules/SKILL.md
@@ -30,7 +30,7 @@ SmellRule{
 
 ### The query contract
 
-Return columns **in this order**: `source_id, node_id, start_byte, end_byte, start_row, start_col, metric`. The `%s` placeholder receives the scope clause (so a rule can be run against one file). `metric` drives sorting (desc) and `min_metric` filtering — use `0 AS metric` for non-metric rules.
+Return columns **in this order**: `source_id, node_id, start_byte, end_byte, start_row, start_col, metric`. The `%s` placeholder receives the scope clause (so a rule can be run against one file). The handler applies `min_metric` **filtering** on the `metric` column, but does **not** sort — rows come back in the query's order, so if you want top-N-by-metric you must add `ORDER BY metric DESC` to your SQL yourself (the metric-bearing built-ins do). Use `0 AS metric` for non-metric rules.
 
 ## ⚠ The capability split (`Requires`) — get this right
 
@@ -39,7 +39,7 @@ What tables exist depends on who built the `.db`:
 - **standalone mache** emits: `nodes`, `node_refs`, `node_defs`.
 - **ley-line-open–built `.db`** additionally has: `_ast`, `_source`, `_imports`, `_lsp*`.
 
-A rule that `Requires: ["_ast"]` silently can't run on a standalone build — 4 of the 9 built-ins (complexity, long_function, long_file, magic_int) are `_ast`-only for exactly this reason (ADR-0012). **Prefer `nodes`/`node_defs`/`node_refs` if you want the rule to run everywhere; only reach for `_ast`/`_source` when the smell genuinely needs syntax.** List every table the query reads in `Requires` so agents can tell upfront whether it'll run.
+A rule that `Requires: ["_ast"]` can't run on a standalone build — and several of the built-ins (complexity, long_function, long_file, magic_int) are `_ast`-only for exactly this reason (ADR-0012). It does **not** fail silently: `find_smells` runs a **pre-flight table check** (`cmd/find_smells_cli.go`) against `Requires` and returns a friendly error listing the missing tables (exit code 2) when the active backend lacks them. **Prefer `nodes`/`node_defs`/`node_refs` if you want the rule to run everywhere; only reach for `_ast`/`_source` when the smell genuinely needs syntax.** List **every** table the query reads in `Requires` — that's what pre-flight checks against (see the red flag below for what happens if you don't).
 
 ## Polarity — must-NOT-hold vs must-hold
 
@@ -63,7 +63,7 @@ Most rules are **must-not-hold**: a match IS the smell (duplicate def, magic int
 
 ## Red flags
 
-- Query reads `_ast` but `Requires` omits it → silently empty on standalone builds.
+- Query reads `_ast` but `Requires` omits it → pre-flight (which only checks declared tables) doesn't catch it, so on a standalone build it fails at query time with a raw `no such table: _ast` SQL error. List every table you read.
 - Wrong column count/order → findings render garbage or crash `smell_findings.go`.
 - Only a happy-path fixture → false confidence; add the negative/boundary case.
 - A long tail of trivial low-metric rows → set `DefaultMinMetric`.


### PR DESCRIPTION
## What
Two mache-plugin skills (invoked as `/mache:<name>`, alongside the existing `mache-explore`) that encode the **non-obvious contracts** for extending mache — so an agent (or human) authoring a schema or a smell rule has the gotchas up front.

### `authoring-schemas`
- Both selector **dialects**: tree-sitter S-expressions (code) vs JSONPath (data).
- The **`@scope`-on-inner-node** gotcha (the real ASTWalker bug fixed in the parity work — `mache-33b53c`).
- The **`.db` (SQLiteGraph) vs JSON-walker capability split** — nested `$[*]` / `_parent` only work on JSON ingestion; keep `.db` schemas flat.
- The full JSONPath toolbox (computed names, `_parent`, `dict|json`, multi-root) drawn from a maximal real-world example.
- Validation via `task parity` / `task validate`.

### `authoring-smell-rules`
- The `SmellRule` struct + the **7-column query contract**.
- The **`Requires` capability split** (standalone `nodes`/`node_defs`/`node_refs` vs ley-line-built `_ast`/`_source`/`_lsp`).
- Polarity (must-hold vs must-not-hold), severity/gating (ADR-0018), tags.
- The **adversarial-fixture** discipline (positive + negative, not just happy path).

## Why
mache had no repo-local authoring guidance; both surfaces have learnable-but-sharp contracts. Repo-local (ships with the mache plugin) so the guidance travels with the code.

Refs `mache-442fd9`, `mache-444483`. (Standalone-smell-tool idea tracked separately on `mache-445887`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)