### PR TITLE
fix(serve): honest MCP annotation hints — read tools no longer leak destructive/open-world defaults

### DIFF
--- a/cmd/mcp_registry_invariants_test.go
+++ b/cmd/mcp_registry_invariants_test.go
@@ -74,6 +74,46 @@ var mutatingTools = map[string]bool{
 	"write_file": true,
 }
 
+// openWorldTools reach an external entity (the ley-line daemon over UDS /
+// the arena) and so legitimately advertise openWorldHint=true. Every
+// other tool operates on the in-process projected graph and must be
+// closed-world. This pins the set so a leaked mcp-go default (which seeds
+// openWorldHint=true for ALL tools) can't slip back in.
+var openWorldTools = map[string]bool{
+	"semantic_search":  true,
+	"get_type_info":    true,
+	"get_diagnostics":  true,
+	"get_sheaf_status": true,
+}
+
+// TestMCPRegistry_AnnotationHintsHonest pins destructiveHint and
+// openWorldHint to their true values per tool. mcp.NewTool pre-seeds BOTH
+// to true (the MCP spec defaults), so this guards against the regression
+// where overriding only readOnlyHint leaves a read-only tool dishonestly
+// advertising destructiveHint=true / openWorldHint=true.
+//
+// Falsified by: a read tool advertising destructiveHint=true, a non-write
+// tool whose openWorldHint disagrees with openWorldTools, or write_file
+// not marked destructive.
+func TestMCPRegistry_AnnotationHintsHonest(t *testing.T) {
+	tools := inspectRegisteredToolsForInvariants(t)
+	for _, tool := range tools.Result.Tools {
+		de, ow := tool.Annotations.DestructiveHint, tool.Annotations.OpenWorldHint
+		if de == nil || ow == nil {
+			t.Errorf("tool %q missing destructiveHint/openWorldHint annotation", tool.Name)
+			continue
+		}
+		// Only the mutating tool may be destructive.
+		if *de != mutatingTools[tool.Name] {
+			t.Errorf("tool %q destructiveHint=%v, want %v", tool.Name, *de, mutatingTools[tool.Name])
+		}
+		// openWorldHint must match the pinned external-interaction set.
+		if *ow != openWorldTools[tool.Name] {
+			t.Errorf("tool %q openWorldHint=%v, want %v (leaked mcp-go default?)", tool.Name, *ow, openWorldTools[tool.Name])
+		}
+	}
+}
+
 // TestMCPRegistry_ToolsDeclareReadOnlyHint enforces that EVERY registered
 // tool carries an explicit readOnlyHint annotation, and that only the
 // known mutating tools (write_file) declare readOnlyHint=false. Without

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -16,6 +16,11 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 	// destructive/open-world. WithToolAnnotation REPLACES the whole
 	// annotation struct, so we state every hint explicitly here
 	// (mache-974697 follow-up: the single-field overrides leaked defaults).
+	//
+	// Each preset is built once and reused across many AddTool calls. The
+	// ToolAnnotation is copied by value per tool but the inner *bool
+	// pointers are shared — safe because they are write-once (set here, read
+	// at tools/list, never mutated). Do not introduce in-place hint mutation.
 	readTool := mcp.WithToolAnnotation(mcp.ToolAnnotation{
 		ReadOnlyHint:    mcp.ToBoolPtr(true),
 		DestructiveHint: mcp.ToBoolPtr(false),

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -10,38 +10,45 @@ import (
 // graph and returns errors for unsupported operations at call time. This lets
 // different sessions (with different graph backends) coexist on one server.
 func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
-	// Annotation presets. mcp.NewTool pre-seeds destructiveHint and
-	// openWorldHint to true (the MCP spec defaults), so overriding only
+	// Annotation preset FACTORIES. mcp.NewTool pre-seeds destructiveHint
+	// and openWorldHint to true (the MCP spec defaults), so overriding only
 	// readOnlyHint leaves read tools dishonestly advertising
 	// destructive/open-world. WithToolAnnotation REPLACES the whole
-	// annotation struct, so we state every hint explicitly here
+	// annotation struct, so we state every hint explicitly
 	// (mache-974697 follow-up: the single-field overrides leaked defaults).
 	//
-	// Each preset is built once and reused across many AddTool calls. The
-	// ToolAnnotation is copied by value per tool but the inner *bool
-	// pointers are shared — safe because they are write-once (set here, read
-	// at tools/list, never mutated). Do not introduce in-place hint mutation.
-	readTool := mcp.WithToolAnnotation(mcp.ToolAnnotation{
-		ReadOnlyHint:    mcp.ToBoolPtr(true),
-		DestructiveHint: mcp.ToBoolPtr(false),
-		OpenWorldHint:   mcp.ToBoolPtr(false),
-	})
+	// These are functions, not shared values: ToolAnnotation hints are
+	// *bool, so one shared instance reused across every AddTool would alias
+	// the same pointers — an in-place mutation on one tool's hint would
+	// silently corrupt every other tool sharing the preset. Each call mints
+	// a fresh ToolAnnotation with its own pointers, so tools are independent.
+	readTool := func() mcp.ToolOption {
+		return mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			ReadOnlyHint:    mcp.ToBoolPtr(true),
+			DestructiveHint: mcp.ToBoolPtr(false),
+			OpenWorldHint:   mcp.ToBoolPtr(false),
+		})
+	}
 	// readToolExternal: read-only, but reaches the external ley-line daemon.
-	readToolExternal := mcp.WithToolAnnotation(mcp.ToolAnnotation{
-		ReadOnlyHint:    mcp.ToBoolPtr(true),
-		DestructiveHint: mcp.ToBoolPtr(false),
-		OpenWorldHint:   mcp.ToBoolPtr(true),
-	})
+	readToolExternal := func() mcp.ToolOption {
+		return mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			ReadOnlyHint:    mcp.ToBoolPtr(true),
+			DestructiveHint: mcp.ToBoolPtr(false),
+			OpenWorldHint:   mcp.ToBoolPtr(true),
+		})
+	}
 	// writeTool: the only mutating tool (write_file).
-	writeTool := mcp.WithToolAnnotation(mcp.ToolAnnotation{
-		ReadOnlyHint:    mcp.ToBoolPtr(false),
-		DestructiveHint: mcp.ToBoolPtr(true),
-		OpenWorldHint:   mcp.ToBoolPtr(false),
-	})
+	writeTool := func() mcp.ToolOption {
+		return mcp.WithToolAnnotation(mcp.ToolAnnotation{
+			ReadOnlyHint:    mcp.ToBoolPtr(false),
+			DestructiveHint: mcp.ToBoolPtr(true),
+			OpenWorldHint:   mcp.ToBoolPtr(false),
+		})
+	}
 
 	s.AddTool(
 		mcp.NewTool("list_directory",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Browse the projected tree. Use instead of ls/find for 'what's in directory X?', 'list packages under Y'. Use empty path for root."),
 			mcp.WithString("path", mcp.Description("Directory path (empty for root)")),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Exclude Test* and Benchmark* entries (default false). Recommended for large packages.")),
@@ -51,7 +58,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("read_file",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Read the text content of one or more file nodes. Pass a single path or a JSON array of paths for batch reads."),
 			mcp.WithString("path", mcp.Description("Single file node path")),
 			mcp.WithString("paths", mcp.Description("JSON array of file node paths for batch read, e.g. [\"path/a\", \"path/b\"]")),
@@ -61,7 +68,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callers",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Find all constructs that reference a symbol. Use for 'who calls X?', 'where is X used?', 'find usages of X'. More accurate than grep for symbol lookup."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Symbol or token name (e.g. 'GetCallers', 'ParseVuln')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the CALLERS (e.g. kind=method narrows to method-callers only). Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -71,7 +78,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callees",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Find what a function/method calls. Use for 'what does X invoke?', 'dependencies of X'. Note: generic names (String, New, Error) may have false positives — prefer qualified calls."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("Construct directory path (e.g. 'go/graph/methods/GetCallees')")),
 		),
@@ -80,7 +87,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("search",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Search for symbols by name pattern. Use instead of grep -r for 'find functions named X', 'find all X*', 'search for *auth*'. SQL LIKE wildcards: % = any chars. role=definition finds declarations."),
 			mcp.WithString("pattern", mcp.Required(), mcp.Description("Search pattern, e.g. 'Login%' or '%auth%'")),
 			mcp.WithString("type", mcp.Description("Filter by construct type in path, e.g. 'functions', 'methods', 'types', 'structs'")),
@@ -92,7 +99,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("semantic_search",
-			readToolExternal,
+			readToolExternal(),
 			mcp.WithDescription("Find code by meaning using embedding similarity. Use for 'find code that does X', 'functions related to authentication', 'error handling patterns'. More flexible than pattern search — finds conceptually similar code even without exact name matches. Requires ley-line daemon with --embed flag."),
 			mcp.WithString("query", mcp.Required(), mcp.Description("Natural language description of what you're looking for")),
 			mcp.WithNumber("k", mcp.Description("Max results (default 10)")),
@@ -102,7 +109,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_communities",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Find clusters of related code using Louvain modularity detection. Use for 'what code works together?', 'find subsystems'. Requires dense cross-references. Use summary=true for large codebases."),
 			mcp.WithNumber("min_size", mcp.Description("Minimum community size (default 2)")),
 			mcp.WithBoolean("summary", mcp.Description("Return summary only (ID, size, top 5 members per community) instead of full member lists. Recommended for large codebases.")),
@@ -112,7 +119,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_definition",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Find where a symbol is declared. Use for 'where is X defined?', 'where does X come from?'. Default match is anchored: case-sensitive exact, then case-insensitive exact. Set fuzzy=true to also fall back to substring suggestions when no anchored match exists (recommended only for short queries in unfamiliar codebases — fuzzy is noisy in monorepos)."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to find definition for (e.g. 'GetCallers' or 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -123,7 +130,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_type_info",
-			readToolExternal,
+			readToolExternal(),
 			mcp.WithDescription("Get type signature and documentation for a symbol from LSP hover data. Returns the language server's type information (e.g. function signatures, struct definitions). If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to look up (e.g. 'NewEncoder', 'Model')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -134,7 +141,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagnostics",
-			readToolExternal,
+			readToolExternal(),
 			mcp.WithDescription("Get LSP diagnostics (errors, warnings) for symbols. Returns diagnostics from the language server. If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Description("Symbol name to filter by (optional, returns all if empty)")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to result NodeIDs. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -146,7 +153,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_overview",
-			readTool,
+			readTool(),
 			mcp.WithDescription("START HERE when exploring a codebase. Returns top-level structure, node counts, cross-reference stats, and a usage guide for all tools."),
 		),
 		r.wrapHandler(makeGetOverviewHandler),
@@ -162,7 +169,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 	// well-known socket path.
 	s.AddTool(
 		mcp.NewTool("get_sheaf_status",
-			readToolExternal,
+			readToolExternal(),
 			mcp.WithDescription("Returns the ley-line daemon's sheaf cache state (generation counter, valid/total entries, defect score) AND the local subscriber state (whether mache is receiving sheaf.invalidate events, last event seen, last generation observed). Use to decide whether cached find_callers / find_definition / get_architecture results are still fresh after an edit. Returns {available: false, reason: ...} when the daemon is not reachable rather than erroring — safe to call periodically."),
 		),
 		makeGetSheafStatusHandler(r.sheafSubscriberAccessor()),
@@ -170,7 +177,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_impact",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Change impact analysis: given a symbol, trace through the refs graph to show affected callers and/or callees (multi-hop BFS traversal). Use for 'what would be affected if I change X?', 'blast radius of modifying Y'."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to analyze (e.g. 'GetCallers', 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the STARTING symbol's root (e.g. kind=function picks the function-Encoder as the BFS root when both a type and function are named Encoder). Traversal at depth>0 follows callers/callees regardless of their kind. Accepted values: function, method, type, constant, variable, import. Omit to use all matching roots.")),
@@ -182,7 +189,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_architecture",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Structured architectural analysis of the codebase. Returns entry points (high fan-in), key abstractions (most defs), dependency layers (community-based), test files, API surface (exported symbols), file count, and language breakdown. Use after get_overview for deeper orientation."),
 		),
 		r.wrapHandler(makeGetArchitectureHandler),
@@ -190,7 +197,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagram",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Render a mermaid diagram of the projected system's structure. Uses community detection to group related code, then renders the quotient graph (classes + cross-class edges) as mermaid syntax. Edge labels show the most significant boundary tokens (above-mean weight)."),
 			mcp.WithString("name", mcp.Description("Diagram name from schema (default: full system view)")),
 			mcp.WithString("layout", mcp.Description("Layout direction: TD (top-down), LR (left-right), BT (bottom-top), RL (right-left). Default: TD")),
@@ -202,7 +209,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("write_file",
-			writeTool,
+			writeTool(),
 			mcp.WithDescription("Write new content to a source file node. Pipeline: validate (tree-sitter, always) → format (gofumpt/hclwrite, opt-out via format=false) → atomic splice into source file → update graph. The node must have a source origin. Set format=false when the caller (LLM, pre-commit) already owns formatting and wants mache to splice verbatim."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("File node path (e.g. 'go/graph/methods/MemoryStore.GetCallees/source')")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("New content to write")),
@@ -213,7 +220,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("resolve_ref",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Resolve a typed cross-language ref token (scheme:locator) to its target. First milestone of the cross-language ref graph (mache-q43l). Today supports the `mod:` scheme with local-relative paths (./X, ../Y) — returns the resolved absolute path plus a directory listing with detected languages. Other schemes return a `remote_hint` so the caller knows resolution was skipped. Useful for following Terraform `module { source = ... }` references into the projected target."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Typed ref token in `scheme:locator` form (e.g. `mod:./modules/vpc`).")),
 			mcp.WithString("base_path", mcp.Description("File or directory the locator is interpreted relative to. Required for local-relative locators.")),
@@ -223,7 +230,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_smells",
-			readTool,
+			readTool(),
 			mcp.WithDescription("Run structural code-smell rules against the parsed _ast table. Call with no arguments for the registry listing; call with `rule` to scan. Rules look for patterns like 'magic int literal in a binary expression' (Go) — useful for sweeping a monorepo before adding named constants. Each finding includes line/column and a short snippet so editors can jump to it. Requires a leyline-parsed .db (the _ast table)."),
 			mcp.WithString("rule", mcp.Description("Rule ID to run. Omit to list available rules.")),
 			mcp.WithString("source_id", mcp.Description("Limit the scan to one parsed source file (matches _source.id, e.g. 'main.go').")),

--- a/cmd/serve_handlers.go
+++ b/cmd/serve_handlers.go
@@ -10,9 +10,33 @@ import (
 // graph and returns errors for unsupported operations at call time. This lets
 // different sessions (with different graph backends) coexist on one server.
 func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
+	// Annotation presets. mcp.NewTool pre-seeds destructiveHint and
+	// openWorldHint to true (the MCP spec defaults), so overriding only
+	// readOnlyHint leaves read tools dishonestly advertising
+	// destructive/open-world. WithToolAnnotation REPLACES the whole
+	// annotation struct, so we state every hint explicitly here
+	// (mache-974697 follow-up: the single-field overrides leaked defaults).
+	readTool := mcp.WithToolAnnotation(mcp.ToolAnnotation{
+		ReadOnlyHint:    mcp.ToBoolPtr(true),
+		DestructiveHint: mcp.ToBoolPtr(false),
+		OpenWorldHint:   mcp.ToBoolPtr(false),
+	})
+	// readToolExternal: read-only, but reaches the external ley-line daemon.
+	readToolExternal := mcp.WithToolAnnotation(mcp.ToolAnnotation{
+		ReadOnlyHint:    mcp.ToBoolPtr(true),
+		DestructiveHint: mcp.ToBoolPtr(false),
+		OpenWorldHint:   mcp.ToBoolPtr(true),
+	})
+	// writeTool: the only mutating tool (write_file).
+	writeTool := mcp.WithToolAnnotation(mcp.ToolAnnotation{
+		ReadOnlyHint:    mcp.ToBoolPtr(false),
+		DestructiveHint: mcp.ToBoolPtr(true),
+		OpenWorldHint:   mcp.ToBoolPtr(false),
+	})
+
 	s.AddTool(
 		mcp.NewTool("list_directory",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Browse the projected tree. Use instead of ls/find for 'what's in directory X?', 'list packages under Y'. Use empty path for root."),
 			mcp.WithString("path", mcp.Description("Directory path (empty for root)")),
 			mcp.WithBoolean("exclude_tests", mcp.Description("Exclude Test* and Benchmark* entries (default false). Recommended for large packages.")),
@@ -22,7 +46,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("read_file",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Read the text content of one or more file nodes. Pass a single path or a JSON array of paths for batch reads."),
 			mcp.WithString("path", mcp.Description("Single file node path")),
 			mcp.WithString("paths", mcp.Description("JSON array of file node paths for batch read, e.g. [\"path/a\", \"path/b\"]")),
@@ -32,7 +56,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callers",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Find all constructs that reference a symbol. Use for 'who calls X?', 'where is X used?', 'find usages of X'. More accurate than grep for symbol lookup."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Symbol or token name (e.g. 'GetCallers', 'ParseVuln')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the CALLERS (e.g. kind=method narrows to method-callers only). Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -42,7 +66,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_callees",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Find what a function/method calls. Use for 'what does X invoke?', 'dependencies of X'. Note: generic names (String, New, Error) may have false positives — prefer qualified calls."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("Construct directory path (e.g. 'go/graph/methods/GetCallees')")),
 		),
@@ -51,7 +75,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("search",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Search for symbols by name pattern. Use instead of grep -r for 'find functions named X', 'find all X*', 'search for *auth*'. SQL LIKE wildcards: % = any chars. role=definition finds declarations."),
 			mcp.WithString("pattern", mcp.Required(), mcp.Description("Search pattern, e.g. 'Login%' or '%auth%'")),
 			mcp.WithString("type", mcp.Description("Filter by construct type in path, e.g. 'functions', 'methods', 'types', 'structs'")),
@@ -63,8 +87,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("semantic_search",
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithOpenWorldHintAnnotation(true),
+			readToolExternal,
 			mcp.WithDescription("Find code by meaning using embedding similarity. Use for 'find code that does X', 'functions related to authentication', 'error handling patterns'. More flexible than pattern search — finds conceptually similar code even without exact name matches. Requires ley-line daemon with --embed flag."),
 			mcp.WithString("query", mcp.Required(), mcp.Description("Natural language description of what you're looking for")),
 			mcp.WithNumber("k", mcp.Description("Max results (default 10)")),
@@ -74,7 +97,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_communities",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Find clusters of related code using Louvain modularity detection. Use for 'what code works together?', 'find subsystems'. Requires dense cross-references. Use summary=true for large codebases."),
 			mcp.WithNumber("min_size", mcp.Description("Minimum community size (default 2)")),
 			mcp.WithBoolean("summary", mcp.Description("Return summary only (ID, size, top 5 members per community) instead of full member lists. Recommended for large codebases.")),
@@ -84,7 +107,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_definition",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Find where a symbol is declared. Use for 'where is X defined?', 'where does X come from?'. Default match is anchored: case-sensitive exact, then case-insensitive exact. Set fuzzy=true to also fall back to substring suggestions when no anchored match exists (recommended only for short queries in unfamiliar codebases — fuzzy is noisy in monorepos)."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to find definition for (e.g. 'GetCallers' or 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -95,8 +118,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_type_info",
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithOpenWorldHintAnnotation(true),
+			readToolExternal,
 			mcp.WithDescription("Get type signature and documentation for a symbol from LSP hover data. Returns the language server's type information (e.g. function signatures, struct definitions). If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to look up (e.g. 'NewEncoder', 'Model')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter to disambiguate when the same name appears in multiple kinds. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -107,8 +129,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagnostics",
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithOpenWorldHintAnnotation(true),
+			readToolExternal,
 			mcp.WithDescription("Get LSP diagnostics (errors, warnings) for symbols. Returns diagnostics from the language server. If LSP data is missing and 'file' is provided, auto-enriches via ley-line daemon."),
 			mcp.WithString("symbol", mcp.Description("Symbol name to filter by (optional, returns all if empty)")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to result NodeIDs. Accepted values: function, method, type, constant, variable, import. Omit to return all kinds.")),
@@ -120,7 +141,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_overview",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("START HERE when exploring a codebase. Returns top-level structure, node counts, cross-reference stats, and a usage guide for all tools."),
 		),
 		r.wrapHandler(makeGetOverviewHandler),
@@ -136,8 +157,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 	// well-known socket path.
 	s.AddTool(
 		mcp.NewTool("get_sheaf_status",
-			mcp.WithReadOnlyHintAnnotation(true),
-			mcp.WithOpenWorldHintAnnotation(true),
+			readToolExternal,
 			mcp.WithDescription("Returns the ley-line daemon's sheaf cache state (generation counter, valid/total entries, defect score) AND the local subscriber state (whether mache is receiving sheaf.invalidate events, last event seen, last generation observed). Use to decide whether cached find_callers / find_definition / get_architecture results are still fresh after an edit. Returns {available: false, reason: ...} when the daemon is not reachable rather than erroring — safe to call periodically."),
 		),
 		makeGetSheafStatusHandler(r.sheafSubscriberAccessor()),
@@ -145,7 +165,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_impact",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Change impact analysis: given a symbol, trace through the refs graph to show affected callers and/or callees (multi-hop BFS traversal). Use for 'what would be affected if I change X?', 'blast radius of modifying Y'."),
 			mcp.WithString("symbol", mcp.Required(), mcp.Description("Symbol name to analyze (e.g. 'GetCallers', 'auth.Validate')")),
 			mcp.WithString("kind", mcp.Description("Optional construct-kind filter applied to the STARTING symbol's root (e.g. kind=function picks the function-Encoder as the BFS root when both a type and function are named Encoder). Traversal at depth>0 follows callers/callees regardless of their kind. Accepted values: function, method, type, constant, variable, import. Omit to use all matching roots.")),
@@ -157,7 +177,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_architecture",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Structured architectural analysis of the codebase. Returns entry points (high fan-in), key abstractions (most defs), dependency layers (community-based), test files, API surface (exported symbols), file count, and language breakdown. Use after get_overview for deeper orientation."),
 		),
 		r.wrapHandler(makeGetArchitectureHandler),
@@ -165,7 +185,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("get_diagram",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Render a mermaid diagram of the projected system's structure. Uses community detection to group related code, then renders the quotient graph (classes + cross-class edges) as mermaid syntax. Edge labels show the most significant boundary tokens (above-mean weight)."),
 			mcp.WithString("name", mcp.Description("Diagram name from schema (default: full system view)")),
 			mcp.WithString("layout", mcp.Description("Layout direction: TD (top-down), LR (left-right), BT (bottom-top), RL (right-left). Default: TD")),
@@ -177,8 +197,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("write_file",
-			mcp.WithReadOnlyHintAnnotation(false),
-			mcp.WithDestructiveHintAnnotation(true),
+			writeTool,
 			mcp.WithDescription("Write new content to a source file node. Pipeline: validate (tree-sitter, always) → format (gofumpt/hclwrite, opt-out via format=false) → atomic splice into source file → update graph. The node must have a source origin. Set format=false when the caller (LLM, pre-commit) already owns formatting and wants mache to splice verbatim."),
 			mcp.WithString("path", mcp.Required(), mcp.Description("File node path (e.g. 'go/graph/methods/MemoryStore.GetCallees/source')")),
 			mcp.WithString("content", mcp.Required(), mcp.Description("New content to write")),
@@ -189,7 +208,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("resolve_ref",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Resolve a typed cross-language ref token (scheme:locator) to its target. First milestone of the cross-language ref graph (mache-q43l). Today supports the `mod:` scheme with local-relative paths (./X, ../Y) — returns the resolved absolute path plus a directory listing with detected languages. Other schemes return a `remote_hint` so the caller knows resolution was skipped. Useful for following Terraform `module { source = ... }` references into the projected target."),
 			mcp.WithString("token", mcp.Required(), mcp.Description("Typed ref token in `scheme:locator` form (e.g. `mod:./modules/vpc`).")),
 			mcp.WithString("base_path", mcp.Description("File or directory the locator is interpreted relative to. Required for local-relative locators.")),
@@ -199,7 +218,7 @@ func registerMCPTools(s *server.MCPServer, r *graphRegistry) {
 
 	s.AddTool(
 		mcp.NewTool("find_smells",
-			mcp.WithReadOnlyHintAnnotation(true),
+			readTool,
 			mcp.WithDescription("Run structural code-smell rules against the parsed _ast table. Call with no arguments for the registry listing; call with `rule` to scan. Rules look for patterns like 'magic int literal in a binary expression' (Go) — useful for sweeping a monorepo before adding named constants. Each finding includes line/column and a short snippet so editors can jump to it. Requires a leyline-parsed .db (the _ast table)."),
 			mcp.WithString("rule", mcp.Description("Rule ID to run. Omit to list available rules.")),
 			mcp.WithString("source_id", mcp.Description("Limit the scan to one parsed source file (matches _source.id, e.g. 'main.go').")),


### PR DESCRIPTION
Follow-up to #448 (mache-974697), found by verifying the **installed binary** post-merge (per "ensure mache produces what you expect").

## Problem

After #448 added `readOnlyHint=true`, a `tools/list` probe showed every tool *also* carrying `destructiveHint=true` and `openWorldHint=true`:

```
18 tools | readOnly=true: 17 | destructive=true: ALL 18 | openWorld=true: ALL 18
```

Root cause: `mcp.NewTool` pre-seeds the annotation struct with the MCP spec defaults (`destructive=true`, `openWorld=true`), and the single-field `WithReadOnlyHintAnnotation` override left those intact. The `/mcp` *badge* was fixed (clients ignore `destructiveHint` when `readOnlyHint=true`), but the raw annotations were dishonest — a read-only tool shouldn't advertise destructive, and `list_directory` isn't open-world.

## Fix

Three `WithToolAnnotation(ToolAnnotation{...})` presets that **replace** the whole struct (wiping leaked defaults):
- `readTool` — readOnly=true, destructive=false, openWorld=false (13 tools)
- `readToolExternal` — same, openWorld=true (the 4 that reach the ley-line daemon)
- `writeTool` — readOnly=false, destructive=true (write_file)

## Verified on the installed binary

```
18 tools | readOnly=true: 17 | destructive=true: ['write_file'] | openWorld=true: ['get_diagnostics','get_sheaf_status','get_type_info','semantic_search']
```

`TestMCPRegistry_AnnotationHintsHonest` pins `destructiveHint` (only `mutatingTools`) and `openWorldHint` (only `openWorldTools`) per tool so a leaked default can't slip back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)