### PR TITLE
fix(lsp): parse daemon object-row query results + bump leyline v0.5.5 — get_type_info returns real hover end-to-end

### DIFF
--- a/cmd/serve_lsp.go
+++ b/cmd/serve_lsp.go
@@ -25,6 +25,14 @@ const lspEnrichHint = "Pre-enrich your database with ll-open, or install ley-lin
 	"See: github.com/agentic-research/ley-line-open\n" +
 	"Capability matrix: docs/ARCHITECTURE.md#interplay-with-ley-line-open"
 
+// lspEnrichTimeout bounds how long mache waits for the daemon's synchronous
+// `enrich` op (which spawns the language server and indexes the file). It
+// MUST exceed the daemon's per-language per-file budget — gopls's is 50s
+// (rust-analyzer indexes far faster). The prior 30s tripped mache's own
+// deadline before the daemon's, surfacing a confusing client-side
+// "i/o timeout" instead of the daemon's clean skip/result (mache-303036).
+const lspEnrichTimeout = 90 * time.Second
+
 func lspTableMissing(table, feature string) *mcp.CallToolResult {
 	return mcp.NewToolResultError(fmt.Sprintf("no %s table in database. To get %s, either:\n"+
 		"  1. Pre-enrich with: ll-open enrich-lsp (see github.com/agentic-research/ley-line-open)\n"+
@@ -230,7 +238,7 @@ func enrichAndQueryTypeInfo(filePath, symbol, kind string) (*mcp.CallToolResult,
 	defer func() { _ = client.Close() }()
 
 	// Enrichment phase — 30s timeout for LSP
-	if err := client.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+	if err := client.SetDeadline(time.Now().Add(lspEnrichTimeout)); err != nil {
 		return nil, fmt.Errorf("set deadline: %w", err)
 	}
 	resp, err := client.Enrich("lsp", []string{relForEnrich(filePath)})
@@ -373,7 +381,7 @@ func enrichAndQueryDiagnostics(filePath, symbol, kind string, limit int) (*mcp.C
 	}
 	defer func() { _ = client.Close() }()
 
-	if err := client.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
+	if err := client.SetDeadline(time.Now().Add(lspEnrichTimeout)); err != nil {
 		return nil, fmt.Errorf("set deadline: %w", err)
 	}
 	resp, err := client.Enrich("lsp", []string{relForEnrich(filePath)})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.5
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3 h1:pblxdgbOMwn8a6SZ7CGI1kl+DpeJgjhBWcd4bmh4G+8=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.3/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.5 h1:pkbVwjQwH0xEoC9a8eLHA5+wvs1m9mTzBUKivZUY57c=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.5/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -540,8 +540,17 @@ func (c *SocketClient) Enrich(pass string, files []string) (map[string]any, erro
 	return resp, nil
 }
 
-// Query runs a SQL query against the active arena buffer via the `query` op.
-// Returns the rows as [][]any.
+// Query runs a SQL query against the active arena buffer via the `query` op
+// and returns the rows as [][]any (one slice per row, column order matching
+// the SELECT / the response's `columns` field).
+//
+// The daemon's `query` op returns each row as a JSON OBJECT keyed by column
+// name ({"node_id":..,"hover_text":..}), with a separate ordered `columns`
+// array — NOT an array of values. (A legacy array-of-arrays shape is also
+// accepted for forward/back-compat.) The prior parser only handled the
+// array shape and silently dropped every object row, so any query against
+// the daemon returned zero rows — which is exactly why LSP get_type_info
+// surfaced no hover even though enrichment populated _lsp_hover (mache-303036).
 func (c *SocketClient) Query(sql string) ([][]any, error) {
 	resp, err := c.SendOp(map[string]any{
 		"op":  "query",
@@ -553,22 +562,34 @@ func (c *SocketClient) Query(sql string) ([][]any, error) {
 	if errMsg, ok := resp["error"]; ok {
 		return nil, fmt.Errorf("query: %v", errMsg)
 	}
-	rows, ok := resp["rows"]
-	if !ok {
+	rowsVal, hasRows := resp["rows"]
+	if !hasRows {
 		return nil, nil
 	}
-	// rows is []any where each element is []any
-	rawRows, ok := rows.([]any)
+	rawRows, ok := rowsVal.([]any)
 	if !ok {
-		return nil, fmt.Errorf("unexpected rows type: %T", rows)
+		return nil, fmt.Errorf("unexpected rows type: %T", rowsVal)
 	}
-	result := make([][]any, len(rawRows))
-	for i, r := range rawRows {
-		row, ok := r.([]any)
-		if !ok {
-			continue
+	// Ordered column names — used to flatten object-shaped rows in SELECT order.
+	var cols []string
+	if cv, ok := resp["columns"].([]any); ok {
+		cols = make([]string, len(cv))
+		for i, v := range cv {
+			cols[i] = fmt.Sprint(v)
 		}
-		result[i] = row
+	}
+	result := make([][]any, 0, len(rawRows))
+	for _, r := range rawRows {
+		switch row := r.(type) {
+		case []any: // legacy array-of-values shape
+			result = append(result, row)
+		case map[string]any: // daemon shape: object keyed by column name
+			ordered := make([]any, len(cols))
+			for i, col := range cols {
+				ordered[i] = row[col]
+			}
+			result = append(result, ordered)
+		}
 	}
 	return result, nil
 }
@@ -717,18 +738,17 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, the daemon binary is v0.5.4 while go.mod tracks
-// leyline-schema v0.5.3. These can diverge by a PATCH: v0.5.4 (LLO #120) is
-// a daemon-only fix — it makes the LSP enrichment pass await rust-analyzer
-// indexer readiness (quiescent / $/progress end) before issuing hover/def/
-// ref queries — and ships NO wire/schema change, so the v0.5.3 Go
-// schema-client decodes a v0.5.4 daemon's responses identically. The
-// major/minor must still match (wire format); only the patch floats here.
-// v0.5.4 ships all four leyline-<os>-<arch> daemon binaries (darwin/linux ×
-// amd64/arm64). (The release omits the libleyline_fs-darwin-amd64
-// *staticlib* — same gap as v0.5.0–v0.5.3 — but mache doesn't link the cgo
-// FFI: internal/leyline/client.go is //go:build leyline, off in releases,
-// so the download path is unaffected.)
+// As of this pin, the daemon binary AND go.mod's leyline-schema both track
+// v0.5.5 — they travel together here because v0.5.5 carries a wire/schema
+// change (unlike the v0.5.4 daemon-only patch, where only the binary moved
+// and the schema stayed at v0.5.3). When the schema bumps, the binary pin
+// must move with it: mache built against schema vX.Y.Z must run a daemon at
+// the same version or it will mis-decode the wire format. v0.5.5 ships all
+// four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64).
+// (The release omits the libleyline_fs-darwin-amd64 *staticlib* — same gap
+// as v0.5.0–v0.5.4 — but mache doesn't link the cgo FFI:
+// internal/leyline/client.go is //go:build leyline, off in releases, so the
+// download path is unaffected.)
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets;
 // bump the go.mod leyline-schema pin too whenever the WIRE format changes.
@@ -737,7 +757,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // version and refuse to proceed if it disagrees — though note LLO has no
 // `version` op today (verified against 0.5.x), so 8kif needs a different
 // mechanism.
-const leylineBinaryVersion = "v0.5.4"
+const leylineBinaryVersion = "v0.5.5"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -198,6 +198,44 @@ func TestQuery_ParsesRows(t *testing.T) {
 	}
 }
 
+// TestQuery_ParsesObjectRows pins the daemon's ACTUAL wire shape: rows are
+// objects keyed by column name + a separate ordered `columns` array, NOT
+// arrays of values. The prior parser dropped every object row, which made
+// every daemon query return nothing — the root cause of LSP get_type_info
+// surfacing no hover despite enrichment populating _lsp_hover (mache-303036).
+func TestQuery_ParsesObjectRows(t *testing.T) {
+	sockPath := mockServer(t, func(req map[string]any) map[string]any {
+		return map[string]any{
+			"columns": []any{"node_id", "hover_text"},
+			"rows": []any{
+				map[string]any{"node_id": "symbols/config", "hover_text": "pub mod config"},
+				map[string]any{"node_id": "symbols/auth", "hover_text": "pub mod auth"},
+			},
+		}
+	})
+
+	client, err := DialSocket(sockPath)
+	if err != nil {
+		t.Fatalf("DialSocket: %v", err)
+	}
+	defer client.Close() //nolint:errcheck
+
+	rows, err := client.Query("SELECT node_id, hover_text FROM _lsp_hover")
+	if err != nil {
+		t.Fatalf("Query: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	// Object rows must be flattened in `columns` order: [node_id, hover_text].
+	if rows[0][0] != "symbols/config" || rows[0][1] != "pub mod config" {
+		t.Errorf("row0 mis-ordered: %v", rows[0])
+	}
+	if rows[1][0] != "symbols/auth" {
+		t.Errorf("row1[0] = %v, want symbols/auth", rows[1][0])
+	}
+}
+
 func TestDialSocket_ErrorOnMissingSocket(t *testing.T) {
 	_, err := DialSocket("/tmp/nonexistent-leyline-test.sock")
 	if err == nil {


### PR DESCRIPTION
## The final bug — `Client.Query` dropped every daemon row

The daemon's `query` op returns rows as **objects keyed by column name** (`[{"node_id":…,"hover_text":…}]`) with a separate ordered `columns` array. mache's `Client.Query` parsed rows as **arrays of values** and silently `continue`d past any non-array — so **every daemon query returned zero rows**.

That's the root cause of `get_type_info` surfacing no hover despite enrichment working: the enrich populated `_lsp_hover` with real rust-analyzer data (489 items / 22 hovers), and the query **threw all the rows away**. Never caught before because the LSP path never got past the old `unknown op: tool` (#452) to reach the query.

**Fix:** `Client.Query` flattens object-shaped rows in `columns` order (legacy array shape still accepted; absent `rows` → nil; present-but-wrong-type → error preserved). `TestQuery_ParsesObjectRows` pins the real wire shape.

## Also: leyline v0.5.4 → v0.5.5

v0.5.5 (LLO #121) adds **active-probe rust-analyzer readiness + per-language per-file timeout** — making cold-start LSP enrichment **reliable** (verified: 3/3 fresh daemons → 22 hovers / ~22 defs / ~420 refs, consistent, ~8s each). v0.5.5 carries a wire/schema change, so the binary pin and `go.mod` `leyline-schema` move together.

## ✅ Verified end-to-end (cold start)

`mache get_type_info(symbol=config, file=crates/memory-core/src/lib.rs)` on a freshly-cleared `~/.mache`:
```json
{ "node_id": "symbols/config",
  "hover_text": "```rust pub mod config``` --- Shared configuration for the CLI and the daemon (bead:lectio-016d7d)..." }
```

That's rust-analyzer's real type signature + doc comment, through mache's MCP tool, cold. **The "Rust find_callers weak / LSP never works" problem is solved.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)