### PR TITLE
feat(version): git-derive the binary version + enforce tag==base at release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,15 @@ jobs:
         run: |
           # TAG can originate from repository_dispatch client_payload (attacker-
           # settable), so validate its shape before it's used anywhere — reject
-          # anything that isn't a clean semver tag. Passed via env (not inline
-          # ${{ }}) to avoid shell injection.
-          if [ -n "${TAG}" ] && ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
-            echo "::error::invalid release tag '${TAG}' — expected vMAJOR.MINOR.PATCH"
+          # anything that isn't a clean semver release tag (no pre-release/build
+          # suffix; release tags are always vMAJOR.MINOR.PATCH and must equal the
+          # clean version.txt base checked below). Passed via env (not inline
+          # ${{ }}). The error message does NOT echo the raw TAG: pre-validation
+          # it may contain a CR/newline that would break out of the ::error::
+          # workflow command (workflow-command injection). After this gate TAG is
+          # known clean, so the mismatch error below can safely include it.
+          if [ -n "${TAG}" ] && ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::release tag failed validation — expected a clean semver tag like v0.10.0 (no pre-release or build suffix)"
             exit 1
           fi
           # Release-honesty gate: the tag must match the clean release base in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           lfs: true
+          # Full history + tags so `git describe` works for the dev fallback.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
@@ -58,18 +60,39 @@ jobs:
 
       - name: Build mache
         # CGO on for the tree-sitter grammars only (they carry their own #cgo
-        # directives). No external libs, no FUSE, no sudo. Version is
-        # single-sourced from embedded internal/buildinfo; only Commit/Date
-        # come via ldflags.
+        # directives). No external libs, no FUSE, no sudo. The binary's
+        # cmd.Version is injected from the release TAG so it matches the tag
+        # exactly; the CLEAN release base in internal/buildinfo (version.txt)
+        # is what server.json + melange derive from — gated to agree below.
         env:
           CGO_ENABLED: '1'
+          TAG: ${{ env.TAG }}
         run: |
+          # TAG can originate from repository_dispatch client_payload (attacker-
+          # settable), so validate its shape before it's used anywhere — reject
+          # anything that isn't a clean semver tag. Passed via env (not inline
+          # ${{ }}) to avoid shell injection.
+          if [ -n "${TAG}" ] && ! printf '%s' "${TAG}" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "::error::invalid release tag '${TAG}' — expected vMAJOR.MINOR.PATCH"
+            exit 1
+          fi
+          # Release-honesty gate: the tag must match the clean release base in
+          # version.txt, so we never publish a binary/package whose version
+          # disagrees with the tag. Bump internal/buildinfo/version.txt (and
+          # melange.yaml + server.json) to the new version before tagging.
+          BASE="v$(tr -d '[:space:]' < internal/buildinfo/version.txt)"
+          if [ -n "${TAG}" ] && [ "${TAG}" != "${BASE}" ]; then
+            echo "::error::release tag ${TAG} != version.txt ${BASE} — bump internal/buildinfo/version.txt, melange.yaml, and server.json to match the tag before releasing"
+            exit 1
+          fi
           GIT_COMMIT=$(git rev-parse --short HEAD)
           BUILD_DATE=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+          VERSION="${TAG:-$(git describe --tags --always --dirty)}"
           go build \
             -ldflags "-s -w \
               -X github.com/agentic-research/mache/cmd.Commit=${GIT_COMMIT} \
-              -X github.com/agentic-research/mache/cmd.Date=${BUILD_DATE}" \
+              -X github.com/agentic-research/mache/cmd.Date=${BUILD_DATE} \
+              -X github.com/agentic-research/mache/cmd.buildVersion=${VERSION}" \
             -o ${{ matrix.artifact }} .
 
       - name: Codesign (macOS)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -28,13 +28,20 @@ tasks:
         sh: git rev-parse --short HEAD 2>/dev/null || echo "none"
       BUILD_DATE:
         sh: date -u '+%Y-%m-%dT%H:%M:%SZ'
+      # Honest build version: the clean tag on a tagged build (e.g. v0.10.0),
+      # else a git-distance string (v0.9.0-9-gabc1234), else the version.txt
+      # base when git is unavailable. cmd.Version strips the leading "v".
+      GIT_VERSION:
+        sh: git describe --tags --always --dirty 2>/dev/null || cat internal/buildinfo/version.txt
     cmds:
-      # Version is NOT injected here — it is the single source of truth in
-      # internal/buildinfo (embedded version.txt). Only Commit/Date, which
-      # are genuinely build-specific, come in via -ldflags.
+      # cmd.Version is injected from `git describe` so the binary's reported
+      # version tracks the built code. The CLEAN release base still lives in
+      # internal/buildinfo (version.txt); server.json + melange derive from
+      # that, not from this build string.
       - >-
         go build         -ldflags "-X github.com/agentic-research/mache/cmd.Commit={{.GIT_COMMIT}}
-        -X github.com/agentic-research/mache/cmd.Date={{.BUILD_DATE}}"
+        -X github.com/agentic-research/mache/cmd.Date={{.BUILD_DATE}}
+        -X github.com/agentic-research/mache/cmd.buildVersion={{.GIT_VERSION}}"
         -o {{.BINARY_NAME}} .
       # No leading ./ — BINARY_NAME may be an absolute path (CI overrides it,
       # e.g. find-smells builds to /tmp/mache); ./ would yield .//tmp/mache.
@@ -388,6 +395,21 @@ tasks:
     cmds:
       - go run ./tools/server-json-gen/ > server.json
       - echo "regenerated server.json"
+
+  gen:version:
+    desc: |
+      Stamp the clean release version from internal/buildinfo/version.txt into
+      the artifacts that require a stable semver — melange.yaml + server.json —
+      then verify single-sourcing. Release flow: edit version.txt, run
+      `task gen:version`, commit, tag `v<version>`. (sed not yq, so CI without
+      yq still works; the .bak dance is portable across BSD/GNU sed.)
+    cmds:
+      - |
+        VER="$(tr -d '[:space:]' < internal/buildinfo/version.txt)"
+        sed -i.bak -E "s/^  version:.*/  version: ${VER}/" melange.yaml && rm -f melange.yaml.bak
+        echo "stamped melange.yaml version: ${VER}"
+      - task: gen:server-json
+      - task: version:check
 
   gen:server-json:check:
     desc: |

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/agentic-research/mache/api"
@@ -23,14 +24,35 @@ import (
 )
 
 var (
-	// Version is the mache release version, sourced from the embedded
-	// internal/buildinfo (the single source of truth — see that package).
-	// Commit and Date are still injected at build time via -ldflags since
-	// they are genuinely build-specific; Version is not.
-	Version = buildinfo.Version
+	// Version is the binary's build version, shown by `mache version` and
+	// stamped into build artifacts (_mache_meta, the build-cache lockfile
+	// producer field, the MCP server version). `task build` and release.yml
+	// inject it from `git describe --tags` via -ldflags, so it tells the truth
+	// about the built code: a clean tag (0.10.0) on a tagged release, a
+	// git-distance string (0.9.0-9-gabc1234) between releases. A bare
+	// `go build` / `go test` (no ldflags) falls back to the clean release base
+	// in internal/buildinfo (version.txt).
+	//
+	// NOTE: server.json and melange.yaml derive from buildinfo.Version (the
+	// clean, committed, drift-checked release base) — never from this string —
+	// so a dev-distance build version can't break the server-json drift gate or
+	// produce an invalid apk package version.
+	Version = resolveBuildVersion()
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+// buildVersion is injected via
+// -ldflags "-X github.com/agentic-research/mache/cmd.buildVersion=<git describe>".
+// Empty for a bare build; see Version's doc for the fallback.
+var buildVersion string
+
+func resolveBuildVersion() string {
+	if v := strings.TrimSpace(buildVersion); v != "" {
+		return strings.TrimPrefix(v, "v")
+	}
+	return buildinfo.Version
+}
 
 var (
 	schemaPath  string

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,20 +1,24 @@
-// Package buildinfo is the single source of truth for mache's release
-// version. The version lives in version.txt (embedded at compile time) so
-// that every consumer — the binary's `mache version` output, the build-cache
-// lockfile producer field, the generated server.json, and the Wolfi/melange
-// package — derives the same value from one place.
+// Package buildinfo holds the canonical CLEAN release version for mache —
+// the committed, drift-checked base that server.json (tools/server-json-gen)
+// and the Wolfi/melange package derive from. It lives in version.txt, embedded
+// at compile time, because those artifacts need a stable, valid semver that is
+// independent of git state (an apk version can't be "0.9.0-9-gabc", and the
+// committed server.json is drift-gated in CI).
+//
+// This is NOT the string the binary reports. `mache version` shows cmd.Version,
+// which is injected from `git describe --tags` at build time (see cmd.Version),
+// so the binary tells the truth about the built code — a clean tag on a release,
+// a git-distance string between releases. version.txt is only the FALLBACK for a
+// bare `go build`/`go test` that injects no ldflags.
 //
 // Before buildinfo, the version was duplicated across at least four sites that
-// drifted independently:
+// drifted independently (cmd.Version "dev", a never-filled MacheProducerVersion
+// placeholder, server-json-gen, melange.yaml). Consolidating the clean base
+// here removed that drift.
 //
-//   - cmd.Version            "dev" (ldflags from git tag; goreleaser never
-//     injected it, so release binaries reported "dev")
-//   - cmd.MacheProducerVersion "0.x.y" (a never-filled placeholder)
-//   - server-json-gen.serverVersion "0.8.0"
-//   - melange.yaml version:  0.8.0
-//
-// To bump the version, edit version.txt and run `task version:check` to
-// confirm the git tag and melange.yaml agree.
+// To cut a release: bump version.txt to the new version, run `task gen:version`
+// (stamps melange.yaml + regenerates server.json) and `task version:check`, then
+// tag `v<version>` — release.yml gates that the tag matches this base.
 package buildinfo
 
 import (


### PR DESCRIPTION
The binary reported a flat `0.9.0` at commits past the v0.9.0 tag — the version string **lied** between releases, and nothing in the release process enforced that a release's tag matched the embedded version.

## What changed
- **`cmd.Version` is git-derived** — injected from `git describe --tags` via ldflags (`task build` + `release.yml`). The binary now tells the truth: a clean tag on a tagged release, a git-distance string (`0.9.0-9-gSHA`) between. Bare `go build`/`go test` (no ldflags) fall back to the clean base.
- **`release.yml` gates `tag == version.txt`** (fails the release on mismatch) and **semver-validates** the dispatch tag (it can originate from attacker-settable `client_payload`; passed via `env`, not inline `${{ }}`).
- **`task gen:version`** — edit `version.txt` → stamp melange + regenerate server.json + `version:check`, one command.
- **`buildinfo.go` package doc corrected** (it claimed the binary derives from `version.txt` — no longer true).

## Why `version.txt` stays (not "the weird Go way")
The clean release base stays in `internal/buildinfo/version.txt` because **`server.json`** (committed + drift-gated in CI) and **melange** (apk needs valid semver) require a *stable* semver — a git-distance string like `0.9.0-9-gabc` would break the `server-json-drift` gate and produce an invalid apk version. Those artifacts derive from `buildinfo.Version`; the **binary** is the thing that gets git-derived. The two have genuinely different requirements, which is exactly why one file can't serve both.

## Release flow now
```
edit internal/buildinfo/version.txt → task gen:version → commit → tag v<version>
# release.yml: gate tag==base, inject cmd.Version from the tag, build + publish
```

## Verification
`go vet`, `task version:check`, `task gen:version` (idempotent — no spurious changes at 0.9.0), and `cmd`/`buildinfo` tests all green. Bare build → `0.9.0`; ldflags build → `0.9.0-9-gSHA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)