### PR TITLE
fix(leyline): configurable daemon-start timeout + crash-vs-timeout diagnostics (mache-0a1ded)

### DIFF
--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -383,6 +383,12 @@ func DiscoverOrStart() (string, error) {
 		select {
 		case werr := <-waitErr:
 			managed.discard()
+			if werr == nil {
+				// Clean exit (status 0) before binding is still a failure —
+				// nothing is listening on the socket. Return an explicit error
+				// rather than wrapping nil (which renders "%!w(<nil>)").
+				return "", fmt.Errorf("leyline daemon exited cleanly (status 0) during startup before socket %s appeared", sockPath)
+			}
 			return "", fmt.Errorf("leyline daemon exited during startup before socket %s appeared: %w", sockPath, werr)
 		default:
 		}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -355,25 +356,70 @@ func DiscoverOrStart() (string, error) {
 	managed.proc = cmd.Process
 	managed.sock = sockPath
 
-	// Background goroutine to wait on the process (prevent zombie)
-	go func() { _ = cmd.Wait() }()
+	// Wait on the process in the background (prevents a zombie) and surface
+	// its exit to the poll below so we can distinguish "daemon crashed on
+	// startup" from "daemon is still initializing" (mache-0a1ded). Buffered
+	// so the send never blocks after the poll returns.
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- cmd.Wait() }()
 
 	// Poll for socket to appear AND accept a connection. Mere os.Stat is
 	// insufficient — the kernel can create the inode before the daemon
 	// finishes its accept loop bind, and a stat-only wait would return a
 	// path that DialSocket can't connect to.
-	deadline := time.Now().Add(5 * time.Second)
+	//
+	// The wait is configurable (MACHE_LEYLINE_START_TIMEOUT): a cold start —
+	// first run, arena init, enrichment setup, or contention with co-tenant
+	// daemons on the shared arena — can exceed the old fixed 5s.
+	timeout := leylineStartTimeout()
+	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if isSocketAlive(sockPath) {
 			log.Printf("leyline daemon ready (pid=%d, socket=%s)", cmd.Process.Pid, sockPath)
 			return sockPath, nil
 		}
+		// If the daemon already exited, the socket will never appear — stop
+		// waiting and report it as a crash, not a timeout.
+		select {
+		case werr := <-waitErr:
+			managed.discard()
+			return "", fmt.Errorf("leyline daemon exited during startup before socket %s appeared: %w", sockPath, werr)
+		default:
+		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Timed out — discard the group (daemon + any child it spawned) and report.
+	// Timed out with the process still running — initializing too slowly or
+	// wedged. Discard the group (daemon + any child it spawned) and point at
+	// the knob to extend the wait and the likely-contended arena.
 	managed.discard()
-	return "", fmt.Errorf("leyline daemon started but socket %s did not appear within 5s", sockPath)
+	return "", fmt.Errorf("leyline daemon started but socket %s did not appear within %s — it may still be initializing or contending for %s; raise MACHE_LEYLINE_START_TIMEOUT to allow longer",
+		sockPath, timeout, arenaPath)
+}
+
+// defaultLeylineStartTimeout is how long DiscoverOrStart waits for a freshly
+// spawned daemon's socket to accept connections. Raised from the original
+// fixed 5s (mache-0a1ded): a cold start — first run, arena init, enrichment
+// setup, or contention with co-tenant daemons on the shared
+// ~/.mache/default.arena — routinely needs longer.
+const defaultLeylineStartTimeout = 15 * time.Second
+
+// leylineStartTimeout returns the socket-appear wait, overridable via
+// MACHE_LEYLINE_START_TIMEOUT (a Go duration like "30s", or a bare integer
+// interpreted as seconds). Invalid or non-positive values fall back to the
+// default.
+func leylineStartTimeout() time.Duration {
+	v := strings.TrimSpace(os.Getenv("MACHE_LEYLINE_START_TIMEOUT"))
+	if v == "" {
+		return defaultLeylineStartTimeout
+	}
+	if d, err := time.ParseDuration(v); err == nil && d > 0 {
+		return d
+	}
+	if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		return time.Duration(n) * time.Second
+	}
+	return defaultLeylineStartTimeout
 }
 
 // StopManaged gracefully stops the auto-spawned leyline daemon, if any.

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -953,18 +953,18 @@ func e2eHome(t *testing.T) string {
 // TestDiscoverOrStart_LocalBinFallback_SocketTimeout covers two production
 // branches that the on-PATH happy path skips:
 //
-//   - The `~/.mache/bin/leyline` fallback (lines 218-222): leyline not on
-//     PATH but a cached binary exists in the local bin dir.
-//   - The "spawned but socket never appeared within 5s" timeout (lines
-//     300-303): exec.Start succeeds but the binary doesn't bind the
-//     daemon UDS, so the poll loop must time out, kill the process, and
-//     surface a distinctive error.
+//   - The `~/.mache/bin/leyline` fallback: leyline not on PATH but a cached
+//     binary exists in the local bin dir.
+//   - The "spawned but socket never appeared" timeout: exec.Start succeeds
+//     and the process stays alive, but it never binds the daemon UDS, so the
+//     poll loop must time out, kill the process, and surface a distinctive
+//     error naming the MACHE_LEYLINE_START_TIMEOUT knob.
 //
-// We satisfy both with /bin/sh as the fake binary — it ignores the
-// daemon flags, exits immediately, and never binds a socket. The poll
-// loop runs the full 5s before declaring failure, so this test costs
-// ~5s; that's the price of covering the timeout path without a more
-// elaborate harness binary.
+// The fake binary is a shell script that sleeps without binding a socket, and
+// MACHE_LEYLINE_START_TIMEOUT is pinned to 1s so the timeout path runs in ~1s
+// instead of the 15s default (mache-0a1ded). A binary that *exits* during
+// startup takes the separate crash branch — see
+// TestDiscoverOrStart_DaemonExitsDuringStartup.
 func TestDiscoverOrStart_LocalBinFallback_SocketTimeout(t *testing.T) {
 	resetManaged(t)
 	t.Cleanup(func() { resetManaged(t) })
@@ -972,31 +972,80 @@ func TestDiscoverOrStart_LocalBinFallback_SocketTimeout(t *testing.T) {
 	home := e2eHome(t)
 	binDir := filepath.Join(home, ".mache", "bin")
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
-	// Symlink /bin/sh into ~/.mache/bin/leyline. exec.LookPath against
-	// PATH must fail (sentinel path), then os.Stat on the local-bin
-	// fallback succeeds, so DiscoverOrStart picks up the fake binary
-	// from the cache location and proceeds to cmd.Start.
-	require.NoError(t, os.Symlink("/bin/sh", filepath.Join(binDir, "leyline")))
+	// A fake leyline that starts and stays alive but never binds the socket.
+	// exec.LookPath against PATH fails (sentinel path), os.Stat on the
+	// local-bin fallback succeeds, so DiscoverOrStart picks it up and spawns
+	// it; the poll loop then times out while the process is still running.
+	//
+	// It answers `--version` fast (so the resolved-version probe doesn't block
+	// on the sleep) and uses an absolute PATH for `sleep` because the test
+	// nukes PATH — otherwise `sleep` isn't found and the process would exit
+	// (taking the crash branch instead of the timeout branch).
+	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'fake leyline'; exit 0;; esac\nPATH=/bin:/usr/bin exec sleep 30\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "leyline"), []byte(fake), 0o755))
 
 	t.Setenv("HOME", home)
 	t.Setenv("LEYLINE_SOCKET", "")
 	t.Setenv("PATH", "/nonexistent-path-for-test")
 	t.Setenv("MACHE_NO_LEYLINE", "")
+	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "1s")
 
 	_, err := DiscoverOrStart()
 	require.Error(t, err, "fake binary that doesn't bind the socket must time out")
-	assert.Contains(t, err.Error(), "did not appear within 5s",
-		"timeout path must surface the documented 'socket did not appear' error")
+	assert.Contains(t, err.Error(), "did not appear within 1s",
+		"timeout path must surface the 'socket did not appear' error with the configured wait")
+	assert.Contains(t, err.Error(), "MACHE_LEYLINE_START_TIMEOUT",
+		"timeout error must point at the override knob")
 
-	// Singleton must be reset by the timeout cleanup (lines 301-302) so
-	// a follow-up DiscoverOrStart can retry without inheriting the
-	// dead fake process.
+	// Singleton must be reset by the timeout cleanup so a follow-up
+	// DiscoverOrStart can retry without inheriting the dead fake process.
 	managed.mu.Lock()
 	leftoverProc := managed.proc
 	leftoverSock := managed.sock
 	managed.mu.Unlock()
 	assert.Nil(t, leftoverProc, "timeout cleanup must clear managed.proc")
 	assert.Empty(t, leftoverSock, "timeout cleanup must clear managed.sock")
+}
+
+// TestDiscoverOrStart_DaemonExitsDuringStartup pins the crash branch added in
+// mache-0a1ded: if the spawned daemon exits before the socket appears, the
+// poll loop detects the exit and reports a startup crash rather than waiting
+// out the full timeout for a socket that can never appear. /bin/sh ignores the
+// daemon flags and exits immediately (non-zero), standing in for a leyline
+// that dies on startup.
+func TestDiscoverOrStart_DaemonExitsDuringStartup(t *testing.T) {
+	resetManaged(t)
+	t.Cleanup(func() { resetManaged(t) })
+
+	home := e2eHome(t)
+	binDir := filepath.Join(home, ".mache", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.Symlink("/bin/sh", filepath.Join(binDir, "leyline")))
+
+	t.Setenv("HOME", home)
+	t.Setenv("LEYLINE_SOCKET", "")
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+	t.Setenv("MACHE_NO_LEYLINE", "")
+	// Generous timeout so the assertion proves we returned on exit-detection,
+	// not because the wait elapsed.
+	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "30s")
+
+	start := time.Now()
+	_, err := DiscoverOrStart()
+	elapsed := time.Since(start)
+
+	require.Error(t, err, "a daemon that exits during startup must error")
+	assert.Contains(t, err.Error(), "exited during startup",
+		"crash path must surface the 'exited during startup' error, not a timeout")
+	assert.Less(t, elapsed, 5*time.Second,
+		"must return on exit-detection, not wait out the 30s timeout")
+
+	managed.mu.Lock()
+	leftoverProc := managed.proc
+	leftoverSock := managed.sock
+	managed.mu.Unlock()
+	assert.Nil(t, leftoverProc, "crash cleanup must clear managed.proc")
+	assert.Empty(t, leftoverSock, "crash cleanup must clear managed.sock")
 }
 
 // TestDiscoverOrStart_ManagedFastPathReturnsLiveSocket pins fast-path 2

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -1048,6 +1048,34 @@ func TestDiscoverOrStart_DaemonExitsDuringStartup(t *testing.T) {
 	assert.Empty(t, leftoverSock, "crash cleanup must clear managed.sock")
 }
 
+// TestDiscoverOrStart_DaemonExitsCleanlyDuringStartup covers the werr==nil
+// edge of the crash branch (Copilot review on #468): a daemon that exits with
+// status 0 before binding the socket is still a failure, and the error must
+// not wrap a nil (which would render "%!w(<nil>)").
+func TestDiscoverOrStart_DaemonExitsCleanlyDuringStartup(t *testing.T) {
+	resetManaged(t)
+	t.Cleanup(func() { resetManaged(t) })
+
+	home := e2eHome(t)
+	binDir := filepath.Join(home, ".mache", "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	// Answers --version fast, then exits 0 for the daemon invocation without
+	// binding a socket.
+	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'fake leyline'; exit 0;; esac\nexit 0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "leyline"), []byte(fake), 0o755))
+
+	t.Setenv("HOME", home)
+	t.Setenv("LEYLINE_SOCKET", "")
+	t.Setenv("PATH", "/nonexistent-path-for-test")
+	t.Setenv("MACHE_NO_LEYLINE", "")
+	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "30s")
+
+	_, err := DiscoverOrStart()
+	require.Error(t, err, "a daemon that exits 0 without binding is still a failure")
+	assert.Contains(t, err.Error(), "exited cleanly (status 0)")
+	assert.NotContains(t, err.Error(), "%!w", "must not wrap a nil error")
+}
+
 // TestDiscoverOrStart_ManagedFastPathReturnsLiveSocket pins fast-path 2
 // (the `managed.sock != "" && isSocketAlive(managed.sock)` happy branch
 // at lines 197-200). Normally a second in-process call short-circuits

--- a/internal/leyline/start_timeout_test.go
+++ b/internal/leyline/start_timeout_test.go
@@ -1,0 +1,41 @@
+package leyline
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeylineStartTimeout pins the MACHE_LEYLINE_START_TIMEOUT override that
+// mache-0a1ded added so a cold leyline daemon start (which can exceed the old
+// fixed 5s) doesn't spuriously fail with "socket did not appear".
+func TestLeylineStartTimeout(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{"unset falls back to default", "", defaultLeylineStartTimeout},
+		{"go duration seconds", "30s", 30 * time.Second},
+		{"go duration minutes", "2m", 2 * time.Minute},
+		{"bare integer is seconds", "20", 20 * time.Second},
+		{"garbage falls back", "not-a-duration", defaultLeylineStartTimeout},
+		{"zero falls back", "0", defaultLeylineStartTimeout},
+		{"negative falls back", "-5s", defaultLeylineStartTimeout},
+		{"whitespace trimmed", "  45s  ", 45 * time.Second},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("MACHE_LEYLINE_START_TIMEOUT", c.env)
+			require.Equal(t, c.want, leylineStartTimeout())
+		})
+	}
+}
+
+// TestDefaultLeylineStartTimeout guards the default from silently regressing
+// back to the too-short 5s that motivated mache-0a1ded.
+func TestDefaultLeylineStartTimeout(t *testing.T) {
+	require.GreaterOrEqual(t, defaultLeylineStartTimeout, 10*time.Second,
+		"default must stay comfortably above the old 5s cold-start failure point")
+}


### PR DESCRIPTION
## The bug
Auto-started leyline daemons failed with `socket did not appear within 5s` on cold starts — first run, arena init/enrichment setup, or contention with co-tenant daemons on the shared `~/.mache/default.arena` (surfaced with ≥1 `mache serve` already live). Two root problems:
1. The 5s socket-appear wait was **hardcoded and too short** for a cold start.
2. A daemon that **crashed** on startup was still reported as a *timeout* — after a full 5s wait for a socket that could never appear.

## Fix
- **Configurable timeout** via `MACHE_LEYLINE_START_TIMEOUT` (a Go duration like `30s`, or a bare integer = seconds). Default raised **5s → 15s**.
- **Crash vs timeout**: the poll loop now watches the spawned process. If it exits before the socket appears, return immediately with `exited during startup: <exit status>` instead of waiting out the timeout. The timeout error now names the contended arena and points at `MACHE_LEYLINE_START_TIMEOUT`.

## Tests
- `leylineStartTimeout` env-parsing table (duration, bare-seconds, garbage/zero/negative fallback, whitespace) + a guard that the default stays ≥10s.
- The existing timeout test now uses a **sleeper fake + `MACHE_LEYLINE_START_TIMEOUT=1s`** — fast, and still exercises the real timeout path (previously a `/bin/sh` fake that exited immediately, which now correctly takes the crash branch).
- New crash-path test: a fast-exiting fake asserts exit-detection returns in <5s with the `exited during startup` message (not a timeout).

## Not in scope (follow-up)
The **cross-process arena isolation** half of the contention story — two separate `mache serve` processes racing on the same `~/.mache/default.{arena,ctrl,sock}` — is left for follow-up under `mache-0a1ded` / the `mache-823d91` reliability half. This PR removes the spurious-timeout failures and makes the knob available.

## Verification
- `go test ./internal/leyline/` → ok (full package)
- `go vet` + `golangci-lint` (pre-commit) → pass