### PR TITLE
fix(leyline): reap daemon process group — stop orphaning the daemon's mache child

### DIFF
--- a/internal/leyline/daemon_lifecycle_test.go
+++ b/internal/leyline/daemon_lifecycle_test.go
@@ -1,0 +1,38 @@
+package leyline
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestManagedDaemon_AllTerminationViaSeam is the consistency measure for
+// the managed-daemon lifecycle: every kill site in socket.go MUST go
+// through the managedDaemon seam (signalGroup / discard), which signals
+// the daemon's whole process GROUP so the `mache serve --control` child it
+// spawns is reaped rather than orphaned (mache-823d91).
+//
+// A direct os.Process.Kill() / .Signal() in socket.go would silently
+// reintroduce the orphan leak this fix removed — there were FOUR such
+// sites before the seam, and each had to independently remember the
+// group discipline. This test makes "add a new kill site, forget the
+// group-kill" a compile-green-but-test-red mistake instead of a latent leak.
+//
+// The legitimate process-signaling primitive lives in procgroup_unix.go
+// (signalProcessGroup) and is reached only via the seam methods; this test
+// deliberately scans socket.go alone.
+func TestManagedDaemon_AllTerminationViaSeam(t *testing.T) {
+	src, err := os.ReadFile("socket.go")
+	if err != nil {
+		t.Fatalf("read socket.go: %v", err)
+	}
+	text := string(src)
+	for _, forbidden := range []string{".Kill()", ".Signal("} {
+		if strings.Contains(text, forbidden) {
+			t.Errorf("socket.go contains a direct process %q call — terminate the "+
+				"managed daemon via managed.signalGroup/discard (the group-aware seam), "+
+				"not a raw process call, or the daemon's mache child gets orphaned (mache-823d91)",
+				forbidden)
+		}
+	}
+}

--- a/internal/leyline/procgroup_other.go
+++ b/internal/leyline/procgroup_other.go
@@ -1,0 +1,23 @@
+//go:build !unix
+
+package leyline
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup is a no-op on non-unix platforms (no POSIX process
+// groups). mache targets darwin/linux; this stub only keeps the package
+// compiling elsewhere.
+func setProcessGroup(_ *exec.Cmd) {}
+
+// signalProcessGroup degrades to signaling just the leader process on
+// platforms without POSIX process groups.
+func signalProcessGroup(proc *os.Process, sig syscall.Signal) error {
+	if proc == nil {
+		return os.ErrProcessDone
+	}
+	return proc.Signal(sig)
+}

--- a/internal/leyline/procgroup_unix.go
+++ b/internal/leyline/procgroup_unix.go
@@ -1,0 +1,38 @@
+//go:build unix
+
+package leyline
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup makes the spawned command a process-group leader, so its
+// own children (e.g. the `mache serve --control` that `leyline daemon`
+// spawns) inherit the group. signalProcessGroup can then reap the whole
+// tree instead of orphaning the grandchild (mache-823d91).
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// signalProcessGroup delivers sig to the entire process group led by proc.
+// Because proc was started with setProcessGroup, its PID is also its PGID,
+// so a negative-PID kill targets the daemon AND every child it spawned.
+// Falls back to signaling just proc if the group send fails (e.g. the
+// leader already exited and the group is gone). Returns the underlying
+// error so callers can detect an already-dead group.
+func signalProcessGroup(proc *os.Process, sig syscall.Signal) error {
+	if proc == nil {
+		return os.ErrProcessDone
+	}
+	if err := syscall.Kill(-proc.Pid, sig); err != nil {
+		// Group gone (leader already reaped) — try the leader directly so
+		// callers still get a meaningful result.
+		return proc.Signal(sig)
+	}
+	return nil
+}

--- a/internal/leyline/procgroup_unix_test.go
+++ b/internal/leyline/procgroup_unix_test.go
@@ -1,0 +1,63 @@
+//go:build unix
+
+package leyline
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestSignalProcessGroup_ReapsChild reproduces the daemon orphan bug
+// (mache-823d91): a spawned process itself spawns a child; killing only
+// the parent leaves the child orphaned. setProcessGroup + signalProcessGroup
+// must reap the WHOLE tree. Here the parent shell backgrounds a child
+// `sleep` (mirroring `leyline daemon` spawning `mache serve --control`),
+// prints the child PID, then waits. Group-killing the parent must also
+// kill the child.
+func TestSignalProcessGroup_ReapsChild(t *testing.T) {
+	// Parent backgrounds a long sleep (the "grandchild mache"), prints its
+	// PID, then sleeps itself so the group stays alive until we kill it.
+	cmd := exec.Command("sh", "-c", "sleep 60 & echo $!; sleep 60")
+	setProcessGroup(cmd)
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	n, _ := out.Read(buf)
+	childPID, err := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if err != nil {
+		t.Fatalf("parse child pid from %q: %v", string(buf[:n]), err)
+	}
+
+	// Sanity: the backgrounded child is alive before we kill the group.
+	if err := syscall.Kill(childPID, 0); err != nil {
+		t.Fatalf("child %d should be alive before kill: %v", childPID, err)
+	}
+
+	// Kill the whole group — must reap the parent AND the child.
+	if err := signalProcessGroup(cmd.Process, syscall.SIGKILL); err != nil {
+		t.Fatalf("signalProcessGroup: %v", err)
+	}
+	_, _ = cmd.Process.Wait()
+
+	// The child must be gone. Poll briefly to absorb reaping latency.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := syscall.Kill(childPID, 0); err != nil {
+			return // ESRCH — child reaped, success
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Clean up the leak if the fix failed, so the test doesn't orphan it.
+	_ = syscall.Kill(childPID, syscall.SIGKILL)
+	t.Fatalf("child %d survived group kill — orphan not reaped", childPID)
+}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -295,6 +295,13 @@ func DiscoverOrStart() (string, error) {
 	cmd.Stderr = nil
 	cmd.Stdin = nil
 
+	// Run the daemon as a process-group leader so that the `mache serve
+	// --control` child it spawns is reaped together with it — otherwise
+	// killing the daemon (timeout below, or StopManaged) orphans that
+	// child, which accumulates and contends for the shared arena/socket
+	// (mache-823d91).
+	setProcessGroup(cmd)
+
 	log.Printf("auto-starting leyline daemon: %s", strings.Join(cmd.Args, " "))
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("start leyline: %w", err)
@@ -319,8 +326,8 @@ func DiscoverOrStart() (string, error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Timed out — kill the process and report
-	_ = cmd.Process.Kill()
+	// Timed out — kill the whole group (daemon + any child it spawned) and report
+	_ = signalProcessGroup(cmd.Process, syscall.SIGKILL)
 	managed.proc = nil
 	managed.sock = ""
 	return "", fmt.Errorf("leyline daemon started but socket %s did not appear within 5s", sockPath)
@@ -341,9 +348,11 @@ func StopManaged() {
 	pid := managed.proc.Pid
 	log.Printf("stopping managed leyline daemon (pid=%d)", pid)
 
-	// SIGTERM: leyline's signal handler unmounts NFS then exits
-	if err := managed.proc.Signal(syscall.SIGTERM); err != nil {
-		// Process already dead — just clean up
+	// SIGTERM the whole group: leyline's signal handler unmounts NFS then
+	// exits, and the `mache serve --control` child it spawned is terminated
+	// alongside it rather than orphaned (mache-823d91).
+	if err := signalProcessGroup(managed.proc, syscall.SIGTERM); err != nil {
+		// Group already gone — just clean up
 		_ = managed.proc.Release()
 		managed.proc = nil
 		managed.sock = ""
@@ -362,7 +371,7 @@ func StopManaged() {
 		log.Printf("leyline daemon (pid=%d) exited gracefully", pid)
 	case <-time.After(3 * time.Second):
 		log.Printf("leyline daemon (pid=%d) did not exit after SIGTERM, sending SIGKILL", pid)
-		_ = managed.proc.Kill()
+		_ = signalProcessGroup(managed.proc, syscall.SIGKILL)
 		<-done
 	}
 

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -94,12 +94,43 @@ func (c *SocketClient) SubscribeDropped() uint64 {
 // low enough that the consumer notices within a second on a noisy stream.
 const maxConsecutiveParseFailures = 16
 
-// managed holds state for a leyline daemon subprocess auto-spawned by mache.
-// At most one managed daemon per process. Cleaned up on process exit.
-var managed struct {
+// managedDaemon owns the lifecycle of the leyline daemon subprocess
+// auto-spawned by mache. At most one per process, cleaned up on exit.
+//
+// ALL termination goes through its methods (signalGroup / discard) — no
+// caller signals .proc directly. The daemon is spawned as a process-group
+// leader (setProcessGroup) and these methods signal the whole GROUP, so
+// the `mache serve --control` child the daemon spawns is reaped with it
+// rather than orphaned (mache-823d91). Routing every kill site through one
+// seam is what keeps that discipline from drifting as sites are added;
+// TestManagedDaemon_AllTerminationViaSeam enforces it.
+type managedDaemon struct {
 	mu   sync.Mutex
 	proc *os.Process
 	sock string
+}
+
+var managed managedDaemon
+
+// signalGroup delivers sig to the daemon's whole process group. Caller
+// must hold mu. Returns the underlying error (e.g. ESRCH if the group is
+// already gone) so callers can branch on a dead daemon.
+func (m *managedDaemon) signalGroup(sig syscall.Signal) error {
+	return signalProcessGroup(m.proc, sig)
+}
+
+// discard SIGKILLs the daemon's group, removes its socket file, and clears
+// state. Caller must hold mu. The immediate, non-graceful counterpart to
+// StopManaged — used when a managed daemon is stale or failed to start.
+func (m *managedDaemon) discard() {
+	if m.proc != nil {
+		_ = signalProcessGroup(m.proc, syscall.SIGKILL)
+	}
+	if m.sock != "" {
+		_ = os.Remove(m.sock)
+	}
+	m.proc = nil
+	m.sock = ""
 }
 
 // DialSocket connects to the ley-line control socket at sockPath.
@@ -212,13 +243,10 @@ func DiscoverOrStart() (string, error) {
 		if isSocketAlive(managed.sock) {
 			return managed.sock, nil
 		}
-		// Stale managed daemon: reap and reset so the spawn block runs.
-		if managed.proc != nil {
-			_ = managed.proc.Kill()
-		}
-		_ = os.Remove(managed.sock)
-		managed.proc = nil
-		managed.sock = ""
+		// Stale managed daemon: reap its group + clear so the spawn block
+		// re-runs. discard() does the group-kill that avoids orphaning the
+		// daemon's mache child.
+		managed.discard()
 	}
 
 	// Find the leyline binary: PATH → ~/.mache/bin/ → auto-download
@@ -326,10 +354,8 @@ func DiscoverOrStart() (string, error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Timed out — kill the whole group (daemon + any child it spawned) and report
-	_ = signalProcessGroup(cmd.Process, syscall.SIGKILL)
-	managed.proc = nil
-	managed.sock = ""
+	// Timed out — discard the group (daemon + any child it spawned) and report.
+	managed.discard()
 	return "", fmt.Errorf("leyline daemon started but socket %s did not appear within 5s", sockPath)
 }
 
@@ -351,7 +377,7 @@ func StopManaged() {
 	// SIGTERM the whole group: leyline's signal handler unmounts NFS then
 	// exits, and the `mache serve --control` child it spawned is terminated
 	// alongside it rather than orphaned (mache-823d91).
-	if err := signalProcessGroup(managed.proc, syscall.SIGTERM); err != nil {
+	if err := managed.signalGroup(syscall.SIGTERM); err != nil {
 		// Group already gone — just clean up
 		_ = managed.proc.Release()
 		managed.proc = nil
@@ -371,7 +397,7 @@ func StopManaged() {
 		log.Printf("leyline daemon (pid=%d) exited gracefully", pid)
 	case <-time.After(3 * time.Second):
 		log.Printf("leyline daemon (pid=%d) did not exit after SIGTERM, sending SIGKILL", pid)
-		_ = signalProcessGroup(managed.proc, syscall.SIGKILL)
+		_ = managed.signalGroup(syscall.SIGKILL)
 		<-done
 	}
 


### PR DESCRIPTION
## Problem (root-caused, not guessed)

`mache serve <dir>` auto-starts `leyline daemon`, which in turn spawns a `mache serve --control` child. mache killed **only the daemon process** (the post-spawn 5s-timeout `Kill()`, and `StopManaged`'s SIGTERM→SIGKILL), so that child was **orphaned**. Across sessions these pile up (32 observed live this session) and contend for the shared `~/.mache` arena/socket — a major contributor to the "leyline daemon started but socket did not appear within 5s" / "connection refused" flakiness that makes mache *feel* broken.

Measured directly: the LLO daemon binds its socket in **0.15s** — it is **not** slow. The flakiness is mache↔LLO *lifecycle*, not LLO performance.

## Fix

Spawn the daemon as a **process-group leader** (`setProcessGroup`) and signal the **whole group** (`signalProcessGroup`) at all three kill sites, so the daemon and its spawned child are reaped together. The process-group syscalls (`Setpgid`, `Kill(-pgid)`) are isolated behind `unix`/`!unix` build tags — the package already targets darwin+linux (CGO tree-sitter, `unix.Mmap`); the `!unix` stub degrades to single-process signaling.

## Verification (two layers)

1. **`TestSignalProcessGroup_ReapsChild`** — a parent backgrounds a child (mirroring daemon→mache), is group-killed, and the test asserts the child is reaped.
2. **Real-daemon probe** — confirmed the leyline daemon's `mache --control` child shares the daemon's PGID (`child pgid == daemon pid`) and is reaped by the group kill (`child alive=false` after `Kill(-pgid)`). So leyline does *not* detach its child into a new group; the fix genuinely reaches it.

## Scope

This fixes the **orphan-leak** mechanism. The remaining `mache-823d91` surface — the global `~/.mache/default.sock` singleton clobber (any daemon repoints it; stale → ECONNREFUSED) and the launchd keep-alive — is tracked separately on the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review response (fresh-context review: SHIP w/ NITs)

- **4th kill site (should-fix) → fixed via refactor.** The review caught a 4th `managed.proc.Kill()` (stale-managed-daemon reap) left single-process. Rather than convert it and keep four sites each remembering the discipline, introduced a single lifecycle seam: `managed` is now a `managedDaemon` type with `signalGroup()` / `discard()`; all four sites route through it. `TestManagedDaemon_AllTerminationViaSeam` scans socket.go and fails on any raw `.Kill()`/`.Signal()` so it cannot drift.
- **PID-reuse window (acknowledged):** `Kill(-pid)` lacks `os.Process.Signal`'s done-guard, so it widens the blast radius vs the old single-proc kill. This is a pre-existing class (the old post-`Wait()` `proc.Kill()` had it too) and runs under `managed.mu`; the window is the same. Noted, not changed.
- **Gated integration test (follow-up):** the unit test + seam guard cover the mechanism; the load-bearing external assumption (leyline keeps its child in the daemon group) was verified by a manual real-daemon probe (child pgid == daemon pid, reaped). A gated (env-var) integration test to catch future leyline drift is worth adding — tracked on mache-823d91.
