### PR TITLE
feat(ingest): ASTWalker.ExtractFileLevelRefs — pure-Go file-level ref parity (S4 prep)

### DIFF
--- a/internal/ingest/ast_file_level_refs_parity_test.go
+++ b/internal/ingest/ast_file_level_refs_parity_test.go
@@ -1,0 +1,113 @@
+package ingest
+
+import (
+	"context"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/lang"
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fileLevelParitySrc exercises every file-level ref pattern:
+//   - a cobra-style struct var whose field VALUE is a func reference
+//     (keyed_element > literal_element > identifier)
+//   - a bare call            (call_expression > identifier)
+//   - a selector call        (call_expression > selector_expression > field_identifier)
+//   - an identifier argument (call_expression > argument_list > identifier)
+//
+// These are the top-level/nested identifiers that per-scope ExtractCalls
+// can't see and that feed the _file_level: sentinel dead_code reads.
+const fileLevelParitySrc = `package demo
+
+import "fmt"
+
+func handler() {}
+
+var rootCmd = Command{
+	Use:  "root",
+	RunE: handler,
+}
+
+func run() {
+	fmt.Println(greet())
+	handler()
+}
+
+func greet() string { return "hi" }
+
+type Command struct {
+	Use  string
+	RunE func()
+}
+`
+
+// TestASTFileLevelRefsParity_Go asserts ASTWalker.ExtractFileLevelRefs
+// (pure-Go SQL over _ast/nodes) returns the SAME token set as
+// SitterWalker.ExtractFileLevelRefs (CGO tree-sitter). This is the
+// missing file-level extractor that S4 needs before it can stop running
+// the CGO parse in ingest — the projection parity gate (callers-based)
+// excludes the _file_level: sentinel, so this divergence would otherwise
+// be invisible.
+func TestASTFileLevelRefsParity_Go(t *testing.T) {
+	src := []byte(fileLevelParitySrc)
+	grammar := lang.ForName("go").Grammar()
+
+	// SitterWalker (CGO) — parse live, extract from the file root.
+	parser := sitter.NewParser()
+	parser.SetLanguage(grammar)
+	tree, err := parser.ParseCtx(context.Background(), nil, src)
+	require.NoError(t, err)
+	defer tree.Close()
+	sw := NewSitterWalker()
+	defer sw.Close()
+	sitterRefs, err := sw.ExtractFileLevelRefs(tree.RootNode(), src, grammar, "go")
+	require.NoError(t, err)
+	require.NotEmpty(t, sitterRefs, "fixture must exercise file-level refs (non-vacuity guard)")
+
+	// ASTWalker (pure-Go) — query an _ast db emitted from the SAME parse.
+	db := sitterToASTDB(t, filepath.Join(t.TempDir(), "ast.db"), "demo.go", "go", src)
+	defer func() { _ = db.Close() }()
+	astRefs, err := NewASTWalker(db).ExtractFileLevelRefs("demo.go", "go")
+	require.NoError(t, err)
+
+	assert.Equal(t, sortedCopy(sitterRefs), sortedCopy(astRefs),
+		"file-level ref token set must match across walkers")
+}
+
+// TestASTContextParity_Go asserts ASTWalker.ExtractContext matches
+// SitterWalker.ExtractContext — the top-level import/const/var/type
+// source blob the engine attaches to context fields. Also a building
+// block S4 serves from SQL instead of the CGO parse.
+func TestASTContextParity_Go(t *testing.T) {
+	src := []byte(fileLevelParitySrc)
+	grammar := lang.ForName("go").Grammar()
+
+	parser := sitter.NewParser()
+	parser.SetLanguage(grammar)
+	tree, err := parser.ParseCtx(context.Background(), nil, src)
+	require.NoError(t, err)
+	defer tree.Close()
+	sw := NewSitterWalker()
+	defer sw.Close()
+	sitterCtx, err := sw.ExtractContext(tree.RootNode(), src, grammar, "go")
+	require.NoError(t, err)
+	require.NotEmpty(t, sitterCtx, "fixture must produce a context blob (non-vacuity guard)")
+
+	db := sitterToASTDB(t, filepath.Join(t.TempDir(), "ast.db"), "demo.go", "go", src)
+	defer func() { _ = db.Close() }()
+	astCtx, err := NewASTWalker(db).ExtractContext("demo.go", "go")
+	require.NoError(t, err)
+
+	assert.Equal(t, string(sitterCtx), string(astCtx),
+		"context blob must match across walkers")
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/ingest/ast_file_level_refs_parity_test.go
+++ b/internal/ingest/ast_file_level_refs_parity_test.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"context"
+	"database/sql"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
 )
 
 // fileLevelParitySrc exercises every file-level ref pattern:
@@ -104,6 +106,27 @@ func TestASTContextParity_Go(t *testing.T) {
 
 	assert.Equal(t, string(sitterCtx), string(astCtx),
 		"context blob must match across walkers")
+}
+
+// TestExtractFileLevelRefs_InvalidPatternErrors pins that a malformed
+// CallPattern surfaces instead of being silently swallowed (Copilot
+// review on #443). A RequirePriorSibling pattern with no ancestors is
+// invalid; queryCallPattern must reject it AND ExtractFileLevelRefs must
+// propagate the error — these tokens feed the _file_level: sentinel
+// dead_code reads, so a silently-incomplete set with nil error is a
+// latent correctness bug.
+func TestExtractFileLevelRefs_InvalidPatternErrors(t *testing.T) {
+	// Unique langName so we don't perturb the real "go" registry.
+	RegisterASTFileLevelRefPatterns("faketest_invalid", []CallPattern{
+		{OuterKind: "x", LeafKind: "y", RequirePriorSibling: true}, // no ancestors → invalid
+	})
+
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "x.db"))
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = NewASTWalker(db).ExtractFileLevelRefs("f.go", "faketest_invalid")
+	require.Error(t, err, "malformed RequirePriorSibling pattern must surface, not silently skip")
 }
 
 func sortedCopy(in []string) []string {

--- a/internal/ingest/ast_walker_calls.go
+++ b/internal/ingest/ast_walker_calls.go
@@ -140,9 +140,16 @@ func (w *ASTWalker) ExtractFileLevelRefs(sourceID, langName string) ([]string, e
 	seen := make(map[string]bool)
 	var refs []string
 	for _, p := range patterns {
+		// Unlike the generic Query path (where a selector may legitimately
+		// be unsupported), queryCallPattern generates SQL from a structured
+		// kind-chain — an error here is a real bug (invalid pattern or a
+		// failed query), not an unsupported pattern. Surface it rather than
+		// returning a silently-incomplete ref set: these tokens feed the
+		// _file_level: sentinel dead_code reads, so a short set with nil
+		// error would manifest as silent dead_code false positives.
 		rows, err := w.queryCallPattern(sourceID, p, false, "")
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("file-level ref pattern %s/%s: %w", p.OuterKind, p.LeafKind, err)
 		}
 		for _, r := range rows {
 			if r.token != "" && !seen[r.token] {
@@ -205,6 +212,12 @@ type callRow struct {
 func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifier bool, scopePrefix string) ([]callRow, error) {
 	if p.OuterKind == "" || p.LeafKind == "" {
 		return nil, fmt.Errorf("invalid CallPattern: OuterKind and LeafKind required")
+	}
+	// RequirePriorSibling references the immediate-ancestor alias (a_anc0),
+	// so it's meaningless without at least one ancestor. Reject rather than
+	// silently dropping the constraint, which would over-capture undetectably.
+	if p.RequirePriorSibling && len(p.Ancestors) == 0 {
+		return nil, fmt.Errorf("invalid CallPattern: RequirePriorSibling requires at least one ancestor")
 	}
 
 	// Build the ancestor JOIN chain.
@@ -274,7 +287,8 @@ func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifi
 	// the immediate ancestor under the outer node (e.g. the key
 	// literal_element preceding the value literal_element in a
 	// keyed_element). Reproduces tree-sitter positional capture.
-	if p.RequirePriorSibling && len(p.Ancestors) > 0 {
+	// len(Ancestors) >= 1 is guaranteed by the validation above.
+	if p.RequirePriorSibling {
 		sb.WriteString(`
 			AND EXISTS (
 				SELECT 1 FROM nodes sib

--- a/internal/ingest/ast_walker_calls.go
+++ b/internal/ingest/ast_walker_calls.go
@@ -24,6 +24,14 @@ type CallPattern struct {
 	Ancestors     []string // intermediate kinds between outer and leaf
 	LeafKind      string   // node kind whose record is the call name (@call)
 	QualifierKind string   // optional sibling-leaf kind for the package qualifier (@pkg); empty when not qualified
+	// RequirePriorSibling, when true, restricts the match to leaves whose
+	// immediate ancestor (Ancestors[0], the direct child of OuterKind) has
+	// an EARLIER same-kind sibling under OuterKind. This reproduces
+	// tree-sitter's positional matching for value-position captures like
+	//   (keyed_element (literal_element) (literal_element (identifier) @x))
+	// where only the SECOND literal_element (the value) is captured, not
+	// the first (the key). Requires len(Ancestors) >= 1.
+	RequirePriorSibling bool
 }
 
 // callPatternRegistry stores per-language CallPatterns for ASTWalker.
@@ -99,6 +107,51 @@ func (w *ASTWalker) ExtractCallsScoped(sourceID, scopeID, langName string) ([]st
 		}
 	}
 	return calls, nil
+}
+
+// fileLevelRefPatternRegistry stores per-language CallPatterns used by
+// ExtractFileLevelRefs — the file-wide identifier-capture shapes that
+// per-scope ExtractCalls can't see (e.g. Go top-level cobra var func
+// values, mache-02r9). Mirrors SitterWalker's file-level ref query, but
+// as structured kind-chains queried over _ast/nodes.
+var fileLevelRefPatternRegistry sync.Map // langName → []CallPattern
+
+// RegisterASTFileLevelRefPatterns registers the per-language file-level
+// ref capture shapes for ExtractFileLevelRefs.
+func RegisterASTFileLevelRefPatterns(langName string, patterns []CallPattern) {
+	fileLevelRefPatternRegistry.Store(langName, patterns)
+}
+
+// ExtractFileLevelRefs returns deduplicated identifier tokens captured by
+// the language's file-level ref patterns across the WHOLE file. Mirrors
+// SitterWalker.ExtractFileLevelRefs (the _file_level: sentinel feed that
+// dead_code reads) but queries _ast/nodes via SQL instead of CGO
+// tree-sitter. sourceID is the _source key (filepath.Base of the file).
+// Returns (nil, nil) when no patterns are registered for the language.
+func (w *ASTWalker) ExtractFileLevelRefs(sourceID, langName string) ([]string, error) {
+	raw, ok := fileLevelRefPatternRegistry.Load(langName)
+	if !ok {
+		return nil, nil
+	}
+	patterns := raw.([]CallPattern)
+	if len(patterns) == 0 {
+		return nil, nil
+	}
+	seen := make(map[string]bool)
+	var refs []string
+	for _, p := range patterns {
+		rows, err := w.queryCallPattern(sourceID, p, false, "")
+		if err != nil {
+			continue
+		}
+		for _, r := range rows {
+			if r.token != "" && !seen[r.token] {
+				seen[r.token] = true
+				refs = append(refs, r.token)
+			}
+		}
+	}
+	return refs, nil
 }
 
 // ExtractQualifiedCalls returns call tokens with optional package qualifiers.
@@ -217,6 +270,21 @@ func (w *ASTWalker) queryCallPattern(sourceID string, p CallPattern, wantQualifi
 	}
 	sb.WriteString(` AND a_outer.node_kind = ?`)
 	args = append(args, p.OuterKind)
+	// Value-position constraint: require an earlier same-kind sibling of
+	// the immediate ancestor under the outer node (e.g. the key
+	// literal_element preceding the value literal_element in a
+	// keyed_element). Reproduces tree-sitter positional capture.
+	if p.RequirePriorSibling && len(p.Ancestors) > 0 {
+		sb.WriteString(`
+			AND EXISTS (
+				SELECT 1 FROM nodes sib
+				JOIN _ast a_sib ON a_sib.node_id = sib.id
+				WHERE sib.parent_id = n_outer.id
+				  AND a_sib.node_kind = ?
+				  AND a_sib.start_byte < a_anc0.start_byte
+			)`)
+		args = append(args, p.Ancestors[0])
+	}
 	if wantQualifier && p.QualifierKind != "" {
 		// Match only rows where the qualifier sibling actually exists.
 		sb.WriteString(` AND n_pkg.id IS NOT NULL`)

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -134,6 +134,22 @@ func init() {
 		"import_declaration", "const_declaration", "var_declaration", "type_declaration",
 	})
 
+	// ASTWalker file-level ref patterns — the pure-Go mirror of the Go
+	// RegisterFileLevelRefQuery above. Each tree-sitter capture becomes a
+	// CallPattern kind-chain (queryCallPattern matches by parent_id):
+	//   (keyed_element (literal_element) (literal_element (identifier) @call))
+	//   (call_expression function: (identifier) @call)
+	//   (call_expression function: (selector_expression field: (field_identifier) @call))
+	//   (call_expression arguments: (argument_list (identifier) @call))
+	// Parity with SitterWalker.ExtractFileLevelRefs is asserted by
+	// TestASTFileLevelRefsParity_Go.
+	RegisterASTFileLevelRefPatterns("go", []CallPattern{
+		{OuterKind: "keyed_element", Ancestors: []string{"literal_element"}, LeafKind: "identifier", RequirePriorSibling: true},
+		{OuterKind: "call_expression", LeafKind: "identifier"},
+		{OuterKind: "call_expression", Ancestors: []string{"selector_expression"}, LeafKind: "field_identifier"},
+		{OuterKind: "call_expression", Ancestors: []string{"argument_list"}, LeafKind: "identifier"},
+	})
+
 	// ASTWalker (pure-Go path): batched JOIN-style fast path. One CallPattern
 	// per shape; ExtractCalls/ExtractQualifiedCalls translate each into a
 	// single SQL query that returns all matches in one pass.


### PR DESCRIPTION
## What

**Slice A of S4** (`mache-33de70`: stop CGO running in ingest). Builds the one missing ASTWalker file-level extractor and proves parity, so the actual Phase-1 CGO gating (slice B) lands on a verified safety net.

## Why

S4 makes the Phase-1 tree-sitter parse conditional on backend — when ASTWalker is available, skip the CGO parse and serve context/imports/file-level-refs from SQL. Two of those three extractors already exist on ASTWalker (`ExtractContext`, `ExtractGoImports`); the gap was **file-level refs** — whole-file identifier captures that per-scope `ExtractCalls` can't see (Go top-level cobra func-value vars, `mache-02r9`). These feed the `_file_level:` sentinel that `dead_code` reads.

## How

- `ASTWalker.ExtractFileLevelRefs` — thin wrapper over the existing `queryCallPattern` machinery + a per-language pattern registry mirroring `SitterWalker.RegisterFileLevelRefQuery`. The four Go capture shapes become `CallPattern` kind-chains.
- `CallPattern.RequirePriorSibling` — the `keyed_element` capture needs tree-sitter's **positional** semantics: `(keyed_element (literal_element) (literal_element (identifier) @call))` captures only the *value* identifier (second `literal_element`), not the key. A generic kind-chain over-captures both. This flag requires an earlier same-kind sibling of the immediate ancestor, reproducing value-position capture generally. Inert for every existing pattern (defaults false).

## The gate hole this closes

The projection parity gate is **callers-based and excludes the `_file_level:` sentinel** — so a file-level-ref divergence between walkers is invisible to it. Two new direct parity tests close that hole:
- `TestASTFileLevelRefsParity_Go` — sitter vs AST file-level ref token set, with a non-vacuity guard
- `TestASTContextParity_Go` — sitter vs AST context blob

TDD immediately earned its keep: the file-level test went RED because AST grabbed the struct-field **keys** (`Use`, `RunE`) while sitter captures only the func-value (`handler`). Fixed via `RequirePriorSibling`, then GREEN. Context parity passed first try.

## Scope / follow-up (slice B)

This PR is extractor + parity only — **no ingest-path change**. Slice B wires the Phase-1 / single-file CGO gating and `ExtractGoImports` parity (needs the `_imports` table, which the synthetic gate db doesn't emit).

Verified: full `internal/ingest` suite green; parity + call machinery green under `-race`; vet + golangci-lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)