### PR TITLE
fix(lsp): speak the daemon's named enrich UDS op + spawn with --source

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -111,6 +111,15 @@ func runServe(cmd *cobra.Command, args []string) error {
 	defer registry.Close()
 	registry.repoCloneDir = repoCloneDir
 
+	// Configure the leyline daemon's --source so live LSP/embed enrichment
+	// (get_type_info / get_diagnostics with file=) can run: op_enrich
+	// requires the daemon to know the source tree (mache-303036). Only set
+	// when serving a source directory; a pre-baked .db carries its own
+	// _lsp* tables and needs no live enrichment.
+	if src := servedSourceDir(args, servePath, serveRepo != ""); src != "" {
+		leyline.SetDaemonSource(src)
+	}
+
 	// Start the sheaf-invalidate event subscriber (mache-c14c43).
 	// One subscriber per process feeds the router; the router fans
 	// events out to every lazyGraph's invalidator. When no daemon
@@ -657,6 +666,28 @@ func openDBGraph(dbPath string, schema *api.Topology, extraCleanup func()) (grap
 		_ = sg.Close()
 		extraCleanup()
 	}, nil
+}
+
+// servedSourceDir returns the absolute source-tree directory mache is
+// serving, for configuring the leyline daemon's --source. It prefers a
+// positional argument that is an existing directory; for --repo mode (no
+// positional source) the clone at basePath is the tree. Returns "" when
+// serving a pre-baked .db — there's no live source to enrich, and the .db
+// carries its own _lsp* tables.
+func servedSourceDir(args []string, basePath string, repoMode bool) string {
+	for _, a := range args {
+		if fi, err := os.Stat(a); err == nil && fi.IsDir() {
+			if abs, err := filepath.Abs(a); err == nil {
+				return abs
+			}
+		}
+	}
+	if repoMode {
+		if abs, err := filepath.Abs(basePath); err == nil {
+			return abs
+		}
+	}
+	return ""
 }
 
 // autoInvokeLeylineParse runs `leyline parse <sourceDir> -o <tmpdb>` and

--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -33,6 +34,22 @@ func lspTableMissing(table, feature string) *mcp.CallToolResult {
 
 func lspEnrichFailed(feature string) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf("%s not available — LSP enrichment requires ley-line daemon.\n%s", feature, lspEnrichHint))
+}
+
+// relForEnrich makes filePath relative to the daemon's --source dir, which
+// is what the `enrich` op expects ("files relative to source dir"). An
+// absolute path under the source root is relativized; an already-relative
+// path, or one outside the root, is passed through unchanged.
+func relForEnrich(filePath string) string {
+	src := leyline.DaemonSource()
+	if src == "" || !filepath.IsAbs(filePath) {
+		return filePath
+	}
+	rel, err := filepath.Rel(src, filePath)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return filePath
+	}
+	return rel
 }
 
 func makeGetTypeInfoHandler(g graph.Graph) server.ToolHandlerFunc {
@@ -146,7 +163,7 @@ func enrichAndQueryTypeInfo(filePath, symbol, kind string) (*mcp.CallToolResult,
 	if err := client.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
 		return nil, fmt.Errorf("set deadline: %w", err)
 	}
-	resp, err := client.Tool("lsp", map[string]any{"file": filePath})
+	resp, err := client.Enrich("lsp", []string{relForEnrich(filePath)})
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +300,7 @@ func enrichAndQueryDiagnostics(filePath, symbol, kind string, limit int) (*mcp.C
 	if err := client.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
 		return nil, fmt.Errorf("set deadline: %w", err)
 	}
-	resp, err := client.Tool("lsp", map[string]any{"file": filePath})
+	resp, err := client.Enrich("lsp", []string{relForEnrich(filePath)})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/serve_lsp_enrich_test.go
+++ b/cmd/serve_lsp_enrich_test.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+)
+
+// TestRelForEnrich pins how mache maps an MCP `file` param to the
+// source-relative path the daemon `enrich` op expects (mache-303036).
+func TestRelForEnrich(t *testing.T) {
+	leyline.SetDaemonSource("/src/root")
+	t.Cleanup(func() { leyline.SetDaemonSource("") })
+
+	cases := []struct{ in, want string }{
+		{"/src/root/crates/x/lib.rs", "crates/x/lib.rs"}, // absolute under root → relativized
+		{"crates/x/lib.rs", "crates/x/lib.rs"},           // already relative → unchanged
+		{"/elsewhere/y.rs", "/elsewhere/y.rs"},           // outside root → passthrough
+	}
+	for _, c := range cases {
+		if got := relForEnrich(c.in); got != c.want {
+			t.Errorf("relForEnrich(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	// With no source configured, paths pass through untouched.
+	leyline.SetDaemonSource("")
+	if got := relForEnrich("/src/root/a.rs"); got != "/src/root/a.rs" {
+		t.Errorf("no-source passthrough: got %q", got)
+	}
+}
+
+// TestServedSourceDir confirms a directory arg yields a source root while a
+// .db arg yields "" (no live enrichment for pre-baked dbs).
+func TestServedSourceDir(t *testing.T) {
+	dir := t.TempDir()
+	db := filepath.Join(dir, "code.db")
+	if err := os.WriteFile(db, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := servedSourceDir([]string{dir}, "", false); got != dir {
+		t.Errorf("dir arg: got %q want %q", got, dir)
+	}
+	if got := servedSourceDir([]string{db}, "", false); got != "" {
+		t.Errorf(".db arg should yield empty source, got %q", got)
+	}
+	if got := servedSourceDir(nil, dir, true); got != dir {
+		t.Errorf("repo mode: got %q want %q", got, dir)
+	}
+	if got := servedSourceDir(nil, dir, false); got != "" {
+		t.Errorf("no positional + not repo mode should be empty, got %q", got)
+	}
+}

--- a/internal/leyline/daemon_source.go
+++ b/internal/leyline/daemon_source.go
@@ -1,0 +1,29 @@
+package leyline
+
+import "sync/atomic"
+
+// daemonSourceDir is the source tree the auto-spawned daemon is started
+// against (--source). It is read at spawn time in DiscoverOrStart. The
+// daemon needs it to run enrichment passes — op_enrich fails "no --source
+// configured" without it — so live LSP/embed enrichment (get_type_info /
+// get_diagnostics with file=) only works when this is set (mache-303036).
+//
+// Empty (the zero value) means "no --source", which is correct for serving
+// a pre-baked .db that already carries its own _lsp* tables.
+var daemonSourceDir atomic.Pointer[string]
+
+// SetDaemonSource configures the source directory passed to the
+// auto-spawned leyline daemon. Call once at serve startup when serving a
+// source tree. Safe for concurrent use; takes effect on the next daemon
+// spawn (a daemon already running is not restarted).
+func SetDaemonSource(dir string) {
+	daemonSourceDir.Store(&dir)
+}
+
+// DaemonSource returns the configured daemon --source dir, or "" if unset.
+func DaemonSource() string {
+	if p := daemonSourceDir.Load(); p != nil {
+		return *p
+	}
+	return ""
+}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -320,12 +320,21 @@ func DiscoverOrStart() (string, error) {
 	// Start leyline daemon as a background subprocess.
 	// `daemon` creates the UDS socket at <ctrl>.sock that mache connects to.
 	// `serve` mounts only (no socket) — wrong for our use case.
-	cmd := exec.Command(leylineBin, "daemon",
+	daemonArgs := []string{
+		"daemon",
 		"--arena", arenaPath,
 		"--arena-size-mib", "64",
 		"--control", ctrlPath,
 		"--mount", mountDir,
-	)
+	}
+	// --source lets the daemon run enrichment passes: op_enrich requires
+	// ctx.source_dir, so without it lsp/embed enrichment fails with "no
+	// --source configured". Set via SetDaemonSource at serve startup when
+	// serving a source tree; empty for pre-baked .db serves (mache-303036).
+	if src := DaemonSource(); src != "" {
+		daemonArgs = append(daemonArgs, "--source", src)
+	}
+	cmd := exec.Command(leylineBin, daemonArgs...)
 	// Detach from our stdio so it doesn't interfere with MCP transport
 	cmd.Stdout = nil
 	cmd.Stderr = nil
@@ -503,20 +512,30 @@ func (c *SocketClient) sendRaw(req map[string]any) ([]byte, error) {
 	return []byte(strings.TrimSpace(line)), nil
 }
 
-// Tool invokes a named tool with the given args via the `tool` op.
-// Returns the full response map on success.
-func (c *SocketClient) Tool(name string, args map[string]any) (map[string]any, error) {
-	req := map[string]any{
-		"op":   "tool",
-		"name": name,
-		"args": args,
+// Enrich runs a daemon enrichment pass (e.g. "lsp", "embed") over the
+// given files via the `enrich` op, populating the corresponding arena
+// tables (for "lsp": _lsp_hover / _lsp / _lsp_defs / _lsp_refs). `files`
+// are paths relative to the daemon's --source dir; nil/empty enriches every
+// file. The op is SYNCHRONOUS on the daemon side — it runs the pass and
+// snapshots the living db to the arena before responding — so a subsequent
+// Query observes the populated tables.
+//
+// This replaces the prior `tool` op: the leyline daemon's UDS dispatch
+// speaks named ops directly ({"op":"enrich","pass":...}); the MCP
+// tools/call envelope ({"op":"tool","name":...}) only exists on the HTTP
+// /mcp endpoint, so sending it over UDS returned "unknown op: tool"
+// (mache-303036).
+func (c *SocketClient) Enrich(pass string, files []string) (map[string]any, error) {
+	req := map[string]any{"op": "enrich", "pass": pass}
+	if len(files) > 0 {
+		req["files"] = files
 	}
 	resp, err := c.SendOp(req)
 	if err != nil {
 		return nil, err
 	}
 	if errMsg, ok := resp["error"]; ok {
-		return nil, fmt.Errorf("tool %s: %v", name, errMsg)
+		return nil, fmt.Errorf("enrich %s: %v", pass, errMsg)
 	}
 	return resp, nil
 }

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -111,17 +111,24 @@ func TestSendOp_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestTool_FormatsCorrectly(t *testing.T) {
+func TestEnrich_SendsNamedOpWireShape(t *testing.T) {
+	// Pin the EXACT wire shape leyline's UDS dispatch expects:
+	// {"op":"enrich","pass":"lsp","files":[...]} — NOT the old
+	// {"op":"tool","name":"lsp","args":{...}} (mache-303036).
 	sockPath := mockServer(t, func(req map[string]any) map[string]any {
-		name, _ := req["name"].(string)
-		args, _ := req["args"].(map[string]any)
-		file, _ := args["file"].(string)
+		if req["op"] != "enrich" {
+			return map[string]any{"error": "unknown op: " + fmt.Sprint(req["op"])}
+		}
+		files, _ := req["files"].([]any)
+		var first string
+		if len(files) > 0 {
+			first, _ = files[0].(string)
+		}
 		return map[string]any{
 			"ok":         true,
-			"tool":       name,
+			"pass_echo":  req["pass"],
+			"file_echo":  first,
 			"generation": 42,
-			"stats":      map[string]any{"symbols": 15, "hovers": 15, "diagnostics": 3},
-			"file_echo":  file,
 		}
 	})
 
@@ -131,25 +138,21 @@ func TestTool_FormatsCorrectly(t *testing.T) {
 	}
 	defer client.Close() //nolint:errcheck
 
-	resp, err := client.Tool("lsp", map[string]any{"file": "/tmp/main.go"})
+	resp, err := client.Enrich("lsp", []string{"crates/x/src/lib.rs"})
 	if err != nil {
-		t.Fatalf("Tool: %v", err)
+		t.Fatalf("Enrich: %v", err)
 	}
-	if resp["tool"] != "lsp" {
-		t.Errorf("expected tool=lsp, got %v", resp["tool"])
+	if resp["pass_echo"] != "lsp" {
+		t.Errorf("expected pass=lsp, got %v", resp["pass_echo"])
 	}
-	if resp["file_echo"] != "/tmp/main.go" {
-		t.Errorf("expected file_echo=/tmp/main.go, got %v", resp["file_echo"])
-	}
-	// generation comes back as float64 from JSON
-	if gen, ok := resp["generation"].(float64); !ok || gen != 42 {
-		t.Errorf("expected generation=42, got %v", resp["generation"])
+	if resp["file_echo"] != "crates/x/src/lib.rs" {
+		t.Errorf("expected file echoed, got %v", resp["file_echo"])
 	}
 }
 
-func TestTool_ReturnsErrorOnToolFailure(t *testing.T) {
+func TestEnrich_ReturnsErrorOnFailure(t *testing.T) {
 	sockPath := mockServer(t, func(req map[string]any) map[string]any {
-		return map[string]any{"error": "unknown tool: bad"}
+		return map[string]any{"error": "unknown enrichment pass: bad"}
 	})
 
 	client, err := DialSocket(sockPath)
@@ -158,12 +161,12 @@ func TestTool_ReturnsErrorOnToolFailure(t *testing.T) {
 	}
 	defer client.Close() //nolint:errcheck
 
-	_, err = client.Tool("bad", nil)
+	_, err = client.Enrich("bad", nil)
 	if err == nil {
-		t.Fatal("expected error for unknown tool")
+		t.Fatal("expected error for unknown pass")
 	}
-	if !strings.Contains(err.Error(), "unknown tool") {
-		t.Errorf("expected 'unknown tool' in error, got: %v", err)
+	if !strings.Contains(err.Error(), "unknown enrichment pass") {
+		t.Errorf("expected pass error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## The bug

LSP live enrichment was dead. mache sent `{"op":"tool","name":"lsp","args":{...}}` — the MCP `tools/call` envelope that only exists on the daemon's **HTTP `/mcp`** endpoint — over the **UDS socket**, which speaks **named ops directly**. The daemon replied `unknown op: tool`, so `get_type_info` / `get_diagnostics` live enrichment never ran. (Thanks to the LLO author for the protocol correction.)

## The fix (verified end-to-end against the real leyline 0.5.1 daemon)

- **`internal/leyline`** — replace `Client.Tool` with **`Client.Enrich(pass, files)`**, sending `{"op":"enrich","pass":"lsp","files":[...]}` (the op LLO's UDS dispatch actually exposes — `wire.rs` `BaseRequest::Enrich`, `ops.rs::op_enrich`). It runs the pass synchronously and snapshots to the arena before replying, so the subsequent SQL query sees populated tables.
- **`internal/leyline`** — spawn the daemon with `--source <root>` when set (`SetDaemonSource`); `op_enrich` requires `ctx.source_dir` or fails `no --source configured`. `cmd/serve` wires it from the served source dir (`servedSourceDir`; empty for pre-baked `.db` serves).
- **`cmd/serve_lsp`** — `relForEnrich` maps the MCP `file` param to the source-relative path `enrich` expects.

### Proven
Serving lectio, `get_type_info(file=…)` now spawns the daemon `--source /…/lectio`, the enrich op runs, and rust-analyzer's LSP pass **completes** (`pass_name:lsp items_added:25`) — where before it died at `unknown op: tool`.

### Tests
`TestEnrich_SendsNamedOpWireShape` pins the `{op:enrich,pass,files}` wire shape (vs the old `tool` envelope); `TestRelForEnrich` / `TestServedSourceDir` cover path mapping + source detection.

## Scope — this fixes the wire protocol completely

Two **separate, newly-uncovered LLO-side gaps** remain before hover *text* surfaces via `get_type_info` (documented on mache-303036 for the LLO author):
1. The enrich LSP pass populates `_lsp` **skeleton rows** (`detail` empty) and does **not** fill `_lsp_hover` — hover text isn't in the tables mache queries.
2. The daemon `query` op serializes int64 columns (`start_row`/`start_col`) as **empty strings**, so mache can't read positions to drive the live position-based `lsp_hover` op (`expected u32`).

Both are LLO-side; this PR removes the mache-side protocol blocker that gated everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)