### PR TITLE
ci: SHA-pin gate for GitHub Actions uses: refs (mache-b8900d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
       - name: Vet
         run: task vet
 
+      - name: Actions SHA-pin check
+        # Fail if any workflow `uses:` ref isn't SHA-pinned (mache-b8900d).
+        run: task actions:lint
+
       - name: Format check (gofumpt)
         # task fmt:check is the single source for the pinned gofumpt
         # invocation (it diffs instead of writing, so it's CI-safe and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -345,6 +345,11 @@ tasks:
     cmds:
       - bash scripts/docs-lint.sh
 
+  actions:lint:
+    desc: Fail if any .github/workflows `uses:` ref is not SHA-pinned (supply-chain; mache-b8900d)
+    cmds:
+      - bash scripts/actions-pin-lint.sh
+
   coverage-gate:
     desc: Run the diff-aware NEW-CODE coverage gate against the current branch
     vars:
@@ -438,6 +443,7 @@ tasks:
       - task: test
       - task: validate
       - task: docs:lint
+      - task: actions:lint
       - task: gen:server-json:check
 
   ci:
@@ -460,6 +466,7 @@ tasks:
       - task: test
       - task: validate
       - task: docs:lint
+      - task: actions:lint
       - task: gen:server-json:check
 
   # ────────────────────────────────────────────────────────────────

--- a/cmd/actions_pin_lint_test.go
+++ b/cmd/actions_pin_lint_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -42,20 +43,24 @@ func TestActionsPinLint_FlagsUnpinnedRef(t *testing.T) {
 	out, err := exec.Command("bash", actionsPinScript(t), dir).CombinedOutput()
 	require.Error(t, err, "must exit non-zero when an unpinned ref is present\n%s", out)
 	assert.Contains(t, string(out), "UNPINNED")
-	assert.Contains(t, string(out), "actions/checkout@v4")
+	assert.Contains(t, string(out), "actions/checkout@v4", "bare tag must be flagged")
+	assert.Contains(t, string(out), "docker://alpine:3.19", "mutable docker tag must be flagged")
 	assert.NotContains(t, string(out), "setup-go", "SHA-pinned ref must not be flagged")
 	assert.NotContains(t, string(out), "actions/local", "local ./ ref is exempt")
-	assert.NotContains(t, string(out), "docker://", "docker ref is exempt")
 }
 
 func TestActionsPinLint_PassesWhenAllPinned(t *testing.T) {
 	dir := t.TempDir()
+	upperSHA := strings.Repeat("A", 40)     // uppercase 40-hex must be accepted
+	dockerDigest := strings.Repeat("a", 64) // docker digest pin
 	wf := "jobs:\n  a:\n    steps:\n" +
-		"      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0\n"
+		"      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0\n" +
+		"      - uses: actions/foo@" + upperSHA + "\n" +
+		"      - uses: docker://alpine@sha256:" + dockerDigest + "\n"
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "wf.yml"), []byte(wf), 0o644))
 
 	out, err := exec.Command("bash", actionsPinScript(t), dir).CombinedOutput()
-	require.NoError(t, err, "must exit zero when all refs are SHA-pinned; got:\n%s", out)
+	require.NoError(t, err, "must exit zero when all refs are SHA-pinned (incl. uppercase SHA + docker digest); got:\n%s", out)
 	assert.Contains(t, string(out), "SHA-pinned")
 }
 

--- a/cmd/actions_pin_lint_test.go
+++ b/cmd/actions_pin_lint_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// actionsPinScript locates scripts/actions-pin-lint.sh by walking up to the
+// module root. Bead mache-b8900d.
+func actionsPinScript(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return filepath.Join(dir, "scripts", "actions-pin-lint.sh")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("go.mod not found walking up from cwd")
+		}
+		dir = parent
+	}
+}
+
+func TestActionsPinLint_FlagsUnpinnedRef(t *testing.T) {
+	dir := t.TempDir()
+	// One unpinned tag, one properly SHA-pinned, one exempt local ref, one
+	// exempt docker ref.
+	wf := "jobs:\n  a:\n    steps:\n" +
+		"      - uses: actions/checkout@v4\n" +
+		"      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6\n" +
+		"      - uses: ./.github/actions/local\n" +
+		"      - uses: docker://alpine:3.19\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wf.yml"), []byte(wf), 0o644))
+
+	out, err := exec.Command("bash", actionsPinScript(t), dir).CombinedOutput()
+	require.Error(t, err, "must exit non-zero when an unpinned ref is present\n%s", out)
+	assert.Contains(t, string(out), "UNPINNED")
+	assert.Contains(t, string(out), "actions/checkout@v4")
+	assert.NotContains(t, string(out), "setup-go", "SHA-pinned ref must not be flagged")
+	assert.NotContains(t, string(out), "actions/local", "local ./ ref is exempt")
+	assert.NotContains(t, string(out), "docker://", "docker ref is exempt")
+}
+
+func TestActionsPinLint_PassesWhenAllPinned(t *testing.T) {
+	dir := t.TempDir()
+	wf := "jobs:\n  a:\n    steps:\n" +
+		"      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "wf.yml"), []byte(wf), 0o644))
+
+	out, err := exec.Command("bash", actionsPinScript(t), dir).CombinedOutput()
+	require.NoError(t, err, "must exit zero when all refs are SHA-pinned; got:\n%s", out)
+	assert.Contains(t, string(out), "SHA-pinned")
+}
+
+// TestActionsPinLint_RepoIsClean is the live guard: every workflow ref in this
+// repo must be SHA-pinned. Mirrors what CI runs via `task actions:lint`, so a
+// regression fails `go test ./cmd/` too.
+func TestActionsPinLint_RepoIsClean(t *testing.T) {
+	out, err := exec.Command("bash", actionsPinScript(t)).CombinedOutput()
+	assert.NoError(t, err, "repo has unpinned workflow refs:\n%s", out)
+}

--- a/scripts/actions-pin-lint.sh
+++ b/scripts/actions-pin-lint.sh
@@ -11,7 +11,9 @@
 #
 # Exemptions:
 #   - local composite refs `uses: ./...` (nothing to pin)
-#   - docker refs `uses: docker://...` (digest-pinned in their own format)
+# Docker refs (`uses: docker://image@sha256:<64-hex>`) must be digest-pinned;
+# a mutable docker tag (docker://alpine:3.19) is flagged like any other
+# unpinned ref.
 #
 # Usage: actions-pin-lint.sh [workflows-dir]   (defaults to repo .github/workflows)
 set -euo pipefail
@@ -25,21 +27,33 @@ if [ ! -d "$wf_dir" ]; then
 fi
 
 fail=0
-# Anchor on step-style `uses:` lines (optional leading `- `). grep -rn emits
-# file:line:content; we parse the file for reporting and the ref from content.
+# Anchor on step-style `uses:` lines (optional leading `- `). We use
+# `find … -exec grep -H` rather than `grep -r --include` because the latter's
+# flags are GNU extensions; this form is portable to BSD/macOS grep. grep -H
+# emits file:line:content; we parse the file for reporting and the ref from
+# the content.
 while IFS= read -r hit; do
 	file="${hit%%:*}"
 	ref="$(printf '%s' "$hit" | sed -E 's/.*uses:[[:space:]]*//; s/[[:space:]#].*//; s/["'"'"']//g')"
 	[ -n "$ref" ] || continue
 	case "$ref" in
-	./* | docker://*) continue ;;
+	./*) continue ;; # local composite action — nothing to pin
+	docker://*)
+		# Docker actions pin by digest: docker://image@sha256:<64-hex>.
+		if ! printf '%s' "$ref" | grep -qE '@sha256:[0-9a-fA-F]{64}$'; then
+			echo "UNPINNED: $file → $ref"
+			fail=1
+		fi
+		continue
+		;;
 	esac
+	# Everything after the last @ must be a 40-hex commit SHA (either case).
 	after="${ref##*@}"
-	if ! printf '%s' "$after" | grep -qE '^[0-9a-f]{40}$'; then
+	if ! printf '%s' "$after" | grep -qE '^[0-9a-fA-F]{40}$'; then
 		echo "UNPINNED: $file → $ref"
 		fail=1
 	fi
-done < <(grep -rniE '^[[:space:]]*-?[[:space:]]*uses:' "$wf_dir" --include='*.yml' --include='*.yaml' 2>/dev/null || true)
+done < <(find "$wf_dir" -type f \( -name '*.yml' -o -name '*.yaml' \) -exec grep -nHE '^[[:space:]]*-?[[:space:]]*uses:' {} + 2>/dev/null || true)
 
 if [ "$fail" -ne 0 ]; then
 	echo

--- a/scripts/actions-pin-lint.sh
+++ b/scripts/actions-pin-lint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# actions-pin-lint.sh — fail if any GitHub Actions `uses:` ref under
+# .github/workflows/ is not pinned to a 40-hex commit SHA.
+#
+# Why: a bare tag (actions/checkout@v4) is a mutable, remotely-controlled
+# pointer — a supply-chain foothold. Dependabot bumps these but occasionally
+# leaves a bare tag behind (it did on lfs-guard.yml in #457, caught by hand).
+# This makes the invariant executable so the next one can't merge unnoticed.
+# Pairs with actionlint (workflow *syntax*, mache-f60571); this is *pinning*.
+# Bead mache-b8900d.
+#
+# Exemptions:
+#   - local composite refs `uses: ./...` (nothing to pin)
+#   - docker refs `uses: docker://...` (digest-pinned in their own format)
+#
+# Usage: actions-pin-lint.sh [workflows-dir]   (defaults to repo .github/workflows)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+wf_dir="${1:-$repo_root/.github/workflows}"
+
+if [ ! -d "$wf_dir" ]; then
+	echo "actions-pin-lint: no $wf_dir — nothing to check"
+	exit 0
+fi
+
+fail=0
+# Anchor on step-style `uses:` lines (optional leading `- `). grep -rn emits
+# file:line:content; we parse the file for reporting and the ref from content.
+while IFS= read -r hit; do
+	file="${hit%%:*}"
+	ref="$(printf '%s' "$hit" | sed -E 's/.*uses:[[:space:]]*//; s/[[:space:]#].*//; s/["'"'"']//g')"
+	[ -n "$ref" ] || continue
+	case "$ref" in
+	./* | docker://*) continue ;;
+	esac
+	after="${ref##*@}"
+	if ! printf '%s' "$after" | grep -qE '^[0-9a-f]{40}$'; then
+		echo "UNPINNED: $file → $ref"
+		fail=1
+	fi
+done < <(grep -rniE '^[[:space:]]*-?[[:space:]]*uses:' "$wf_dir" --include='*.yml' --include='*.yaml' 2>/dev/null || true)
+
+if [ "$fail" -ne 0 ]; then
+	echo
+	echo "actions-pin-lint: unpinned action ref(s) above — pin to a 40-hex commit SHA"
+	echo "  (keep a '# vX.Y.Z' trailing comment for readability). Dependabot will still bump the SHA."
+	exit 1
+fi
+
+echo "actions-pin-lint: all workflow \`uses:\` refs are SHA-pinned ✓"


### PR DESCRIPTION
## Motivation
Dependabot bumps action refs but occasionally leaves a **bare tag** behind — it did on `lfs-guard.yml` in #457, caught only by hand. A bare tag (`actions/checkout@v4`) is a mutable, remotely-controlled pointer — a supply-chain foothold. This makes "all actions must be SHA-pinned" executable so the next one can't merge unnoticed.

## Reframing vs the bead
`mache-b8900d` was filed as a `find_smells` rule, but **find_smells is SQL-only over the parsed code `.db`**, and workflow YAML isn't in that DB. A text rule would need a new engine rule-type — that's the larger `mache-445887` ("find_smells as a standalone lint") work, out of scope here. So this delivers the value the way mache already does workflow/doc hygiene: a **script + Taskfile target + CI wiring**, mirroring `scripts/docs-lint.sh`.

## Changes
- **`scripts/actions-pin-lint.sh`** — flags any `.github/workflows` `uses:` ref whose `@`-suffix isn't a 40-hex SHA. Exempts local `./` composite refs and `docker://` refs (different pinning format).
- **`task actions:lint`** — wired into the `check` + `ci` aggregates **and** the GitHub CI `lint` job, so it gates PRs (taskfile-ci-parity: CI invokes the task target, not a re-implemented command).
- **Go tests** (`cmd/actions_pin_lint_test.go`) — flags an unpinned ref, passes when pinned, exempts local/docker, and a **live guard** that the repo itself stays clean (a regression fails `go test ./cmd/` too).

Pairs with actionlint (workflow *syntax*, `mache-f60571`); this is *pinning*.

## Verification
- `task actions:lint` → all refs SHA-pinned ✓ (incl. this PR's ci.yml edit)
- `go test ./cmd/ -run TestActionsPinLint` → 3/3 pass
- `go vet` + `golangci-lint` (pre-commit) → pass