### PR TITLE
docs: smell-debt baseline 2026-06-24 (Go-accurate; cross-repo blocked on Rust parsing)

### DIFF
--- a/docs/smell-debt-baseline-2026-06-24.md
+++ b/docs/smell-debt-baseline-2026-06-24.md
@@ -1,0 +1,90 @@
+# Smell-debt baseline — 2026-06-24
+
+First measured snapshot of structural smell debt across the ART repos, the
+input the advisory→enforced **ratchet** will eventually grandfather. Produced
+with `mache find-smells` (commit `dac8ac5`) over leyline-parsed `.db`s.
+
+> **Headline:** the baseline is **Go-only**. The non-Go repos are not parseable
+> by the current tooling, so they are invisible to the smell engine — see
+> [the blocker](#the-cross-repo-blocker) (`mache-048fb6`). "Standardize across
+> repos" has an unmet prerequisite.
+
+## Method
+
+- `mache build <repo> <db>` (leyline backend → full `_ast` + `node_defs`/`node_refs`).
+- `mache find-smells --db <db> --rule '*' --limit 10000 --fail-on=none --format=ci`
+  — every rule, uncapped (the default 200 cap silently understates; raised here).
+- Counts **denoised** of generated / vendored / test-snapshot paths
+  (`testdata/`, `/target/`, `node_modules/`, `*_generated.go`, `*.pb.go`,
+  `*.capnp.go`, `.gen.`, `_agent_log`, `/dist/`).
+- Locations are real (`file:line`) as of `dac8ac5` — earlier runs reported
+  `:1:1` on the `node_defs` rules.
+
+## Go repos (accurate)
+
+| Repo  | Files | Denoised findings |
+| ----- | ----- | ----------------- |
+| mache | 896   | 4568              |
+| assay | 27    | 172               |
+
+### Per-rule
+
+| Rule                      | mache | assay | Read                                                                                                                                              |
+| ------------------------- | ----: | ----: | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cyclomatic_complexity`   |  2929 |   111 | **noisy** — one per control-flow node; meaningless without `min_metric` (≥10 noteworthy, ≥20 review). Not 2929 problems.                          |
+| `magic_int_in_comparison` |  1098 |    36 | **noisy** — every int-literal comparison; inherently high, needs curation.                                                                        |
+| `duplicate_definitions`   |   439 |    24 | **FP-inflated** — dominated by interface methods implemented by N types colliding on the bare token (known; see `mache-409569` / `mache-40ae5c`). |
+| `long_function`           |    99 |     1 | **actionable** — bodies >80 lines. mache's real sprawl signal.                                                                                    |
+| `long_file`               |     3 |     0 | **actionable** — all three are *test* files (`serve_test.go` 3076, `serve_find_smells_test.go` 3365, `socket_test.go` 1578).                      |
+| `god_file`                |     0 |     0 | clean — no file ≥10 defs AND >3× mean.                                                                                                            |
+| `dead_code`               |     0 |     0 | clean.                                                                                                                                            |
+| `fan_out_skew`            |     0 |     0 | clean.                                                                                                                                            |
+| `untested_function`       |     0 |     0 | clean (static proxy).                                                                                                                             |
+| `sleep_in_test`           |     0 |     0 | clean.                                                                                                                                            |
+
+### Truth vs. assumption
+
+The "god files everywhere" intuition is **falsified** for the Go repos:
+`god_file` / `fan_out_skew` = 0. The sprawl that exists wears the mask of **long
+functions** (99 in mache — hotspots: `engine_walk.go` 325-line method,
+`engine_languages.go` 253, `engine_treesitter.go` 232) and **giant test files**,
+not god-files-by-def-count. mache is also the *best*-tended repo (it hosts the
+engine, just finished the S-slice refactors).
+
+### Top files by finding count (denoised)
+
+- **mache**: `cmd/serve_test.go` (182), `tools/coverage-gate/main_test.go` (88),
+  `cmd/serve_find_smells_test.go` (84), `internal/leyline/socket_test.go` (69),
+  `cmd/serve_registry.go` (64) — test files dominate; the lone non-test in the
+  top band is `serve_registry.go`.
+- **assay**: `internal/embeddings/dense.go` (19), `internal/coverage/tokenize.go`
+  (18), `internal/docs/extract.go` (14), `internal/code/extract.go` (13).
+
+## The cross-repo blocker
+
+`mache-048fb6` (P1). Verified 2026-06-24:
+
+- **leyline 0.4.5 does not parse Rust.** `mache build` on a 7-file Rust crate
+  ingested **0** `.rs` files (only markdown). rosary (9 crates),
+  ley-line-open (105 crates), cloister (4 crates + TS) are unmeasured.
+- **`--backend tree-sitter` ingests Rust files but extracts 0 defs** — the
+  28-language registry has the grammar, but the default FCA build produces no
+  symbol defs/refs without a per-language def/ref schema, so every `node_defs`
+  rule returns nothing.
+
+Until one of these is closed, cross-repo standardization is Go-only:
+
+- (a) leyline gains Rust (+JS/TS) parsing → emits `_ast`/`node_defs` like Go (preferred — unifies on the LLO substrate);
+- (b) author tree-sitter def/ref schemas (`examples/rust-schema.json`, `ts-schema.json`) so the standalone backend extracts defs;
+- (c) both — schema as the standalone floor, leyline as the enriched tier (the fidelity-ladder pattern).
+
+## Next steps
+
+1. **Unblock non-Go parsing** (`mache-048fb6`) — prerequisite for any cross-repo claim.
+1. **Tune the noisy rules** — `cyclomatic`/`magic_int` need default `min_metric`s or
+   they drown the digest; `duplicate_definitions` FP class is `mache-409569`/`mache-40ae5c`.
+1. **Build the ratchet** — once counts are trustworthy and stable, snapshot a
+   per-repo baseline file and gate on *new* findings (advisory→enforced).
+1. **Burn down** the actionable Go set — 99 long functions, 3 long test files.
+
+_Generated from `mache find-smells`. Re-run `task install && /tmp/baseline_go.sh` to refresh._

--- a/docs/smell-debt-baseline-2026-06-24.md
+++ b/docs/smell-debt-baseline-2026-06-24.md
@@ -4,10 +4,13 @@ First measured snapshot of structural smell debt across the ART repos, the
 input the advisory→enforced **ratchet** will eventually grandfather. Produced
 with `mache find-smells` (commit `dac8ac5`) over leyline-parsed `.db`s.
 
-> **Headline:** the baseline is **Go-only**. The non-Go repos are not parseable
-> by the current tooling, so they are invisible to the smell engine — see
-> [the blocker](#the-cross-repo-blocker) (`mache-048fb6`). "Standardize across
-> repos" has an unmet prerequisite.
+> **Headline:** this snapshot is **Go-only** — but the cross-repo gap is
+> narrower than it looks. A *current* leyline parses Rust into a full `_ast`
+> (the installed binary is just stale); the genuine missing piece is **Rust
+> def/ref extraction** (`node_defs`), which is Go-only in LLO today. So the
+> structural rules can't yet run on Rust/TS — see
+> [the blocker](#the-cross-repo-blocker). One LLO function (`extract_rust`) plus
+> cross-lang rule generalization unlocks it.
 
 ## Method
 
@@ -62,29 +65,40 @@ engine, just finished the S-slice refactors).
 
 ## The cross-repo blocker
 
-`mache-048fb6` (P1). Verified 2026-06-24:
+The gap is narrower than a first pass suggested. Corrected against **current LLO
+source** (not the stale installed binary), 2026-06-24:
 
-- **leyline 0.4.5 does not parse Rust.** `mache build` on a 7-file Rust crate
-  ingested **0** `.rs` files (only markdown). rosary (9 crates),
-  ley-line-open (105 crates), cloister (4 crates + TS) are unmeasured.
-- **`--backend tree-sitter` ingests Rust files but extracts 0 defs** — the
-  28-language registry has the grammar, but the default FCA build produces no
-  symbol defs/refs without a per-language def/ref schema, so every `node_defs`
-  rule returns nothing.
+- **leyline _does_ parse Rust.** The `rust` cargo feature (added 2026-06-22,
+  pulled transitively by the default `hdc` feature) wires `tree-sitter-rust`. A
+  binary built from current source parses a 7-file crate into a full `_ast`
+  (743 identifiers, 181 call-expressions, function nodes). The earlier "0 files"
+  result was the **stale `~/.local/bin/leyline` (May-23 build, pre-`rust`-feature)** —
+  an install-currency problem, not a capability gap. **Action: rebuild + install
+  current leyline.**
+- **The real gap is def/ref extraction, which is Go-only.** On a current build,
+  Rust `node_defs = 0` while Go = 49. `rs/ll-open/ts/src/refs.rs` matches on
+  language with a single `TsLanguage::Go => extract_go(...)` arm; the file's own
+  doc says *"add new languages by adding a match arm + an `extract_<lang>`
+  function."* So Rust gets AST but no symbols → the `node_defs` rules
+  (`god_file`/`dead_code`/`duplicate_definitions`/`fan_out_skew`/`untested_function`)
+  return nothing. **This is an LLO bead: write `extract_rust`** (`ley-line-open-…`).
+- **Several rules are Go-language-gated.** `cyclomatic_complexity` /
+  `long_function` / `magic_int_in_comparison` carry `languages: ["go"]`, so they
+  won't fire on Rust even though the AST has the nodes (`function_item`,
+  `if_expression`, …). Cross-lang generalization is a mache concern (`mache-048fb6`).
 
-Until one of these is closed, cross-repo standardization is Go-only:
-
-- (a) leyline gains Rust (+JS/TS) parsing → emits `_ast`/`node_defs` like Go (preferred — unifies on the LLO substrate);
-- (b) author tree-sitter def/ref schemas (`examples/rust-schema.json`, `ts-schema.json`) so the standalone backend extracts defs;
-- (c) both — schema as the standalone floor, leyline as the enriched tier (the fidelity-ladder pattern).
+What **already works for Rust** on a current leyline: cross-lang `_ast` rules —
+`long_file` correctly lists `round_trip.rs`, `projection.rs`, etc. So the moment
+`extract_rust` lands (and the metric rules generalize), rosary (9 crates),
+ley-line-open (105), and cloister (4 + TS) become measurable.
 
 ## Next steps
 
-1. **Unblock non-Go parsing** (`mache-048fb6`) — prerequisite for any cross-repo claim.
-1. **Tune the noisy rules** — `cyclomatic`/`magic_int` need default `min_metric`s or
-   they drown the digest; `duplicate_definitions` FP class is `mache-409569`/`mache-40ae5c`.
-1. **Build the ratchet** — once counts are trustworthy and stable, snapshot a
-   per-repo baseline file and gate on *new* findings (advisory→enforced).
+1. **Install current leyline** — the May-23 binary predates Rust support.
+1. **`extract_rust` in LLO** (`ts/src/refs.rs`) → Rust `node_defs`/`node_refs`; unblocks the structural rules cross-repo.
+1. **Generalize the Go-gated metric rules** cross-lang (`mache-048fb6`) — the Rust/JS AST nodes exist; the rules just need non-Go arms.
+1. **Tune the noisy rules** — `cyclomatic`/`magic_int` need default `min_metric`s; `duplicate_definitions` FP class is `mache-409569`/`mache-40ae5c`.
+1. **Build the ratchet** — once counts are trustworthy + cross-repo, snapshot a per-repo baseline and gate on *new* findings (advisory→enforced).
 1. **Burn down** the actionable Go set — 99 long functions, 3 long test files.
 
 _Generated from `mache find-smells`. Re-run `task install && /tmp/baseline_go.sh` to refresh._


### PR DESCRIPTION
First measured snapshot of structural smell debt across the ART repos — the input the advisory→enforced **ratchet** will grandfather. Dogfoods the `find_smells` location + digest work from #434.

## Headline — Go-only
Non-Go repos can't be parsed by current tooling, so they're invisible to the smell engine (`mache-048fb6`, P1):
- **leyline 0.4.5 doesn't parse Rust** — `mache build` on a 7-file crate ingested 0 `.rs` files (markdown only). rosary (9 crates), ley-line-open (105), cloister (4 + TS) unmeasured.
- **`--backend tree-sitter` ingests Rust files but extracts 0 defs** (no per-language def/ref schema).

## Go truth (mache 896 files, assay 27)
- `god_file` / `dead_code` / `fan_out_skew` / `untested_function` = **0** across both — the "god files everywhere" intuition is **falsified**.
- Real sprawl = **`long_function`** (99 in mache) + **giant test files** (3 long files, all tests).
- `cyclomatic` (2929) / `magic_int` (1098) = per-expression noise needing thresholds; `duplicate_definitions` (439) is interface-method FP-inflated (`mache-409569` / `mache-40ae5c`).

## Method
`mache build` (leyline) → `find-smells --rule '*' --limit 10000` (uncapped) → denoised of generated/vendored/test-snapshot paths. Real `file:line` as of `dac8ac5`.

## Next
Unblock non-Go parsing (`mache-048fb6`) → tune noisy rules → build the ratchet → burn down 99 long functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)