### PR TITLE
chore(deps): pin leyline-schema + daemon binary to v0.5.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0 h1:uG172a7v0dzk4kgDy8ljKRhOVZObA8S9jWiEEdZ0uPU=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1 h1:+QZYqa5yGgBUruxVEkxNoWwEVAUA4JE6B45Q0mmOHqs=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -655,21 +655,21 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, go.mod tracks leyline-schema v0.5.0 and the matching
-// release with binary assets is v0.5.0. The Go schema-client and the daemon
+// As of this pin, go.mod tracks leyline-schema v0.5.1 and the matching
+// release with binary assets is v0.5.1. The Go schema-client and the daemon
 // binary travel together — mache built against schema vX.Y.Z must run a daemon
-// at the same major/minor or it will mis-decode the wire format. v0.5.0 ships
+// at the same major/minor or it will mis-decode the wire format. v0.5.1 ships
 // all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64),
 // including leyline-darwin-amd64 for Intel macs. (The release omits the
-// libleyline_fs-darwin-amd64 *staticlib*, but mache doesn't link the cgo FFI —
-// internal/leyline/client.go is //go:build leyline, off in releases — so the
-// download path is unaffected.)
+// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0 — but mache
+// doesn't link the cgo FFI: internal/leyline/client.go is //go:build leyline,
+// off in releases, so the download path is unaffected.)
 //
 // BUMP THIS WHEN UPDATING leyline-schema in go.mod to a newer published tag.
 //
 // Future hardening (mache-8kif): on socket connect, query the daemon's
 // `version` op and refuse to proceed if it disagrees with this constant.
-const leylineBinaryVersion = "v0.5.0"
+const leylineBinaryVersion = "v0.5.1"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
Pins the two coupled LLO references to **v0.5.1** (released 2026-06-25):

| Pin | From | To |
|-----|------|-----|
| `go.mod` leyline-schema (wire decoder) | v0.5.0 | v0.5.1 |
| `internal/leyline/socket.go` `leylineBinaryVersion` (downloaded daemon) | v0.5.0 | v0.5.1 |

These travel together — mache built against schema vX.Y.Z must run a daemon at the same major/minor or it mis-decodes the wire format.

**Patch-bump, low-risk:** `go.sum` shows the module's own `/go.mod` hash is unchanged → no new transitive deps, wire-compatible at the same minor. Build, `internal/leyline` tests, and the AST↔Sitter parity smoke (which exercises the schema-client wire) all pass. golangci-lint + vet clean.

The v0.5.1 release still omits `libleyline_fs-darwin-amd64` (same gap as v0.5.0); mache doesn't link the cgo FFI in releases, so the binary download path is unaffected — comment updated to note the continued gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)