### PR TITLE
docs(dx): daemon-lifecycle drift + fix docs:lint on main (mache-823d91, mache-89e322)

### DIFF
--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -53,7 +53,7 @@ mache serve .                 # ← long-running daemon on localhost:7532 — KE
 claude mcp add --transport http mache http://localhost:7532/mcp
 ```
 
-> ⚠️ `mache serve` (HTTP) is a **foreground daemon** — it blocks the terminal and must stay alive for the client to connect. Run it in a second terminal, background it (`mache serve . &`), or install it as a login service. If the client reports `localhost:7532/mcp` **connection refused**, the daemon isn't running — that's the #1 first-run gotcha. (A launchd LaunchAgent that keeps it alive across logins is tracked in mache-823d91.)
+> ⚠️ `mache serve` (HTTP) is a **foreground daemon** — it blocks the terminal and must stay alive for the client to connect. If the client reports `localhost:7532/mcp` **connection refused**, the daemon isn't running — that's the #1 first-run gotcha. The fix is a one-time `mache init --global`, which installs a per-user supervisor (**launchd** LaunchAgent on macOS, **systemd `--user`** unit on Linux) that starts the daemon at login and keepalives it across restarts — no terminal to babysit. For an ad-hoc run instead, background it (`mache serve . &`) in a second terminal.
 
 **stdio (subprocess per session — no standing daemon to babysit):**
 

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -53,7 +53,7 @@ mache serve .                 # ← long-running daemon on localhost:7532 — KE
 claude mcp add --transport http mache http://localhost:7532/mcp
 ```
 
-> ⚠️ `mache serve` (HTTP) is a **foreground daemon** — it blocks the terminal and must stay alive for the client to connect. If the client reports `localhost:7532/mcp` **connection refused**, the daemon isn't running — that's the #1 first-run gotcha. The fix is a one-time `mache init --global`, which installs a per-user supervisor (**launchd** LaunchAgent on macOS, **systemd `--user`** unit on Linux) that starts the daemon at login and keepalives it across restarts — no terminal to babysit. For an ad-hoc run instead, background it (`mache serve . &`) in a second terminal.
+> ⚠️ `mache serve` (HTTP) is a **foreground daemon** — it blocks the terminal and must stay alive for the client to connect. If the client reports `localhost:7532/mcp` **connection refused**, the daemon isn't running — that's the #1 first-run gotcha. The fix is a one-time `mache init --global`, which installs a per-user supervisor (**launchd** LaunchAgent on macOS, **systemd `--user`** unit on Linux) that starts the daemon at login and keeps it alive across restarts — no terminal to babysit. For an ad-hoc run instead, background it (`mache serve . &`) in a second terminal.
 
 **stdio (subprocess per session — no standing daemon to babysit):**
 

--- a/docs/smell-debt-baseline-2026-06-24.md
+++ b/docs/smell-debt-baseline-2026-06-24.md
@@ -1,3 +1,9 @@
+---
+status: current
+covers-version: v0.8.0
+last-verified: 2026-06-24
+---
+
 # Smell-debt baseline — 2026-06-24
 
 First measured snapshot of structural smell debt across the ART repos, the


### PR DESCRIPTION
DX docs-hygiene pass. Two independent doc defects, both green-gate now.

## `mache-89e322` — docs:lint red on main
`docs/smell-debt-baseline-2026-06-24.md` shipped without frontmatter, so `task docs:lint` failed on `main` (`missing frontmatter`). Added minimal valid frontmatter (`covers-version: v0.8.0` to match ARCHITECTURE.md / latest CHANGELOG, `last-verified` = measurement date). `docs:lint` now reports **0 fail, 0 warn**.

## `mache-823d91` — stale claim on a shipped feature
The keepalive supervisor shipped in v0.10.0 (#464): `mache init --global` installs a **launchd** LaunchAgent (macOS) or **systemd `--user`** unit (Linux) that starts + keepalives the shared HTTP daemon (`cmd/daemon_agent.go`, wired at `cmd/init.go:62`, 5 passing tests). But `GETTING-STARTED.md` still told users the connection-refused fix was unbuilt and "tracked in mache-823d91". Updated the #1 first-run gotcha to point at the shipped one-command fix.

## Not in scope
`mache-823d91`'s *second half* — daemon-reliability hardening (stale `~/.mache` state, singleton-socket clobber; see ADR-0022 + `mache-0a1ded`) — is untouched here and stays open. This PR only closes the supervisor-doc gap.

## Verification
- `task docs:lint` → 0 fail, 0 warn
- `go test ./cmd/ -run 'TestLaunchAgent|TestSystemd|TestDaemonAgent'` → ok
- Docs-only; no Go changed.