### PR TITLE
feat(lsp): surface ley-line enrich skip reasons + bump leyline v0.5.1 → v0.5.3

### DIFF
--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -52,6 +52,76 @@ func relForEnrich(filePath string) string {
 	return rel
 }
 
+// formatNoHoverMessage builds the user-facing string returned when LSP
+// enrichment completes but `_lsp_hover` has no row for the requested
+// symbol. Per-pass skip reasons (from leyline-v0.5.3+) are appended so
+// the operator sees WHY the enrich pass didn't write hover rows
+// (rust-analyzer not on PATH, scope mismatched _source.id, language has
+// no bundled server, etc.) instead of guessing.
+func formatNoHoverMessage(symbol, kind string, skipReasons []string) string {
+	var base string
+	if kind != "" {
+		base = fmt.Sprintf("LSP enrichment completed but no hover info found for %q with kind=%s", symbol, kind)
+	} else {
+		base = fmt.Sprintf("LSP enrichment completed but no hover info found for %q", symbol)
+	}
+	if len(skipReasons) == 0 {
+		return base
+	}
+	var sb strings.Builder
+	sb.WriteString(base)
+	sb.WriteString("\n\nEnrichment pass skip reasons:")
+	for _, r := range skipReasons {
+		sb.WriteString("\n  - ")
+		sb.WriteString(r)
+	}
+	return sb.String()
+}
+
+// extractEnrichSkipReasons returns the per-pass skip reasons surfaced by
+// the daemon's `enrich` op response. Each pass's `skipped` field is a
+// `[]string` carrying human-readable reasons that portions of the
+// requested scope did not write rows (no bundled LSP server for the
+// language, server not on PATH, scope matched no _source.id rows, etc.
+// — see ley-line-open's EnrichmentStats.skipped, bead 661727).
+//
+// Pre-leyline-v0.5.3 daemons drop this field at the capnp wire boundary
+// even when the JSON response carried it (Rust serde path worked, capnp
+// path did not). Returns nil for those daemons — callers must accept
+// nil-or-empty as "no skip-reason visibility available" rather than
+// "definitely nothing was skipped." The leyline binary pin lives at
+// `internal/leyline.leylineBinaryVersion`.
+func extractEnrichSkipReasons(resp map[string]any) []string {
+	passes, ok := resp["passes"].([]any)
+	if !ok {
+		return nil
+	}
+	var reasons []string
+	for _, p := range passes {
+		pmap, ok := p.(map[string]any)
+		if !ok {
+			continue
+		}
+		passName, _ := pmap["pass_name"].(string)
+		skipped, ok := pmap["skipped"].([]any)
+		if !ok {
+			continue
+		}
+		for _, s := range skipped {
+			str, ok := s.(string)
+			if !ok || str == "" {
+				continue
+			}
+			if passName != "" {
+				reasons = append(reasons, fmt.Sprintf("[%s] %s", passName, str))
+			} else {
+				reasons = append(reasons, str)
+			}
+		}
+	}
+	return reasons
+}
+
 func makeGetTypeInfoHandler(g graph.Graph) server.ToolHandlerFunc {
 	return func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		symbol := request.GetString("symbol", "")
@@ -168,6 +238,15 @@ func enrichAndQueryTypeInfo(filePath, symbol, kind string) (*mcp.CallToolResult,
 		return nil, err
 	}
 	log.Printf("LSP enrichment via ley-line daemon: %v", resp)
+	skipReasons := extractEnrichSkipReasons(resp)
+	if len(skipReasons) > 0 {
+		// Surface concretely so the operator sees WHY enrich silently
+		// returned 0 rows. Requires ley-line-open ≥ v0.5.3 (bead 661727).
+		log.Printf("LSP enrichment SKIPPED reasons (file=%s):", filePath)
+		for _, r := range skipReasons {
+			log.Printf("  - %s", r)
+		}
+	}
 
 	// Query phase — reuse same connection, reset deadline
 	if err := client.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
@@ -213,15 +292,12 @@ func enrichAndQueryTypeInfo(filePath, symbol, kind string) (*mcp.CallToolResult,
 	}
 
 	if len(results) == 0 {
-		return mcp.NewToolResultText(fmt.Sprintf("LSP enrichment completed but no hover info found for %q", symbol)), nil
+		return mcp.NewToolResultText(formatNoHoverMessage(symbol, "", skipReasons)), nil
 	}
 
 	results = filterByNodeIDKind(results, kind, func(r hoverResult) string { return r.NodeID })
 	if len(results) == 0 {
-		if kind != "" {
-			return mcp.NewToolResultText(fmt.Sprintf("LSP enrichment completed but no hover info found for %q with kind=%s", symbol, kind)), nil
-		}
-		return mcp.NewToolResultText(fmt.Sprintf("LSP enrichment completed but no hover info found for %q", symbol)), nil
+		return mcp.NewToolResultText(formatNoHoverMessage(symbol, kind, skipReasons)), nil
 	}
 
 	data, _ := json.MarshalIndent(results, "", "  ")
@@ -305,6 +381,13 @@ func enrichAndQueryDiagnostics(filePath, symbol, kind string, limit int) (*mcp.C
 		return nil, err
 	}
 	log.Printf("LSP enrichment via ley-line daemon: %v", resp)
+	skipReasons := extractEnrichSkipReasons(resp)
+	if len(skipReasons) > 0 {
+		log.Printf("LSP enrichment SKIPPED reasons (file=%s):", filePath)
+		for _, r := range skipReasons {
+			log.Printf("  - %s", r)
+		}
+	}
 
 	if err := client.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 		return nil, fmt.Errorf("set query deadline: %w", err)
@@ -346,7 +429,7 @@ func enrichAndQueryDiagnostics(filePath, symbol, kind string, limit int) (*mcp.C
 
 	results = filterByNodeIDKind(results, kind, func(r diagResult) string { return r.NodeID })
 	if len(results) == 0 {
-		return noDiagnosticsResult(symbol, kind), nil
+		return noDiagnosticsResultWithSkipReasons(symbol, kind, skipReasons), nil
 	}
 
 	data, _ := json.MarshalIndent(results, "", "  ")
@@ -368,6 +451,30 @@ func noDiagnosticsResult(symbol, kind string) *mcp.CallToolResult {
 	default:
 		return mcp.NewToolResultText("no diagnostics found")
 	}
+}
+
+// noDiagnosticsResultWithSkipReasons appends per-pass enrich skip
+// reasons to the base "no diagnostics found" message so the operator
+// sees WHY the daemon didn't write any diagnostic rows for the file.
+// Requires ley-line-open ≥ v0.5.3 to populate skipReasons; older
+// daemons return an empty slice (silent path).
+func noDiagnosticsResultWithSkipReasons(symbol, kind string, skipReasons []string) *mcp.CallToolResult {
+	base := noDiagnosticsResult(symbol, kind)
+	if len(skipReasons) == 0 {
+		return base
+	}
+	var sb strings.Builder
+	for _, c := range base.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			sb.WriteString(tc.Text)
+		}
+	}
+	sb.WriteString("\n\nEnrichment pass skip reasons:")
+	for _, r := range skipReasons {
+		sb.WriteString("\n  - ")
+		sb.WriteString(r)
+	}
+	return mcp.NewToolResultText(sb.String())
 }
 
 // queryDiagnosticsFromGraph queries _lsp from mache's in-memory graph.

--- a/cmd/serve_lsp_skip_reasons_test.go
+++ b/cmd/serve_lsp_skip_reasons_test.go
@@ -1,0 +1,119 @@
+// Tests for the extractEnrichSkipReasons + formatNoHoverMessage helpers
+// — the consumer surface of leyline-v0.5.3's `EnrichmentStats.skipped`
+// wire field (bead ley-line-open-661727).
+//
+// The helpers fail closed: pre-v0.5.3 daemons drop `skipped` at the
+// capnp boundary so the response carries no field; helpers return nil,
+// and callers fall back to the prior "no hover info found" message.
+
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractEnrichSkipReasons_PopulatedPasses(t *testing.T) {
+	// Shape of a leyline-v0.5.3 enrich response: passes is a JSON array
+	// of {pass_name, files_processed, items_added, duration_ms, skipped}
+	// objects. The Go capnp-JSON decoder maps each pass entry to
+	// map[string]any.
+	resp := map[string]any{
+		"ok":           true,
+		"current_root": "abc123",
+		"passes": []any{
+			map[string]any{
+				"pass_name":       "tree-sitter",
+				"files_processed": uint64(1),
+				"items_added":     uint64(25),
+				"duration_ms":     uint64(5),
+				"skipped":         []any{},
+			},
+			map[string]any{
+				"pass_name":       "lsp",
+				"files_processed": uint64(1),
+				"items_added":     uint64(0),
+				"duration_ms":     uint64(150),
+				"skipped": []any{
+					"language server 'rust-analyzer' not on PATH for language 'rust' (1 file(s) skipped)",
+				},
+			},
+		},
+	}
+
+	got := extractEnrichSkipReasons(resp)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one skip reason, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "[lsp]") {
+		t.Errorf("skip reason must prefix with pass_name; got: %s", got[0])
+	}
+	if !strings.Contains(got[0], "rust-analyzer") {
+		t.Errorf("skip reason must carry the underlying daemon message; got: %s", got[0])
+	}
+}
+
+func TestExtractEnrichSkipReasons_NoSkippedField(t *testing.T) {
+	// Pre-v0.5.3 daemon shape: passes entries don't carry a skipped
+	// field (the capnp builder dropped it). Helper returns nil so the
+	// caller doesn't tack on an empty "Enrichment pass skip reasons:"
+	// section.
+	resp := map[string]any{
+		"ok": true,
+		"passes": []any{
+			map[string]any{
+				"pass_name":       "lsp",
+				"files_processed": uint64(1),
+				"items_added":     uint64(0),
+				"duration_ms":     uint64(150),
+			},
+		},
+	}
+	got := extractEnrichSkipReasons(resp)
+	if len(got) != 0 {
+		t.Errorf("pre-v0.5.3 response (no skipped field) must return empty; got: %v", got)
+	}
+}
+
+func TestExtractEnrichSkipReasons_MalformedResponse(t *testing.T) {
+	// passes field missing entirely.
+	if got := extractEnrichSkipReasons(map[string]any{"ok": true}); len(got) != 0 {
+		t.Errorf("missing passes field must return empty; got: %v", got)
+	}
+	// passes is wrong type.
+	if got := extractEnrichSkipReasons(map[string]any{"passes": "not a list"}); len(got) != 0 {
+		t.Errorf("malformed passes must return empty; got: %v", got)
+	}
+}
+
+func TestFormatNoHoverMessage_WithSkipReasons(t *testing.T) {
+	reasons := []string{
+		"[lsp] language server 'rust-analyzer' not on PATH for language 'rust' (1 file(s) skipped)",
+		"[lsp] scope matched no _source.id rows; requested 1 file(s): [\"crates/memory-core/src/lib.rs\"]",
+	}
+	got := formatNoHoverMessage("Foo", "function", reasons)
+	if !strings.Contains(got, "Foo") {
+		t.Errorf("message must name the symbol; got: %s", got)
+	}
+	if !strings.Contains(got, "kind=function") {
+		t.Errorf("message must name the kind when provided; got: %s", got)
+	}
+	if !strings.Contains(got, "Enrichment pass skip reasons:") {
+		t.Errorf("message must label the skip-reason section; got: %s", got)
+	}
+	for _, r := range reasons {
+		if !strings.Contains(got, r) {
+			t.Errorf("message must include each skip reason verbatim; missing %q in: %s", r, got)
+		}
+	}
+}
+
+func TestFormatNoHoverMessage_NoSkipReasons(t *testing.T) {
+	got := formatNoHoverMessage("Foo", "", nil)
+	if strings.Contains(got, "Enrichment pass skip reasons:") {
+		t.Errorf("must not include the skip-reason section when none given; got: %s", got)
+	}
+	if !strings.Contains(got, "Foo") {
+		t.Errorf("must still name the symbol; got: %s", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1 h1:+QZYqa5yGgBUruxVEkxNoWwEVAUA4JE6B45Q0mmOHqs=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3 h1:pblxdgbOMwn8a6SZ7CGI1kl+DpeJgjhBWcd4bmh4G+8=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -717,13 +717,13 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, go.mod tracks leyline-schema v0.5.1 and the matching
-// release with binary assets is v0.5.1. The Go schema-client and the daemon
+// As of this pin, go.mod tracks leyline-schema v0.5.3 and the matching
+// release with binary assets is v0.5.3. The Go schema-client and the daemon
 // binary travel together — mache built against schema vX.Y.Z must run a daemon
-// at the same major/minor or it will mis-decode the wire format. v0.5.1 ships
+// at the same major/minor or it will mis-decode the wire format. v0.5.3 ships
 // all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64),
 // including leyline-darwin-amd64 for Intel macs. (The release omits the
-// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0 — but mache
+// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0/v0.5.1 — but mache
 // doesn't link the cgo FFI: internal/leyline/client.go is //go:build leyline,
 // off in releases, so the download path is unaffected.)
 //
@@ -731,7 +731,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 //
 // Future hardening (mache-8kif): on socket connect, query the daemon's
 // `version` op and refuse to proceed if it disagrees with this constant.
-const leylineBinaryVersion = "v0.5.1"
+const leylineBinaryVersion = "v0.5.3"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
## Summary

Closes the consumer half of [mache-303036](https://github.com/agentic-research/mache/issues/303036). When mache's enrich pass silently no-ops (rust-analyzer not on PATH, scope mismatches `_source.id`, language has no bundled server), mache was reading `items_added: 0` with **no visibility into why** — the original misdiagnosis was "leyline was built without LSP" but it wasn't; the silent-skip path made the cause invisible.

ley-line-open v0.5.3 (just-published) surfaces per-pass skip reasons in `EnrichmentStats.skipped`. This PR plumbs them through mache's consumer.

## Chain of fixes (all this session)

1. **ley-line-open PR #117** (v0.5.2) — added `skipped: Vec<String>` to the Rust `EnrichmentStats` struct + JSON round-trip test
2. **ley-line-open PR #119** (v0.5.3) — wired the field through the capnp wire serialization (the JSON-only test passed but capnp was incomplete; mache reads via Go capnp bindings so the wire shape matters)
3. **This PR** — mache consumer reads `Skipped()` accessor, surfaces reasons in MCP tool result

## Changes

- **`go.mod` / `go.sum`** — leyline-schema v0.5.1 → v0.5.3
- **`internal/leyline/socket.go`** — `leylineBinaryVersion` v0.5.1 → v0.5.3 + comment update
- **`cmd/serve_lsp.go`** — new helpers:
  - `extractEnrichSkipReasons(resp map[string]any) []string` — parses per-pass `skipped` field, prefixes each with `[pass_name]`. Returns nil for pre-v0.5.3 responses (silent fallback).
  - `formatNoHoverMessage(symbol, kind, reasons)` — appends skip reasons under "Enrichment pass skip reasons:" label
  - `noDiagnosticsResultWithSkipReasons(symbol, kind, reasons)` — same for diagnostics path
- **`cmd/serve_lsp_skip_reasons_test.go`** — 4 tests pinning: populated-with-prefix, missing-field-returns-nil, malformed-returns-nil, format-with-reasons-includes-them-verbatim

## Behavior after

Pre-v0.5.3 daemon → mache sees no `skipped` field → existing fallback message preserved (backward compat).

v0.5.3+ daemon, rust-analyzer missing → operator sees:
```
no hover info found for "Foo"

Enrichment pass skip reasons:
  - [lsp] language server 'rust-analyzer' not on PATH for language 'rust' (1 file(s) skipped)
```

v0.5.3+ daemon, scope-mismatch → operator sees:
```
no hover info found for "Foo"

Enrichment pass skip reasons:
  - [lsp] scope matched no _source.id rows; requested 1 file(s): ["crates/memory-core/src/lib.rs"]
```

v0.5.3+ daemon, rust-analyzer ran but returned 0 hovers → operator sees the prior message (no skip reasons; the remaining LLO-side problem documented at bead ley-line-open-661727 for cold-index hover-empty cases).

## Test plan
- [x] `go test ./cmd/...` clean (4 new tests pass)
- [x] `go test -tags boltdb -race -count=1 ./cmd/` clean (race-detector + boltdb tag)
- [x] pre-push hooks pass (gofumpt / vet / golangci-lint / go mod tidy)
- [ ] CI green on PR
- [ ] Post-merge: rebuild mache + verify enrich call surfaces skip reasons against running v0.5.3 daemon