### PR TITLE
feat(smells): find-smells --baseline ratchet gate — W5.2 (mache-4d155c)

### DIFF
--- a/cmd/find_smells_baseline_test.go
+++ b/cmd/find_smells_baseline_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindSmellsCLI_BaselineRatchet_EndToEnd is the W5.2 "it actually works"
+// proof (mache-4d155c): a REAL find-smells scan over a fixture .db, gated by
+// the count-ratchet. Writing a baseline grandfathers the current finding;
+// re-running within it passes (exit 0); running against an empty baseline
+// makes that same finding new debt and fails (exit 1).
+func TestFindSmellsCLI_BaselineRatchet_EndToEnd(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t) // one dead_code finding: pkg/Dead
+	baselinePath := filepath.Join(t.TempDir(), "baseline.json")
+
+	saved := saveCLIFlags()
+	defer saved.restore()
+	findSmellsRule = "dead_code"
+	findSmellsDBPath = dbPath
+	findSmellsFormat = "ci"
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+
+	// 1. Regenerate the baseline from the current scan → exit 0, file written.
+	findSmellsWriteBaseline = baselinePath
+	code, err := runFindSmells(findSmellsCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code, "--write-baseline exits 0")
+	require.FileExists(t, baselinePath)
+	findSmellsWriteBaseline = ""
+
+	// 2. Gate against that baseline: current == baseline → no new debt → exit 0.
+	findSmellsBaseline = baselinePath
+	code, err = runFindSmells(findSmellsCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, code, "findings within the baseline → gate passes")
+
+	// 3. Gate against an EMPTY baseline: the dead_code finding is now new debt
+	//    → exit 1, and the new finding is reported. This is the gate biting.
+	emptyBaseline := filepath.Join(t.TempDir(), "empty.json")
+	require.NoError(t, os.WriteFile(emptyBaseline, []byte(`{"version":1,"counts":[]}`), 0o644))
+	findSmellsBaseline = emptyBaseline
+	buf.Reset()
+	code, err = runFindSmells(findSmellsCmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, code, "a finding absent from the baseline is new debt → gate fails")
+	assert.Contains(t, buf.String(), "NEW finding")
+	assert.Contains(t, buf.String(), "dead_code")
+}
+
+// TestBaseline_LoadWriteRoundTrip pins the on-disk baseline format.
+func TestBaseline_LoadWriteRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "b.json")
+	orig := computeBaseline([]smellFinding{
+		rf("long_function", "a.go", 10),
+		rf("long_function", "a.go", 40),
+		rf("dead_code", "b.go", 3),
+	})
+	require.NoError(t, writeBaseline(path, orig))
+
+	got, err := loadBaseline(path)
+	require.NoError(t, err)
+	assert.Equal(t, 2, got.lookup("long_function", "a.go"))
+	assert.Equal(t, 1, got.lookup("dead_code", "b.go"))
+}

--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -40,6 +40,13 @@ var (
 	findSmellsFormat    string
 	findSmellsFailOn    string
 	findSmellsTags      string
+
+	// findSmellsBaseline gates on new-findings-vs-baseline (the W5 ratchet):
+	// when set, exit non-zero iff any (rule,file) exceeds the committed
+	// baseline count, ignoring --fail-on. findSmellsWriteBaseline regenerates
+	// the committed baseline from the current scan. Bead mache-4d155c.
+	findSmellsBaseline      string
+	findSmellsWriteBaseline string
 )
 
 // exitFunc is the process-exit hook the CLI uses after RunE returns a
@@ -238,6 +245,29 @@ func runFindSmells(cmd *cobra.Command, _ []string) (int, error) {
 				return 0, err
 			}
 		}
+	}
+
+	// W5 ratchet (mache-4d155c): --write-baseline regenerates the committed
+	// baseline (grandfathers current findings); --baseline gates on
+	// new-findings-vs-baseline, overriding --fail-on. Both operate on the
+	// flattened finding set.
+	if findSmellsWriteBaseline != "" {
+		if err := writeBaseline(findSmellsWriteBaseline, computeBaseline(allFindings(results))); err != nil {
+			return printAndCode(4, fmt.Errorf("write baseline %s: %w", findSmellsWriteBaseline, err))
+		}
+		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "wrote smell baseline: %s\n", findSmellsWriteBaseline)
+		return 0, nil
+	}
+	if findSmellsBaseline != "" {
+		base, err := loadBaseline(findSmellsBaseline)
+		if err != nil {
+			return printAndCode(4, fmt.Errorf("load baseline %s: %w", findSmellsBaseline, err))
+		}
+		if debt := newDebt(allFindings(results), base); len(debt) > 0 {
+			renderNewDebt(cmd.ErrOrStderr(), debt)
+			return 1, nil
+		}
+		return 0, nil
 	}
 
 	// Gate decision (ADR-0018). --fail-on=none preserves the legacy
@@ -502,5 +532,7 @@ func init() {
 	findSmellsCmd.Flags().StringVar(&findSmellsFormat, "format", "json", "output format: json, md, or ci")
 	findSmellsCmd.Flags().StringVar(&findSmellsFailOn, "fail-on", "error", "exit non-zero when findings reach severity: none | warn | error (ADR-0018)")
 	findSmellsCmd.Flags().StringVar(&findSmellsTags, "tags", "", "comma-separated tags; runs rules whose Tags contain ANY of these values (set union)")
+	findSmellsCmd.Flags().StringVar(&findSmellsBaseline, "baseline", "", "path to a committed smell baseline JSON; exit non-zero only on findings that EXCEED the baseline count per (rule,file) — the W5 ratchet")
+	findSmellsCmd.Flags().StringVar(&findSmellsWriteBaseline, "write-baseline", "", "regenerate the baseline JSON at this path from the current scan (grandfathers all current findings), then exit 0")
 	rootCmd.AddCommand(findSmellsCmd)
 }

--- a/cmd/find_smells_cli_test.go
+++ b/cmd/find_smells_cli_test.go
@@ -590,6 +590,7 @@ func (s *stderrCapture) restore() {
 // ADR-0018 PR 2 to cover --fail-on / --tags and the exitFunc override.
 type cliFlagSnapshot struct {
 	rule, db, sourceID, format, failOn, tags string
+	baseline, writeBaseline                  string
 	limit                                    int
 	minMetric                                int64
 	exitFunc                                 func(int)
@@ -597,15 +598,17 @@ type cliFlagSnapshot struct {
 
 func saveCLIFlags() cliFlagSnapshot {
 	return cliFlagSnapshot{
-		rule:      findSmellsRule,
-		db:        findSmellsDBPath,
-		sourceID:  findSmellsSourceID,
-		format:    findSmellsFormat,
-		failOn:    findSmellsFailOn,
-		tags:      findSmellsTags,
-		limit:     findSmellsLimit,
-		minMetric: findSmellsMinMetric,
-		exitFunc:  exitFunc,
+		rule:          findSmellsRule,
+		db:            findSmellsDBPath,
+		sourceID:      findSmellsSourceID,
+		format:        findSmellsFormat,
+		failOn:        findSmellsFailOn,
+		tags:          findSmellsTags,
+		baseline:      findSmellsBaseline,
+		writeBaseline: findSmellsWriteBaseline,
+		limit:         findSmellsLimit,
+		minMetric:     findSmellsMinMetric,
+		exitFunc:      exitFunc,
 	}
 }
 
@@ -616,6 +619,8 @@ func (s cliFlagSnapshot) restore() {
 	findSmellsFormat = s.format
 	findSmellsFailOn = s.failOn
 	findSmellsTags = s.tags
+	findSmellsBaseline = s.baseline
+	findSmellsWriteBaseline = s.writeBaseline
 	findSmellsLimit = s.limit
 	findSmellsMinMetric = s.minMetric
 	exitFunc = s.exitFunc

--- a/cmd/smell_ratchet.go
+++ b/cmd/smell_ratchet.go
@@ -1,6 +1,12 @@
 package cmd
 
-import "sort"
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
 
 // smellBaseline is the grandfathered count of findings per (rule_id, source_id)
 // — a count-based ratchet that generalizes rosary's god-files-vs-origin/main:
@@ -102,4 +108,48 @@ func sortFindingsByPosition(f []smellFinding) {
 		}
 		return f[i].StartByte < f[j].StartByte
 	})
+}
+
+// loadBaseline reads a committed smellBaseline JSON file.
+func loadBaseline(path string) (smellBaseline, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return smellBaseline{}, err
+	}
+	var b smellBaseline
+	if err := json.Unmarshal(data, &b); err != nil {
+		return smellBaseline{}, fmt.Errorf("parse baseline: %w", err)
+	}
+	return b, nil
+}
+
+// writeBaseline writes a deterministic (sorted) smellBaseline JSON file.
+func writeBaseline(path string, b smellBaseline) error {
+	data, err := json.MarshalIndent(b, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, append(data, '\n'), 0o644)
+}
+
+// allFindings flattens the per-rule results into a single finding slice.
+func allFindings(results []ruleRunResult) []smellFinding {
+	var out []smellFinding
+	for _, r := range results {
+		out = append(out, r.findings...)
+	}
+	return out
+}
+
+// renderNewDebt prints the findings that exceed the baseline — the actionable
+// output of a ratcheted gate (one line per finding + a count header).
+func renderNewDebt(w io.Writer, debt []smellFinding) {
+	_, _ = fmt.Fprintf(w, "smell ratchet: %d NEW finding(s) above baseline:\n", len(debt))
+	for _, f := range debt {
+		loc := f.SourceID
+		if f.Line > 0 {
+			loc = fmt.Sprintf("%s:%d", f.SourceID, f.Line)
+		}
+		_, _ = fmt.Fprintf(w, "  [%s] %s\n", f.RuleID, loc)
+	}
 }


### PR DESCRIPTION
Wires the W5.1 count-ratchet (#476) into the `find-smells` CLI.

- **`--write-baseline <file>`** — regenerate the committed baseline (grandfathers current findings), exit 0.
- **`--baseline <file>`** — gate on **new-findings-vs-baseline** (overrides `--fail-on`): exit 1 iff any `(rule,file)` exceeds the baseline count, printing the new debt.

## "It actually works" — end-to-end proof (TDD)
`TestFindSmellsCLI_BaselineRatchet_EndToEnd` runs a **real** `find-smells dead_code` scan over a fixture `.db`: `--write-baseline` → exit **0**; re-run `--baseline` → exit **0**; `--baseline <empty>` → exit **1** with the `dead_code` finding reported as new debt. Plus `loadBaseline`/`writeBaseline` round-trip. RED→GREEN.

Next: **W5.3** (`mache-4da90e`) — `task smells` over mache's own repo = the first working gate on real source; then W6 wraps it in a GHA.

`go build`, `go vet`, `go test ./cmd/`, golangci-lint all green.