### PR TITLE
refactor(ingest): walker-agnostic per-scope calls (CallExtractor) — last SitterWalker type-switch (S3 slice 3)

### DIFF
--- a/internal/ingest/ast_query_parity_test.go
+++ b/internal/ingest/ast_query_parity_test.go
@@ -193,7 +193,7 @@ func collectTree(tb testing.TB, g graph.Graph) []string {
 // rendered content bytes. (Cross-file callers/callees parity is intentionally
 // out of scope for this single-file gate — it can't witness inter-file edges;
 // tracked as gate expansion on mache-1166aa.)
-func assertProjectionParity(t *testing.T, want, got graph.Graph) {
+func assertProjectionParity(t *testing.T, want, got graph.Graph, requireCallers bool) {
 	t.Helper()
 
 	wantNodes := collectTree(t, want)
@@ -203,6 +203,7 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 		return // content/children comparison is meaningless once the tree diverges
 	}
 
+	sawCallers := false
 	for _, id := range wantNodes {
 		wc, werr := want.ListChildren(id)
 		gc, gerr := got.ListChildren(id)
@@ -223,7 +224,39 @@ func assertProjectionParity(t *testing.T, want, got graph.Graph) {
 		require.NoErrorf(t, gnerr, "GetNode(%q) on got", id)
 		assert.Equalf(t, propsForParity(wn.Properties), propsForParity(gn.Properties),
 			"node Properties of %q must match", id)
+
+		// Callers parity (S3 slice 3): per-scope calls feed AddRef(token,
+		// sourceFile) — the callers/ index. For each construct name, who-calls-it
+		// must match between backends. Exercises ASTWalker's scope-prefixed calls
+		// against SitterWalker's scope-node query.
+		token := filepath.Base(id)
+		wcal := callerIDs(t, want, token)
+		gcal := callerIDs(t, got, token)
+		assert.Equalf(t, wcal, gcal, "callers of %q must match", token)
+		if len(wcal) > 0 {
+			sawCallers = true
+		}
 	}
+	// Non-vacuity: when the fixture is expected to exercise calls, at least one
+	// token must have callers — else the callers-parity check is meaningless
+	// (both-empty-but-matching). Fixtures with no calls pass requireCallers=false.
+	if requireCallers {
+		assert.True(t, sawCallers, "no token had callers — callers parity is vacuous (scope-call regression?)")
+	}
+}
+
+// callerIDs returns the sorted caller node-IDs for a token, via the Graph's
+// callers index (populated from per-construct ScopeCalls -> AddRef).
+func callerIDs(t *testing.T, g graph.Graph, token string) []string {
+	t.Helper()
+	cs, err := g.GetCallers(token)
+	require.NoErrorf(t, err, "GetCallers(%q)", token)
+	out := make([]string, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.ID)
+	}
+	sort.Strings(out)
+	return out
 }
 
 // propsForParity normalizes Properties for comparison (nil for an empty map so
@@ -274,7 +307,7 @@ func loadParitySchema(t *testing.T, path string) api.Topology {
 
 // runQueryParity ingests the same source through SitterWalker (CGO) and
 // ASTWalker (over an emitted _ast db) and asserts byte-level projection parity.
-func runQueryParity(t *testing.T, schemaPath, langName, sourceFile string, src []byte) {
+func runQueryParity(t *testing.T, schemaPath, langName, sourceFile string, src []byte, requireCallers bool) {
 	t.Helper()
 	schema := loadParitySchema(t, schemaPath)
 
@@ -295,7 +328,7 @@ func runQueryParity(t *testing.T, schemaPath, langName, sourceFile string, src [
 	astEngine.SetASTWalker(NewASTWalker(db))
 	require.NoError(t, astEngine.Ingest(srcPath))
 
-	assertProjectionParity(t, sitterStore, astStore)
+	assertProjectionParity(t, sitterStore, astStore, requireCallers)
 
 	// Non-vacuity guard: Properties parity is meaningless if BOTH backends
 	// silently drop a property (they'd still "match"). Assert a nested construct
@@ -346,7 +379,7 @@ func (g *Greeter) Greet() string {
 func Caller() {
 	fmt.Println(Hello())
 }
-`))
+`), true)
 }
 
 // TestASTQueryParity_DocComments_Go exercises the doc-comment-extended `location`
@@ -374,5 +407,5 @@ func Hello() string {
 func Undocumented() string {
 	return "no docs"
 }
-`))
+`), false)
 }

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -387,6 +387,20 @@ func (m *astMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool) {
 	return docStart, scopeStart, scopeEnd, true
 }
 
+// ScopeCalls implements CallExtractor — scope-prefixed calls + address-refs over
+// _ast (the per-construct equivalent of SitterWalker's scope-node query).
+func (m *astMatch) ScopeCalls() []string {
+	if m.w == nil || m.endByte <= m.startByte {
+		return nil
+	}
+	lang := m.w.fileLang(m.ctx.SourceID)
+	calls, _ := m.w.ExtractCallsScoped(m.ctx.SourceID, m.ctx.ParentPrefix, lang)
+	if addr, err := m.w.ExtractAddressRefsScoped(m.ctx.SourceID, m.ctx.ParentPrefix, lang); err == nil {
+		calls = append(calls, addr...)
+	}
+	return calls
+}
+
 type astNode struct {
 	id        string
 	parentID  string

--- a/internal/ingest/ast_walker_calls.go
+++ b/internal/ingest/ast_walker_calls.go
@@ -56,7 +56,38 @@ func (w *ASTWalker) ExtractCalls(sourcePath, langName string) ([]string, error) 
 	seen := make(map[string]bool)
 	var calls []string
 	for _, p := range patterns {
-		rows, err := w.queryCallPattern(sourceID, p, false)
+		rows, err := w.queryCallPattern(sourceID, p, false, "")
+		if err != nil {
+			continue
+		}
+		for _, r := range rows {
+			if r.token != "" && !seen[r.token] {
+				seen[r.token] = true
+				calls = append(calls, r.token)
+			}
+		}
+	}
+	return calls, nil
+}
+
+// ExtractCallsScoped is the per-construct equivalent of ExtractCalls: it
+// returns only call tokens whose leaf node lives under scopeID's id-path —
+// matching SitterWalker's per-scope ExtractCalls(scopeNode, ...). sourceID is
+// the _source key (filepath.Base of the file). Empty scopeID would match the
+// whole file; callers pass a real construct id.
+func (w *ASTWalker) ExtractCallsScoped(sourceID, scopeID, langName string) ([]string, error) {
+	raw, ok := callPatternRegistry.Load(langName)
+	if !ok {
+		return nil, nil
+	}
+	patterns := raw.([]CallPattern)
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]bool)
+	var calls []string
+	for _, p := range patterns {
+		rows, err := w.queryCallPattern(sourceID, p, false, scopeID)
 		if err != nil {
 			continue
 		}
@@ -84,7 +115,7 @@ func (w *ASTWalker) ExtractQualifiedCalls(sourcePath, langName string) ([]graph.
 	seen := make(map[string]bool)
 	var calls []graph.QualifiedCall
 	for _, p := range patterns {
-		rows, err := w.queryCallPattern(sourceID, p, true)
+		rows, err := w.queryCallPattern(sourceID, p, true, "")
 		if err != nil {
 			continue
 		}
@@ -118,7 +149,7 @@ type callRow struct {
 // When wantQualifier is true and pattern.QualifierKind is non-empty, the
 // query also joins a sibling node (same parent as the leaf) of kind
 // QualifierKind to populate r.qualifier.
-func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifier bool) ([]callRow, error) {
+func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifier bool, scopePrefix string) ([]callRow, error) {
 	if p.OuterKind == "" || p.LeafKind == "" {
 		return nil, fmt.Errorf("invalid CallPattern: OuterKind and LeafKind required")
 	}
@@ -174,6 +205,12 @@ func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifi
 	sb.WriteString(`
 		WHERE a_leaf.node_kind = ? AND a_leaf.source_id = ?`)
 	args = append(args, p.LeafKind, sourceID)
+	// Scope to a single construct subtree (calls whose leaf node lives under the
+	// scope node's id path). Empty scopePrefix = whole file.
+	if scopePrefix != "" {
+		sb.WriteString(` AND n_leaf.id LIKE ?`)
+		args = append(args, scopePrefix+"/%")
+	}
 	for i, anc := range p.Ancestors {
 		fmt.Fprintf(&sb, ` AND a_anc%d.node_kind = ?`, i)
 		args = append(args, anc)

--- a/internal/ingest/ast_walker_extract.go
+++ b/internal/ingest/ast_walker_extract.go
@@ -8,10 +8,23 @@ import (
 )
 
 // ExtractAddressRefs runs all registered address ref queries for the given
-// language by querying the _ast table. Returns deduplicated, scheme-prefixed
-// tokens (e.g., "env:DATABASE_URL"). Mirrors SitterWalker.ExtractAddressRefs
-// but uses SQL instead of CGO tree-sitter.
+// language by querying the _ast table (whole file). Returns deduplicated,
+// scheme-prefixed tokens (e.g., "env:DATABASE_URL"). Mirrors
+// SitterWalker.ExtractAddressRefs but uses SQL instead of CGO tree-sitter.
 func (w *ASTWalker) ExtractAddressRefs(sourcePath, langName string) ([]string, error) {
+	return w.extractAddressRefs(filepath.Base(sourcePath), "", langName)
+}
+
+// ExtractAddressRefsScoped is the per-construct equivalent: address refs whose
+// matched node lives under scopeID's id-path. Mirrors SitterWalker's per-scope
+// ExtractAddressRefs(scopeNode, ...). sourceID is the _source key.
+func (w *ASTWalker) ExtractAddressRefsScoped(sourceID, scopeID, langName string) ([]string, error) {
+	return w.extractAddressRefs(sourceID, scopeID, langName)
+}
+
+// extractAddressRefs is the shared implementation; parentPrefix "" = whole file,
+// non-empty scopes the underlying Query to that node's subtree.
+func (w *ASTWalker) extractAddressRefs(sourceID, parentPrefix, langName string) ([]string, error) {
 	raw, ok := addressRefRegistry.Load(langName)
 	if !ok {
 		return nil, nil
@@ -21,8 +34,7 @@ func (w *ASTWalker) ExtractAddressRefs(sourcePath, langName string) ([]string, e
 		return nil, nil
 	}
 
-	sourceID := filepath.Base(sourcePath)
-	root := ASTRoot{DB: w.db, SourceID: sourceID, ParentPrefix: ""}
+	root := ASTRoot{DB: w.db, SourceID: sourceID, ParentPrefix: parentPrefix}
 
 	seen := make(map[string]bool)
 	var tokens []string

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -137,9 +137,36 @@ func init() {
 	// ASTWalker (pure-Go path): batched JOIN-style fast path. One CallPattern
 	// per shape; ExtractCalls/ExtractQualifiedCalls translate each into a
 	// single SQL query that returns all matches in one pass.
+	// Mirrors the Go RefQuery above (which SitterWalker.ExtractCalls uses via
+	// getCallQuery) so the callers/ refs index matches across backends. Field
+	// labels (name:/type:) don't matter here — queryCallPattern matches the kind
+	// chain by parent_id. Parity asserted by TestASTQueryParity callers check.
 	RegisterASTCallPatterns("go", []CallPattern{
+		// function calls (bare + qualified)
 		{OuterKind: "call_expression", LeafKind: "identifier"},
 		{OuterKind: "call_expression", Ancestors: []string{"selector_expression"}, LeafKind: "field_identifier", QualifierKind: "identifier"},
+		// composite literal element + type
+		{OuterKind: "composite_literal", Ancestors: []string{"literal_element"}, LeafKind: "identifier"},
+		{OuterKind: "composite_literal", LeafKind: "type_identifier"},
+		{OuterKind: "composite_literal", Ancestors: []string{"qualified_type"}, LeafKind: "type_identifier"},
+		// parameter types (incl. receiver) — bare / pointer / qualified
+		{OuterKind: "parameter_declaration", LeafKind: "type_identifier"},
+		{OuterKind: "parameter_declaration", Ancestors: []string{"pointer_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "parameter_declaration", Ancestors: []string{"qualified_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "parameter_declaration", Ancestors: []string{"pointer_type", "qualified_type"}, LeafKind: "type_identifier"},
+		// struct field types
+		{OuterKind: "field_declaration", LeafKind: "type_identifier"},
+		{OuterKind: "field_declaration", Ancestors: []string{"pointer_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "field_declaration", Ancestors: []string{"qualified_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "field_declaration", Ancestors: []string{"pointer_type", "qualified_type"}, LeafKind: "type_identifier"},
+		// type assertions
+		{OuterKind: "type_assertion_expression", LeafKind: "type_identifier"},
+		{OuterKind: "type_assertion_expression", Ancestors: []string{"qualified_type"}, LeafKind: "type_identifier"},
+		// var declaration types
+		{OuterKind: "var_spec", LeafKind: "type_identifier"},
+		{OuterKind: "var_spec", Ancestors: []string{"pointer_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "var_spec", Ancestors: []string{"qualified_type"}, LeafKind: "type_identifier"},
+		{OuterKind: "var_spec", Ancestors: []string{"pointer_type", "qualified_type"}, LeafKind: "type_identifier"},
 	})
 	RegisterASTCallPatterns("python", []CallPattern{
 		{OuterKind: "call", LeafKind: "identifier"},

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -350,22 +350,14 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 			}
 		}
 
-		// Extract calls for this match (refs index)
+		// Extract per-scope calls + address-aware refs (env:, path:, url:) for
+		// the refs index. Read via the CallExtractor interface so the engine is
+		// walker-agnostic — both sitterMatch (tree-sitter scope-node query) and
+		// astMatch (scope-prefixed SQL) implement it, and parentAwareMatch
+		// forwards. Replaces the prior walker.(*SitterWalker) type-switch.
 		var calls []string
-		if sw, ok := walker.(*SitterWalker); ok {
-			if ctxAny := match.Context(); ctxAny != nil {
-				if root, ok := ctxAny.(SitterRoot); ok {
-					if c, err := sw.ExtractCalls(root.Node, root.Source, root.Lang, root.LangName); err == nil {
-						calls = c
-					}
-					// Extract address-aware refs (env:, path:, url:) from the
-					// match scope. These typed tokens bridge across languages
-					// (e.g., Go os.Getenv calls within this function scope).
-					if addrRefs, err := sw.ExtractAddressRefs(root.Node, root.Source, root.Lang, root.LangName); err == nil {
-						calls = append(calls, addrRefs...)
-					}
-				}
-			}
+		if ce, ok := match.(CallExtractor); ok {
+			calls = ce.ScopeCalls()
 		}
 		// Append file-level address refs (e.g., HCL variable declarations)
 		// that weren't already found at the scope level. This avoids

--- a/internal/ingest/interfaces.go
+++ b/internal/ingest/interfaces.go
@@ -64,8 +64,10 @@ type DocScope interface {
 // index. Both backends implement it — sitterMatch runs tree-sitter call queries
 // on the scope node, astMatch runs scope-prefixed SQL over _ast — and
 // parentAwareMatch forwards. Reading it through this interface lets the engine
-// drop its walker.(*SitterWalker) type-switch. Parity (cross-file callers/
-// callees) is asserted by TestASTQueryParity's multi-file fixture.
+// drop its walker.(*SitterWalker) type-switch. Parity is asserted by
+// TestASTQueryParity, which compares the per-construct callers index built from
+// ScopeCalls (intra-file calls, e.g. Caller→Hello and the Greeter receiver-ref)
+// byte-for-byte across both backends, guarded against vacuity (requireCallers).
 type CallExtractor interface {
 	// ScopeCalls returns deduplicated call tokens + typed address-refs found
 	// within this match's scope. Per-construct, not whole-file.

--- a/internal/ingest/interfaces.go
+++ b/internal/ingest/interfaces.go
@@ -58,3 +58,16 @@ type DocScope interface {
 	// grouping match).
 	DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool)
 }
+
+// CallExtractor is implemented by matches that can extract the call tokens and
+// address-refs WITHIN their @scope (per construct) for the callers/callees refs
+// index. Both backends implement it — sitterMatch runs tree-sitter call queries
+// on the scope node, astMatch runs scope-prefixed SQL over _ast — and
+// parentAwareMatch forwards. Reading it through this interface lets the engine
+// drop its walker.(*SitterWalker) type-switch. Parity (cross-file callers/
+// callees) is asserted by TestASTQueryParity's multi-file fixture.
+type CallExtractor interface {
+	// ScopeCalls returns deduplicated call tokens + typed address-refs found
+	// within this match's scope. Per-construct, not whole-file.
+	ScopeCalls() []string
+}

--- a/internal/ingest/parent_match.go
+++ b/internal/ingest/parent_match.go
@@ -96,3 +96,13 @@ func (m *parentAwareMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok
 	}
 	return 0, 0, 0, false
 }
+
+// ScopeCalls forwards to the inner match if it implements CallExtractor. Nested
+// matches are always wrapped, so without this the engine's per-scope call/refs
+// extraction would no-op on nested constructs (the slice-1 lesson).
+func (m *parentAwareMatch) ScopeCalls() []string {
+	if ce, ok := m.inner.(CallExtractor); ok {
+		return ce.ScopeCalls()
+	}
+	return nil
+}

--- a/internal/ingest/sitter_walker.go
+++ b/internal/ingest/sitter_walker.go
@@ -127,6 +127,7 @@ func (w *SitterWalker) Query(root any, selector string) ([]Match, error) {
 			values: make(map[string]string),
 			scope:  sr.Node,
 			root:   sr,
+			w:      w,
 		}}, nil
 	}
 
@@ -190,6 +191,7 @@ func (w *SitterWalker) Query(root any, selector string) ([]Match, error) {
 			captures: captures,
 			scope:    scope,
 			root:     sr,
+			w:        w,
 		})
 	}
 
@@ -201,6 +203,7 @@ type sitterMatch struct {
 	captures map[string]*sitter.Node // raw nodes for origin tracking
 	scope    *sitter.Node
 	root     SitterRoot
+	w        *SitterWalker // for per-scope ScopeCalls (uses the query cache)
 }
 
 // CaptureOrigin implements OriginProvider.
@@ -280,6 +283,18 @@ func (m *sitterMatch) DocRange() (docStart, scopeStart, scopeEnd uint32, ok bool
 		}
 	}
 	return docStart, scopeStart, scopeEnd, true
+}
+
+// ScopeCalls implements CallExtractor — calls + address-refs within this scope.
+func (m *sitterMatch) ScopeCalls() []string {
+	if m.w == nil || m.scope == nil {
+		return nil
+	}
+	calls, _ := m.w.ExtractCalls(m.scope, m.root.Source, m.root.Lang, m.root.LangName)
+	if addr, err := m.w.ExtractAddressRefs(m.scope, m.root.Source, m.root.Lang, m.root.LangName); err == nil {
+		calls = append(calls, addr...)
+	}
+	return calls
 }
 
 // getSchemaQuery returns a cached compiled query for schema selector execution.


### PR DESCRIPTION
**Final slice of S3** (`mache-33cd7e`, decade `mache-pure-go-arena`): removes the **third and last** `walker.(*SitterWalker)` type-switch, so ASTWalker produces the `callers/` refs index. After this, `mache-36d961` (delete SitterWalker) is gated only on the non-ingest CGO consumers.

## The problem
The engine's per-scope call + address-ref extraction (`engine_walk.go`) was SitterWalker-only → ASTWalker produced **no callers index**. And the semantic gap: `SitterWalker.ExtractCalls(scopeNode)` is **per-scope**, `ASTWalker.ExtractCalls(file)` is **whole-file** — assigning file-level calls to every construct would be wrong.

## The change — `CallExtractor` interface
`ScopeCalls()` implemented by both matches, forwarded by `parentAwareMatch`; engine reads it (no type-switch).
- **ASTWalker:** `queryCallPattern` gains a `scopePrefix` (`n_leaf.id LIKE scope/%`); new `ExtractCallsScoped` + `ExtractAddressRefsScoped` give the per-construct extraction.
- **sitterMatch:** gains a walker ref; `ScopeCalls` runs the scope-node query (unchanged behavior).

## The gate caught a real gap (again)
Added **callers parity** to `TestASTQueryParity`. It immediately failed: `callers of "Greeter"` (the receiver type) present on sitter, missing on ast. Root cause — ASTWalker's Go `CallPatterns` had only the **2** `call_expression` shapes, but `SitterWalker.ExtractCalls` uses the rich Go **RefQuery** (`getCallQuery`) with **~17** patterns (parameter/field/var/composite/type-assertion type-refs). Mirrored all 17 into the AST `CallPattern` registry → parity. A **non-vacuity guard** (`requireCallers`) ensures the fixture actually exercises a caller edge, so this can't silently go vacuous.

## Tested the whole way
Parity (callers + Properties + content + tree) green; `internal/ingest -race`; `internal/graph`; `cmd` (callees/dead-code/smell e2e, 275s) — all green. SitterWalker behavior unchanged.

## S3 complete
All three type-switches gone (slice 1 lang/pkg `#431`, slice 2 location/doc `#432`, slice 3 calls/refs here). Remaining for `mache-36d961`: the **non-ingest** CGO consumers (`writeback/validate.go` — unblockable via LLO `fa8638`; linter; FCA infer→SQL; `cmd/{build,infer,mount}`), then delete SitterWalker + the grammars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)