### PR TITLE
feat(smell): deterministic duplicate_code rule via AST structural hashing

### DIFF
--- a/cmd/find_smells_duplicate_code_test.go
+++ b/cmd/find_smells_duplicate_code_test.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// seedDuplicateCodeAST builds an _ast fixture with three Go functions:
+//
+//   - fnA (a.go) and fnB (b.go): byte-for-byte different source, but
+//     STRUCTURALLY identical — same node_kind sequence at the same
+//     relative depths. These are a Type-2 clone (differ only in
+//     identifiers/literals, which leaf-erased structural hashing
+//     ignores). Both must be flagged.
+//   - fnC (c.go): a different shape (a for-loop instead of a bare
+//     return) — a unique structure that must NOT be flagged.
+//
+// The rule's signature is the ordered (relative_depth ':' node_kind)
+// sequence of every node in the function subtree, so fnA and fnB
+// collide and fnC does not.
+func seedDuplicateCodeAST(t *testing.T) *smellTestGraph {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "dup.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT NOT NULL, content BLOB NOT NULL);
+	`)
+	require.NoError(t, err)
+
+	for _, s := range []string{"a.go", "b.go", "c.go"} {
+		_, err = db.Exec("INSERT INTO _source VALUES (?, 'go', ?)", s, []byte("package main\n"))
+		require.NoError(t, err)
+	}
+
+	type ast struct {
+		id, src, kind string
+		s             int
+	}
+	rows := []ast{
+		// fnA — structure S1 (function/params/block/return/identifier).
+		{"a", "a.go", "function_declaration", 0},
+		{"a/params", "a.go", "parameter_list", 10},
+		{"a/body", "a.go", "block", 20},
+		{"a/body/ret", "a.go", "return_statement", 25},
+		{"a/body/ret/id", "a.go", "identifier", 30},
+		// fnB — same structure S1, different file + byte offsets.
+		{"b", "b.go", "function_declaration", 0},
+		{"b/params", "b.go", "parameter_list", 10},
+		{"b/body", "b.go", "block", 20},
+		{"b/body/ret", "b.go", "return_statement", 25},
+		{"b/body/ret/id", "b.go", "identifier", 30},
+		// fnC — different structure (for-loop, no params), unique.
+		{"c", "c.go", "function_declaration", 0},
+		{"c/body", "c.go", "block", 20},
+		{"c/body/forl", "c.go", "for_statement", 25},
+	}
+	for _, a := range rows {
+		_, err = db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, ?, ?, ?, ?, 0, 0, 0, 0)",
+			a.id, a.src, a.kind, a.s, a.s+1,
+		)
+		require.NoError(t, err)
+	}
+
+	return &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+}
+
+// TestFindSmells_DuplicateCode pins the deterministic clone-detection
+// rule: two structurally-identical function subtrees (in different
+// files, with different identifiers) are flagged as duplicate_code;
+// a structurally-distinct function is not. Detection is leaf-erased
+// AST structural hashing — pure SQL over the _ast table, no heuristic
+// token matching. min_metric=0 bypasses the default size floor so the
+// small fixture functions surface.
+func TestFindSmells_DuplicateCode(t *testing.T) {
+	tg := seedDuplicateCodeAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "duplicate_code",
+		"min_metric": 0,
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "duplicate_code should run cleanly: %s", resultText(t, res))
+
+	var resp struct {
+		Rule     string         `json:"rule"`
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	assert.Equal(t, "duplicate_code", resp.Rule)
+	require.Equal(t, 2, resp.Total, "exactly the fnA/fnB clone pair; fnC is structurally unique")
+
+	got := map[string]bool{}
+	for _, f := range resp.Findings {
+		got[f.NodeID] = true
+		assert.Equal(t, int64(5), f.Metric, "metric is the duplicated subtree node count (5)")
+	}
+	assert.True(t, got["a"], "fnA must be flagged")
+	assert.True(t, got["b"], "fnB must be flagged")
+	assert.False(t, got["c"], "fnC (unique structure) must NOT be flagged")
+}
+
+// TestFindSmells_DuplicateCode_ExcludesGenerated pins that generated
+// code is excluded from clone candidates entirely (matching every other
+// structural rule — capnp/pb/*_generated/*.gen produce wide identical
+// method sets by design). A generated function structurally identical to
+// two production functions must NOT itself be flagged, and must NOT keep
+// the production pair from being detected on their own.
+func TestFindSmells_DuplicateCode_ExcludesGenerated(t *testing.T) {
+	tg := seedDuplicateCodeAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	// Add a third structural twin of fnA/fnB, but in a generated file.
+	_, err := tg.db.Exec("INSERT INTO _source VALUES ('z.gen.go', 'go', ?)", []byte("package main\n"))
+	require.NoError(t, err)
+	// Same byte layout as fnA/fnB so z is a genuine structural twin —
+	// distinct start_bytes (10/20/25/30) reproduce the params-before-body
+	// document order; otherwise the ORDER BY tiebreak would reorder the
+	// sequence and z wouldn't collide (a vacuity trap).
+	for _, r := range []struct {
+		id, kind string
+		b        int
+	}{
+		{"z", "function_declaration", 0},
+		{"z/params", "parameter_list", 10},
+		{"z/body", "block", 20},
+		{"z/body/ret", "return_statement", 25},
+		{"z/body/ret/id", "identifier", 30},
+	} {
+		_, err = tg.db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, 'z.gen.go', ?, ?, ?, 0, 0, 0, 0)",
+			r.id, r.kind, r.b, r.b+1,
+		)
+		require.NoError(t, err)
+	}
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "duplicate_code",
+		"min_metric": 0,
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "duplicate_code should run cleanly: %s", resultText(t, res))
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	got := map[string]bool{}
+	for _, f := range resp.Findings {
+		got[f.NodeID] = true
+	}
+	assert.False(t, got["z"], "generated-file clone must NOT be flagged")
+	assert.True(t, got["a"], "production fnA still detected via its fnB pair")
+	assert.True(t, got["b"], "production fnB still detected via its fnA pair")
+	assert.Equal(t, 2, resp.Total, "only the two production clones; generated twin excluded")
+}
+
+// TestFindSmells_DuplicateCode_DefaultFloorDropsTrivial pins that the
+// rule's DefaultMinMetric (24-node floor) is load-bearing: the 5-node
+// fixture clones are real structural duplicates, but below the default
+// floor, so running WITHOUT min_metric returns nothing. This is what
+// keeps one-line accessors and matching stubs out of the default view.
+func TestFindSmells_DuplicateCode_DefaultFloorDropsTrivial(t *testing.T) {
+	tg := seedDuplicateCodeAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule": "duplicate_code", // no min_metric → DefaultMinMetric=24 applies
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "duplicate_code should run cleanly: %s", resultText(t, res))
+
+	var resp struct {
+		Total int `json:"total"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	assert.Equal(t, 0, resp.Total, "5-node clones are below the 24-node default floor")
+}
+
+// TestFindSmells_DuplicateCode_SourceIDScopes pins that detection is
+// GLOBAL but the returned findings are scoped: the fnA/fnB clone group
+// spans a.go and b.go, so scoping to a.go must still recognize fnA as a
+// clone (its pair lives in b.go) yet return only the a.go instance.
+func TestFindSmells_DuplicateCode_SourceIDScopes(t *testing.T) {
+	tg := seedDuplicateCodeAST(t)
+	defer func() { _ = tg.db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "duplicate_code",
+		"min_metric": 0,
+		"source_id":  "a.go",
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "duplicate_code should run cleanly: %s", resultText(t, res))
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+	require.Equal(t, 1, resp.Total, "only the a.go instance is returned, but it was detected via its b.go pair")
+	assert.Equal(t, "a", resp.Findings[0].NodeID)
+	assert.Equal(t, "a.go", resp.Findings[0].SourceID)
+}

--- a/cmd/find_smells_duplicate_code_test.go
+++ b/cmd/find_smells_duplicate_code_test.go
@@ -180,6 +180,79 @@ func TestFindSmells_DuplicateCode_ExcludesGenerated(t *testing.T) {
 	assert.Equal(t, 2, resp.Total, "only the two production clones; generated twin excluded")
 }
 
+// TestFindSmells_DuplicateCode_IgnoresComments pins that comment nodes
+// do not participate in the structural signature: two functions that are
+// identical except for an inline comment must still be detected as
+// clones (Copilot review on #442). Comments live in _ast as
+// node_kind='comment'; leaving them in the signature makes detection
+// comment-sensitive and produces false negatives that contradict the
+// rule's "comments are erased" contract.
+func TestFindSmells_DuplicateCode_IgnoresComments(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "dupcomment.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL, node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER, end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE _source (id TEXT PRIMARY KEY, language TEXT NOT NULL, content BLOB NOT NULL);
+		INSERT INTO _source VALUES ('d.go','go',x'0a'), ('e.go','go',x'0a');
+	`)
+	require.NoError(t, err)
+
+	type ast struct {
+		id, src, kind string
+		b             int
+	}
+	rows := []ast{
+		// fnD — plain.
+		{"d", "d.go", "function_declaration", 0},
+		{"d/body", "d.go", "block", 10},
+		{"d/body/ret", "d.go", "return_statement", 20},
+		{"d/body/ret/id", "d.go", "identifier", 25},
+		// fnE — identical structure PLUS an inline comment in the body.
+		{"e", "e.go", "function_declaration", 0},
+		{"e/body", "e.go", "block", 10},
+		{"e/body/cmt", "e.go", "comment", 15},
+		{"e/body/ret", "e.go", "return_statement", 20},
+		{"e/body/ret/id", "e.go", "identifier", 25},
+	}
+	for _, a := range rows {
+		_, err = db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col) VALUES (?, ?, ?, ?, ?, 0, 0, 0, 0)",
+			a.id, a.src, a.kind, a.b, a.b+1,
+		)
+		require.NoError(t, err)
+	}
+	tg := &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+	defer func() { _ = db.Close() }()
+
+	handler := makeFindSmellsHandler(tg)
+	res, err := handler(context.Background(), makeRequest(map[string]any{
+		"rule":       "duplicate_code",
+		"min_metric": 0,
+	}))
+	require.NoError(t, err)
+	require.False(t, res.IsError, "duplicate_code should run cleanly: %s", resultText(t, res))
+
+	var resp struct {
+		Total    int            `json:"total"`
+		Findings []smellFinding `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, res)), &resp))
+
+	got := map[string]bool{}
+	for _, f := range resp.Findings {
+		got[f.NodeID] = true
+		assert.Equal(t, int64(4), f.Metric, "metric counts structural nodes only — the comment is erased")
+	}
+	require.Equal(t, 2, resp.Total, "fnD and fnE are clones despite the comment-only difference")
+	assert.True(t, got["d"], "fnD must be flagged")
+	assert.True(t, got["e"], "fnE must be flagged")
+}
+
 // TestFindSmells_DuplicateCode_DefaultFloorDropsTrivial pins that the
 // rule's DefaultMinMetric (24-node floor) is load-bearing: the 5-node
 // fixture clones are real structural duplicates, but below the default

--- a/cmd/smell_rules.go
+++ b/cmd/smell_rules.go
@@ -619,6 +619,81 @@ var smellRegistry = []SmellRule{
 		`,
 	},
 	{
+		ID:          "duplicate_code",
+		Languages:   []string{"go"},
+		Description: "Structurally-identical function/method bodies — Type-1/Type-2 code clones detected by leaf-erased AST structural hashing (Deckard-style), NOT token or name matching. Each function_declaration/method_declaration subtree is reduced to its signature: the document-ordered `(relative_depth:node_kind)` sequence of every descendant node. Identifiers, literals, and comments are erased (only node_kind survives), so two functions that differ only in variable names or constant values collide; two functions with different control-flow shapes do not. Functions sharing a signature with ≥1 other function are flagged — each clone instance is a separate finding pointing at the function's own file:line. Metric is the duplicated subtree's node count (bigger duplicated blocks rank first); pair with min_metric to drop trivial clones (default floor 24 nodes ≈ skips one-line accessors and matching stubs). This is the pure-Go baseline: it runs on any LLO-built .db with an _ast table and finds exact structural clones within the indexed scope. It does NOT do near-miss (gapped/Type-3) detection — that's the additive HDC/Merkle tier (LLO `_hdc`, mache-40ae5c). The depth+kind serialization is a strong structural approximation, not a perfect tree encoding, so rare distinct shapes can collide; the metric and file:line let an agent confirm. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) is excluded from candidates (wide identical method sets by design). Test files (`*_test.go`) are NOT excluded — duplicated test setup is a legitimate refactor target (extract a helper / table-driven test). Currently Go-only: the candidate-root kinds are Go's; other languages need their function kinds added to the WHERE.",
+		Requires:    []string{"_ast"},
+		ScopeColumn: "s.source_id",
+		// Heuristic floor: a duplicated subtree must be at least this
+		// many AST nodes to be reported by default. A trivial getter
+		// (`func (x X) F() int { return x.f }`) is ~8-12 nodes and
+		// would otherwise flag against every same-shaped accessor; 24
+		// keeps the long tail of matching stubs/getters out of the
+		// default view. Callers pass min_metric=0 to see every clone
+		// regardless of size, or a higher value to focus on big blocks.
+		DefaultMinMetric: 24,
+		Tags:             []string{"duplication", "structure"},
+		Query: `
+			-- Candidate clone roots: every function/method. The subtree
+			-- under each is reduced to a structural signature; roots whose
+			-- signature is shared by another root are clones.
+			WITH candidates AS (
+				SELECT node_id AS root_id, source_id,
+				       (LENGTH(node_id) - LENGTH(REPLACE(node_id, '/', ''))) AS root_depth,
+				       start_byte, end_byte, start_row, start_col
+				FROM _ast
+				WHERE node_kind IN ('function_declaration', 'method_declaration')
+				  -- Generated code (capnp / protobuf / *_generated / *.gen)
+				  -- emits wide identical method sets by design — that's not
+				  -- architectural duplication. Excluded from candidates so a
+				  -- generated function is neither flagged nor able to inflate
+				  -- a clone group. Mirrors dead_code / duplicate_definitions /
+				  -- god_file. Test files are deliberately NOT excluded:
+				  -- duplicated test setup is a legitimate refactor target
+				  -- (extract a helper / table-driven test).
+				  AND source_id NOT LIKE '%%.capnp.go'
+				  AND source_id NOT LIKE '%%.pb.go'
+				  AND source_id NOT LIKE '%%_generated.go'
+				  AND source_id NOT LIKE '%%.gen.go'
+			),
+			-- Signature = document-ordered (relative_depth ':' node_kind)
+			-- of every node in the subtree. Leaf-erased: only node_kind
+			-- contributes, so identifier/literal text is ignored (Type-2
+			-- clones collide). Relative depth disambiguates trees with the
+			-- same flat kind-bag but different nesting. group_concat ORDER
+			-- BY makes the sequence deterministic; start_byte gives
+			-- pre-order, node_id breaks parent/child byte ties (the parent
+			-- id is a prefix, so it sorts first).
+			sigs AS (
+				SELECT c.root_id, c.source_id,
+				       c.start_byte, c.end_byte, c.start_row, c.start_col,
+				       COUNT(*) AS node_count,
+				       group_concat(
+				           ((LENGTH(d.node_id) - LENGTH(REPLACE(d.node_id, '/', ''))) - c.root_depth) || ':' || d.node_kind,
+				           '>' ORDER BY d.start_byte, d.node_id
+				       ) AS sig
+				FROM candidates c
+				JOIN _ast d
+				  ON d.source_id = c.source_id
+				 AND (d.node_id = c.root_id OR d.node_id LIKE c.root_id || '/%%')
+				GROUP BY c.root_id, c.source_id
+			),
+			-- Signatures shared by 2+ functions are the clone groups.
+			clone_sigs AS (
+				SELECT sig FROM sigs GROUP BY sig HAVING COUNT(*) > 1
+			)
+			SELECT s.source_id,
+			       s.root_id AS node_id,
+			       s.start_byte, s.end_byte, s.start_row, s.start_col,
+			       s.node_count AS metric
+			FROM sigs s
+			JOIN clone_sigs g ON g.sig = s.sig
+			WHERE 1=1
+			%s
+			ORDER BY metric DESC, s.source_id, s.start_byte
+		`,
+	},
+	{
 		ID:          "god_file",
 		Description: "Source files whose distinct-definition count is at least 10 AND more than 3× the project mean — a fuzzy 'god file' detector that surfaces sprawl relative to the codebase's own distribution rather than a hard line-count cutoff. Metric is the def count, sorted descending. Cross-language since node_defs is populated by every backend. source_file is resolved via the construct dir's child leaves (the schema engine attaches Origin to source / ast.json / doc, not the wrapping dir), so this works on FCA-inferred mounts too. Generated code (`*.capnp.go`, `*.pb.go`, `*_generated.go`, `*.gen.go`) and Go test files (`*_test.go`) are excluded — generators produce wide method sets by design and test files accumulate many TestXxx / setupXxx helpers without representing architectural sprawl. Pairs with long_file (line-count via _ast) for a 'lots of code' vs 'lots of API' split.",
 		Requires:    []string{"node_defs", "nodes"},

--- a/cmd/smell_rules.go
+++ b/cmd/smell_rules.go
@@ -676,6 +676,12 @@ var smellRegistry = []SmellRule{
 				JOIN _ast d
 				  ON d.source_id = c.source_id
 				 AND (d.node_id = c.root_id OR d.node_id LIKE c.root_id || '/%%')
+				 -- Erase comments: they live in _ast as node_kind='comment'
+				 -- and would otherwise make the signature (and node_count
+				 -- metric) comment-sensitive — two bodies identical except
+				 -- for a comment would not match, a false negative that
+				 -- contradicts the "comments are erased" contract.
+				 AND d.node_kind != 'comment'
 				GROUP BY c.root_id, c.source_id
 			),
 			-- Signatures shared by 2+ functions are the clone groups.


### PR DESCRIPTION
## What

Adds a `duplicate_code` find_smells rule that detects **Type-1/Type-2 code clones structurally**, not by token/name heuristics. This is the pure-Go baseline for **mache-40ae5c** — the deterministic answer to "find duplicated code."

## How it works

Each `function_declaration`/`method_declaration` subtree is reduced to a **leaf-erased structural signature**: the document-ordered `(relative_depth:node_kind)` sequence of every descendant node, computed in pure SQL over the `_ast` table. Functions sharing a signature are clones. Identifier/literal text is erased (only `node_kind` survives), so renamed-only copies collide; different control-flow shapes don't.

This supersedes the heuristic gap noted in `duplicate_definitions` (which finds same-*named* defs, not same-*code* bodies). Near-miss (gapped/Type-3) detection stays the additive HDC/Merkle tier.

## Design choices

- **metric** = duplicated subtree node count (biggest blocks rank first); `DefaultMinMetric=24` keeps trivial accessors/stubs out of the default view
- detection is **global**; `source_id` scopes only the *returned* findings
- generated code (`*.capnp.go`/`*.pb.go`/`*_generated.go`/`*.gen.go`) excluded from candidates — matches `dead_code`/`duplicate_definitions`/`god_file`. Test files are **kept** (duplicated test setup is a legitimate refactor target)
- `group_concat(... ORDER BY ...)` for deterministic signatures (SQLite 3.44+, bundled by modernc v1.52)

## Validation

Run against mache's own `_ast` (479K nodes): **74 high-signal production clones**, including:
- `camelToKebab` ↔ `greedyCamelToKebab` (byte-identical bodies, different file)
- the paired `sitterMatch` constructions in `sitter_walker.go`
- cross-file `lattice/greedy.go` ↔ `lattice/project.go`

Zero generated-code false positives.

## Tests

`cmd/find_smells_duplicate_code_test.go` — detection, default size-floor, `source_id` scoping (global detect / scoped return), and generated-code exclusion. The exclusion test ships with a **fixture-vacuity guard**: an initial version gave all twin nodes a uniform `start_byte`, which reordered the signature and masked the assertion (it passed for the wrong reason). Fixed so the generated twin is a genuine structural match before asserting it's excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)