### PR TITLE
feat(smells): count-based ratchet — W5 local-first gate core (mache-491b9f)

### DIFF
--- a/cmd/smell_ratchet.go
+++ b/cmd/smell_ratchet.go
@@ -1,0 +1,105 @@
+package cmd
+
+import "sort"
+
+// smellBaseline is the grandfathered count of findings per (rule_id, source_id)
+// — a count-based ratchet that generalizes rosary's god-files-vs-origin/main:
+// existing debt is allowed; the gate fails only on findings ABOVE the baseline
+// count, and the baseline may shrink freely (improvement). Count-based rather
+// than line-based so it's stable across incidental line shifts (adding a line
+// above a finding must not "move" it into new-debt).
+//
+// This is the enforced ratchet the observational smell-debt-baseline doc was
+// missing; `task smells` (W5) wraps `mache find-smells` + this to become the
+// local-first gate, and the find-smells GHA (W6) wraps `task smells`.
+// Bead mache-491b9f (analysis-substrate/W5).
+type smellBaseline struct {
+	Version int             `json:"version"`
+	Counts  []baselineEntry `json:"counts"`
+}
+
+type baselineEntry struct {
+	RuleID   string `json:"rule_id"`
+	SourceID string `json:"source_id"`
+	Count    int    `json:"count"`
+}
+
+// computeBaseline counts findings per (rule, file). The output is sorted
+// deterministically so a committed baseline file doesn't churn on regeneration.
+func computeBaseline(findings []smellFinding) smellBaseline {
+	counts := map[[2]string]int{}
+	for _, f := range findings {
+		counts[[2]string{f.RuleID, f.SourceID}]++
+	}
+	out := smellBaseline{Version: 1, Counts: make([]baselineEntry, 0, len(counts))}
+	for k, n := range counts {
+		out.Counts = append(out.Counts, baselineEntry{RuleID: k[0], SourceID: k[1], Count: n})
+	}
+	sortEntries(out.Counts)
+	return out
+}
+
+// lookup returns the grandfathered count for (rule, file), or 0 if absent.
+func (b smellBaseline) lookup(ruleID, sourceID string) int {
+	for _, e := range b.Counts {
+		if e.RuleID == ruleID && e.SourceID == sourceID {
+			return e.Count
+		}
+	}
+	return 0
+}
+
+// newDebt returns the findings that exceed the baseline count for their
+// (rule, file) — exactly what a ratcheted gate fails on. Within each group the
+// first `allowed` findings (sorted by position) are grandfathered and the rest
+// are returned. Deterministic in group order and within-group order.
+func newDebt(current []smellFinding, base smellBaseline) []smellFinding {
+	groups := map[[2]string][]smellFinding{}
+	var order [][2]string
+	for _, f := range current {
+		k := [2]string{f.RuleID, f.SourceID}
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], f)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		if order[i][0] != order[j][0] {
+			return order[i][0] < order[j][0]
+		}
+		return order[i][1] < order[j][1]
+	})
+
+	var debt []smellFinding
+	for _, k := range order {
+		g := groups[k]
+		allowed := base.lookup(k[0], k[1])
+		if len(g) <= allowed {
+			continue
+		}
+		sortFindingsByPosition(g)
+		debt = append(debt, g[allowed:]...)
+	}
+	return debt
+}
+
+func sortEntries(e []baselineEntry) {
+	sort.Slice(e, func(i, j int) bool {
+		if e[i].RuleID != e[j].RuleID {
+			return e[i].RuleID < e[j].RuleID
+		}
+		return e[i].SourceID < e[j].SourceID
+	})
+}
+
+func sortFindingsByPosition(f []smellFinding) {
+	sort.Slice(f, func(i, j int) bool {
+		if f[i].Line != f[j].Line {
+			return f[i].Line < f[j].Line
+		}
+		if f[i].Column != f[j].Column {
+			return f[i].Column < f[j].Column
+		}
+		return f[i].StartByte < f[j].StartByte
+	})
+}

--- a/cmd/smell_ratchet_test.go
+++ b/cmd/smell_ratchet_test.go
@@ -1,0 +1,101 @@
+package cmd
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rf builds a minimal smellFinding for ratchet tests (only rule/file/line matter).
+func rf(rule, src string, line int) smellFinding {
+	return smellFinding{RuleID: rule, SourceID: src, Line: line}
+}
+
+func TestSmellBaseline_ComputeAndLookup(t *testing.T) {
+	base := computeBaseline([]smellFinding{
+		rf("long_function", "a.go", 10),
+		rf("long_function", "a.go", 40),
+		rf("long_function", "b.go", 5),
+		rf("magic_int", "a.go", 3),
+	})
+	assert.Equal(t, 2, base.lookup("long_function", "a.go"))
+	assert.Equal(t, 1, base.lookup("long_function", "b.go"))
+	assert.Equal(t, 1, base.lookup("magic_int", "a.go"))
+	assert.Equal(t, 0, base.lookup("long_function", "c.go"), "unknown file → 0")
+	assert.Equal(t, 0, base.lookup("dead_code", "a.go"), "unknown rule → 0")
+}
+
+func TestSmellBaseline_JSONRoundTrip_Deterministic(t *testing.T) {
+	orig := computeBaseline([]smellFinding{
+		rf("long_function", "a.go", 10),
+		rf("long_function", "a.go", 40),
+		rf("magic_int", "z.go", 3),
+	})
+	blob, err := json.Marshal(orig)
+	require.NoError(t, err)
+
+	var got smellBaseline
+	require.NoError(t, json.Unmarshal(blob, &got))
+	assert.Equal(t, 2, got.lookup("long_function", "a.go"))
+	assert.Equal(t, 1, got.lookup("magic_int", "z.go"))
+
+	// Output must be order-independent so a committed baseline file doesn't
+	// churn on every regeneration.
+	shuffled, err := json.Marshal(computeBaseline([]smellFinding{
+		rf("magic_int", "z.go", 3),
+		rf("long_function", "a.go", 40),
+		rf("long_function", "a.go", 10),
+	}))
+	require.NoError(t, err)
+	assert.JSONEq(t, string(blob), string(shuffled), "baseline serialization must be deterministic")
+}
+
+func TestNewDebt(t *testing.T) {
+	baseline := computeBaseline([]smellFinding{
+		rf("long_function", "a.go", 10),
+		rf("long_function", "a.go", 40),
+		rf("magic_int", "a.go", 3),
+	})
+
+	t.Run("no change → no debt", func(t *testing.T) {
+		cur := []smellFinding{rf("long_function", "a.go", 12), rf("long_function", "a.go", 44), rf("magic_int", "a.go", 3)}
+		assert.Empty(t, newDebt(cur, baseline))
+	})
+
+	t.Run("improvement (fewer) → no debt", func(t *testing.T) {
+		cur := []smellFinding{rf("long_function", "a.go", 12)} // was 2, now 1
+		assert.Empty(t, newDebt(cur, baseline))
+	})
+
+	t.Run("+1 in existing (rule,file) → exactly 1 debt", func(t *testing.T) {
+		cur := []smellFinding{rf("long_function", "a.go", 12), rf("long_function", "a.go", 44), rf("long_function", "a.go", 88)}
+		d := newDebt(cur, baseline)
+		require.Len(t, d, 1)
+		assert.Equal(t, "long_function", d[0].RuleID)
+		assert.Equal(t, "a.go", d[0].SourceID)
+	})
+
+	t.Run("new (rule,file) → all its findings are debt", func(t *testing.T) {
+		cur := []smellFinding{rf("dead_code", "new.go", 1), rf("dead_code", "new.go", 9)}
+		d := newDebt(cur, baseline)
+		require.Len(t, d, 2)
+		for _, x := range d {
+			assert.Equal(t, "dead_code", x.RuleID)
+		}
+	})
+
+	t.Run("empty baseline → all findings are debt", func(t *testing.T) {
+		cur := []smellFinding{rf("x", "a", 1), rf("y", "b", 2)}
+		assert.Len(t, newDebt(cur, smellBaseline{}), 2)
+	})
+
+	t.Run("deterministic output", func(t *testing.T) {
+		cur := []smellFinding{rf("long_function", "a.go", 88), rf("long_function", "a.go", 12), rf("long_function", "a.go", 44), rf("long_function", "a.go", 60)}
+		d1 := newDebt(cur, baseline)
+		d2 := newDebt(cur, baseline)
+		assert.Equal(t, d1, d2)
+		assert.Len(t, d1, 2, "baseline 2, current 4 → 2 new")
+	})
+}


### PR DESCRIPTION
First brick of **W5** (analysis-substrate decade): the enforced **ratchet** the observational smell-debt-baseline doc was missing.

A **count-based** ratchet over `find_smells` output, generalizing rosary's `god-files`-vs-`origin/main`: the baseline records findings-per-`(rule_id, source_id)`; the gate fails only on findings **above** the baseline count (new debt), and the baseline may **shrink freely** (improvement). Count-based rather than line-based so it's **stable across incidental line shifts** (adding a line above a finding must not move it into new-debt).

- `computeBaseline([]smellFinding)` → deterministically-sorted per-(rule,file) counts (committed baseline doesn't churn).
- `newDebt(current, baseline)` → the excess findings a ratcheted gate fails on; grandfathers the first `allowed` per group, deterministic order.
- JSON-serializable baseline.

**TDD**: tests written first (RED → GREEN) — compute/lookup, deterministic JSON round-trip, and `newDebt` across no-change / improvement / +1 / new-(rule,file) / empty-baseline / determinism.

Next W5 bricks wire this into `mache find-smells --baseline` + a `task smells` target (the local gate); the W6 GHA wraps `task smells`.

`go vet`, `go build ./...`, `go test -run 'TestSmellBaseline|TestNewDebt' ./cmd/` all green; golangci-lint pass.