### PR TITLE
chore(leyline): pin v0.5.7 — Go LSP enrichment works + README/prior-art

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ For the full first-run flow — source choice (directory vs `.db` vs live hot-sw
 
 ## What it gives an agent
 
-Seventeen MCP tools wrap the projected graph (sixteen read-surface plus `write_file`). Fourteen work standalone; three (`semantic_search`, `get_type_info`, `get_diagnostics`) require [ley-line-open](https://github.com/agentic-research/ley-line-open) enrichment. `find_smells` covers nine structural code-smell rules (`dead_code`, `cyclomatic_complexity`, `god_file`, `fan_out_skew`, `untested_function`, …); four of those require a `.db` built by ley-line-open.
+Seventeen MCP tools wrap the projected graph (sixteen read-surface plus `write_file`). Fourteen work standalone; three (`semantic_search`, `get_type_info`, `get_diagnostics`) draw on [ley-line-open](https://github.com/agentic-research/ley-line-open) enrichment. `find_smells` covers nine structural code-smell rules (`dead_code`, `cyclomatic_complexity`, `god_file`, `fan_out_skew`, `untested_function`, …); four of those require a `.db` built by ley-line-open.
+
+**Live LSP enrichment.** `get_type_info` / `get_diagnostics` no longer need a pre-baked `.db` — pass a `file=` and mache auto-spawns the ley-line daemon, which drives the language server (rust-analyzer, gopls, …) on demand and projects real hover / type / diagnostic data into the graph. Verified end-to-end on **Rust and Go** (e.g. `get_type_info(symbol, file)` returns rust-analyzer's signature + doc comment). This is the same primitive [Serena](https://github.com/oraios/serena) is built on, but as one enrichment *tier* over a tree-sitter base that still works without a language server — see [`prior-art/`](prior-art/) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
 
 For the full tool inventory and capability matrix (which tools need which tables), see [ARCHITECTURE.md § MCP Server](docs/ARCHITECTURE.md#core-abstractions) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
 

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -738,17 +738,23 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, the daemon binary AND go.mod's leyline-schema both track
-// v0.5.5 — they travel together here because v0.5.5 carries a wire/schema
-// change (unlike the v0.5.4 daemon-only patch, where only the binary moved
-// and the schema stayed at v0.5.3). When the schema bumps, the binary pin
-// must move with it: mache built against schema vX.Y.Z must run a daemon at
-// the same version or it will mis-decode the wire format. v0.5.5 ships all
-// four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64).
-// (The release omits the libleyline_fs-darwin-amd64 *staticlib* — same gap
-// as v0.5.0–v0.5.4 — but mache doesn't link the cgo FFI:
-// internal/leyline/client.go is //go:build leyline, off in releases, so the
-// download path is unaffected.)
+// As of this pin, the daemon binary is v0.5.7 while go.mod's leyline-schema
+// stays at v0.5.5: v0.5.6 and v0.5.7 are BOTH daemon-only LSP fixes with no
+// wire/schema change, so the v0.5.5 Go schema-client decodes a v0.5.7
+// daemon's responses identically.
+//   - v0.5.6: gopls workspace init (workspaceFolders + per-language
+//     initializationOptions).
+//   - v0.5.7: the LSP client now answers server→client requests
+//     (workspace/configuration, window/workDoneProgress/create) — without
+//     this gopls blocked indefinitely and Go enrichment produced 0 hovers;
+//     with it, get_type_info returns real Go hover end-to-end (mache-6584a0).
+//
+// The major/minor must still match the schema (wire format); only the patch
+// floats. v0.5.7 ships all four leyline-<os>-<arch> daemon binaries
+// (darwin/linux × amd64/arm64). (The release omits the
+// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0–v0.5.6 — but
+// mache doesn't link the cgo FFI: internal/leyline/client.go is //go:build
+// leyline, off in releases, so the download path is unaffected.)
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets;
 // bump the go.mod leyline-schema pin too whenever the WIRE format changes.
@@ -757,7 +763,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // version and refuse to proceed if it disagrees — though note LLO has no
 // `version` op today (verified against 0.5.x), so 8kif needs a different
 // mechanism.
-const leylineBinaryVersion = "v0.5.5"
+const leylineBinaryVersion = "v0.5.7"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private

--- a/prior-art/README.md
+++ b/prior-art/README.md
@@ -1,0 +1,28 @@
+# Prior art
+
+How mache relates to adjacent code-intelligence systems. Each claim cites a primary source; this index is a cross-cutting matrix, with per-system notes in sibling files.
+
+## Cross-cutting matrix
+
+| System                                     | Semantic source                                                                                | Live vs precomputed                              | Degrades without a language server?                                                      | Surface                  |
+| ------------------------------------------ | ---------------------------------------------------------------------------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------- | ------------------------ |
+| **mache**                                  | tree-sitter base **+** LSP enrichment tier (rust-analyzer / gopls / … via the ley-line daemon) | live (daemon, on-demand) **and** pre-baked `.db` | **Yes** — tree-sitter tier answers `find_callers`/`search`/`find_definition` with no LSP | MCP tools + mountable FS |
+| [Serena](https://github.com/oraios/serena) | language servers (via [multilspy](https://github.com/microsoft/multilspy))                     | live, per-query                                  | No — LSP-or-nothing                                                                      | MCP tools                |
+| Sourcegraph / GitHub code-nav              | [SCIP](https://github.com/sourcegraph/scip) / LSIF indexes                                     | precomputed (batch-baked)                        | n/a (no live server)                                                                     | web + API                |
+| ctags / tree-sitter MCP servers            | syntactic only                                                                                 | n/a                                              | yes (no semantic tier at all)                                                            | varies                   |
+
+## Serena — the closest "does the LSP thing" comparison
+
+Serena is LSP-native: it drives real language servers through multilspy and answers symbol / definition / reference / hover requests **live, per call** ([Serena README](https://github.com/oraios/serena)). That is the same primitive mache's `get_type_info` / `get_diagnostics` now use (rust-analyzer + gopls verified end-to-end, mache-6584a0).
+
+Where mache differs:
+
+1. **LSP is one tier, not the floor.** mache projects a tree-sitter graph first; LSP enrichment layers compiler-grade hover/defs/refs **on top**. With no language server present, `find_callers` / `find_definition` / `search` still work off the tree-sitter tier — Serena returns nothing without a server.
+1. **Projected, not just proxied.** mache writes LSP output into a queryable SQLite/graph (`_lsp_hover`, `_lsp_defs`, `_lsp_refs`, …) and a content-addressed `.db`, so results are cacheable, portable (`mache cache`), and joinable against structural data — rather than a live pass-through per request.
+1. **Enrichment is pluggable.** LSP sits beside other ley-line passes (tree-sitter, HDC, embeddings); the same daemon/op surface adds tiers without changing the consumer contract.
+
+Net: the *LSP capability* is not novel (Serena predates it); the *tiering + projection + graceful degradation* is the distinguishing frame.
+
+## SCIP / LSIF systems
+
+Sourcegraph and GitHub code navigation consume **precomputed** semantic indexes ([SCIP](https://github.com/sourcegraph/scip)) — the same class of data an LSP server produces, serialized and batch-baked rather than queried live. mache can ingest a pre-baked `.db` (the precomputed mode) **or** enrich live (the Serena mode); it spans both.


### PR DESCRIPTION
Completes the cross-repo LSP thread: **Go now works end-to-end** (gopls), alongside Rust.

## Changes
- **Pin `leylineBinaryVersion` v0.5.5 → v0.5.7.** v0.5.6 (gopls workspace init) and v0.5.7 (LSP client answers server→client requests — the fix that unblocks gopls) are both **daemon-only, no wire change**, so `go.mod` `leyline-schema` stays v0.5.5.
- **README**: `get_type_info`/`get_diagnostics` now do **live LSP enrichment** via the daemon (auto-spawn rust-analyzer/gopls on `file=`), verified on **Rust AND Go** — not just a pre-baked `.db`.
- **`prior-art/README.md`**: answers "do other tools do the LSP thing?" — Serena (LSP-native, live-only) vs mache (LSP as one *tier* over a tree-sitter base that degrades gracefully); the SCIP/LSIF precomputed camp.

## Verified end-to-end (through mache's MCP tool)
```
get_type_info(symbol=Greet, file=greet.go) →
  "func Greet(name string) string\nGreet returns a friendly greeting for the given name..."
```
Real gopls hover (signature + doc comment). The full chain (LLO #123 fix → v0.5.7 release → this pin) is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)