### PR TITLE
feat(smells): real find_smells locations + L1 digest (make the tool usable)

### DIFF
--- a/cmd/serve_find_smells.go
+++ b/cmd/serve_find_smells.go
@@ -28,6 +28,21 @@ func makeFindSmellsHandler(g graph.Graph) server.ToolHandlerFunc {
 			return mcp.NewToolResultText(jsonOrPanic(rulesListing())), nil
 		}
 
+		if ruleID == "*" {
+			// L1 digest mode — "shape without weight": per-rule counts +
+			// per-file rollup + a few worst exemplars, instead of a flat
+			// (capped) dump. Drill to L2 with rule=<id> (+ source_id).
+			qg, ok := g.(refsQuerier)
+			if !ok { // coverage:ignore — all test graphs implement refsQuerier
+				return mcp.NewToolResultError("the active graph backend doesn't expose a SQL handle; find_smells requires a leyline-parsed .db"), nil // coverage:ignore
+			} // coverage:ignore
+			digest, err := buildSmellDigest(qg, 5, 10)
+			if err != nil { // coverage:ignore — buildSmellDigest only errors on DB IO; unreachable with in-memory fixtures
+				return mcp.NewToolResultError(fmt.Sprintf("digest: %v", err)), nil // coverage:ignore
+			} // coverage:ignore
+			return mcp.NewToolResultText(jsonOrPanic(digest)), nil
+		}
+
 		var rule *SmellRule
 		for i := range smellRegistry {
 			if smellRegistry[i].ID == ruleID {
@@ -161,7 +176,7 @@ func rulesListing() any {
 		Help  string        `json:"help"`
 		Rules []ruleSummary `json:"rules"`
 	}{
-		Help:  "find_smells runs structural pattern queries against the _ast / nodes / node_defs / node_refs tables. Pass `rule` to scan; omit it (this response) to list available rules. Each rule entry includes a `requires` list of SQL tables it reads — agents can use it to skip rules whose tables aren't present on the active backend (e.g. _ast is only populated by ley-line-open's leyline parse). Optional `source_id` filters to one parsed file; `limit` caps results (default 200); `min_metric` drops findings whose metric column is below the threshold. Rules that surface a `default_min_metric` apply that as the threshold when the caller omits `min_metric`; an explicit `min_metric=0` overrides the default and returns everything sorted by metric.",
+		Help:  "find_smells runs structural pattern queries against the _ast / nodes / node_defs / node_refs tables. Three tiers: omit `rule` (this response) to LIST rules; pass `rule=*` for an L1 DIGEST — per-rule counts + per-file rollup + a few worst exemplars, bounded regardless of debt size (start here on an unfamiliar repo); pass `rule=<id>` for the full findings of one rule (L2), each with its real file:line backfilled from _ast, optionally scoped with `source_id=<file>`. Each rule entry includes a `requires` list of SQL tables it reads — agents can use it to skip rules whose tables aren't present on the active backend (e.g. _ast is only populated by ley-line-open's leyline parse). `limit` caps L2 results (default 200); `min_metric` drops findings whose metric column is below the threshold. Rules that surface a `default_min_metric` apply that as the threshold when the caller omits `min_metric`; an explicit `min_metric=0` overrides the default and returns everything sorted by metric.",
 		Rules: out,
 	}
 }

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -449,6 +449,87 @@ func TestFindSmells_DeadCode(t *testing.T) {
 		"source_id comes from the construct dir's source_file column")
 }
 
+// TestFindSmells_NodeDefsRuleCarriesASTLocation asserts that node_defs-based
+// rules (dead_code here) backfill a real byte/line/col span from _ast keyed by
+// node_id, instead of the historical hardcoded 0/0 → line:1. The location data
+// already ships in _ast; mache-ae54d8 enriches findings from it so L2/L3
+// drill-down is actionable. When _ast lacks the node (or is absent entirely —
+// standalone tree-sitter backend) the finding degrades to file-level (0/1).
+func TestFindSmells_NodeDefsRuleCarriesASTLocation(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- One dead function, with its real span recorded in _ast keyed by
+		-- node_id. dead_code skips nodes with no resolvable source_file (orphan
+		-- filter), so source_file is set; the span backfill is what's under test.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/funcs/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/Orphan', 'pkg/funcs', 'Orphan', 1, 0, 'orphan.go', '');
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES ('pkg/funcs/Orphan', 'orphan.go', 'function_declaration', 900, 1000, 41, 2, 60, 1);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total)
+	f := resp.Findings[0]
+	assert.Equal(t, "pkg/funcs/Orphan", f.NodeID)
+	assert.Equal(t, "orphan.go", f.SourceID)
+	assert.Equal(t, 42, f.Line, "Line = _ast.start_row+1, not the hardcoded 1")
+	assert.Equal(t, 3, f.Column, "Column = _ast.start_col+1")
+	assert.Equal(t, 900, f.StartByte, "start_byte backfilled from _ast")
+	assert.Equal(t, 1000, f.EndByte, "end_byte backfilled from _ast")
+}
+
+// TestFindSmells_DuplicateDefinitionsBackfillsFileFromAST asserts the
+// source_id (file) backfill path: duplicate_definitions resolves source_id from
+// nodes.source_file, which is empty for a construct dir whose leaves carry the
+// Origin — so the rule emits source_id "". _ast carries source_id keyed by
+// node_id, so mache-ae54d8 backfills the file, making the finding actionable
+// (file:line, not :line). Verified live on the real assay db.
+func TestFindSmells_DuplicateDefinitionsBackfillsFileFromAST(t *testing.T) {
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- Same token defined twice (a real duplicate). source_file empty on
+		-- both construct dirs so the rule's source_id resolves to "".
+		INSERT INTO node_defs VALUES ('DupFn', 'functions/DupFn'), ('DupFn', 'pkg/functions/DupFn');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('functions/DupFn',     'functions',     'DupFn', 1, 0, '', ''),
+		  ('pkg/functions/DupFn', 'pkg/functions', 'DupFn', 1, 0, '', '');
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES
+		  ('functions/DupFn',     'a.go', 'function_declaration', 10, 50, 4, 0, 8, 1),
+		  ('pkg/functions/DupFn', 'b.go', 'function_declaration', 60, 90, 12, 0, 16, 1);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "duplicate_definitions"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.NotEmpty(t, resp.Findings)
+	for _, f := range resp.Findings {
+		assert.NotEmpty(t, f.SourceID, "file backfilled from _ast.source_id (was empty from SQL)")
+		assert.Greater(t, f.Line, 1, "line backfilled from _ast.start_row")
+	}
+}
+
 // TestFindSmells_DeadCodeSkipsImports asserts that imports/ nodes
 // don't surface in dead_code, mirroring the same skip in
 // duplicate_definitions (#227). Imports are references TO external

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -491,6 +491,50 @@ func TestFindSmells_NodeDefsRuleCarriesASTLocation(t *testing.T) {
 	assert.Equal(t, 1000, f.EndByte, "end_byte backfilled from _ast")
 }
 
+// TestFindSmells_DigestMode asserts the L1 "shape without weight" digest:
+// rule="*" returns per-rule counts + worst exemplars (with real _ast locations)
+// + a by-file rollup, instead of a flat capped dump. This is the default-flood
+// fix (mache-ae54d8): one bounded response answering "how bad, where's the
+// worst" — drill to L2 with rule=<id>.
+func TestFindSmells_DigestMode(t *testing.T) {
+	tg := seedSmellAST(t) // seeds magic_int fixtures (2 binexprs)
+	defer func() { _ = tg.db.Close() }()
+
+	_, err := tg.db.Exec(`
+		-- A dead function with a real _ast span, so dead_code contributes a
+		-- located exemplar to the digest.
+		INSERT INTO node_defs VALUES ('Orphan', 'pkg/funcs/Orphan');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/Orphan', 'pkg/funcs', 'Orphan', 1, 0, 'orphan.go', '');
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+		VALUES ('pkg/funcs/Orphan', 'orphan.go', 'function_declaration', 900, 1000, 41, 0, 60, 1);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "*"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	var d smellDigest
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &d))
+	assert.Greater(t, d.Total, 0, "digest aggregates findings across rules")
+	assert.NotEmpty(t, d.ByRule, "per-rule counts present")
+	assert.NotEmpty(t, d.ByFileTop, "by-file rollup present")
+
+	// dead_code must appear with a located worst exemplar.
+	var dead *ruleDigest
+	for i := range d.ByRule {
+		if d.ByRule[i].Rule == "dead_code" {
+			dead = &d.ByRule[i]
+		}
+	}
+	require.NotNil(t, dead, "dead_code in digest")
+	assert.Equal(t, 1, dead.Count)
+	require.NotEmpty(t, dead.Worst)
+	assert.Equal(t, 42, dead.Worst[0].Line, "worst exemplar carries the real _ast line, not 1")
+}
+
 // TestFindSmells_DuplicateDefinitionsBackfillsFileFromAST asserts the
 // source_id (file) backfill path: duplicate_definitions resolves source_id from
 // nodes.source_file, which is empty for a construct dir whose leaves carry the

--- a/cmd/serve_find_smells_test.go
+++ b/cmd/serve_find_smells_test.go
@@ -535,6 +535,77 @@ func TestFindSmells_DigestMode(t *testing.T) {
 	assert.Equal(t, 42, dead.Worst[0].Line, "worst exemplar carries the real _ast line, not 1")
 }
 
+// TestEnrichLocations_ChunksLargeIDSets asserts the _ast location lookup is
+// chunked under SQLite's bound-variable limit: with the chunk size forced to 2
+// and 3 findings, the lookup spans 2 batches and every finding is still located
+// (Copilot review on PR #434 — an un-chunked IN(?,…) would fail past ~999 vars
+// and silently revert findings to line:1 on large repos).
+func TestEnrichLocations_ChunksLargeIDSets(t *testing.T) {
+	orig := enrichLocChunk
+	enrichLocChunk = 2
+	defer func() { enrichLocChunk = orig }()
+
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+	_, err := tg.db.Exec(`
+		INSERT INTO node_defs VALUES ('D1','pkg/funcs/D1'),('D2','pkg/funcs/D2'),('D3','pkg/funcs/D3');
+		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file, record) VALUES
+		  ('pkg/funcs/D1','pkg/funcs','D1',1,0,'d1.go',''),
+		  ('pkg/funcs/D2','pkg/funcs','D2',1,0,'d2.go',''),
+		  ('pkg/funcs/D3','pkg/funcs','D3',1,0,'d3.go','');
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES
+		  ('pkg/funcs/D1','d1.go','function_declaration',10,20,5,0,9,1),
+		  ('pkg/funcs/D2','d2.go','function_declaration',30,40,15,0,19,1),
+		  ('pkg/funcs/D3','d3.go','function_declaration',50,60,25,0,29,1);
+	`)
+	require.NoError(t, err)
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{"rule": "dead_code"}))
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+	var resp struct {
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Len(t, resp.Findings, 3)
+	for _, f := range resp.Findings {
+		assert.Greater(t, f.Line, 1, "finding %s must be located across chunk boundaries", f.NodeID)
+	}
+}
+
+// TestFindSmells_DigestTruncatedReflectsScanNotFilter asserts Truncated is
+// computed from the pre-filter scan size, not the post-threshold count (Copilot
+// review on PR #434). With the cap forced to 2, long_function scans 2 rows
+// (capped) but the >=81 threshold drops it to 1 — Truncated must stay true so
+// callers know the count is incomplete.
+func TestFindSmells_DigestTruncatedReflectsScanNotFilter(t *testing.T) {
+	orig := digestScanCap
+	digestScanCap = 2
+	defer func() { digestScanCap = orig }()
+
+	tg := seedSmellAST(t)
+	defer func() { _ = tg.db.Close() }()
+	_, err := tg.db.Exec(`
+		INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES
+		  ('a.go/long',  'a.go', 'function_declaration', 0, 5000, 10, 0, 210, 0),
+		  ('b.go/short', 'b.go', 'function_declaration', 0, 800,  10, 0, 60, 0);
+	`)
+	require.NoError(t, err)
+
+	d, err := buildSmellDigest(tg, 5, 10)
+	require.NoError(t, err)
+	var lf *ruleDigest
+	for i := range d.ByRule {
+		if d.ByRule[i].Rule == "long_function" {
+			lf = &d.ByRule[i]
+		}
+	}
+	require.NotNil(t, lf, "long_function in digest")
+	assert.Equal(t, 1, lf.Count, "only the 200-line fn passes the >=81 threshold")
+	assert.True(t, lf.Truncated, "scan hit the cap (2) even though the filter dropped the count to 1")
+}
+
 // TestFindSmells_DuplicateDefinitionsBackfillsFileFromAST asserts the
 // source_id (file) backfill path: duplicate_definitions resolves source_id from
 // nodes.source_file, which is empty for a construct dir whose leaves carry the

--- a/cmd/smell_digest.go
+++ b/cmd/smell_digest.go
@@ -9,7 +9,7 @@ import (
 // count is exact in practice; when a rule does hit the cap the digest marks it
 // truncated rather than silently undercounting (the exact failure mode the
 // tiered response exists to avoid).
-const digestScanCap = 10000
+var digestScanCap = 10000
 
 // ruleDigest is the L1 summary for one rule: how many findings, a handful of
 // the worst (highest-metric) exemplars with real locations, and whether the
@@ -67,6 +67,11 @@ func buildSmellDigest(qg refsQuerier, worstN, fileTopN int) (smellDigest, error)
 		if err != nil {
 			return smellDigest{}, err
 		}
+		// Capture whether the SCAN hit the cap before any metric filtering —
+		// otherwise a rule whose default threshold drops the result below the
+		// cap would mis-report Truncated=false while the underlying scan was
+		// actually capped (and Count understated).
+		scannedAtCap := len(findings) >= digestScanCap
 		// Apply the rule's default metric threshold so the digest counts match
 		// what a bare `rule=<id>` call would surface (which also applies it).
 		if rule.DefaultMinMetric > 0 {
@@ -96,7 +101,7 @@ func buildSmellDigest(qg refsQuerier, worstN, fileTopN int) (smellDigest, error)
 		rd := ruleDigest{
 			Rule:      rule.ID,
 			Count:     len(findings),
-			Truncated: len(findings) >= digestScanCap,
+			Truncated: scannedAtCap,
 		}
 		for j := 0; j < worstN && j < len(findings); j++ {
 			rd.Worst = append(rd.Worst, findings[j])

--- a/cmd/smell_digest.go
+++ b/cmd/smell_digest.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"sort"
+)
+
+// digestScanCap bounds how many findings each rule contributes to a digest
+// scan. Far above any rule's realistic finding count on a single repo, so the
+// count is exact in practice; when a rule does hit the cap the digest marks it
+// truncated rather than silently undercounting (the exact failure mode the
+// tiered response exists to avoid).
+const digestScanCap = 10000
+
+// ruleDigest is the L1 summary for one rule: how many findings, a handful of
+// the worst (highest-metric) exemplars with real locations, and whether the
+// scan was truncated at the cap.
+type ruleDigest struct {
+	Rule      string         `json:"rule"`
+	Count     int            `json:"count"`
+	Truncated bool           `json:"truncated,omitempty"`
+	Worst     []smellFinding `json:"worst,omitempty"`
+}
+
+// fileCount is one row of the by-file rollup.
+type fileCount struct {
+	File  string `json:"file"`
+	Count int    `json:"count"`
+}
+
+// smellDigest is the L1 "shape without weight" response: total + per-rule
+// counts + per-file rollup + a few worst exemplars per rule, instead of a flat
+// (capped) dump of every finding. Drill down to L2 with `rule=<id>` (optionally
+// `source_id=<file>`), which returns the full findings for that slice with the
+// real _ast locations enrichLocations backfills.
+type smellDigest struct {
+	Total     int          `json:"total"`
+	Rules     int          `json:"rules_scanned"`
+	Skipped   []string     `json:"rules_skipped,omitempty"` // tables not present on this backend
+	ByRule    []ruleDigest `json:"by_rule"`
+	ByFileTop []fileCount  `json:"by_file_top,omitempty"`
+	DrillHelp string       `json:"drill_help"`
+}
+
+// buildSmellDigest runs every registered rule whose Requires tables are present
+// and rolls the findings up into an L1 digest. Rules whose tables are absent are
+// reported in Skipped rather than erroring — the same graceful-degradation the
+// per-rule pre-flight uses.
+func buildSmellDigest(qg refsQuerier, worstN, fileTopN int) (smellDigest, error) {
+	d := smellDigest{
+		DrillHelp: "drill down with rule=<id> (+ optional source_id=<file>) for the full findings of one rule, each with its real file:line from _ast.",
+	}
+	byFile := map[string]int{}
+
+	for i := range smellRegistry {
+		rule := &smellRegistry[i]
+		missing, err := missingTables(qg, rule.Requires)
+		if err != nil {
+			return smellDigest{}, err
+		}
+		if len(missing) > 0 {
+			d.Skipped = append(d.Skipped, rule.ID)
+			continue
+		}
+		d.Rules++
+
+		findings, err := runSmellRule(qg, rule, "", digestScanCap)
+		if err != nil {
+			return smellDigest{}, err
+		}
+		// Apply the rule's default metric threshold so the digest counts match
+		// what a bare `rule=<id>` call would surface (which also applies it).
+		if rule.DefaultMinMetric > 0 {
+			kept := findings[:0]
+			for _, f := range findings {
+				if f.Metric >= rule.DefaultMinMetric {
+					kept = append(kept, f)
+				}
+			}
+			findings = kept
+		}
+		if len(findings) == 0 {
+			continue
+		}
+
+		// Worst-first by metric (ties broken by file then line for stability).
+		sort.Slice(findings, func(a, b int) bool {
+			if findings[a].Metric != findings[b].Metric {
+				return findings[a].Metric > findings[b].Metric
+			}
+			if findings[a].SourceID != findings[b].SourceID {
+				return findings[a].SourceID < findings[b].SourceID
+			}
+			return findings[a].Line < findings[b].Line
+		})
+
+		rd := ruleDigest{
+			Rule:      rule.ID,
+			Count:     len(findings),
+			Truncated: len(findings) >= digestScanCap,
+		}
+		for j := 0; j < worstN && j < len(findings); j++ {
+			rd.Worst = append(rd.Worst, findings[j])
+		}
+		d.ByRule = append(d.ByRule, rd)
+		d.Total += len(findings)
+		for _, f := range findings {
+			if f.SourceID != "" {
+				byFile[f.SourceID]++
+			}
+		}
+	}
+
+	// Stable per-rule order: worst (highest count) first.
+	sort.Slice(d.ByRule, func(a, b int) bool {
+		if d.ByRule[a].Count != d.ByRule[b].Count {
+			return d.ByRule[a].Count > d.ByRule[b].Count
+		}
+		return d.ByRule[a].Rule < d.ByRule[b].Rule
+	})
+
+	d.ByFileTop = topFiles(byFile, fileTopN)
+	return d, nil
+}
+
+// topFiles returns the n files with the most findings, count-descending then
+// path-ascending for stability.
+func topFiles(byFile map[string]int, n int) []fileCount {
+	out := make([]fileCount, 0, len(byFile))
+	for f, c := range byFile {
+		out = append(out, fileCount{File: f, Count: c})
+	}
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].Count != out[b].Count {
+			return out[a].Count > out[b].Count
+		}
+		return out[a].File < out[b].File
+	})
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}

--- a/cmd/smell_findings.go
+++ b/cmd/smell_findings.go
@@ -84,9 +84,16 @@ func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) (
 	// Release the connection before the enrichment query so we don't hold
 	// two open cursors on a single-connection backend.
 	_ = rows.Close()
-	enrichLocations(qg, out)
+	if err := enrichLocations(qg, out); err != nil {
+		return nil, err
+	}
 	return out, nil
 }
+
+// enrichLocChunk bounds the _ast IN(...) lookup batch size, kept well under
+// SQLite's default 999 bound-variable limit so a rule returning thousands of
+// findings can't blow the query (var for test injection).
+var enrichLocChunk = 900
 
 // enrichLocations backfills byte/line/column on findings whose rule left them
 // at the zero-location default. The node_defs-based rules (dead_code,
@@ -97,7 +104,7 @@ func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) (
 // standalone tree-sitter backend) — the query errors and findings keep their
 // file-level location, an honest degradation. _ast-native rules (long_function,
 // cyclomatic, …) already compute a span in SQL and are left untouched.
-func enrichLocations(qg refsQuerier, findings []smellFinding) {
+func enrichLocations(qg refsQuerier, findings []smellFinding) error {
 	needsLoc := func(f smellFinding) bool { return f.StartByte == 0 && f.Line <= 1 }
 	ids := make([]string, 0)
 	seen := make(map[string]bool)
@@ -112,19 +119,19 @@ func enrichLocations(qg refsQuerier, findings []smellFinding) {
 		}
 	}
 	if len(ids) == 0 {
-		return
+		return nil
 	}
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
-	q := "SELECT node_id, source_id, start_byte, end_byte, start_row, start_col FROM _ast WHERE node_id IN (" + placeholders + ")"
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
-	}
-	rows, err := qg.QueryRefs(q, args...)
+	// _ast is absent on the standalone tree-sitter backend — that's an
+	// expected no-op, not an error. Probe once (rather than string-matching a
+	// "no such table" failure) so that any error from the chunked lookups below
+	// is a genuine query failure we must surface, not silent location loss.
+	hasAST, err := tableHasColumn(qg, "_ast", "node_id")
 	if err != nil {
-		return // _ast absent (no such table) → leave file-level locations
+		return fmt.Errorf("enrich locations: probe _ast: %w", err)
 	}
-	defer func() { _ = rows.Close() }()
+	if !hasAST {
+		return nil
+	}
 
 	type loc struct {
 		sourceID           string
@@ -132,17 +139,42 @@ func enrichLocations(qg refsQuerier, findings []smellFinding) {
 		startRow, startCol int
 	}
 	byNode := make(map[string]loc, len(ids))
-	for rows.Next() {
-		var (
-			id, srcID        string
-			sb, eb           int
-			startRow, startC sql.NullInt64
-		)
-		if err := rows.Scan(&id, &srcID, &sb, &eb, &startRow, &startC); err != nil {
-			return
+	// Chunk the IN(...) list under SQLite's bound-variable limit so a large
+	// finding set can't fail the lookup (and silently revert to line:1).
+	for start := 0; start < len(ids); start += enrichLocChunk {
+		end := min(start+enrichLocChunk, len(ids))
+		batch := ids[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		q := "SELECT node_id, source_id, start_byte, end_byte, start_row, start_col FROM _ast WHERE node_id IN (" + placeholders + ")"
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
 		}
-		byNode[id] = loc{srcID, sb, eb, int(startRow.Int64), int(startC.Int64)}
+		rows, err := qg.QueryRefs(q, args...)
+		if err != nil {
+			// _ast exists (probed above) yet the lookup failed — a real error
+			// (e.g. too-many-variables); surface it instead of swallowing.
+			return fmt.Errorf("enrich locations: _ast lookup: %w", err)
+		}
+		for rows.Next() {
+			var (
+				id, srcID        string
+				sb, eb           int
+				startRow, startC sql.NullInt64
+			)
+			if err := rows.Scan(&id, &srcID, &sb, &eb, &startRow, &startC); err != nil {
+				_ = rows.Close()
+				return fmt.Errorf("enrich locations: scan: %w", err)
+			}
+			byNode[id] = loc{srcID, sb, eb, int(startRow.Int64), int(startC.Int64)}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("enrich locations: rows: %w", err)
+		}
+		_ = rows.Close()
 	}
+
 	for i := range findings {
 		l, ok := byNode[findings[i].NodeID]
 		if !ok {
@@ -161,6 +193,7 @@ func enrichLocations(qg refsQuerier, findings []smellFinding) {
 			findings[i].SourceID = l.sourceID
 		}
 	}
+	return nil
 }
 
 // populateSnippets fills the Snippet field on each finding. We batch by

--- a/cmd/smell_findings.go
+++ b/cmd/smell_findings.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -77,7 +78,89 @@ func runSmellRule(qg refsQuerier, rule *SmellRule, sourceID string, limit int) (
 			Metric:    metric,
 		})
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	// Release the connection before the enrichment query so we don't hold
+	// two open cursors on a single-connection backend.
+	_ = rows.Close()
+	enrichLocations(qg, out)
+	return out, nil
+}
+
+// enrichLocations backfills byte/line/column on findings whose rule left them
+// at the zero-location default. The node_defs-based rules (dead_code,
+// duplicate_definitions, god_file, fan_out_skew, untested_function) emit
+// `0 AS start_byte` in SQL because node_defs/nodes don't carry spans — but the
+// span already ships in _ast keyed by node_id (mache-ae54d8). One batched
+// lookup patches every still-zero finding. No-op when _ast is absent (the
+// standalone tree-sitter backend) — the query errors and findings keep their
+// file-level location, an honest degradation. _ast-native rules (long_function,
+// cyclomatic, …) already compute a span in SQL and are left untouched.
+func enrichLocations(qg refsQuerier, findings []smellFinding) {
+	needsLoc := func(f smellFinding) bool { return f.StartByte == 0 && f.Line <= 1 }
+	ids := make([]string, 0)
+	seen := make(map[string]bool)
+	for i := range findings {
+		f := findings[i]
+		if f.NodeID == "" || (!needsLoc(f) && f.SourceID != "") {
+			continue // already fully located, or no node_id to key on
+		}
+		if !seen[f.NodeID] {
+			seen[f.NodeID] = true
+			ids = append(ids, f.NodeID)
+		}
+	}
+	if len(ids) == 0 {
+		return
+	}
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
+	q := "SELECT node_id, source_id, start_byte, end_byte, start_row, start_col FROM _ast WHERE node_id IN (" + placeholders + ")"
+	args := make([]any, len(ids))
+	for i, id := range ids {
+		args[i] = id
+	}
+	rows, err := qg.QueryRefs(q, args...)
+	if err != nil {
+		return // _ast absent (no such table) → leave file-level locations
+	}
+	defer func() { _ = rows.Close() }()
+
+	type loc struct {
+		sourceID           string
+		startByte, endByte int
+		startRow, startCol int
+	}
+	byNode := make(map[string]loc, len(ids))
+	for rows.Next() {
+		var (
+			id, srcID        string
+			sb, eb           int
+			startRow, startC sql.NullInt64
+		)
+		if err := rows.Scan(&id, &srcID, &sb, &eb, &startRow, &startC); err != nil {
+			return
+		}
+		byNode[id] = loc{srcID, sb, eb, int(startRow.Int64), int(startC.Int64)}
+	}
+	for i := range findings {
+		l, ok := byNode[findings[i].NodeID]
+		if !ok {
+			continue
+		}
+		// Backfill the span only when the rule left it zero (don't clobber
+		// SQL-computed spans from _ast-native rules).
+		if needsLoc(findings[i]) {
+			findings[i].StartByte = l.startByte
+			findings[i].EndByte = l.endByte
+			findings[i].Line = l.startRow + 1
+			findings[i].Column = l.startCol + 1
+		}
+		// Backfill the file when the rule's source_file fallback was empty.
+		if findings[i].SourceID == "" {
+			findings[i].SourceID = l.sourceID
+		}
+	}
 }
 
 // populateSnippets fills the Snippet field on each finding. We batch by


### PR DESCRIPTION
Two usability fixes so `find_smells` is actually adoptable — surfaced while building a cross-repo debt baseline (the MCP tool dumped 200 unactionable rows into context). Closes the core of `mache-ae54d8`.

## FIX 1 — real locations (`e8aa0db`)
The `node_defs`-based rules (`dead_code`, `duplicate_definitions`, `god_file`, `fan_out_skew`, `untested_function`) hardcoded `0 AS start_byte/end_byte/start_row/start_col` in SQL because `node_defs`/`nodes` carry no spans — so findings came back `line:1, byte:0`, and (when the `source_file` fallback was empty) with **no file at all**. Un-actionable.

The span already ships in `_ast` keyed by `node_id`. `enrichLocations()` does one batched lookup after the rule scan and backfills byte/line/column + `source_id`. No-op when `_ast` is absent (standalone tree-sitter backend) → honest file-level degradation. `_ast`-native rules untouched. Also fixes snippet extraction (correct byte ranges).

Verified end-to-end on a leyline-parsed db: `duplicate_definitions` goes from `:1:1` → `dense.go:42:1`.

## FIX 2 — L1 digest (`d7e0ec1`)
The MCP tool dumped up to 200 raw findings (default limit), mostly noise. Paging would only reintroduce the per-call round-trip tax ADR-0016 exists to kill. Instead, a tiered response mirroring continuity's memory tree ("shape without weight"):

- `rule=*` → **L1 digest**: per-rule counts + per-file rollup + worst-by-metric exemplars (each with the real `_ast` location), bounded regardless of debt size. Start here on an unfamiliar repo.
- `rule=<id>` (+ optional `source_id=`) → **L2**: full findings for one slice, located.
- `rule=''` → unchanged rule listing (discovery).

Rules whose `Requires` tables are absent are reported in `rules_skipped`, not errored. Non-breaking; discovery help documents the three tiers.

## Tests / verification
- 3 new TDD tests: location backfill (`dead_code`), file backfill (`duplicate_definitions`), digest mode.
- Full `cmd` suite green (202s), `go vet` clean, `golangci-lint` 0 issues.

## Deferred (non-blocking)
- L3 single-node detail tier (`node_id=`) — marginal; L2 already carries locations.
- CLI `--rule '*'` digest parity — CLI keeps the legacy glob (flat `ci` output, correct for grep/CI); the digest is the agent/MCP affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)