### PR TITLE
refactor(ingest): widen Walker via FileMeta — ASTWalker lang/pkg, drop a type-switch (S3)

### DIFF
--- a/internal/ingest/ast_query_parity_test.go
+++ b/internal/ingest/ast_query_parity_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -212,7 +213,36 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 
 		assert.Equalf(t, readAllContent(t, want, id), readAllContent(t, got, id),
 			"rendered content of %q must be byte-identical", id)
+
+		// Node-attribute parity (gate expansion, mache-1166aa): Properties must
+		// match between backends. `location` is excluded — it's still produced
+		// only on the SitterWalker path (doc-comment-coupled); its ASTWalker
+		// parity is a separate S3 slice.
+		wn, wnerr := want.GetNode(id)
+		gn, gnerr := got.GetNode(id)
+		require.NoErrorf(t, wnerr, "GetNode(%q) on want", id)
+		require.NoErrorf(t, gnerr, "GetNode(%q) on got", id)
+		assert.Equalf(t, propsForParity(wn.Properties), propsForParity(gn.Properties),
+			"node Properties of %q must match", id)
 	}
+}
+
+// propsForParity copies Properties minus keys not yet covered by the gate.
+// `location` still comes only from the SitterWalker path (doc-comment-coupled),
+// so its ASTWalker parity is tracked as a follow-up slice; excluding it keeps
+// this gate green while still asserting lang/pkg/imports parity.
+func propsForParity(p map[string][]byte) map[string][]byte {
+	out := make(map[string][]byte, len(p))
+	for k, v := range p {
+		if k == "location" {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func logTreeDiff(t *testing.T, want, got []string) {
@@ -273,6 +303,30 @@ func runQueryParity(t *testing.T, schemaPath, langName, sourceFile string, src [
 	require.NoError(t, astEngine.Ingest(srcPath))
 
 	assertProjectionParity(t, sitterStore, astStore)
+
+	// Non-vacuity guard: Properties parity is meaningless if BOTH backends
+	// silently drop a property (they'd still "match"). Assert a nested construct
+	// actually carries the `lang` property — this is the exact class of bug that
+	// the parentAwareMatch FileMeta-forwarding gap produced (nested matches are
+	// always wrapped, so both walkers lost lang/pkg on nested nodes and still
+	// matched). See TestEngine_MethodReceiverShape_RegistersBareLeafDef.
+	assertNestedConstructHasLang(t, sitterStore)
+}
+
+// assertNestedConstructHasLang fails if no nested (depth ≥ 2) node carries a
+// non-empty `lang` property — which would mean the Properties parity assertion
+// is vacuous for the parentAwareMatch wrapping path.
+func assertNestedConstructHasLang(t *testing.T, g graph.Graph) {
+	t.Helper()
+	for _, id := range collectTree(t, g) {
+		if strings.Count(id, "/") < 2 {
+			continue
+		}
+		if n, err := g.GetNode(id); err == nil && len(n.Properties["lang"]) > 0 {
+			return // a nested construct carries lang — parity is non-vacuous
+		}
+	}
+	t.Fatalf("no nested construct carries a `lang` property — Properties parity would be vacuous (parentAwareMatch FileMeta-forwarding regression)")
 }
 
 func TestASTQueryParity_Go(t *testing.T) {

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	_ "modernc.org/sqlite"
 )
@@ -17,6 +18,59 @@ import (
 // See ADR-014 for the design rationale.
 type ASTWalker struct {
 	db *sql.DB
+	// langCache/pkgCache memoize per-file FileMeta keyed by source_id. The
+	// engine calls Lang()/PackageName() for every construct node, but both are
+	// file-level facts — caching avoids an N+1 SQL pattern on the ingest path.
+	langCache sync.Map // sourceID -> string
+	pkgCache  sync.Map // sourceID -> string
+}
+
+// fileLang returns the source language for sourceID, computed once and cached.
+func (w *ASTWalker) fileLang(sourceID string) string {
+	if v, ok := w.langCache.Load(sourceID); ok {
+		return v.(string)
+	}
+	var lang string
+	if sourceID != "" {
+		_ = w.db.QueryRow("SELECT language FROM _source WHERE id = ?", sourceID).Scan(&lang)
+	}
+	w.langCache.Store(sourceID, lang)
+	return lang
+}
+
+// filePkg returns the package name for sourceID (Go only), computed once and
+// cached. Non-Go files resolve to "" with no per-node SQL.
+func (w *ASTWalker) filePkg(sourceID string) string {
+	if v, ok := w.pkgCache.Load(sourceID); ok {
+		return v.(string)
+	}
+	pkg := ""
+	if w.fileLang(sourceID) == "go" && sourceID != "" {
+		// package_identifier under the package_clause — the SQL mirror of
+		// SitterWalker's extractGoPackageName. Text from nodes.record, else the
+		// _source byte range.
+		var rec string
+		var sb, eb int
+		err := w.db.QueryRow(`SELECT COALESCE(n.record, ''), a.start_byte, a.end_byte
+			FROM _ast a JOIN nodes n ON n.id = a.node_id
+			WHERE a.source_id = ? AND a.node_kind = 'package_identifier'
+			ORDER BY a.start_byte LIMIT 1`, sourceID).Scan(&rec, &sb, &eb)
+		switch {
+		case err != nil:
+			pkg = ""
+		case rec != "":
+			pkg = rec
+		default:
+			var content []byte
+			if e := w.db.QueryRow("SELECT content FROM _source WHERE id = ?", sourceID).Scan(&content); e == nil {
+				if sb >= 0 && sb < eb && eb <= len(content) {
+					pkg = string(content[sb:eb])
+				}
+			}
+		}
+	}
+	w.pkgCache.Store(sourceID, pkg)
+	return pkg
 }
 
 // NewASTWalker creates a walker backed by a SQLite database containing
@@ -62,6 +116,7 @@ func (w *ASTWalker) Query(root any, selector string) ([]Match, error) {
 		return []Match{&astMatch{
 			values: map[string]any{},
 			ctx:    ar,
+			w:      w,
 		}}, nil
 	}
 
@@ -200,6 +255,7 @@ func (w *ASTWalker) Query(root any, selector string) ([]Match, error) {
 			},
 			startByte: scopeForText.startByte,
 			endByte:   scopeForText.endByte,
+			w:         w,
 		}
 		matches = append(matches, m)
 	}
@@ -239,6 +295,7 @@ type astMatch struct {
 	ctx           ASTRoot
 	startByte     int
 	endByte       int
+	w             *ASTWalker // for cached FileMeta (lang/pkg) lookups
 }
 
 func (m *astMatch) Values() map[string]any { return m.values }
@@ -257,46 +314,22 @@ func (m *astMatch) CaptureOrigin(name string) (uint32, uint32, bool) {
 	return 0, 0, false
 }
 
-// Lang implements FileMeta — reads _source.language for this match's file.
+// Lang implements FileMeta — the file's source language (cached on the walker,
+// so the engine's per-construct calls don't issue per-node SQL).
 func (m *astMatch) Lang() string {
-	if m.ctx.DB == nil || m.ctx.SourceID == "" {
+	if m.w == nil {
 		return ""
 	}
-	var lang string
-	if err := m.ctx.DB.QueryRow("SELECT language FROM _source WHERE id = ?", m.ctx.SourceID).Scan(&lang); err != nil {
-		return ""
-	}
-	return lang
+	return m.w.fileLang(m.ctx.SourceID)
 }
 
-// PackageName implements FileMeta. For Go, reads the package_identifier from
-// the _ast table — the SQL mirror of SitterWalker's extractGoPackageName. The
-// node's text comes from nodes.record, falling back to the _source byte range.
-// "" for non-Go or when no package clause is present.
+// PackageName implements FileMeta — the file's Go package (cached on the
+// walker; "" for non-Go). SQL mirror of SitterWalker's extractGoPackageName.
 func (m *astMatch) PackageName() string {
-	if m.ctx.DB == nil || m.ctx.SourceID == "" || m.Lang() != "go" {
+	if m.w == nil {
 		return ""
 	}
-	var rec string
-	var sb, eb int
-	err := m.ctx.DB.QueryRow(`SELECT COALESCE(n.record, ''), a.start_byte, a.end_byte
-		FROM _ast a JOIN nodes n ON n.id = a.node_id
-		WHERE a.source_id = ? AND a.node_kind = 'package_identifier'
-		ORDER BY a.start_byte LIMIT 1`, m.ctx.SourceID).Scan(&rec, &sb, &eb)
-	if err != nil {
-		return ""
-	}
-	if rec != "" {
-		return rec
-	}
-	// Fallback: slice the package_identifier's bytes out of the source.
-	var content []byte
-	if e := m.ctx.DB.QueryRow("SELECT content FROM _source WHERE id = ?", m.ctx.SourceID).Scan(&content); e == nil {
-		if sb >= 0 && sb < eb && eb <= len(content) {
-			return string(content[sb:eb])
-		}
-	}
-	return ""
+	return m.w.filePkg(m.ctx.SourceID)
 }
 
 type astNode struct {

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -257,6 +257,48 @@ func (m *astMatch) CaptureOrigin(name string) (uint32, uint32, bool) {
 	return 0, 0, false
 }
 
+// Lang implements FileMeta — reads _source.language for this match's file.
+func (m *astMatch) Lang() string {
+	if m.ctx.DB == nil || m.ctx.SourceID == "" {
+		return ""
+	}
+	var lang string
+	if err := m.ctx.DB.QueryRow("SELECT language FROM _source WHERE id = ?", m.ctx.SourceID).Scan(&lang); err != nil {
+		return ""
+	}
+	return lang
+}
+
+// PackageName implements FileMeta. For Go, reads the package_identifier from
+// the _ast table — the SQL mirror of SitterWalker's extractGoPackageName. The
+// node's text comes from nodes.record, falling back to the _source byte range.
+// "" for non-Go or when no package clause is present.
+func (m *astMatch) PackageName() string {
+	if m.ctx.DB == nil || m.ctx.SourceID == "" || m.Lang() != "go" {
+		return ""
+	}
+	var rec string
+	var sb, eb int
+	err := m.ctx.DB.QueryRow(`SELECT COALESCE(n.record, ''), a.start_byte, a.end_byte
+		FROM _ast a JOIN nodes n ON n.id = a.node_id
+		WHERE a.source_id = ? AND a.node_kind = 'package_identifier'
+		ORDER BY a.start_byte LIMIT 1`, m.ctx.SourceID).Scan(&rec, &sb, &eb)
+	if err != nil {
+		return ""
+	}
+	if rec != "" {
+		return rec
+	}
+	// Fallback: slice the package_identifier's bytes out of the source.
+	var content []byte
+	if e := m.ctx.DB.QueryRow("SELECT content FROM _source WHERE id = ?", m.ctx.SourceID).Scan(&content); e == nil {
+		if sb >= 0 && sb < eb && eb <= len(content) {
+			return string(content[sb:eb])
+		}
+	}
+	return ""
+}
+
 type astNode struct {
 	id        string
 	parentID  string

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -241,21 +241,23 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 			Children: existingChildren,
 		}
 
-		// Store language name, package name for callees/ resolution (SitterWalker path)
-		if _, ok := walker.(*SitterWalker); ok {
-			if ctxAny := match.Context(); ctxAny != nil {
-				if root, ok := ctxAny.(SitterRoot); ok && root.LangName != "" {
-					if node.Properties == nil {
-						node.Properties = make(map[string][]byte)
-					}
-					node.Properties["lang"] = []byte(root.LangName)
+		// Store language + package name as node properties (used for callees/
+		// qualified-def resolution). Read through the FileMeta interface so the
+		// engine stays walker-agnostic — both sitterMatch and astMatch implement
+		// it (and parentAwareMatch forwards to its inner), so this no longer
+		// type-switches on the concrete walker. Parity between the two backends is
+		// asserted by TestASTQueryParity; correctness of the values by
+		// TestEngine_MethodReceiverShape_RegistersBareLeafDef.
+		if fm, ok := match.(FileMeta); ok {
+			if l := fm.Lang(); l != "" {
+				if node.Properties == nil {
+					node.Properties = make(map[string][]byte)
+				}
+				node.Properties["lang"] = []byte(l)
 
-					// Extract Go package name for qualified def resolution
-					if root.LangName == "go" && root.FileRoot != nil {
-						if pkgName := extractGoPackageName(root.FileRoot, root.Source, root.Lang); pkgName != "" {
-							node.Properties["pkg"] = []byte(pkgName)
-						}
-					}
+				// Go package name, for qualified def resolution.
+				if pkg := fm.PackageName(); pkg != "" {
+					node.Properties["pkg"] = []byte(pkg)
 				}
 			}
 		}

--- a/internal/ingest/interfaces.go
+++ b/internal/ingest/interfaces.go
@@ -28,3 +28,17 @@ type Match interface {
 type OriginProvider interface {
 	CaptureOrigin(name string) (startByte, endByte uint32, ok bool)
 }
+
+// FileMeta is an optional interface a Match implements to expose per-file
+// metadata the engine records as node Properties (lang, pkg). Reading it
+// through this interface lets the engine stay walker-agnostic — both the
+// tree-sitter (sitterMatch) and SQL (astMatch) backends implement it, so the
+// engine no longer type-switches on the concrete walker to set these. The
+// parity gate (TestASTQueryParity) asserts both backends return identical values.
+type FileMeta interface {
+	// Lang is the source language ("go", "python", ...), or "" if unknown.
+	Lang() string
+	// PackageName is the file's package/namespace (Go package, etc.), or ""
+	// when the language has no such concept or it can't be determined.
+	PackageName() string
+}

--- a/internal/ingest/parent_match.go
+++ b/internal/ingest/parent_match.go
@@ -59,3 +59,22 @@ func (m *parentAwareMatch) GetCaptureNode(name string) *sitter.Node {
 	}
 	return nil
 }
+
+// Lang forwards to the inner match if it implements FileMeta. Without this,
+// nested matches (which are always wrapped in parentAwareMatch) would lose the
+// lang/pkg node properties the engine sets via FileMeta — a regression caught by
+// TestEngine_MethodReceiverShape_RegistersBareLeafDef.
+func (m *parentAwareMatch) Lang() string {
+	if fm, ok := m.inner.(FileMeta); ok {
+		return fm.Lang()
+	}
+	return ""
+}
+
+// PackageName forwards to the inner match if it implements FileMeta.
+func (m *parentAwareMatch) PackageName() string {
+	if fm, ok := m.inner.(FileMeta); ok {
+		return fm.PackageName()
+	}
+	return ""
+}

--- a/internal/ingest/sitter_walker.go
+++ b/internal/ingest/sitter_walker.go
@@ -241,6 +241,18 @@ func (m *sitterMatch) Context() any {
 	return nil
 }
 
+// Lang implements FileMeta.
+func (m *sitterMatch) Lang() string { return m.root.LangName }
+
+// PackageName implements FileMeta. Go-only today (mirrors the engine's prior
+// SitterWalker-gated behavior); other languages return "".
+func (m *sitterMatch) PackageName() string {
+	if m.root.LangName == "go" && m.root.FileRoot != nil {
+		return extractGoPackageName(m.root.FileRoot, m.root.Source, m.root.Lang)
+	}
+	return ""
+}
+
 // getSchemaQuery returns a cached compiled query for schema selector execution.
 // The compiled query is reused across all files of the same language, avoiding
 // recompilation of the same S-expression on every file (e.g., 50K files × 20


### PR DESCRIPTION
First slice of **S3** (`mache-33cd7e`) under decade `mache-pure-go-arena`: replace one of the engine's `walker.(*SitterWalker)` type-switches with an interface, so ASTWalker produces the same node properties — the load-bearing step toward deleting SitterWalker (`mache-36d961`).

## The problem
The engine set node `Properties["lang"]`/`["pkg"]` **only** inside a `walker.(*SitterWalker)` type-switch (`engine_walk.go:245`). ASTWalker never produced them → consumers that read `pkg` (qualified-def resolution, `callees/`) silently degraded on the pure-Go path.

## The change
- New **`FileMeta`** interface (`Lang()`, `PackageName()`) in `interfaces.go`.
- `sitterMatch` implements it (lang from `SitterRoot.LangName`, pkg via `extractGoPackageName`).
- `astMatch` implements it (lang from `_source.language`, pkg from the `_ast` `package_clause` — the SQL mirror).
- `parentAwareMatch` **forwards** it to its inner match (see regression below).
- Engine reads `match.(FileMeta)` instead of type-switching. One type-switch gone.

## How the gate caught a real bug (your call)
The parity gate only checks the two backends **match**, not that values are **correct**. Nested matches are always wrapped in `parentAwareMatch`, which didn't forward `FileMeta` — so **both** walkers lost lang/pkg on nested nodes and still "matched". The value-level `TestEngine_MethodReceiverShape_RegistersBareLeafDef` caught it. Fixes:
1. `parentAwareMatch` now forwards `FileMeta`.
2. **Non-vacuity guard** added to the gate: a nested construct *must* carry `lang`, so a both-drop-it regression fails loudly (verified — it fails with the forwarding removed).

## Tested the whole way
- parity gate + Properties parity (lang/pkg/imports) + non-vacuity guard ✅
- `internal/ingest -race` ✅, `internal/graph` ✅, `cmd` (callees/smells/e2e) ✅

## Scope
This slice: **lang + pkg**. Follow-up slices (tracked on `mache-33cd7e`): `location` (doc-comment-coupled, `:406`) and `calls`/address-refs (`:353`, needs the multi-file fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)