### PR TITLE
chore(deps): pin leyline-schema to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.4.6-0.20260523221739-5ee058ebf3e1
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.4.6-0.20260523221739-5ee058ebf3e1 h1:ZkDDsqmG1h/Fc0pgBO56EXmhRmOBtiV8xRMGUBjHES0=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.4.6-0.20260523221739-5ee058ebf3e1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0 h1:uG172a7v0dzk4kgDy8ljKRhOVZObA8S9jWiEEdZ0uPU=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -655,18 +655,21 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, go.mod tracks leyline-schema v0.4.6-pre and the latest
-// release with binary assets is v0.4.5. The Go schema-client and the daemon
+// As of this pin, go.mod tracks leyline-schema v0.5.0 and the matching
+// release with binary assets is v0.5.0. The Go schema-client and the daemon
 // binary travel together — mache built against schema vX.Y.Z must run a daemon
-// at the same major/minor or it will mis-decode the wire format. v0.4.5 also
-// satisfies mache's v0.4.3+ requirement for daemon-pushed sheaf cascades and,
-// unlike v0.4.1, ships a leyline-darwin-amd64 asset (Intel macs 404'd before).
+// at the same major/minor or it will mis-decode the wire format. v0.5.0 ships
+// all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64),
+// including leyline-darwin-amd64 for Intel macs. (The release omits the
+// libleyline_fs-darwin-amd64 *staticlib*, but mache doesn't link the cgo FFI —
+// internal/leyline/client.go is //go:build leyline, off in releases — so the
+// download path is unaffected.)
 //
 // BUMP THIS WHEN UPDATING leyline-schema in go.mod to a newer published tag.
 //
 // Future hardening (mache-8kif): on socket connect, query the daemon's
 // `version` op and refuse to proceed if it disagrees with this constant.
-const leylineBinaryVersion = "v0.4.5"
+const leylineBinaryVersion = "v0.5.0"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
Bumps `github.com/agentic-research/ley-line-open/clients/go/leyline-schema` from the May-23 pre-release pseudo-version (`v0.4.6-0.20260523…`) to the tagged **`v0.5.0`** release.

- **Pure-Go schema client — zero cgo.** This is the wire/schema types mache compiles against; it does not touch the cgo FFI path (`internal/leyline/client.go`, `//go:build leyline`, off in releases).
- The clean `@v0.5.0` resolve was gated on LLO publishing the **nested** module tag `clients/go/leyline-schema/v0.5.0` alongside the root `v0.5.0` (now on proxy.golang.org).
- `go build ./...`, `go vet`, and `internal/leyline` tests green locally; CI gates the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)