### PR TITLE
feat(leyline): surface which leyline binary mache resolved (log + get_sheaf_status)

### DIFF
--- a/cmd/serve_handler_get_sheaf_status.go
+++ b/cmd/serve_handler_get_sheaf_status.go
@@ -52,6 +52,15 @@ func makeGetSheafStatusHandler(subscriberStatus func() (leyline.SubscriberStatus
 			}
 		}
 
+		// leyline binary provenance is independent of daemon reachability
+		// (it's "which binary did mache resolve"), so attach it to every
+		// response shape — including {available:false} (mache-0dcd98).
+		addProvenance := func(body map[string]any) {
+			if prov, ok := leyline.Provenance(); ok {
+				body["leyline"] = prov
+			}
+		}
+
 		unavailable := func(reason string) (*mcp.CallToolResult, error) {
 			body := map[string]any{
 				"available": false,
@@ -60,6 +69,7 @@ func makeGetSheafStatusHandler(subscriberStatus func() (leyline.SubscriberStatus
 			if subState != nil { // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
 				body["subscriber"] = subscriberFieldsFor(*subState) // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
 			} // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
+			addProvenance(body)
 			data, _ := json.Marshal(body)
 			return mcp.NewToolResultText(string(data)), nil
 		}
@@ -90,6 +100,7 @@ func makeGetSheafStatusHandler(subscriberStatus func() (leyline.SubscriberStatus
 		if subState != nil {
 			body["subscriber"] = subscriberFieldsFor(*subState)
 		}
+		addProvenance(body)
 		data, _ := json.Marshal(body)
 		return mcp.NewToolResultText(string(data)), nil
 	}

--- a/internal/leyline/provenance.go
+++ b/internal/leyline/provenance.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"os/exec"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -60,8 +61,21 @@ func Provenance() (LeylineProvenance, bool) {
 		Version:         resolvedLeyline.version,
 		Source:          resolvedLeyline.source,
 		ExpectedVersion: leylineBinaryVersion,
-		VersionMatches:  resolvedLeyline.version != "" && strings.Contains(resolvedLeyline.version, tag),
+		VersionMatches:  versionContainsTag(resolvedLeyline.version, tag),
 	}, true
+}
+
+// versionContainsTag reports whether the pinned version tag appears as a
+// whole dotted-number token in a `--version` line — NOT a raw substring,
+// so the pin "0.5.1" does not false-match a "0.5.11" release. Tokenizes on
+// any non-[0-9.] rune, so "leyline 0.5.1 (open)" → ["0.5.1"].
+func versionContainsTag(version, tag string) bool {
+	if version == "" || tag == "" {
+		return false
+	}
+	return slices.Contains(strings.FieldsFunc(version, func(r rune) bool {
+		return (r < '0' || r > '9') && r != '.'
+	}), tag)
 }
 
 // queryBinaryVersion runs `<bin> --version` and returns the trimmed output

--- a/internal/leyline/provenance.go
+++ b/internal/leyline/provenance.go
@@ -1,0 +1,78 @@
+package leyline
+
+import (
+	"context"
+	"log"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// resolvedLeyline records which leyline binary mache resolved for the
+// auto-spawned daemon, from which tier, at what version. Populated by
+// DiscoverOrStart's binary resolution; read by Provenance (surfaced via
+// get_sheaf_status, mache-0dcd98). Zero value means mache hasn't resolved
+// a binary this process — e.g. a pure-.db serve that never needs leyline,
+// or a daemon started externally rather than auto-spawned.
+var resolvedLeyline struct {
+	mu      sync.Mutex
+	path    string
+	version string
+	source  string // "PATH" | "cached" | "downloaded"
+}
+
+// LeylineProvenance is the observable provenance of the leyline binary
+// mache resolved for the managed daemon. Surfaced so "which leyline is
+// mache using?" is a log grep / MCP tool call instead of an archaeology
+// dig (the failure mode that hid the stale-cached-0.4.1 skew, mache-0acdf6).
+type LeylineProvenance struct {
+	Path            string `json:"path"`
+	Version         string `json:"version"`          // as reported by `<bin> --version` (best-effort)
+	Source          string `json:"source"`           // PATH | cached | downloaded
+	ExpectedVersion string `json:"expected_version"` // the compile-time pin (leylineBinaryVersion)
+	VersionMatches  bool   `json:"version_matches"`  // reported version contains the pinned tag
+}
+
+// recordResolvedLeyline stores and logs the resolved binary's provenance.
+func recordResolvedLeyline(path, source string) {
+	version := queryBinaryVersion(path)
+	resolvedLeyline.mu.Lock()
+	resolvedLeyline.path = path
+	resolvedLeyline.version = version
+	resolvedLeyline.source = source
+	resolvedLeyline.mu.Unlock()
+	log.Printf("resolved leyline: %s (%s) [%s], expected %s", path, version, source, leylineBinaryVersion)
+}
+
+// Provenance returns the resolved leyline binary's provenance, or ok=false
+// if mache hasn't resolved one this process. The returned ExpectedVersion
+// is always populated (the compile-time pin) even when ok is false.
+func Provenance() (LeylineProvenance, bool) {
+	resolvedLeyline.mu.Lock()
+	defer resolvedLeyline.mu.Unlock()
+	if resolvedLeyline.path == "" {
+		return LeylineProvenance{ExpectedVersion: leylineBinaryVersion}, false
+	}
+	tag := strings.TrimPrefix(leylineBinaryVersion, "v")
+	return LeylineProvenance{
+		Path:            resolvedLeyline.path,
+		Version:         resolvedLeyline.version,
+		Source:          resolvedLeyline.source,
+		ExpectedVersion: leylineBinaryVersion,
+		VersionMatches:  resolvedLeyline.version != "" && strings.Contains(resolvedLeyline.version, tag),
+	}, true
+}
+
+// queryBinaryVersion runs `<bin> --version` and returns the trimmed output
+// (best-effort, "" on any error). Bounded so a hung binary can't block the
+// spawn path; provenance is informational, never load-bearing.
+func queryBinaryVersion(bin string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "--version").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/leyline/provenance_test.go
+++ b/internal/leyline/provenance_test.go
@@ -1,0 +1,61 @@
+package leyline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestProvenance_RecordAndReport verifies the resolved-leyline provenance
+// round-trips and that version_matches reflects whether the reported
+// version contains the pinned tag — the at-a-glance skew signal that the
+// stale-0.4.1 incident lacked (mache-0dcd98 / mache-0acdf6).
+func TestProvenance_RecordAndReport(t *testing.T) {
+	// Reset shared state so the test is order-independent.
+	resolvedLeyline.mu.Lock()
+	resolvedLeyline.path, resolvedLeyline.version, resolvedLeyline.source = "", "", ""
+	resolvedLeyline.mu.Unlock()
+
+	// Before any resolution: ok=false, but expected version still reported.
+	if p, ok := Provenance(); ok || p.ExpectedVersion != leylineBinaryVersion {
+		t.Fatalf("pre-resolution: got ok=%v expected=%q, want ok=false expected=%q", ok, p.ExpectedVersion, leylineBinaryVersion)
+	}
+
+	// A fake binary whose --version prints the PINNED tag → version_matches true.
+	matching := writeFakeLeyline(t, "leyline "+leylineBinaryVersion+" (open)")
+	recordResolvedLeyline(matching, "PATH")
+	p, ok := Provenance()
+	if !ok {
+		t.Fatal("post-resolution: ok=false")
+	}
+	if p.Path != matching || p.Source != "PATH" {
+		t.Errorf("path/source: got %q/%q", p.Path, p.Source)
+	}
+	if !p.VersionMatches {
+		t.Errorf("version %q should match pinned %q", p.Version, leylineBinaryVersion)
+	}
+
+	// A binary reporting a DIFFERENT version → version_matches false (the
+	// exact stale-cached-binary signal).
+	stale := writeFakeLeyline(t, "leyline 0.4.1 (open)")
+	recordResolvedLeyline(stale, "cached")
+	p, _ = Provenance()
+	if p.Source != "cached" {
+		t.Errorf("source: got %q want cached", p.Source)
+	}
+	if p.VersionMatches {
+		t.Errorf("stale version %q must NOT match pinned %q", p.Version, leylineBinaryVersion)
+	}
+}
+
+// writeFakeLeyline writes an executable shell script that prints versionLine
+// on `--version`, returning its path.
+func writeFakeLeyline(t *testing.T, versionLine string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "leyline")
+	script := "#!/bin/sh\necho '" + versionLine + "'\n"
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake leyline: %v", err)
+	}
+	return p
+}

--- a/internal/leyline/provenance_test.go
+++ b/internal/leyline/provenance_test.go
@@ -3,6 +3,7 @@ package leyline
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -11,10 +12,15 @@ import (
 // version contains the pinned tag — the at-a-glance skew signal that the
 // stale-0.4.1 incident lacked (mache-0dcd98 / mache-0acdf6).
 func TestProvenance_RecordAndReport(t *testing.T) {
-	// Reset shared state so the test is order-independent.
-	resolvedLeyline.mu.Lock()
-	resolvedLeyline.path, resolvedLeyline.version, resolvedLeyline.source = "", "", ""
-	resolvedLeyline.mu.Unlock()
+	// Reset shared state so the test is order-independent, and restore the
+	// zero value on exit so we don't leak stale provenance to later tests.
+	resetResolved := func() {
+		resolvedLeyline.mu.Lock()
+		resolvedLeyline.path, resolvedLeyline.version, resolvedLeyline.source = "", "", ""
+		resolvedLeyline.mu.Unlock()
+	}
+	resetResolved()
+	t.Cleanup(resetResolved)
 
 	// Before any resolution: ok=false, but expected version still reported.
 	if p, ok := Provenance(); ok || p.ExpectedVersion != leylineBinaryVersion {
@@ -45,6 +51,14 @@ func TestProvenance_RecordAndReport(t *testing.T) {
 	}
 	if p.VersionMatches {
 		t.Errorf("stale version %q must NOT match pinned %q", p.Version, leylineBinaryVersion)
+	}
+
+	// Substring false-positive guard: a "<pin>1" release (e.g. 0.5.11 vs pin
+	// 0.5.1) must NOT match — version_matches is whole-token, not substring.
+	superstr := writeFakeLeyline(t, "leyline "+strings.TrimPrefix(leylineBinaryVersion, "v")+"1 (open)")
+	recordResolvedLeyline(superstr, "PATH")
+	if p, _ := Provenance(); p.VersionMatches {
+		t.Errorf("version %q must NOT match pinned %q (substring false-positive)", p.Version, leylineBinaryVersion)
 	}
 }
 

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -256,11 +256,13 @@ func DiscoverOrStart() (string, error) {
 	}
 
 	leylineBin, err := exec.LookPath("leyline")
+	source := "PATH"
 	if err != nil {
 		// Fallback: check ~/.mache/bin/leyline
 		localBin := filepath.Join(home, ".mache", "bin", "leyline")
 		if _, statErr := os.Stat(localBin); statErr == nil {
 			leylineBin = localBin
+			source = "cached" // ~/.mache/bin — un-versioned, can shadow the pin (mache-0acdf6)
 		} else if os.Getenv("MACHE_NO_LEYLINE") != "" {
 			// CI / bundle deployments set this to opt out of the
 			// network-fetch path entirely. Surface a clear error
@@ -274,8 +276,14 @@ func DiscoverOrStart() (string, error) {
 				return "", fmt.Errorf("leyline not on PATH and auto-download failed: %w", dlErr)
 			}
 			leylineBin = downloaded
+			source = "downloaded"
 		}
 	}
+	// Record which binary won, from which tier, at what version — so the
+	// resolution is visible in logs AND via get_sheaf_status (mache-0dcd98).
+	// This was invisible before, which made the stale-cached-0.4.1 skew
+	// (mache-0acdf6) an archaeology dig instead of a one-line answer.
+	recordResolvedLeyline(leylineBin, source)
 	dataDir := filepath.Join(home, ".mache")
 	if err := os.MkdirAll(dataDir, 0o755); err != nil {
 		return "", fmt.Errorf("create %s: %w", dataDir, err)


### PR DESCRIPTION
## Why

Debugging the stale-cached-0.4.1 leyline skew (mache-0acdf6) was archaeology because mache gave **zero visibility** into which leyline binary it resolved. `DiscoverOrStart` picks a binary across three tiers (PATH → `~/.mache/bin` cache → auto-download) and logged only the daemon command — not which binary won, from which tier, or at what version. A teammate silently running a stale cached daemon would have no signal.

## What

Record `(path, version, source-tier)` at binary resolution, then:

1. **Log line** — `resolved leyline: <path> (<version>) [PATH|cached|downloaded], expected <pin>`.
2. **MCP exposure** — `get_sheaf_status` gains a `leyline` object on every response shape (including `available:false` — provenance is independent of daemon reachability):

```json
"leyline": {
  "path": "/Users/.../.local/bin/leyline",
  "version": "leyline 0.5.1 (open)",
  "source": "PATH",
  "expected_version": "v0.5.1",
  "version_matches": true
}
```

A stale cached binary would show `source: "cached"` + `version_matches: false` at a glance — the signal this whole incident lacked.

## Verified

- E2E: `get_sheaf_status` over stdio returns the PATH 0.5.1 binary, `version_matches=true`.
- `TestProvenance_RecordAndReport` pins the record→report round-trip and the match/mismatch signal (fake binaries reporting matching vs stale versions).
- Build + `golangci-lint` clean; existing sheaf-status handler tests pass.

## Notes

- The `leyline` field appears once a leyline op has triggered resolution (the daemon auto-spawn is async); the log always shows it at startup. A lazy PATH-only resolve to make it answerable on the very first call (without spawning) is a possible follow-up.
- Pairs with **mache-8kif** (refuse on daemon version mismatch at connect) and **mache-0acdf6** (drop the cache/download tier entirely — once PATH-only, `source` is always PATH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)