### PR TITLE
feat(smells): task smells — working local-first ratchet gate on real source (W5.3, mache-4da90e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,12 @@ jobs:
         # Fail if any workflow `uses:` ref isn't SHA-pinned (mache-b8900d).
         run: task actions:lint
 
+      - name: Smell gate
+        # Build a .db of the repo + fail on NEW structural findings vs the
+        # committed baseline (W5 ratchet, mache-4da90e). Local == CI: the same
+        # `task smells` a developer runs.
+        run: task smells
+
       - name: Format check (gofumpt)
         # task fmt:check is the single source for the pinned gofumpt
         # invocation (it diffs instead of writing, so it's CI-safe and

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -319,8 +319,8 @@ tasks:
     cmds:
       - go run main.go -file subject/parser.go -target FuzzParseToken
 
-  smells:
-    desc: Dogfood — index this repo and run the standalone find_smells rules locally
+  smells:dogfood:
+    desc: "Dogfood — index this repo and PRINT all standalone find_smells findings (no gate; see `task smells` for the ratchet gate)"
     deps: [build]
     vars:
       DB: /tmp/mache-smells.db
@@ -349,6 +349,33 @@ tasks:
     desc: Fail if any .github/workflows `uses:` ref is not SHA-pinned (supply-chain; mache-b8900d)
     cmds:
       - bash scripts/actions-pin-lint.sh
+
+  smells:
+    desc: "Structural smell gate — fail on NEW findings vs docs/smell-baseline.json (W5 local-first gate, mache-4da90e)"
+    deps: [build]
+    cmds:
+      - |
+        set -euo pipefail
+        DB="$(mktemp -t mache-smells.XXXXXX.db)"
+        trap 'rm -f "$DB"' EXIT
+        ./{{.BINARY_NAME}} build . "$DB" --backend tree-sitter >/dev/null
+        # --rule '*' skips rules whose tables are absent on the pure-Go .db;
+        # --baseline-root "$PWD" keeps the committed baseline machine/CI-portable.
+        ./{{.BINARY_NAME}} find-smells --db "$DB" --rule '*' --limit 100000 \
+          --baseline-root "$PWD" --baseline docs/smell-baseline.json >/dev/null
+
+  smells:baseline:
+    desc: "Regenerate docs/smell-baseline.json — grandfather current structural debt (run after a deliberate change)"
+    deps: [build]
+    cmds:
+      - |
+        set -euo pipefail
+        DB="$(mktemp -t mache-smells.XXXXXX.db)"
+        trap 'rm -f "$DB"' EXIT
+        ./{{.BINARY_NAME}} build . "$DB" --backend tree-sitter >/dev/null
+        ./{{.BINARY_NAME}} find-smells --db "$DB" --rule '*' --limit 100000 \
+          --baseline-root "$PWD" --write-baseline docs/smell-baseline.json >/dev/null
+        echo "regenerated docs/smell-baseline.json"
 
   coverage-gate:
     desc: Run the diff-aware NEW-CODE coverage gate against the current branch
@@ -444,6 +471,7 @@ tasks:
       - task: validate
       - task: docs:lint
       - task: actions:lint
+      - task: smells
       - task: gen:server-json:check
 
   ci:
@@ -467,6 +495,7 @@ tasks:
       - task: validate
       - task: docs:lint
       - task: actions:lint
+      - task: smells
       - task: gen:server-json:check
 
   # ────────────────────────────────────────────────────────────────

--- a/cmd/find_smells_baseline_test.go
+++ b/cmd/find_smells_baseline_test.go
@@ -56,6 +56,41 @@ func TestFindSmellsCLI_BaselineRatchet_EndToEnd(t *testing.T) {
 	assert.Contains(t, buf.String(), "dead_code")
 }
 
+// TestRelativizeFindings pins the path-portability transform: mache build
+// records absolute source paths, so a committed baseline must be relativized.
+func TestRelativizeFindings(t *testing.T) {
+	root := filepath.Join("/abs", "repo")
+	in := []smellFinding{
+		{RuleID: "r", SourceID: filepath.Join(root, "cmd", "x.go")},
+		{RuleID: "r", SourceID: filepath.Join(root, "internal", "y.go")},
+	}
+	out := relativizeFindings(in, root)
+	assert.Equal(t, filepath.Join("cmd", "x.go"), out[0].SourceID)
+	assert.Equal(t, filepath.Join("internal", "y.go"), out[1].SourceID)
+	assert.Equal(t, in, relativizeFindings(in, ""), "empty root is a no-op")
+}
+
+// TestFindSmellsCLI_GlobSkipsUnavailableRules pins the W5.3 behavior that makes
+// task smells portable: a glob run skips rules whose tables are absent (e.g.
+// _ast rules on a pure-Go tree-sitter .db) instead of aborting.
+func TestFindSmellsCLI_GlobSkipsUnavailableRules(t *testing.T) {
+	dbPath := writeSmellCLIFixture(t) // nodes/node_defs/node_refs, NO _ast
+
+	saved := saveCLIFlags()
+	defer saved.restore()
+	findSmellsRule = "*"
+	findSmellsDBPath = dbPath
+	findSmellsFormat = "ci"
+
+	var buf bytes.Buffer
+	findSmellsCmd.SetOut(&buf)
+	findSmellsCmd.SetErr(&buf)
+	code, err := runFindSmells(findSmellsCmd, nil)
+	require.NoError(t, err)
+	assert.NotEqual(t, 2, code, "a glob must not abort on rules with missing tables")
+	assert.Contains(t, buf.String(), "skipping rule", "_ast rules are skipped on a pure-Go .db")
+}
+
 // TestBaseline_LoadWriteRoundTrip pins the on-disk baseline format.
 func TestBaseline_LoadWriteRoundTrip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "b.json")

--- a/cmd/find_smells_cli.go
+++ b/cmd/find_smells_cli.go
@@ -47,6 +47,10 @@ var (
 	// the committed baseline from the current scan. Bead mache-4d155c.
 	findSmellsBaseline      string
 	findSmellsWriteBaseline string
+	// findSmellsBaselineRoot relativizes source_id (which mache build records
+	// absolute) against this prefix before baselining/gating, so a committed
+	// baseline is portable across machines and CI. Bead mache-4da90e.
+	findSmellsBaselineRoot string
 )
 
 // exitFunc is the process-exit hook the CLI uses after RunE returns a
@@ -195,6 +199,17 @@ func runFindSmells(cmd *cobra.Command, _ []string) (int, error) {
 		if missing, mErr := missingTables(qg, rule.Requires); mErr != nil {
 			return printAndCode(4, fmt.Errorf("pre-flight: %w", mErr))
 		} else if len(missing) > 0 {
+			// A glob/tag matched multiple rules: skip the ones whose tables
+			// aren't present (e.g. _ast rules on a pure-Go tree-sitter .db)
+			// rather than aborting the whole run — the gate assesses what it
+			// CAN. An explicitly-named single rule still errors (you asked for
+			// exactly it). Bead mache-4da90e (W5.3).
+			if len(matched) > 1 {
+				_, _ = fmt.Fprintf(cmd.ErrOrStderr(),
+					"find-smells: skipping rule %q — requires absent tables [%s]\n",
+					rule.ID, strings.Join(missing, ", "))
+				continue
+			}
 			backendNote := ""
 			if backend := queryBuildBackend(qg); backend != "" {
 				backendNote = fmt.Sprintf(" (built with backend=%q)", backend)
@@ -251,8 +266,9 @@ func runFindSmells(cmd *cobra.Command, _ []string) (int, error) {
 	// baseline (grandfathers current findings); --baseline gates on
 	// new-findings-vs-baseline, overriding --fail-on. Both operate on the
 	// flattened finding set.
+	scanned := relativizeFindings(allFindings(results), findSmellsBaselineRoot)
 	if findSmellsWriteBaseline != "" {
-		if err := writeBaseline(findSmellsWriteBaseline, computeBaseline(allFindings(results))); err != nil {
+		if err := writeBaseline(findSmellsWriteBaseline, computeBaseline(scanned)); err != nil {
 			return printAndCode(4, fmt.Errorf("write baseline %s: %w", findSmellsWriteBaseline, err))
 		}
 		_, _ = fmt.Fprintf(cmd.ErrOrStderr(), "wrote smell baseline: %s\n", findSmellsWriteBaseline)
@@ -263,7 +279,7 @@ func runFindSmells(cmd *cobra.Command, _ []string) (int, error) {
 		if err != nil {
 			return printAndCode(4, fmt.Errorf("load baseline %s: %w", findSmellsBaseline, err))
 		}
-		if debt := newDebt(allFindings(results), base); len(debt) > 0 {
+		if debt := newDebt(scanned, base); len(debt) > 0 {
 			renderNewDebt(cmd.ErrOrStderr(), debt)
 			return 1, nil
 		}
@@ -534,5 +550,6 @@ func init() {
 	findSmellsCmd.Flags().StringVar(&findSmellsTags, "tags", "", "comma-separated tags; runs rules whose Tags contain ANY of these values (set union)")
 	findSmellsCmd.Flags().StringVar(&findSmellsBaseline, "baseline", "", "path to a committed smell baseline JSON; exit non-zero only on findings that EXCEED the baseline count per (rule,file) — the W5 ratchet")
 	findSmellsCmd.Flags().StringVar(&findSmellsWriteBaseline, "write-baseline", "", "regenerate the baseline JSON at this path from the current scan (grandfathers all current findings), then exit 0")
+	findSmellsCmd.Flags().StringVar(&findSmellsBaselineRoot, "baseline-root", "", "trim this path prefix from source_id before baselining/gating so a committed baseline is machine/CI-portable (e.g. --baseline-root \"$PWD\")")
 	rootCmd.AddCommand(findSmellsCmd)
 }

--- a/cmd/find_smells_cli_test.go
+++ b/cmd/find_smells_cli_test.go
@@ -590,7 +590,7 @@ func (s *stderrCapture) restore() {
 // ADR-0018 PR 2 to cover --fail-on / --tags and the exitFunc override.
 type cliFlagSnapshot struct {
 	rule, db, sourceID, format, failOn, tags string
-	baseline, writeBaseline                  string
+	baseline, writeBaseline, baselineRoot    string
 	limit                                    int
 	minMetric                                int64
 	exitFunc                                 func(int)
@@ -606,6 +606,7 @@ func saveCLIFlags() cliFlagSnapshot {
 		tags:          findSmellsTags,
 		baseline:      findSmellsBaseline,
 		writeBaseline: findSmellsWriteBaseline,
+		baselineRoot:  findSmellsBaselineRoot,
 		limit:         findSmellsLimit,
 		minMetric:     findSmellsMinMetric,
 		exitFunc:      exitFunc,
@@ -621,6 +622,7 @@ func (s cliFlagSnapshot) restore() {
 	findSmellsTags = s.tags
 	findSmellsBaseline = s.baseline
 	findSmellsWriteBaseline = s.writeBaseline
+	findSmellsBaselineRoot = s.baselineRoot
 	findSmellsLimit = s.limit
 	findSmellsMinMetric = s.minMetric
 	exitFunc = s.exitFunc

--- a/cmd/smell_ratchet.go
+++ b/cmd/smell_ratchet.go
@@ -6,7 +6,24 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strings"
 )
+
+// relativizeFindings trims root (plus a trailing separator) from each finding's
+// SourceID — mache build records absolute paths, so a committed baseline must
+// be relativized to stay portable across machines and CI. No-op when root == "".
+func relativizeFindings(findings []smellFinding, root string) []smellFinding {
+	if root == "" {
+		return findings
+	}
+	prefix := strings.TrimRight(root, string(os.PathSeparator)) + string(os.PathSeparator)
+	out := make([]smellFinding, len(findings))
+	for i, f := range findings {
+		f.SourceID = strings.TrimPrefix(f.SourceID, prefix)
+		out[i] = f
+	}
+	return out
+}
 
 // smellBaseline is the grandfathered count of findings per (rule_id, source_id)
 // — a count-based ratchet that generalizes rosary's god-files-vs-origin/main:

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -1,0 +1,285 @@
+{
+  "version": 1,
+  "counts": [
+    {
+      "rule_id": "dead_code",
+      "source_id": "cmd/cache_oci.go",
+      "count": 1
+    },
+    {
+      "rule_id": "dead_code",
+      "source_id": "cmd/config.go",
+      "count": 1
+    },
+    {
+      "rule_id": "dead_code",
+      "source_id": "examples/testdata/go_sample.go",
+      "count": 1
+    },
+    {
+      "rule_id": "dead_code",
+      "source_id": "internal/ingest/benchmark_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "dead_code",
+      "source_id": "mount/mount.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/cache.go",
+      "count": 3
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/find_smells_cli.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/infer.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/mount_nfs.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_architecture.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_find_smells.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_find_definition.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_get_communities.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_search.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_impact.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_write.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/graph/sqlite_graph.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/graph/store_local.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/engine_treesitter.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/engine_walk.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/sitter_walker.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/leyline/socket.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/vfs/schema.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "mount/mount.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "tools/notion-fetch/main.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "tools/server-json-gen/main.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "tools/sheaf-subscribe-probe/main.go",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "internal/ingest/sitter_walker.go",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "internal/nfsmount/graphfs.go",
+      "count": 1
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "cmd/serve_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "cmd/sheaf_subscribe_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "cmd/sheaf_wire_test.go",
+      "count": 5
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/graph/arena_writer_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/graph/live_graph_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/graph/writable_graph_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/ingest/engine_modtime_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/ingest/reingest_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/ingest/watcher_test.go",
+      "count": 9
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/procgroup_unix_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/sheaf_cascade_bench_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/sheaf_e2e_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/sheaf_subscriber_e2e_test.go",
+      "count": 2
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/sheaf_subscriber_test.go",
+      "count": 5
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/leyline/socket_test.go",
+      "count": 9
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/nfsmount/graphfs_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "sleep_in_test",
+      "source_id": "internal/writeback/splice_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "cmd/cache_oci.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "examples/testdata/go_sample.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/graph/nodes_table_reader.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/ingest/benchmark_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/leyline/daemon_source.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/leyline/version_check.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/linter/linter.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "internal/writeback/validate.go",
+      "count": 1
+    },
+    {
+      "rule_id": "untested_function",
+      "source_id": "mount/mount.go",
+      "count": 1
+    }
+  ]
+}


### PR DESCRIPTION
**The "it actually works" milestone** — a repo-level structural smell gate that runs on mache's own 629-file codebase, **local == CI**.

## What
- **`find-smells`**: a glob/`*` run now **skips** rules whose tables are absent (e.g. `_ast` rules on a pure-Go tree-sitter `.db`) instead of aborting; an explicit single rule still errors. **`--baseline-root`** relativizes `source_id` (mache build records absolute paths) so the committed baseline is **machine/CI-portable**.
- **`task smells`**: builds a tree-sitter `.db` of the repo (no leyline needed) + `find-smells --rule '*' --baseline docs/smell-baseline.json`. `task smells:baseline` regenerates it; the prior dogfood is now `task smells:dogfood`. Wired into `check`/`ci` aggregates + the CI lint job (taskfile-CI-parity).
- **`docs/smell-baseline.json`**: 56 repo-relative entries grandfathering current structural debt across 9 rules; the gate fails only on **new**.

## Proof (this is the point)
- `task smells` **exits 0** on real mache source (verified locally; CI runs the same step).
- TDD: `TestRelativizeFindings`, `TestFindSmellsCLI_GlobSkipsUnavailableRules`, `TestFindSmellsCLI_BaselineRatchet_EndToEnd` (real fixture `.db`: within-baseline→0, new→1).

Note: `.github/workflows/find-smells.yml` already exists (W6.1 largely pre-built) — reconcile separately.

`go vet`, `golangci-lint`, `go test ./cmd/` all green.