### PR TITLE
fix(serve): project-aware kind filter (_ast.node_kind) + MCP readOnlyHint annotations

### DIFF
--- a/.github/workflows/find-smells.yml
+++ b/.github/workflows/find-smells.yml
@@ -168,7 +168,7 @@ jobs:
               echo "No structural smells in changed files. ✓"
             fi
             echo ""
-            echo "_Rules: see [\`docs/ARCHITECTURE.md\`](../blob/main/docs/ARCHITECTURE.md#interplay-with-ley-line-open) for the full registry. Advisory only — these are heuristics, not gates._"
+            echo "_Rules: the registry is [\`cmd/smell_rules.go\`](../blob/main/cmd/smell_rules.go) (source of truth); see [the authoring guide](../blob/main/plugin/skills/authoring-smell-rules/SKILL.md) to add one. Advisory only — these are heuristics, not gates._"
           } > /tmp/comment.md
           cat /tmp/comment.md
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -28,22 +28,42 @@ mache version
 
 ## First run — MCP server
 
-The simplest way to use mache is as an MCP server pointed at a codebase or `.db` file:
+Running mache as an MCP server is **two decisions**: *what to point it at* (the source) and *how the client connects* (the transport). Get these right once and it just works.
+
+### Decision 1 — the source: directory vs `.db`
+
+`mache serve <source>` accepts either a **directory** or a **`.db` file**, and the choice is a real quality tradeoff:
+
+| Source                        | Command                                                          | Parsing tier                                                                                                                                                | Freshness                                                                                                  | Best for                                                      |
+| ----------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| **Directory**                 | `mache serve .`                                                  | tree-sitter (built-in). `find_callers`/`find_callees` are accurate on Go; weaker on Rust/Python/TS. No `get_type_info`/`get_diagnostics`/`semantic_search`. | Live — re-reads as files change.                                                                           | Go, or a zero-dependency quick start.                         |
+| **ley-line `.db` (snapshot)** | `leyline parse .` → `mache serve ./that.db`                      | semantic. `_ast` + `_lsp` tables make `find_callers`, `get_type_info`, `get_diagnostics` accurate **across all languages**.                                 | Static — reflects the code as of the last `leyline parse`. Re-run to refresh.                              | Rust/Python/TS, or any time you want compiler-grade accuracy. |
+| **ley-line live (hot-swap)**  | `mache serve --control <block>` with the ley-line daemon running | semantic (same as above).                                                                                                                                   | Live — the daemon re-parses on edit and mache **hot-swaps** the graph on each generation bump (zero-copy). | The best of both: semantic accuracy *and* live updates.       |
+
+Rule of thumb: **Go → a directory is fine. Everything else → point at a ley-line `.db`** (or run the live daemon). Pointing stdio at a leyline-parsed `.db` (e.g. `mache serve --stdio ./code.db`) is **correct and recommended**, not a mistake — it's how you get the accurate tier. See [ley-line-open](https://github.com/agentic-research/ley-line-open) to build the `.db`, and [Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open) for which tools need which tables.
+
+> `--control` is **optional** — you only need it for the live hot-swap tier above. Basic config never requires it.
+
+### Decision 2 — the transport: HTTP daemon vs stdio
+
+**HTTP (recommended — one daemon shared across all sessions):**
 
 ```bash
-mache serve .
-# starts on localhost:7532, auto-infers a schema, ready for clients
-```
-
-**Connect from Claude Code (HTTP, recommended — one server shared across sessions):**
-
-```bash
+mache serve .                 # ← long-running daemon on localhost:7532 — KEEP THIS RUNNING
 claude mcp add --transport http mache http://localhost:7532/mcp
 ```
 
-**Connect from Claude Code (stdio — subprocess per session, useful when the host manages lifecycle):**
+> ⚠️ `mache serve` (HTTP) is a **foreground daemon** — it blocks the terminal and must stay alive for the client to connect. Run it in a second terminal, background it (`mache serve . &`), or install it as a login service. If the client reports `localhost:7532/mcp` **connection refused**, the daemon isn't running — that's the #1 first-run gotcha. (A launchd LaunchAgent that keeps it alive across logins is tracked in mache-823d91.)
 
-`.mcp.json`:
+**stdio (subprocess per session — no standing daemon to babysit):**
+
+```bash
+claude mcp add mache -- mache serve --stdio .
+# or point at a leyline .db for the accurate tier:
+claude mcp add mache -- mache serve --stdio ./code.db
+```
+
+Add `--scope user|project|local` to either `claude mcp add` to control where the registration is written (`local` = this project only, `user` = all your projects). Or write `.mcp.json` by hand:
 
 ```json
 {
@@ -56,7 +76,7 @@ claude mcp add --transport http mache http://localhost:7532/mcp
 }
 ```
 
-**Connect from Claude Desktop:**
+**Claude Desktop** (stdio only; use an absolute binary path):
 
 ```json
 {
@@ -69,7 +89,7 @@ claude mcp add --transport http mache http://localhost:7532/mcp
 }
 ```
 
-Once connected, the agent can call `list_directory`, `read_file`, `find_callers`, `find_callees`, `find_definition`, `search`, `get_communities`, `get_overview`, `get_impact`, `get_architecture`, `get_diagram`, `write_file`, `find_smells`, and `resolve_ref`. With [ley-line-open](https://github.com/agentic-research/ley-line-open) installed, three more tools become available: `semantic_search`, `get_type_info`, `get_diagnostics`.
+Once connected, the agent can call `list_directory`, `read_file`, `find_callers`, `find_callees`, `find_definition`, `search`, `get_communities`, `get_overview`, `get_impact`, `get_architecture`, `get_diagram`, `write_file`, `find_smells`, and `resolve_ref`. With a ley-line-built `.db` (or the live daemon), three more light up: `semantic_search`, `get_type_info`, `get_diagnostics`.
 
 See the [MCP Server section in ARCHITECTURE.md](docs/ARCHITECTURE.md#core-abstractions) for the full tool inventory and the [Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open) section for which tools require a `.db` built by ley-line-open.
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ Point it at a codebase. It parses the code, discovers the structure, and lets yo
 ```bash
 git clone https://github.com/agentic-research/mache.git
 cd mache && task build && task install
-mache serve .
+mache serve .   # ← long-running daemon on :7532 — keep it running (use a 2nd terminal)
 claude mcp add --transport http mache http://localhost:7532/mcp
 ```
 
-That's the 30-second path. For the full first-run flow — install on Linux/macOS, Claude Desktop / stdio configs, mount as filesystem, write-back, schema inference, troubleshooting — see [GETTING-STARTED.md](GETTING-STARTED.md).
+That's the 30-second path for a **Go** codebase. Two things new users hit:
+
+- `mache serve` is a **daemon** — it must stay running, or the client gets `connection refused`. Background it or run it in another terminal.
+- For **Rust / Python / TypeScript**, point mache at a [ley-line-open](https://github.com/agentic-research/ley-line-open)-built `.db` instead of a directory (`mache serve ./code.db`) to get accurate `find_callers` + `get_type_info` + `get_diagnostics`. A bare directory uses the built-in tree-sitter tier, which is tuned for Go.
+
+For the full first-run flow — source choice (directory vs `.db` vs live hot-swap), HTTP vs stdio, `--scope`, Claude Desktop, mount as filesystem, write-back, schema inference, troubleshooting — see [GETTING-STARTED.md](GETTING-STARTED.md).
 
 ## What it gives an agent
 

--- a/cmd/kind_discriminator_leyline_ast_test.go
+++ b/cmd/kind_discriminator_leyline_ast_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"io/fs"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/graph"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// buildLeylineRustASTFixture seeds the SAME failure the real-world
+// layer-4 smoke caught (bead mache-5bb181): a leyline-parsed Rust .db
+// where the symbol `parse` exists as BOTH a free function and an impl
+// method. Unlike buildAmbiguousNameFixture (construct-dir projection,
+// `pkg/functions/parse/source`), leyline emits tree-sitter node-kind
+// paths with NO `/functions/` segment:
+//
+//	lib.rs/function_item_0                                  — free fn `parse`
+//	lib.rs/impl_item_0/declaration_list/function_item_1     — method `parse`
+//
+// Both nodes are node_kind=function_item — the function-vs-method
+// distinction lives ONLY in ancestry (the method's parent chain passes
+// through an impl_item). Kind resolution therefore cannot come from the
+// path segment; it must join _ast.node_kind and walk nodes.parent_id.
+//
+// The fixture wires:
+//   - MemoryStore defs: `parse` → both leyline node_ids (drives LookupDef)
+//   - nodes table: parent_id chain (file → impl_item → declaration_list → fn)
+//   - _ast table: node_kind per node (the projection-independent kind source)
+func buildLeylineRustASTFixture(t *testing.T) *smellTestGraph {
+	t.Helper()
+
+	const (
+		fileID   = "lib.rs"
+		freeFn   = "lib.rs/function_item_0"
+		implID   = "lib.rs/impl_item_0"
+		declList = "lib.rs/impl_item_0/declaration_list"
+		methodFn = "lib.rs/impl_item_0/declaration_list/function_item_1"
+	)
+
+	dbPath := filepath.Join(t.TempDir(), "leyline_rust.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
+			mtime INTEGER NOT NULL DEFAULT 0, record_id TEXT, record JSON,
+			source_file TEXT
+		);
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+	`)
+	require.NoError(t, err)
+
+	// nodes: parent_id chain. File is root; free fn hangs off the file;
+	// the method hangs off impl_item via declaration_list.
+	nodeRows := []struct{ id, parent string }{
+		{fileID, ""},
+		{freeFn, fileID},
+		{implID, fileID},
+		{declList, implID},
+		{methodFn, declList},
+	}
+	for _, r := range nodeRows {
+		_, err = db.Exec(
+			"INSERT INTO nodes (id, parent_id, name, kind) VALUES (?, ?, ?, 0)",
+			r.id, r.parent, filepath.Base(r.id))
+		require.NoError(t, err)
+	}
+
+	// _ast: tree-sitter node_kind per node. Both `parse` defs are
+	// function_item; ancestry is what separates them.
+	astRows := []struct{ id, kind string }{
+		{fileID, "source_file"},
+		{freeFn, "function_item"},
+		{implID, "impl_item"},
+		{declList, "declaration_list"},
+		{methodFn, "function_item"},
+	}
+	for _, r := range astRows {
+		_, err = db.Exec(
+			"INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte) VALUES (?, 'lib.rs', ?, 0, 0)",
+			r.id, r.kind)
+		require.NoError(t, err)
+	}
+
+	// node_defs mirrors the in-memory defs so the fixture is faithful to
+	// a real SQLiteGraph (which resolves defs from this table). Both
+	// `parse` defs ALSO call `helper`, so the same two leyline-shaped
+	// node_ids exercise the find_callers kind filter (function-caller
+	// vs method-caller).
+	store := graph.NewMemoryStore()
+	for _, id := range []string{freeFn, methodFn} {
+		// AddRoot registers the node so GetCallers can return it by ID.
+		store.AddRoot(&graph.Node{ID: id, Mode: fs.ModeDir, Children: []string{}})
+		require.NoError(t, store.AddDef("parse", id))
+		require.NoError(t, store.AddRef("helper", id))
+		_, err = db.Exec("INSERT INTO node_defs (token, node_id) VALUES ('parse', ?)", id)
+		require.NoError(t, err)
+	}
+
+	return &smellTestGraph{MemoryStore: store, db: db, path: dbPath}
+}
+
+// TestKindDiscriminator_LeylineAST_FindDefinition is the regression
+// proof for mache-5bb181: kind filtering MUST work against leyline-
+// parsed paths (node_kind in _ast), not just mache's own construct-dir
+// projection. PR #441's integration test only built construct-dir
+// fixtures, so this gap shipped silently until a real-world smoke.
+//
+// Falsifies: any kind filter that pattern-matches `/functions/` path
+// segments instead of resolving kind from _ast.node_kind + ancestry.
+func TestKindDiscriminator_LeylineAST_FindDefinition(t *testing.T) {
+	const (
+		freeFn   = "lib.rs/function_item_0"
+		methodFn = "lib.rs/impl_item_0/declaration_list/function_item_1"
+	)
+
+	g := buildLeylineRustASTFixture(t)
+	handler := makeFindDefinitionHandler(g)
+
+	t.Run("no_kind_returns_both", func(t *testing.T) {
+		req := makeRequest(map[string]any{"symbol": "parse"})
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		dirs := extractDirIDs(t, resultText(t, result))
+		require.Len(t, dirs, 2, "without kind, both `parse` defs should return; got %v", dirs)
+		require.Contains(t, dirs, freeFn)
+		require.Contains(t, dirs, methodFn)
+	})
+
+	t.Run("kind_function_narrows_to_free_function", func(t *testing.T) {
+		req := makeRequest(map[string]any{"symbol": "parse", "kind": "function"})
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		dirs := extractDirIDs(t, resultText(t, result))
+		require.Equal(t, []string{freeFn}, dirs,
+			"kind=function must keep the free function_item (no impl_item ancestor), drop the method")
+	})
+
+	t.Run("kind_method_narrows_to_impl_method", func(t *testing.T) {
+		req := makeRequest(map[string]any{"symbol": "parse", "kind": "method"})
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		dirs := extractDirIDs(t, resultText(t, result))
+		require.Equal(t, []string{methodFn}, dirs,
+			"kind=method must keep the function_item under impl_item, drop the free function")
+	})
+}
+
+// TestKindDiscriminator_LeylineAST_FindCallers is the caller-side proof
+// for the same bug: find_callers narrows by the KIND of caller, and the
+// caller node_ids are leyline-shaped too. `helper` is called by both the
+// free function `parse` and the impl method `parse`.
+func TestKindDiscriminator_LeylineAST_FindCallers(t *testing.T) {
+	const (
+		freeFn   = "lib.rs/function_item_0"
+		methodFn = "lib.rs/impl_item_0/declaration_list/function_item_1"
+	)
+
+	g := buildLeylineRustASTFixture(t)
+	handler := makeFindCallersHandler(g)
+
+	extractCallers := func(t *testing.T, raw string) []string {
+		t.Helper()
+		var bare []string
+		if err := json.Unmarshal([]byte(raw), &bare); err == nil {
+			return bare
+		}
+		var wrapped struct {
+			Callers []string `json:"callers"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(raw), &wrapped))
+		return wrapped.Callers
+	}
+
+	t.Run("kind_function_narrows_to_free_function_caller", func(t *testing.T) {
+		req := makeRequest(map[string]any{"token": "helper", "kind": "function"})
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		callers := extractCallers(t, resultText(t, result))
+		require.Equal(t, []string{freeFn}, callers,
+			"kind=function must keep ONLY the free-function caller")
+	})
+
+	t.Run("kind_method_narrows_to_method_caller", func(t *testing.T) {
+		req := makeRequest(map[string]any{"token": "helper", "kind": "method"})
+		result, err := handler(context.Background(), req)
+		require.NoError(t, err)
+		callers := extractCallers(t, resultText(t, result))
+		require.Equal(t, []string{methodFn}, callers,
+			"kind=method must keep ONLY the method caller (function_item under impl_item)")
+	})
+}

--- a/cmd/kind_discriminator_leyline_ast_test.go
+++ b/cmd/kind_discriminator_leyline_ast_test.go
@@ -162,6 +162,45 @@ func TestKindDiscriminator_LeylineAST_FindDefinition(t *testing.T) {
 	})
 }
 
+// TestResolveKindFromAST_EdgeCases hardens the _ast resolver against the
+// two cases the PR #448 review surfaced:
+//   - a cyclic nodes.parent_id must NOT hang the recursive CTE (the depth
+//     cap bounds it); the node still resolves by its own node_kind.
+//   - function_signature_item (Rust trait method signature, no body)
+//     resolves to "method" directly, without needing ancestry.
+func TestResolveKindFromAST_EdgeCases(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "edge.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE nodes (id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL, kind INTEGER NOT NULL DEFAULT 0);
+		CREATE TABLE _ast (node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL, node_kind TEXT NOT NULL, start_byte INTEGER NOT NULL DEFAULT 0, end_byte INTEGER NOT NULL DEFAULT 0);
+	`)
+	require.NoError(t, err)
+
+	// A <-> B parent_id cycle, with A a function_item. Without the depth
+	// cap the ancestry CTE spins forever; with it, resolution terminates.
+	_, err = db.Exec(`INSERT INTO nodes (id, parent_id, name) VALUES ('A','B','A'), ('B','A','B')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO _ast (node_id, source_id, node_kind) VALUES ('A','f.rs','function_item'), ('B','f.rs','block')`)
+	require.NoError(t, err)
+
+	// A trait method signature — resolves to method by node_kind alone.
+	_, err = db.Exec(`INSERT INTO nodes (id, parent_id, name) VALUES ('sig','','sig')`)
+	require.NoError(t, err)
+	_, err = db.Exec(`INSERT INTO _ast (node_id, source_id, node_kind) VALUES ('sig','f.rs','function_signature_item')`)
+	require.NoError(t, err)
+
+	g := &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db, path: dbPath}
+
+	require.Equal(t, "function", resolveKindFromAST(g, "A"),
+		"cyclic parent_id must terminate (depth cap) and resolve by own node_kind")
+	require.Equal(t, "method", resolveKindFromAST(g, "sig"),
+		"function_signature_item resolves to method without ancestry")
+}
+
 // TestKindDiscriminator_LeylineAST_FindCallers is the caller-side proof
 // for the same bug: find_callers narrows by the KIND of caller, and the
 // caller node_ids are leyline-shaped too. `helper` is called by both the

--- a/cmd/kind_filter.go
+++ b/cmd/kind_filter.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/agentic-research/mache/internal/graph"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -54,6 +55,140 @@ func filterDirIDsByKind(dirIDs []string, kind string) ([]string, bool) {
 	for _, id := range dirIDs {
 		if strings.Contains(id, segment) {
 			filtered = append(filtered, id)
+		}
+	}
+	return filtered, true
+}
+
+// astNodeKindToCanonical maps tree-sitter node-kind names (as emitted
+// by ley-line into _ast.node_kind) to mache's singular canonical kinds
+// (the keys of kindToPathSegment). This is the projection-independent
+// kind source: leyline paths carry no `/functions/` segment, so kind
+// must be resolved from node_kind, not the path string (bead mache-5bb181).
+//
+// `function_item` (Rust) and `function_definition` (Python) are
+// AMBIGUOUS — they are the node kind for BOTH free functions and
+// methods, distinguished only by ancestry. They map to "function" here;
+// resolveKindFromAST upgrades them to "method" when a method-container
+// ancestor (impl_item / trait_item / class) is present.
+var astNodeKindToCanonical = map[string]string{
+	// Go
+	"function_declaration": "function",
+	"method_declaration":   "method",
+	"type_declaration":     "type",
+	"type_spec":            "type",
+	"const_spec":           "constant",
+	"var_spec":             "variable",
+	"import_spec":          "import",
+	// Rust (function_item = function OR method — ancestry decides)
+	"function_item":   "function",
+	"struct_item":     "type",
+	"enum_item":       "type",
+	"trait_item":      "type",
+	"type_item":       "type",
+	"union_item":      "type",
+	"const_item":      "constant",
+	"static_item":     "constant",
+	"let_declaration": "variable",
+	"use_declaration": "import",
+	// Python (function_definition = function OR method — ancestry decides)
+	"function_definition": "function",
+	"class_definition":    "type",
+	// JavaScript / TypeScript
+	"method_definition": "method",
+	"class_declaration": "type",
+	"import_statement":  "import",
+}
+
+// hasASTTable reports whether the backing SQL store exposes an `_ast`
+// table (i.e. it is a ley-line-parsed projection). Construct-dir
+// MemoryStore mounts have no `_ast` and fall back to path-segment matching.
+func hasASTTable(qg refsQuerier) bool {
+	rows, err := qg.QueryRefs(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='_ast' LIMIT 1`)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = rows.Close() }()
+	return rows.Next()
+}
+
+// resolveKindFromAST resolves a node's canonical kind from _ast.node_kind,
+// upgrading ambiguous function kinds to "method" when the node has a
+// method-container ancestor. Returns "" when the node is absent from
+// _ast or its node_kind is unmapped — caller falls back to path-segment.
+func resolveKindFromAST(qg refsQuerier, nodeID string) string {
+	rows, err := qg.QueryRefs(`SELECT node_kind FROM _ast WHERE node_id = ? LIMIT 1`, nodeID)
+	if err != nil {
+		return ""
+	}
+	var nodeKind string
+	func() {
+		defer func() { _ = rows.Close() }()
+		if rows.Next() {
+			_ = rows.Scan(&nodeKind)
+		}
+	}()
+	canonical, ok := astNodeKindToCanonical[nodeKind]
+	if !ok {
+		return ""
+	}
+	if canonical == "function" && astNodeHasMethodContainerAncestor(qg, nodeID) {
+		return "method"
+	}
+	return canonical
+}
+
+// astNodeHasMethodContainerAncestor walks the nodes.parent_id chain and
+// reports whether any ancestor's _ast.node_kind is a method container.
+// A single recursive CTE keeps this one round-trip regardless of depth.
+func astNodeHasMethodContainerAncestor(qg refsQuerier, nodeID string) bool {
+	rows, err := qg.QueryRefs(`
+		WITH RECURSIVE ancestors(id) AS (
+			SELECT parent_id FROM nodes WHERE id = ?
+			UNION ALL
+			SELECT n.parent_id FROM nodes n JOIN ancestors a ON n.id = a.id
+			WHERE n.parent_id IS NOT NULL AND n.parent_id != ''
+		)
+		SELECT 1 FROM ancestors a JOIN _ast x ON x.node_id = a.id
+		WHERE x.node_kind IN ('impl_item','trait_item','class_definition','class_declaration')
+		LIMIT 1`, nodeID)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = rows.Close() }()
+	return rows.Next()
+}
+
+// filterDirIDsByKindGraph is the projection-aware kind filter. When the
+// graph is a ley-line projection (has an `_ast` table), it resolves each
+// candidate's kind from _ast.node_kind (+ ancestry) — the load-bearing
+// path. Otherwise (construct-dir MemoryStore, no _ast) it falls back to
+// filterDirIDsByKind's path-segment match — the documented TRANSITIONAL
+// fallback that goes away when SitterWalker is deleted and every backend
+// has _ast. A node_id absent from _ast also degrades to path-segment so
+// mixed/partial projections never silently drop hits (bead mache-5bb181).
+func filterDirIDsByKindGraph(g graph.Graph, dirIDs []string, kind string) ([]string, bool) {
+	if kind == "" {
+		return dirIDs, true
+	}
+	segment, known := kindToPathSegment[kind]
+	if !known {
+		return nil, false
+	}
+	qg, ok := g.(refsQuerier)
+	if !ok || !hasASTTable(qg) {
+		return filterDirIDsByKind(dirIDs, kind)
+	}
+	filtered := make([]string, 0, len(dirIDs))
+	for _, id := range dirIDs {
+		switch resolveKindFromAST(qg, id) {
+		case kind:
+			filtered = append(filtered, id)
+		case "":
+			// Not in _ast — fall back to path-segment for this id.
+			if strings.Contains(id, segment) {
+				filtered = append(filtered, id)
+			}
 		}
 	}
 	return filtered, true

--- a/cmd/kind_filter.go
+++ b/cmd/kind_filter.go
@@ -81,16 +81,17 @@ var astNodeKindToCanonical = map[string]string{
 	"var_spec":             "variable",
 	"import_spec":          "import",
 	// Rust (function_item = function OR method — ancestry decides)
-	"function_item":   "function",
-	"struct_item":     "type",
-	"enum_item":       "type",
-	"trait_item":      "type",
-	"type_item":       "type",
-	"union_item":      "type",
-	"const_item":      "constant",
-	"static_item":     "constant",
-	"let_declaration": "variable",
-	"use_declaration": "import",
+	"function_item":           "function",
+	"function_signature_item": "method", // trait method signature (no body) — always a method
+	"struct_item":             "type",
+	"enum_item":               "type",
+	"trait_item":              "type",
+	"type_item":               "type",
+	"union_item":              "type",
+	"const_item":              "constant",
+	"static_item":             "constant",
+	"let_declaration":         "variable",
+	"use_declaration":         "import",
 	// Python (function_definition = function OR method — ancestry decides)
 	"function_definition": "function",
 	"class_definition":    "type",
@@ -142,12 +143,16 @@ func resolveKindFromAST(qg refsQuerier, nodeID string) string {
 // reports whether any ancestor's _ast.node_kind is a method container.
 // A single recursive CTE keeps this one round-trip regardless of depth.
 func astNodeHasMethodContainerAncestor(qg refsQuerier, nodeID string) bool {
+	// The depth column bounds recursion at 256 — real AST ancestry to a
+	// method container is shallow; the cap is purely a guard against a
+	// malformed leyline `nodes` table with a cyclic parent_id (which would
+	// otherwise spin forever). No legitimate source nests this deep.
 	rows, err := qg.QueryRefs(`
-		WITH RECURSIVE ancestors(id) AS (
-			SELECT parent_id FROM nodes WHERE id = ?
+		WITH RECURSIVE ancestors(id, depth) AS (
+			SELECT parent_id, 0 FROM nodes WHERE id = ?
 			UNION ALL
-			SELECT n.parent_id FROM nodes n JOIN ancestors a ON n.id = a.id
-			WHERE n.parent_id IS NOT NULL AND n.parent_id != ''
+			SELECT n.parent_id, a.depth + 1 FROM nodes n JOIN ancestors a ON n.id = a.id
+			WHERE n.parent_id IS NOT NULL AND n.parent_id != '' AND a.depth < 256
 		)
 		SELECT 1 FROM ancestors a JOIN _ast x ON x.node_id = a.id
 		WHERE x.node_kind IN ('impl_item','trait_item','class_definition','class_declaration')

--- a/cmd/mcp_registry_invariants_test.go
+++ b/cmd/mcp_registry_invariants_test.go
@@ -21,6 +21,11 @@ type inspectedTools struct {
 			InputSchema struct {
 				Properties map[string]any `json:"properties"`
 			} `json:"inputSchema"`
+			Annotations struct {
+				ReadOnlyHint    *bool `json:"readOnlyHint"`
+				DestructiveHint *bool `json:"destructiveHint"`
+				OpenWorldHint   *bool `json:"openWorldHint"`
+			} `json:"annotations"`
 		} `json:"tools"`
 	} `json:"result"`
 }
@@ -59,6 +64,40 @@ func inspectRegisteredToolsForInvariants(t *testing.T) inspectedTools {
 		t.Fatalf("tools/list returned no tools (body=%s)", body)
 	}
 	return parsed
+}
+
+// mutatingTools is the set of tools that modify state. Everything else
+// in mache's surface is a pure query/navigation tool and MUST advertise
+// readOnlyHint=true — otherwise MCP clients default to "destructive" and
+// show alarming labels in /mcp for read-only tools like semantic_search.
+var mutatingTools = map[string]bool{
+	"write_file": true,
+}
+
+// TestMCPRegistry_ToolsDeclareReadOnlyHint enforces that EVERY registered
+// tool carries an explicit readOnlyHint annotation, and that only the
+// known mutating tools (write_file) declare readOnlyHint=false. Without
+// the annotation, clients assume the worst (destructive) — the user-
+// visible bug where `/mcp` flagged semantic_search and other read tools
+// as destructive.
+//
+// Falsified by: adding a tool without a readOnlyHint annotation, or
+// mis-annotating a read tool as mutating (or vice versa).
+func TestMCPRegistry_ToolsDeclareReadOnlyHint(t *testing.T) {
+	tools := inspectRegisteredToolsForInvariants(t)
+	for _, tool := range tools.Result.Tools {
+		ro := tool.Annotations.ReadOnlyHint
+		if ro == nil {
+			t.Errorf("tool %q has no readOnlyHint annotation — clients default to destructive", tool.Name)
+			continue
+		}
+		switch {
+		case mutatingTools[tool.Name] && *ro:
+			t.Errorf("tool %q mutates state but is annotated readOnlyHint=true", tool.Name)
+		case !mutatingTools[tool.Name] && !*ro:
+			t.Errorf("read-only tool %q is annotated readOnlyHint=false", tool.Name)
+		}
+	}
 }
 
 // TestMCPRegistry_NoLineOrColumnParams enforces the bead-7d321e

--- a/cmd/serve_handler_find_callers.go
+++ b/cmd/serve_handler_find_callers.go
@@ -55,8 +55,11 @@ func makeFindCallersHandler(g graph.Graph) server.ToolHandlerFunc {
 		if qg, ok := g.(refsQuerier); ok {
 			lspRefs, lspErr := queryLSPRefs(qg, token)
 			if lspErr == nil && len(lspRefs) > 0 {
-				// Apply kind filter to LSP refs too (same NodeID
-				// construct-path encoding).
+				// Apply kind filter to LSP refs. NOTE: this still uses
+				// path-segment matching (filterByNodeIDKind), not the
+				// _ast-aware resolver — so on a leyline _lsp projection
+				// with node-kind-shaped ids this filter under-matches.
+				// Tracked in mache-aba090 (symmetric to mache-5bb181).
 				lspRefs = filterByNodeIDKind(lspRefs, kind, func(r lspRefLocation) string { return r.NodeID })
 				type callersResult struct {
 					Callers []string         `json:"callers"`

--- a/cmd/serve_handler_find_callers.go
+++ b/cmd/serve_handler_find_callers.go
@@ -36,7 +36,7 @@ func makeFindCallersHandler(g graph.Graph) server.ToolHandlerFunc {
 		// filter narrows by what KIND of caller is calling — e.g.
 		// "show me only methods that call X." Empty kind is a no-op.
 		if kind != "" {
-			paths, _ = filterDirIDsByKind(paths, kind)
+			paths, _ = filterDirIDsByKindGraph(g, paths, kind)
 		}
 
 		// Cross-repo annotation: when running on a CompositeGraph,

--- a/cmd/serve_handler_find_definition.go
+++ b/cmd/serve_handler_find_definition.go
@@ -113,8 +113,12 @@ func makeFindDefinitionHandler(g graph.Graph) server.ToolHandlerFunc {
 		}
 
 		// 4. LSP fallback: try _lsp_defs from a ley-line pre-baked DB.
-		// LSP results carry their construct path in NodeID, so the
-		// kind filter applies the same way.
+		// NOTE: kind filtering here still uses path-segment matching
+		// (filterByNodeIDKind), not the _ast-aware resolver — so on a
+		// leyline _lsp projection with node-kind-shaped ids this filter
+		// under-matches. Tracked in mache-aba090 (symmetric to
+		// mache-5bb181); _lsp also exposes a symbol_kind column that may
+		// be the cleaner fix.
 		if qg, ok := g.(refsQuerier); ok {
 			lspDefs, err := queryLSPDefs(qg, symbol)
 			if err == nil && len(lspDefs) > 0 {

--- a/cmd/serve_handler_find_definition.go
+++ b/cmd/serve_handler_find_definition.go
@@ -41,7 +41,7 @@ func makeFindDefinitionHandler(g graph.Graph) server.ToolHandlerFunc {
 		// kind filter excludes every candidate — the caller falls
 		// through to the next lookup path.
 		acceptKind := func(dirIDs []string) ([]string, bool) {
-			filtered, _ := filterDirIDsByKind(dirIDs, kind)
+			filtered, _ := filterDirIDsByKindGraph(g, dirIDs, kind)
 			return filtered, len(filtered) > 0
 		}
 

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -12,6 +12,7 @@ import (
 func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 	s.AddTool(
 		mcp.NewTool("list_directory",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Browse the projected tree. Use instead of ls/find for 'what's in directory X?', 'list packages under Y'. Use empty path for root."),
 			mcp.WithString("path", mcp.Description("Directory path (empty for root)")),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Exclude Test* and Benchmark* entries (default false). Recommended for large packages.")),
@@ -21,6 +22,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("read_file",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Read the text content of one or more file nodes. Pass a single path or a JSON array of paths for batch reads."),
 			mcp.WithString("path", mcp.Description("Single file node path")),
 			mcp.WithString("paths", mcp.Description("JSON array of file node paths for batch read, e.g. [\"path/a\", \"path/b\"]")),
@@ -30,6 +32,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callers",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Find all constructs that reference a symbol. Use for 'who calls X?', 'where is X used?', 'find usages of X'. More accurate than grep for symbol lookup."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Symbol or token name (e.g. 'GetCallers', 'ParseVuln')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the CALLERS (e.g. kind=method narrows to method-callers only). Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -39,6 +42,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callees",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Find what a function/method calls. Use for 'what does X invoke?', 'dependencies of X'. Note: generic names (String, New, Error) may have false positives — prefer qualified calls."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("Construct directory path (e.g. 'go/graph/methods/GetCallees')")),
 		),
@@ -47,6 +51,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("search",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Search for symbols by name pattern. Use instead of grep -r for 'find functions named X', 'find all X*', 'search for *auth*'. SQL LIKE wildcards: % = any chars. role=definition finds declarations."),
 			mcp.WithString("pattern", mcp.Required(), mcp.Description("Search pattern, e.g. 'Login%' or '%auth%'")),
 			mcp.WithString("type", mcp.Description("Filter by construct type in path, e.g. 'functions', 'methods', 'types', 'structs'")),
@@ -58,6 +63,8 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("semantic_search",
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDescription("Find code by meaning using embedding similarity. Use for 'find code that does X', 'functions related to authentication', 'error handling patterns'. More flexible than pattern search — finds conceptually similar code even without exact name matches. Requires ley-line daemon with --embed flag."),
 			mcp.WithString("query", mcp.Required(), mcp.Description("Natural language description of what you're looking for")),
 			mcp.WithNumber("k", mcp.Description("Max results (default 10)")),
@@ -67,6 +74,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_communities",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Find clusters of related code using Louvain modularity detection. Use for 'what code works together?', 'find subsystems'. Requires dense cross-references. Use summary=true for large codebases."),
 			mcp.WithNumber("min_size", mcp.Description("Minimum community size (default 2)")),
 			mcp.WithBoolean("summary", mcp.Description("Return summary only (ID, size, top 5 members per community) instead of full member lists. Recommended for large codebases.")),
@@ -76,6 +84,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_definition",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Find where a symbol is declared. Use for 'where is X defined?', 'where does X come from?'. Default match is anchored: case-sensitive exact, then case-insensitive exact. Set fuzzy=true to also fall back to substring suggestions when no anchored match exists (recommended only for short queries in unfamiliar codebases — fuzzy is noisy in monorepos)."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to find definition for (e.g. 'GetCallers' or 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -86,6 +95,8 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_type_info",
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDescription("Get type signature and documentation for a symbol from LSP hover data. Returns the language server's type information (e.g. function signatures, struct definitions). If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to look up (e.g. 'NewEncoder', 'Model')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -96,6 +107,8 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagnostics",
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDescription("Get LSP diagnostics (errors, warnings) for symbols. Returns diagnostics from the language server. If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Description("Symbol name to filter by (optional, returns all if empty)")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to result NodeIDs. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -107,6 +120,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_overview",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("START HERE when exploring a codebase. Returns top-level structure, node counts, cross-reference stats, and a usage guide for all tools."),
 		),
 		r.wrapHandler(makeGetOverviewHandler),
@@ -122,6 +136,8 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 	// well-known socket path.
 	s.AddTool(
 		mcp.NewTool("get_sheaf_status",
+			mcp.WithReadOnlyHintAnnotation(true),
+			mcp.WithOpenWorldHintAnnotation(true),
 			mcp.WithDescription("Returns the ley-line daemon's sheaf cache state (generation counter, valid/total entries, defect score) AND the local subscriber state (whether mache is receiving sheaf.invalidate events, last event seen, last generation observed). Use to decide whether cached find_callers / find_definition / get_architecture results are still fresh after an edit. Returns {available: false, reason: ...} when the daemon is not reachable rather than erroring — safe to call periodically."),
 		),
 		makeGetSheafStatusHandler(r.sheafSubscriberAccessor()),
@@ -129,6 +145,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_impact",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Change impact analysis: given a symbol, trace through the refs graph to show affected callers and/or callees (multi-hop BFS traversal). Use for 'what would be affected if I change X?', 'blast radius of modifying Y'."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to analyze (e.g. 'GetCallers', 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the STARTING symbol's root (e.g. kind=function picks the function-Encoder as the BFS root when both a type and function are named Encoder). Traversal at depth>0 follows callers/callees regardless of their kind. Accepted values: function, method, type, constant, variable, import. Omit to use all matching roots.")),
@@ -140,6 +157,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_architecture",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Structured architectural analysis of the codebase. Returns entry points (high fan-in), key abstractions (most defs), dependency layers (community-based), test files, API surface (exported symbols), file count, and language breakdown. Use after get_overview for deeper orientation."),
 		),
 		r.wrapHandler(makeGetArchitectureHandler),
@@ -147,6 +165,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagram",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Render a mermaid diagram of the projected system's structure. Uses community detection to group related code, then renders the quotient graph (classes + cross-class edges) as mermaid syntax. Edge labels show the most significant boundary tokens (above-mean weight)."),
 			mcp.WithString("name", mcp.Description("Diagram name from schema (default: full system view)")),
 			mcp.WithString("layout", mcp.Description("Layout direction: TD (top-down), LR (left-right), BT (bottom-top), RL (right-left). Default: TD")),
@@ -158,6 +177,8 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("write_file",
+			mcp.WithReadOnlyHintAnnotation(false),
+			mcp.WithDestructiveHintAnnotation(true),
 			mcp.WithDescription("Write new content to a source file node. Pipeline: validate (tree-sitter, always) → format (gofumpt/hclwrite, opt-out via format=false) → atomic splice into source file → update graph. The node must have a source origin. Set format=false when the caller (LLM, pre-commit) already owns formatting and wants mache to splice verbatim."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("File node path (e.g. 'go/graph/methods/MemoryStore.GetCallees/source')")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("New content to write")),
@@ -168,6 +189,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("resolve_ref",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Resolve a typed cross-language ref token (scheme:locator) to its target. First milestone of the cross-language ref graph (mache-q43l). Today supports the `mod:` scheme with local-relative paths (./X, ../Y) — returns the resolved absolute path plus a directory listing with detected languages. Other schemes return a `remote_hint` so the caller knows resolution was skipped. Useful for following Terraform `module { source = ... }` references into the projected target."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Typed ref token in `scheme:locator` form (e.g. `mod:./modules/vpc`).")),
 			mcp.WithString("base_path", mcp.Description("File or directory the locator is interpreted relative to. Required for local-relative locators.")),
@@ -177,6 +199,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_smells",
+			mcp.WithReadOnlyHintAnnotation(true),
 			mcp.WithDescription("Run structural code-smell rules against the parsed _ast table. Call with no arguments for the registry listing; call with `rule` to scan. Rules look for patterns like 'magic int literal in a binary expression' (Go) — useful for sweeping a monorepo before adding named constants. Each finding includes line/column and a short snippet so editors can jump to it. Requires a leyline-parsed .db (the _ast table)."),
 			mcp.WithString("rule", mcp.Description("Rule ID to run. Omit to list available rules.")),
 			mcp.WithString("source_id", mcp.Description("Limit the scan to one parsed source file (matches _source.id, e.g. 'main.go').")),

--- a/cmd/serve_impact.go
+++ b/cmd/serve_impact.go
@@ -69,7 +69,7 @@ func makeGetImpactHandler(g graph.Graph) server.ToolHandlerFunc {
 		// impact through nodes whose kind matches" — depth>0 traversal
 		// follows callers/callees regardless of their construct kind.
 		if found && kind != "" {
-			roots, _ = filterDirIDsByKind(roots, kind)
+			roots, _ = filterDirIDsByKindGraph(g, roots, kind)
 			if len(roots) == 0 {
 				found = false
 			}


### PR DESCRIPTION
Two MCP-surface correctness fixes surfaced by real-world use against leyline-parsed Rust `.db`s and the `/mcp` client view.

## 1. Kind filter resolves `_ast.node_kind`, not path segments (mache-5bb181)

`find_definition` / `find_callers` / `get_impact`'s `kind=` filter pattern-matched mache's **own** construct-dir path segment (`/functions/`). Leyline-parsed `.db`s emit tree-sitter node-kind paths (`file.rs/function_item_0`) with no such segment, so the filter returned empty → tools reported *"no definition found"* against any leyline projection. Caught by a layer-4 smoke on LLO's own Rust `.db`:

```
find_definition(symbol="parse")                  → 2 hits
find_definition(symbol="parse", kind="function") → "no definition found"   ← bug
find_definition(symbol="parse", kind="method")   → "no definition found"   ← bug
```

**Fix:** `filterDirIDsByKindGraph` resolves each candidate's kind from `_ast.node_kind` when the graph exposes an `_ast` table. The ambiguous Rust `function_item` / Python `function_definition` (both free-function and method node kind) is upgraded to `method` when a method-container ancestor (`impl_item` / `trait_item` / class) is found via the `nodes.parent_id` chain. Construct-dir mounts (no `_ast`) keep the path-segment match as a **documented transitional fallback** that retires with SitterWalker. `find_definition`, `find_callers`, `get_impact` all route through the new seam.

**Why PR #441 missed it:** its integration fixtures were construct-dir only; the `_ast` path was never exercised. New `TestKindDiscriminator_LeylineAST_{FindDefinition,FindCallers}` build a leyline-`_ast`-shaped fixture (free fn + impl method both named `parse`, both `node_kind=function_item`) and assert `kind=function`/`kind=method` each narrow correctly.

## 2. MCP tools annotate `readOnlyHint` (mache-974697)

mcp-go defaults `ToolAnnotation.ReadOnlyHint` to a non-nil `false`, so all 18 tools advertised "not read-only" → the `/mcp` view painted read-only tools like `semantic_search` as **destructive**.

**Fix:** every query/navigation tool → `readOnlyHint=true`; the four that reach the external ley-line daemon (`semantic_search`, `get_type_info`, `get_diagnostics`, `get_sheaf_status`) → also `openWorldHint=true`; `write_file` → explicit `readOnlyHint=false` + `destructiveHint=true`. `TestMCPRegistry_ToolsDeclareReadOnlyHint` introspects the live `tools/list` response and fails if any tool is unannotated or mis-classified (`write_file` is the sole `mutatingTools` allowlist entry).

## Testing
- Full `cmd` suite green; build + golangci-lint clean.
- `server.json` not drifted (annotations are a runtime `tools/list` concern, not the registry manifest).

Both are the same two-tier-backend seam: the construct-dir/heuristic path vs the leyline `_ast`/semantic path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 3. Docs: first-run MCP config legible to new users (mache-a38826)

Prompted by a real onboarding failure (configuring on a second machine: "connection refused", and uncertainty whether `mache serve --stdio output.db` was correct). `GETTING-STARTED.md` "First run" was technically correct but omitted the three things that bite new users, now fixed:

- **`mache serve` (HTTP) is a long-running daemon** — must stay running or the client gets "connection refused" (the #1 gotcha; cross-refs the launchd lifecycle bead mache-823d91).
- **directory-vs-`.db` = heuristic-vs-semantic tier** — a tier table explains when to use each, and that pointing stdio at a leyline `.db` is *correct and recommended* for Rust/Python/TS, plus `--control` for live hot-swap (semantic AND live).
- **`--control` is optional; `--scope` controls registration location.**

README quick-start gets a nudge so the 30-second path doesn't imply Go-only or fire-and-forget. Restructured around two decisions (source, transport).
