### PR TITLE
refactor(ingest): walker-agnostic doc-comment scope (DocScope) — ASTWalker location + doc-extended source (S3 slice 2)

### DIFF
--- a/internal/ingest/ast_query_parity_test.go
+++ b/internal/ingest/ast_query_parity_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -215,9 +216,7 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 			"rendered content of %q must be byte-identical", id)
 
 		// Node-attribute parity (gate expansion, mache-1166aa): Properties must
-		// match between backends. `location` is excluded — it's still produced
-		// only on the SitterWalker path (doc-comment-coupled); its ASTWalker
-		// parity is a separate S3 slice.
+		// match between backends — including location (doc-comment-extended).
 		wn, wnerr := want.GetNode(id)
 		gn, gnerr := got.GetNode(id)
 		require.NoErrorf(t, wnerr, "GetNode(%q) on want", id)
@@ -227,21 +226,15 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 	}
 }
 
-// propsForParity copies Properties minus keys not yet covered by the gate.
-// `location` still comes only from the SitterWalker path (doc-comment-coupled),
-// so its ASTWalker parity is tracked as a follow-up slice; excluding it keeps
-// this gate green while still asserting lang/pkg/imports parity.
+// propsForParity normalizes Properties for comparison (nil for an empty map so
+// nil == empty). All node properties the engine sets — lang, pkg, imports, and
+// location (doc-comment-extended) — are now produced by BOTH backends.
 func propsForParity(p map[string][]byte) map[string][]byte {
-	out := make(map[string][]byte, len(p))
-	for k, v := range p {
-		if k == "location" {
-			continue
-		}
-		out[k] = v
-	}
-	if len(out) == 0 {
+	if len(p) == 0 {
 		return nil
 	}
+	out := make(map[string][]byte, len(p))
+	maps.Copy(out, p)
 	return out
 }
 
@@ -352,6 +345,34 @@ func (g *Greeter) Greet() string {
 
 func Caller() {
 	fmt.Println(Hello())
+}
+`))
+}
+
+// TestASTQueryParity_DocComments_Go exercises the doc-comment-extended `location`
+// property: documented constructs must have a location starting at the comment
+// line, undocumented ones at the construct line — identically on both backends.
+// This drives the ASTWalker SQL comment-sibling scan (docExtendStart) against
+// SitterWalker's PrevSibling walk (S3 slice 2 / mache-33cd7e).
+func TestASTQueryParity_DocComments_Go(t *testing.T) {
+	runQueryParity(t, "../../examples/go-schema.json", "go", "example.go", []byte(`package demo
+
+// MaxRetries caps the retries.
+const MaxRetries = 3
+
+// Greeter greets people.
+// Second doc line.
+type Greeter struct {
+	Name string
+}
+
+// Hello says hello.
+func Hello() string {
+	return "hello"
+}
+
+func Undocumented() string {
+	return "no docs"
 }
 `))
 }

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -21,8 +21,9 @@ type ASTWalker struct {
 	// langCache/pkgCache memoize per-file FileMeta keyed by source_id. The
 	// engine calls Lang()/PackageName() for every construct node, but both are
 	// file-level facts — caching avoids an N+1 SQL pattern on the ingest path.
-	langCache sync.Map // sourceID -> string
-	pkgCache  sync.Map // sourceID -> string
+	langCache   sync.Map // sourceID -> string
+	pkgCache    sync.Map // sourceID -> string
+	sourceCache sync.Map // sourceID -> []byte
 }
 
 // fileLang returns the source language for sourceID, computed once and cached.
@@ -71,6 +72,40 @@ func (w *ASTWalker) filePkg(sourceID string) string {
 	}
 	w.pkgCache.Store(sourceID, pkg)
 	return pkg
+}
+
+// fileSource returns the source bytes for sourceID, cached per file.
+func (w *ASTWalker) fileSource(sourceID string) []byte {
+	if v, ok := w.sourceCache.Load(sourceID); ok {
+		return v.([]byte)
+	}
+	src, _ := w.readSource(w.db, sourceID)
+	w.sourceCache.Store(sourceID, src)
+	return src
+}
+
+// docExtendStart walks backward from a scope node over contiguous preceding
+// comment siblings (same parent, <= 2 byte gap), returning the doc-extended
+// start byte. The SQL mirror of SitterWalker's PrevSibling comment scan.
+func (w *ASTWalker) docExtendStart(sourceID, scopeID string, scopeStart uint32) uint32 {
+	var parentID string
+	if err := w.db.QueryRow("SELECT parent_id FROM nodes WHERE id = ?", scopeID).Scan(&parentID); err != nil {
+		return scopeStart
+	}
+	start := scopeStart
+	for {
+		// Closest preceding comment sibling (same parent), by end_byte.
+		var cs, ce int
+		err := w.db.QueryRow(`SELECT a.start_byte, a.end_byte
+			FROM _ast a JOIN nodes n ON n.id = a.node_id
+			WHERE n.parent_id = ? AND a.source_id = ? AND a.node_kind = 'comment' AND a.end_byte <= ?
+			ORDER BY a.end_byte DESC LIMIT 1`, parentID, sourceID, int(start)).Scan(&cs, &ce)
+		if err != nil || int(start)-ce > 2 {
+			break
+		}
+		start = uint32(cs)
+	}
+	return start
 }
 
 // NewASTWalker creates a walker backed by a SQLite database containing
@@ -330,6 +365,26 @@ func (m *astMatch) PackageName() string {
 		return ""
 	}
 	return m.w.filePkg(m.ctx.SourceID)
+}
+
+// ScopeSource implements DocScope — the file's source bytes (cached).
+func (m *astMatch) ScopeSource() []byte {
+	if m.w == nil {
+		return nil
+	}
+	return m.w.fileSource(m.ctx.SourceID)
+}
+
+// DocRange implements DocScope. The scope node's id is ctx.ParentPrefix (set in
+// Query); a zero-width range marks a "$" grouping match with no real scope.
+func (m *astMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool) {
+	if m.w == nil || m.endByte <= m.startByte {
+		return 0, 0, 0, false
+	}
+	scopeStart = uint32(m.startByte)
+	scopeEnd = uint32(m.endByte)
+	docStart = m.w.docExtendStart(m.ctx.SourceID, m.ctx.ParentPrefix, scopeStart)
+	return docStart, scopeStart, scopeEnd, true
 }
 
 type astNode struct {

--- a/internal/ingest/engine_extract.go
+++ b/internal/ingest/engine_extract.go
@@ -18,45 +18,29 @@ func byteOffsetToLine(content []byte, offset uint32) int {
 	return line
 }
 
-// extractDocComments walks backward from a tree-sitter @scope capture to find
-// contiguous preceding comment nodes. Returns the doc comment text (just the
-// comments) and the extended byte range for write-back origin tracking.
+// extractDocComments returns the doc-comment text immediately preceding a
+// match's @scope node, plus the doc-extended byte range (for the `location`
+// property and write-back origin tracking). It reads through the DocScope
+// interface so it is walker-agnostic — sitterMatch walks tree-sitter siblings,
+// astMatch queries the _ast comment rows; both yield identical output.
 func extractDocComments(match Match) (docText string, startByte, endByte uint32, hasScope bool) {
-	sm, ok := match.(interface{ GetCaptureNode(string) *sitter.Node })
+	ds, ok := match.(DocScope)
 	if !ok {
 		return docText, startByte, endByte, hasScope
 	}
-	scopeNode := sm.GetCaptureNode("scope")
-	if scopeNode == nil {
+	docStart, scopeStart, scopeEnd, ok := ds.DocRange()
+	if !ok {
 		return docText, startByte, endByte, hasScope
 	}
 	hasScope = true
-	startByte = scopeNode.StartByte()
-	endByte = scopeNode.EndByte()
+	startByte = docStart
+	endByte = scopeEnd
 
-	// Walk backward to find contiguous comment siblings
-	n := scopeNode
-	prev := n.PrevSibling()
-	for prev != nil && prev.Type() == "comment" {
-		// Check adjacency: <= 2 bytes gap (allow \n or \n\n)
-		if int(n.StartByte())-int(prev.EndByte()) <= 2 {
-			startByte = prev.StartByte()
-			n = prev
-			prev = prev.PrevSibling()
-		} else {
-			break
-		}
-	}
-
-	// Extract doc comment text (just the comments, not the scope body)
-	if startByte < scopeNode.StartByte() {
-		if root, ok := match.Context().(SitterRoot); ok {
-			if scopeNode.StartByte() <= uint32(len(root.Source)) {
-				docText = strings.TrimRight(
-					string(root.Source[startByte:scopeNode.StartByte()]),
-					"\n\r\t ",
-				)
-			}
+	// Extract doc comment text (just the comments, not the scope body).
+	if docStart < scopeStart {
+		src := ds.ScopeSource()
+		if scopeStart <= uint32(len(src)) {
+			docText = strings.TrimRight(string(src[docStart:scopeStart]), "\n\r\t ")
 		}
 	}
 	return docText, startByte, endByte, hasScope

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -403,16 +403,19 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 			Properties: currentProps,
 		}
 
-		// Set location property on directory node from source file's origin
+		// Set location property on directory node from source file's origin.
+		// Read source bytes via DocScope so this is walker-agnostic (extStart/
+		// extEnd already came from the walker-agnostic extractDocComments above).
 		if hasScope && absSourceFile != "" {
-			if root, ok := match.Context().(SitterRoot); ok {
+			if ds, ok := match.(DocScope); ok {
+				src := ds.ScopeSource()
 				if node.Properties == nil {
-					node.Properties = make(map[string][]byte) // coverage:ignore
-				} // coverage:ignore
+					node.Properties = make(map[string][]byte)
+				}
 				relPath, err := filepath.Rel(e.RootPath, absSourceFile)
 				if err == nil {
-					startLine := byteOffsetToLine(root.Source, extStart)
-					endLine := byteOffsetToLine(root.Source, extEnd)
+					startLine := byteOffsetToLine(src, extStart)
+					endLine := byteOffsetToLine(src, extEnd)
 					node.Properties["location"] = fmt.Appendf(nil, "%s:%d:%d", relPath, startLine, endLine)
 				}
 			}
@@ -455,12 +458,15 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 				Data:    []byte(content),
 			}
 
-			// Extend source file content to include preceding doc comments
+			// Extend source file content to include preceding doc comments.
+			// Walker-agnostic via DocScope (extStart/extEnd came from the
+			// walker-agnostic extractDocComments above).
 			if hasScope && docText != "" && fileSchema.Name == "source" {
-				if root, ok := match.Context().(SitterRoot); ok { // coverage:ignore
-					if extEnd <= uint32(len(root.Source)) { // coverage:ignore
-						fileNode.Data = root.Source[extStart:extEnd] // coverage:ignore
-					} // coverage:ignore
+				if ds, ok := match.(DocScope); ok {
+					src := ds.ScopeSource()
+					if extEnd <= uint32(len(src)) {
+						fileNode.Data = src[extStart:extEnd]
+					}
 				}
 			}
 

--- a/internal/ingest/interfaces.go
+++ b/internal/ingest/interfaces.go
@@ -42,3 +42,19 @@ type FileMeta interface {
 	// when the language has no such concept or it can't be determined.
 	PackageName() string
 }
+
+// DocScope is implemented by matches that can locate their @scope node's byte
+// range, extended backward over contiguous preceding comment siblings (doc
+// comments). The engine reads the `location` node property — and doc-comment
+// text — through this interface so it stays walker-agnostic: sitterMatch walks
+// tree-sitter siblings, astMatch queries the _ast comment rows. Parity between
+// the two is asserted by TestASTQueryParity (including a doc-comment fixture).
+type DocScope interface {
+	// ScopeSource returns the file's source bytes (for line/text computation).
+	ScopeSource() []byte
+	// DocRange returns the doc-extended start, the scope start, and the scope
+	// end byte offsets. docStart == scopeStart when there are no contiguous
+	// comment siblings. ok is false when the match has no @scope (e.g. a "$"
+	// grouping match).
+	DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool)
+}

--- a/internal/ingest/parent_match.go
+++ b/internal/ingest/parent_match.go
@@ -78,3 +78,21 @@ func (m *parentAwareMatch) PackageName() string {
 	}
 	return ""
 }
+
+// ScopeSource forwards to the inner match if it implements DocScope. Like the
+// FileMeta forwards above, nested matches are always wrapped — without this the
+// engine's location/doc lookups would silently no-op on nested constructs.
+func (m *parentAwareMatch) ScopeSource() []byte {
+	if ds, ok := m.inner.(DocScope); ok {
+		return ds.ScopeSource()
+	}
+	return nil
+}
+
+// DocRange forwards to the inner match if it implements DocScope.
+func (m *parentAwareMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool) {
+	if ds, ok := m.inner.(DocScope); ok {
+		return ds.DocRange()
+	}
+	return 0, 0, 0, false
+}

--- a/internal/ingest/sitter_walker.go
+++ b/internal/ingest/sitter_walker.go
@@ -253,6 +253,35 @@ func (m *sitterMatch) PackageName() string {
 	return ""
 }
 
+// ScopeSource implements DocScope.
+func (m *sitterMatch) ScopeSource() []byte { return m.root.Source }
+
+// DocRange implements DocScope — walks backward from the @scope capture over
+// contiguous preceding comment siblings (the original extractDocComments logic).
+func (m *sitterMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool) {
+	scopeNode := m.captures["scope"]
+	if scopeNode == nil {
+		return 0, 0, 0, false
+	}
+	scopeStart = scopeNode.StartByte()
+	scopeEnd = scopeNode.EndByte()
+	docStart = scopeStart
+
+	n := scopeNode
+	prev := n.PrevSibling()
+	for prev != nil && prev.Type() == "comment" {
+		// Adjacency: <= 2 bytes gap (allow \n or \n\n).
+		if int(n.StartByte())-int(prev.EndByte()) <= 2 {
+			docStart = prev.StartByte()
+			n = prev
+			prev = prev.PrevSibling()
+		} else {
+			break
+		}
+	}
+	return docStart, scopeStart, scopeEnd, true
+}
+
 // getSchemaQuery returns a cached compiled query for schema selector execution.
 // The compiled query is reused across all files of the same language, avoiding
 // recompilation of the same S-expression on every file (e.g., 50K files × 20


### PR DESCRIPTION
Second slice of **S3** (`mache-33cd7e`) under decade `mache-pure-go-arena`: eliminate two more `match.Context().(SitterRoot)` gates so ASTWalker produces the `location` property and the doc-comment-extended `source` leaf.

## The problem
`location` and the `source`-leaf doc-extension were both gated on `SitterRoot` (`engine_walk.go`), so on the pure-Go path ASTWalker emitted **no `location`** and a **non-doc-extended `source`** (a documented func's `source` leaf dropped its doc comment).

## The change — `DocScope` interface
`ScopeSource()` + `DocRange()` (doc-extended start, scope start/end), implemented by both matches and forwarded by `parentAwareMatch`:
- **sitterMatch** walks tree-sitter `PrevSibling` comment nodes (the original `extractDocComments` logic, moved here verbatim).
- **astMatch** reproduces it via a **SQL backward comment-sibling scan** over `_ast` (`ASTWalker.docExtendStart`) — comments are captured as `_ast` siblings, so the same contiguous-`comment`, ≤2-byte-gap walk works in SQL. Source bytes cached per `source_id`.

`extractDocComments`, the engine `location` block, and the `source`-leaf doc-extension all now read through `DocScope` — walker-agnostic. **SitterWalker output is unchanged** (its existing doc/location/origin tests pass).

## Gate — and the non-vacuity lesson, again
- `location` is no longer excluded from Properties parity.
- New **doc-comment fixture** (`TestASTQueryParity_DocComments_Go`) drives the SQL scan. It immediately surfaced a *second* divergence the no-doc fixture couldn't see — the `source` leaf wasn't doc-extended on the AST path — now fixed. (Same payoff as slice 1's non-vacuity guard: parity-only checks hide both-wrong-but-matching; a fixture that exercises the feature catches it.)

## Tested the whole way
`internal/ingest -race`, `internal/writeback`, doc/location/origin tests, `internal/graph`, `cmd` (e2e, 219s) — all green.

## Scope
Remaining S3 (`mache-33cd7e`): slice 3 = `calls`/address-refs (`engine_walk.go:353` + `engine_treesitter.go:341`, needs a multi-file fixture). After it, the three type-switches are gone and `mache-36d961` (delete SitterWalker) unblocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)