### PR TITLE
fix(ci): release.yml startup failure — literal ${{ }} in a run-block comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,8 +72,8 @@ jobs:
           # settable), so validate its shape before it's used anywhere — reject
           # anything that isn't a clean semver release tag (no pre-release/build
           # suffix; release tags are always vMAJOR.MINOR.PATCH and must equal the
-          # clean version.txt base checked below). Passed via env (not inline
-          # ${{ }}). The error message does NOT echo the raw TAG: pre-validation
+          # clean version.txt base checked below). Passed via env, not an inline
+          # GitHub expression. The error message does NOT echo the raw TAG: pre-validation
           # it may contain a CR/newline that would break out of the ::error::
           # workflow command (workflow-command injection). After this gate TAG is
           # known clean, so the mismatch error below can safely include it.


### PR DESCRIPTION
## Root cause
The build step's `run:` block had a **bash comment** containing a literal `${{ }}`:

```yaml
# clean version.txt base checked below). Passed via env (not inline
# ${{ }}). The error message does NOT echo the raw TAG: pre-validation
```

GitHub Actions evaluates `${{ }}` expressions **before** the shell runs the script — even inside comments — so the empty expression failed to parse at workflow-load time (`unexpected end of input`, confirmed by `actionlint`). That's a **startup_failure** ("This run likely failed because of a workflow file issue"), which fires on **every push** regardless of trigger match.

## Impact
Introduced in #437 (merged after v0.9.0). Every push since has logged a failed release.yml run (dependabot branches included), and — critically — **the `v0.10.0` tag never produced a release**. v0.9.0 was the last successful release because it predates #437.

## Fix
Reword the comment to drop the literal token. No behavior change. `actionlint` now passes clean.

## After merge
Re-trigger the v0.10.0 release (re-push the tag at the fixed HEAD, or `workflow_dispatch` with tag=v0.10.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)