### PR TITLE
chore(leyline): bump auto-download pin v0.5.3 → v0.5.4

### DIFF
--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -717,21 +717,27 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, go.mod tracks leyline-schema v0.5.3 and the matching
-// release with binary assets is v0.5.3. The Go schema-client and the daemon
-// binary travel together — mache built against schema vX.Y.Z must run a daemon
-// at the same major/minor or it will mis-decode the wire format. v0.5.3 ships
-// all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64),
-// including leyline-darwin-amd64 for Intel macs. (The release omits the
-// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0/v0.5.1 — but mache
-// doesn't link the cgo FFI: internal/leyline/client.go is //go:build leyline,
-// off in releases, so the download path is unaffected.)
+// As of this pin, the daemon binary is v0.5.4 while go.mod tracks
+// leyline-schema v0.5.3. These can diverge by a PATCH: v0.5.4 (LLO #120) is
+// a daemon-only fix — it makes the LSP enrichment pass await rust-analyzer
+// indexer readiness (quiescent / $/progress end) before issuing hover/def/
+// ref queries — and ships NO wire/schema change, so the v0.5.3 Go
+// schema-client decodes a v0.5.4 daemon's responses identically. The
+// major/minor must still match (wire format); only the patch floats here.
+// v0.5.4 ships all four leyline-<os>-<arch> daemon binaries (darwin/linux ×
+// amd64/arm64). (The release omits the libleyline_fs-darwin-amd64
+// *staticlib* — same gap as v0.5.0–v0.5.3 — but mache doesn't link the cgo
+// FFI: internal/leyline/client.go is //go:build leyline, off in releases,
+// so the download path is unaffected.)
 //
-// BUMP THIS WHEN UPDATING leyline-schema in go.mod to a newer published tag.
+// BUMP THIS to the latest published ley-line-open release with binary assets;
+// bump the go.mod leyline-schema pin too whenever the WIRE format changes.
 //
 // Future hardening (mache-8kif): on socket connect, query the daemon's
-// `version` op and refuse to proceed if it disagrees with this constant.
-const leylineBinaryVersion = "v0.5.3"
+// version and refuse to proceed if it disagrees — though note LLO has no
+// `version` op today (verified against 0.5.x), so 8kif needs a different
+// mechanism.
+const leylineBinaryVersion = "v0.5.4"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
One-line follow-up flagged by the LLO author after v0.5.4 shipped.

`leylineBinaryVersion` gates the binary mache auto-downloads when leyline isn't on PATH. **v0.5.4** (LLO #120) makes the LSP enrichment pass **await rust-analyzer indexer readiness** (`quiescent` / `$/progress` end) before hover/def/ref queries — the fix that makes the semantic tier work end-to-end.

**Verified** against the real v0.5.4 daemon on lectio: `_lsp_hover` populated with real rust-analyzer hover text (`pub mod config` + docs), 16 defs, up to 152 refs — flowing into the exact tables mache queries (`node_id LIKE '%symbol'` matches).

v0.5.4 is **daemon-only** (no wire change), so `go.mod` `leyline-schema` stays at v0.5.3 — the v0.5.3 client decodes a v0.5.4 daemon identically; only the patch floats. Comment updated to document the binary-vs-schema split (and that LLO has no `version` op, so mache-8kif needs a different mechanism).

No-op for PATH users; keeps the auto-downloader correct for fresh machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)