### PR TITLE
test(ingest): watcher FD-leak test asserts WatchList, not callback count (mache-336016)

### DIFF
--- a/internal/ingest/watcher_test.go
+++ b/internal/ingest/watcher_test.go
@@ -3,6 +3,7 @@ package ingest
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -328,6 +329,23 @@ func TestWatcher_TargetIgnored(t *testing.T) {
 
 	assert.Equal(t, int32(0), called.Load(),
 		"files in target/, dist/, build/ should be ignored by watcher")
+
+	// The callback count alone can't distinguish "dir skipped, FD saved" from
+	// "dir watched, callback filtered, FD still leaked" — a refactor that keeps
+	// the callback filter but drops the SkipDir skip would pass the assertion
+	// above while reintroducing the FD leak (mache-336016). Assert the FD-level
+	// invariant directly: no ignored tree is in the watcher's WatchList, so no
+	// descriptor was consumed for it.
+	watched := w.watcher.WatchList()
+	require.Contains(t, watched, dir,
+		"the root dir must be watched — else this test is vacuous (nothing watched trivially ignores everything)")
+	for _, ignored := range []string{"target", "dist", "build"} {
+		prefix := filepath.Join(dir, ignored)
+		for _, p := range watched {
+			assert.False(t, p == prefix || strings.HasPrefix(p, prefix+string(filepath.Separator)),
+				"ignored dir %q must not be watched (FD leak) — found watched path %s", ignored, p)
+		}
+	}
 }
 
 // TestWatcher_GitignoreSkipsDirs verifies that the watcher respects .gitignore


### PR DESCRIPTION
External-review M2. `TestWatcher_TargetIgnored` asserted only `onChange` fires 0 times for `target/dist/build` files — one layer removed from the real failure mode ("the dir isn't watched / no FD consumed"). A refactor that keeps the callback filter but drops the `SkipDir` skip would pass this test while quietly reintroducing the 129K-FD leak this release fixed.

Now also asserts the **FD-level invariant** directly via `w.watcher.WatchList()` (fsnotify v1.10.1): the root is watched (non-vacuity guard) and no path under `target/`, `dist/`, or `build/` appears in the watch list.

**Verified it catches the regression:** temporarily neutering `shouldIgnoreDir` makes it fail on `…/target/debug/deps` being watched; reverted clean. Keeps the original callback assertion for defense in depth.

Test-only; `go test ./internal/ingest/` green, golangci-lint pass.