### PR TITLE
feat(leyline): startup leyline_version wire-compat handshake (mache-8kif, M3)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -127,6 +127,14 @@ func runServe(cmd *cobra.Command, args []string) error {
 		leyline.SetDaemonSource(src)
 	}
 
+	// Startup wire-compat handshake (mache-8kif): if a leyline daemon is
+	// already reachable, refuse to serve on a structural wire-format mismatch
+	// rather than decoding garbage on the first enrichment op. No-op when no
+	// daemon is running or it predates the leyline_version op.
+	if err := leyline.VerifyReachableDaemonVersion(); err != nil {
+		return err
+	}
+
 	// Start the sheaf-invalidate event subscriber (mache-c14c43).
 	// One subscriber per process feeds the router; the router fans
 	// events out to every lazyGraph's invalidator. When no daemon

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -811,10 +811,11 @@ func (c *SocketClient) Prioritize(files []string) error {
 // BUMP THIS to the latest published ley-line-open release with binary assets;
 // bump the go.mod leyline-schema pin too whenever the WIRE format changes.
 //
-// Future hardening (mache-8kif): on socket connect, query the daemon's
-// version and refuse to proceed if it disagrees — though note LLO has no
-// `version` op today (verified against 0.5.x), so 8kif needs a different
-// mechanism.
+// Doubles as this build's leyline schema-client version for the startup
+// wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
+// queries the daemon's leyline_version op and refuses on a structural
+// mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
+// pin by the version-parity gate (mache-b8af69).
 const leylineBinaryVersion = "v0.5.7"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public

--- a/internal/leyline/version_check.go
+++ b/internal/leyline/version_check.go
@@ -1,0 +1,130 @@
+package leyline
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// expectedLeylineWireFormatMajor is the ley-line-open daemon wire-format major
+// this mache build's schema-client speaks; it mirrors LLO's
+// version::WIRE_FORMAT_MAJOR. A daemon advertising a different major means the
+// capnp/JSON shapes have structurally diverged — the schema-client would decode
+// garbage — so mache refuses rather than proceeding (mache-8kif / M3).
+const expectedLeylineWireFormatMajor uint64 = 1
+
+// VerifyReachableDaemonVersion is the startup wire-compat handshake: if a
+// leyline daemon is ALREADY reachable (it never auto-starts one), it queries the
+// leyline_version op and refuses to proceed on a structural mismatch. It returns
+// nil when no daemon is reachable, when the daemon predates the leyline_version
+// op, or when the versions are compatible — a version probe must never be
+// stricter than the actual wire decode.
+func VerifyReachableDaemonVersion() error {
+	sock, err := DiscoverSocket() // never auto-starts a daemon
+	if err != nil {
+		return nil // nothing running to check
+	}
+	if !isSocketAlive(sock) {
+		return nil // stale socket file, no listener
+	}
+	c, err := DialSocket(sock)
+	if err != nil {
+		return nil // transient dial failure — don't block startup on a probe
+	}
+	defer func() { _ = c.Close() }()
+	return c.VerifyVersion(leylineBinaryVersion)
+}
+
+// VerifyVersion queries the daemon's leyline_version op and checks wire-format
+// and schema compatibility against clientVersion (this build's leyline
+// schema-client version). A daemon that predates the op (SendOp errors) is not
+// an error — older daemons simply can't be verified, and we must not refuse a
+// daemon we might still decode fine.
+func (c *SocketClient) VerifyVersion(clientVersion string) error {
+	resp, err := c.SendOp(map[string]any{"op": "leyline_version"})
+	if err != nil {
+		return nil
+	}
+	return checkLeylineVersionCompat(resp, clientVersion)
+}
+
+// checkLeylineVersionCompat compares a leyline_version response against this
+// build's client version. It returns a non-nil, remediation-carrying error on a
+// genuine incompatibility, and nil when compatible OR when the relevant fields
+// are absent (an older daemon that omits them can't be refused on an unknown).
+// Pure — unit-tested directly (mache-8kif / external-review M3).
+func checkLeylineVersionCompat(resp map[string]any, clientVersion string) error {
+	// 1. Wire-format major: a mismatch is a structural break — the schema-client
+	//    decodes a different shape. Only present-and-different fails.
+	if major, ok := versionUint(resp["wire_format_major"]); ok && major != expectedLeylineWireFormatMajor {
+		return fmt.Errorf(
+			"leyline daemon wire-format is v%d but this mache build speaks v%d (daemon schema %v) — "+
+				"upgrade ley-line-open to a build whose wire_format_major is %d, or rebuild mache against the daemon's schema",
+			major, expectedLeylineWireFormatMajor, resp["schema_version"], expectedLeylineWireFormatMajor)
+	}
+
+	// 2. compat_min: the daemon refuses clients older than this schema version.
+	//    If mache's schema-client is older, fail fast with the daemon's implied
+	//    remediation rather than letting a later op fail cryptically.
+	if compatMin, ok := resp["compat_min"].(string); ok && compatMin != "" {
+		if compareSemver(clientVersion, compatMin) < 0 {
+			return fmt.Errorf(
+				"this mache build's leyline schema-client is %s but the daemon requires >= %s — "+
+					"upgrade mache (bump the go.mod leyline-schema pin and leylineBinaryVersion) to at least %s",
+				strings.TrimPrefix(clientVersion, "v"), compatMin, compatMin)
+		}
+	}
+	return nil
+}
+
+// versionUint extracts an unsigned integer from a JSON-decoded value that may be
+// a number (float64) or a string — the leyline capnp-json codec emits some
+// integers as JSON strings (see SocketClient.SendOpInto).
+func versionUint(v any) (uint64, bool) {
+	switch n := v.(type) {
+	case float64:
+		if n < 0 {
+			return 0, false
+		}
+		return uint64(n), true
+	case string:
+		u, err := strconv.ParseUint(strings.TrimSpace(n), 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return u, true
+	default:
+		return 0, false
+	}
+}
+
+// compareSemver compares two dotted versions (optional leading 'v'; pre-release
+// / build suffixes ignored) by major, then minor, then patch. Returns -1, 0, or
+// +1; missing components count as 0.
+func compareSemver(a, b string) int {
+	pa, pb := parseSemverParts(a), parseSemverParts(b)
+	for i := range 3 {
+		switch {
+		case pa[i] < pb[i]:
+			return -1
+		case pa[i] > pb[i]:
+			return 1
+		}
+	}
+	return 0
+}
+
+func parseSemverParts(v string) [3]uint64 {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	var out [3]uint64
+	for i, p := range strings.SplitN(v, ".", 3) {
+		if i >= 3 {
+			break
+		}
+		out[i], _ = strconv.ParseUint(p, 10, 64)
+	}
+	return out
+}

--- a/internal/leyline/version_check_test.go
+++ b/internal/leyline/version_check_test.go
@@ -1,0 +1,86 @@
+package leyline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckLeylineVersionCompat is the external-review M3 negative test: prove
+// the client-side handshake actually REFUSES on an incompatible daemon version,
+// and stays quiet when it can't tell (old daemon) or when compatible.
+func TestCheckLeylineVersionCompat(t *testing.T) {
+	const client = "v0.5.7"
+	cases := []struct {
+		name    string
+		resp    map[string]any
+		wantErr string // substring; "" = expect nil
+	}{
+		{
+			name: "compatible — matching wire + client >= compat_min",
+			resp: map[string]any{"wire_format_major": float64(1), "compat_min": "0.4.1", "schema_version": "0.5.7"},
+		},
+		{
+			name:    "wire-format major mismatch refuses (M3)",
+			resp:    map[string]any{"wire_format_major": float64(2), "compat_min": "0.4.1", "schema_version": "0.6.0"},
+			wantErr: "wire-format is v2 but this mache build speaks v1",
+		},
+		{
+			name:    "wire major as JSON string still refuses (capnp-json int-as-string)",
+			resp:    map[string]any{"wire_format_major": "2"},
+			wantErr: "wire-format is v2",
+		},
+		{
+			name:    "client older than compat_min refuses",
+			resp:    map[string]any{"wire_format_major": float64(1), "compat_min": "0.9.0"},
+			wantErr: "requires >= 0.9.0",
+		},
+		{
+			name: "absent fields — cannot determine, do not refuse (old daemon)",
+			resp: map[string]any{"ok": true},
+		},
+		{
+			name: "matching wire, no compat_min — ok",
+			resp: map[string]any{"wire_format_major": float64(1)},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := checkLeylineVersionCompat(c.resp, client)
+			if c.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), c.wantErr)
+		})
+	}
+}
+
+func TestCompareSemver(t *testing.T) {
+	assert.Equal(t, 0, compareSemver("v0.5.7", "0.5.7"))
+	assert.Equal(t, -1, compareSemver("0.4.1", "0.5.0"))
+	assert.Equal(t, 1, compareSemver("0.5.7", "0.4.1"))
+	assert.Equal(t, -1, compareSemver("0.5.6", "0.5.7"))
+	assert.Equal(t, 1, compareSemver("1.0.0", "0.99.99"))
+	assert.Equal(t, 0, compareSemver("v0.5.7-rc1", "0.5.7"), "pre-release suffix ignored")
+	assert.Equal(t, 0, compareSemver("0.5", "0.5.0"), "missing patch treated as 0")
+}
+
+func TestVersionUint(t *testing.T) {
+	u, ok := versionUint(float64(3))
+	assert.True(t, ok)
+	assert.Equal(t, uint64(3), u)
+
+	u, ok = versionUint("7")
+	assert.True(t, ok)
+	assert.Equal(t, uint64(7), u)
+
+	_, ok = versionUint("nope")
+	assert.False(t, ok)
+	_, ok = versionUint(nil)
+	assert.False(t, ok)
+	_, ok = versionUint(float64(-1))
+	assert.False(t, ok)
+}


### PR DESCRIPTION
External-review **M3** — the client side of the version handshake. LLO ships a `leyline_version` op (`daemon/ops.rs:1720`) advertising `wire_format_major` + `compat_min`, and its blackbox test asserts the daemon *advertises* correctly — but **mache never called it**, so the refusal the handshake exists to provide had no implementation and no test. The silent `parseUint`-returns-0 drift that bit v0.4.2→v0.4.3 could recur.

## What this adds
- **`VerifyReachableDaemonVersion()`** — if a leyline daemon is *already reachable* (it **never auto-starts** one), query `leyline_version` and **refuse to serve** on a structural `wire_format_major` mismatch, or when this build's schema-client is older than the daemon's `compat_min`. No-op when no daemon is reachable or it predates the op — *a version probe must never be stricter than the actual wire decode*, so it can't false-refuse working setups.
- Wired once into `runServe` after the daemon source is configured.
- **Defensive parse**: capnp-json emits some ints as JSON strings, so `wire_format_major` is read as number *or* string.
- Reuses `leylineBinaryVersion` as the schema-client version (major.minor lockstepped by the `mache-b8af69` parity gate); removes the now-false "LLO has no version op today" comment.

## Tests
`checkLeylineVersionCompat` is pure and unit-tested — the **M3 negative cases** (wire mismatch refuses; client < `compat_min` refuses) plus compatible / absent-fields / string-encoded-major, `compareSemver`, and `versionUint`.

## Verification
`go build ./...`, `go vet`, `go test ./internal/leyline/` all green; golangci-lint pass.