### PR TITLE
feat(build): mache build auto-downloads leyline — LLO in the build path (mache-0ed19b)

### DIFF
--- a/cmd/auto_leyline_test.go
+++ b/cmd/auto_leyline_test.go
@@ -11,15 +11,19 @@ import (
 )
 
 // TestAutoInvokeLeylineParse_NoBinary verifies the helper returns a clear
-// error when leyline is not on PATH and not in the bundled location.
+// error when leyline is not on PATH, not in the bundled location, and
+// auto-download is opted out (MACHE_NO_LEYLINE). Without the opt-out the
+// helper would now attempt a network download (its intended behavior), so the
+// env var keeps this test hermetic.
 func TestAutoInvokeLeylineParse_NoBinary(t *testing.T) {
-	// Hide both PATH and the bundled location for this test
+	// Hide both PATH and the bundled location, and opt out of auto-download.
 	t.Setenv("PATH", "")
 	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "1")
 
 	_, _, err := autoInvokeLeylineParse(t.TempDir())
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "leyline")
+	assert.Contains(t, err.Error(), "MACHE_NO_LEYLINE")
 }
 
 // TestAutoInvokeLeylineParse_Success skips when leyline is unavailable.

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/agentic-research/mache/internal/ingest"
 	"github.com/agentic-research/mache/internal/lang"
 	"github.com/agentic-research/mache/internal/lattice"
+	"github.com/agentic-research/mache/internal/leyline"
 	sitter "github.com/smacker/go-tree-sitter"
 	"github.com/spf13/cobra"
 )
@@ -51,11 +51,16 @@ var buildCmd = &cobra.Command{
 		case "tree-sitter":
 			// Fall through to in-process path below.
 		default: // "auto" or empty
-			if leylineAvailable() {
-				log.Printf("--backend=auto: leyline detected, using leyline path; pass --backend=tree-sitter to force in-process")
+			// Prefer leyline (ADR-0012): resolve or auto-download it, then
+			// build via the LLO path (all rules, _ast-bearing .db). Fall back
+			// to in-process tree-sitter only when leyline is genuinely
+			// unavailable — offline, or MACHE_NO_LEYLINE set.
+			if _, err := leyline.ResolveBinary(true); err == nil {
+				log.Printf("--backend=auto: using leyline; pass --backend=tree-sitter to force in-process")
 				return runBuildViaLeyline(source, output, false /* schemaExplicit */)
+			} else {
+				log.Printf("--backend=auto: leyline unavailable (%v) — using in-process tree-sitter", err)
 			}
-			// No leyline → use in-process. Same as today's behavior.
 		}
 
 		// Load or infer schema. Falls back to FCA inference when no schema file is provided.
@@ -210,29 +215,6 @@ func init() {
 	buildCmd.Flags().StringVarP(&schemaPath, "schema", "s", "", "Path to topology schema (defaults to FCA inference)")
 	buildCmd.Flags().StringVar(&buildBackend, "backend", "auto", "Parsing backend: 'auto' (prefer leyline when on PATH, else in-process tree-sitter), 'leyline' (force leyline; errors if missing), 'tree-sitter' (force in-process even when leyline is available). Per ADR-0012; step 4 deletes the in-process fallback.")
 	rootCmd.AddCommand(buildCmd)
-}
-
-// leylineAvailable returns true when `leyline` is on PATH or at
-// ~/.mache/bin/leyline. Mirrors the lookup autoInvokeLeylineParse
-// does, but as a probe: callers use it to choose between the
-// leyline path and the in-process fallback before any I/O.
-//
-// Cheap call: exec.LookPath consults PATH only; the home-dir check
-// is a single os.Stat. No subprocess invocation. Safe to call
-// repeatedly.
-func leylineAvailable() bool {
-	if _, err := exec.LookPath("leyline"); err == nil {
-		return true
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return false
-	}
-	bundled := filepath.Join(home, ".mache", "bin", "leyline")
-	if _, err := os.Stat(bundled); err == nil {
-		return true
-	}
-	return false
 }
 
 // runBuildViaLeyline implements --backend=leyline: shells out to

--- a/cmd/build_leyline_test.go
+++ b/cmd/build_leyline_test.go
@@ -53,6 +53,9 @@ func TestRunBuildViaLeyline_ReturnsClearErrorWhenLeylineMissing(t *testing.T) {
 	// Hide both PATH and the bundled location ($HOME/.mache/bin/leyline).
 	t.Setenv("PATH", "")
 	t.Setenv("HOME", t.TempDir())
+	// Opt out of the build-path auto-download (mache-0ed19b) so "leyline
+	// missing" surfaces as a clear error instead of a network fetch.
+	t.Setenv("MACHE_NO_LEYLINE", "1")
 
 	src := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),
@@ -102,6 +105,9 @@ func TestBuildCmd_BackendDispatch(t *testing.T) {
 	buildBackend = "leyline"
 	t.Setenv("PATH", "")
 	t.Setenv("HOME", t.TempDir())
+	// Opt out of the build-path auto-download (mache-0ed19b) so "leyline
+	// missing" surfaces as a clear error instead of a network fetch.
+	t.Setenv("MACHE_NO_LEYLINE", "1")
 
 	src := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),
@@ -165,6 +171,9 @@ func TestRunBuildViaLeyline_SchemaAutoOnlyWarns(t *testing.T) {
 	// Hide leyline so the call fails after the warning fires.
 	t.Setenv("PATH", "")
 	t.Setenv("HOME", t.TempDir())
+	// Opt out of the build-path auto-download (mache-0ed19b) so "leyline
+	// missing" surfaces as a clear error instead of a network fetch.
+	t.Setenv("MACHE_NO_LEYLINE", "1")
 
 	src := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(src, "main.go"),

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -711,18 +711,14 @@ func servedSourceDir(args []string, basePath string, repoMode bool) string {
 // location, or if parsing fails. The caller should fall back to the
 // in-process ingest path on any error.
 func autoInvokeLeylineParse(sourceDir string) (string, func(), error) {
-	leylineBin, err := exec.LookPath("leyline")
+	// Resolve — and if absent, auto-download — the leyline binary via the same
+	// provisioning path mache serve uses, so `mache build` no longer silently
+	// degrades to tree-sitter merely because leyline isn't installed.
+	// MACHE_NO_LEYLINE opts out (returns an error the auto caller treats as
+	// "fall back to tree-sitter").
+	leylineBin, err := leyline.ResolveBinary(true)
 	if err != nil {
-		// Fallback: ~/.mache/bin/leyline (matches DiscoverOrStart's lookup)
-		home, herr := os.UserHomeDir()
-		if herr != nil {
-			return "", nil, fmt.Errorf("leyline not on PATH: %w", err)
-		}
-		bundled := filepath.Join(home, ".mache", "bin", "leyline")
-		if _, sErr := os.Stat(bundled); sErr != nil {
-			return "", nil, fmt.Errorf("leyline not on PATH and not at %s", bundled)
-		}
-		leylineBin = bundled
+		return "", nil, err
 	}
 
 	tmpFile, err := os.CreateTemp("", "mache-leyline-*.db")

--- a/internal/leyline/resolve_binary_test.go
+++ b/internal/leyline/resolve_binary_test.go
@@ -1,0 +1,91 @@
+package leyline
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveBinary_FindsOnPath returns the PATH-resolved binary without
+// downloading, even when download is allowed.
+func TestResolveBinary_FindsOnPath(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "leyline")
+	require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755))
+	t.Setenv("PATH", dir)
+	t.Setenv("HOME", t.TempDir())
+
+	got, err := ResolveBinary(true)
+	require.NoError(t, err)
+	assert.Equal(t, fake, got)
+}
+
+// TestResolveBinary_FindsBundled falls back to ~/.mache/bin/leyline when not
+// on PATH, still without downloading.
+func TestResolveBinary_FindsBundled(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("PATH", t.TempDir()) // no leyline on PATH
+	t.Setenv("HOME", home)
+	bundled := filepath.Join(home, ".mache", "bin", "leyline")
+	require.NoError(t, os.MkdirAll(filepath.Dir(bundled), 0o755))
+	require.NoError(t, os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o755))
+
+	got, err := ResolveBinary(true)
+	require.NoError(t, err)
+	assert.Equal(t, bundled, got)
+}
+
+// TestResolveBinary_NoDownloadWhenDisallowed errors (no network) when the
+// binary is absent and allowDownload is false.
+func TestResolveBinary_NoDownloadWhenDisallowed(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := ResolveBinary(false)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "download", "must not attempt a download when disallowed")
+}
+
+// TestResolveBinary_NoLeylineEnvSkipsDownload honors MACHE_NO_LEYLINE: no
+// download is attempted even when allowDownload is true.
+func TestResolveBinary_NoLeylineEnvSkipsDownload(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+
+	_, err := ResolveBinary(true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MACHE_NO_LEYLINE")
+}
+
+// TestResolveBinary_DownloadsWhenMissing fetches the pinned binary to
+// ~/.mache/bin when absent and allowed. Hermetic: swaps the release URL for a
+// local httptest server, so no network is touched.
+func TestResolveBinary_DownloadsWhenMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("#!/bin/sh\necho fake-leyline\n"))
+	}))
+	defer srv.Close()
+
+	orig := leylineReleaseURLTemplate
+	leylineReleaseURLTemplate = srv.URL + "/%s/%s"
+	defer func() { leylineReleaseURLTemplate = orig }()
+
+	home := t.TempDir()
+	t.Setenv("PATH", t.TempDir()) // no leyline on PATH
+	t.Setenv("HOME", home)
+	t.Setenv("MACHE_NO_LEYLINE", "") // ensure not opted out
+
+	got, err := ResolveBinary(true)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".mache", "bin", "leyline"), got)
+
+	fi, err := os.Stat(got)
+	require.NoError(t, err, "downloaded leyline must exist")
+	assert.NotZero(t, fi.Mode()&0o111, "downloaded leyline must be executable")
+}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -839,6 +839,37 @@ var leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-op
 // downloadLeyline fetches the pinned-version leyline binary from GitHub
 // releases (see leylineBinaryVersion) to the specified path. Returns the
 // path on success.
+// ResolveBinary locates a usable leyline binary and returns its path.
+// Resolution order: PATH → ~/.mache/bin/leyline → (when allowDownload)
+// auto-download the pinned ley-line-open release. This is the single
+// provisioning chokepoint shared by the serve path (autoInvokeLeylineParse)
+// and the build path, so `mache build` and `mache serve` acquire leyline
+// identically instead of the build path silently degrading to tree-sitter.
+//
+// Auto-download is skipped — returning an error rather than fetching — when
+// allowDownload is false, or when MACHE_NO_LEYLINE is set (the CI/offline
+// opt-out). A downloaded binary is cached at ~/.mache/bin/leyline for reuse.
+func ResolveBinary(allowDownload bool) (string, error) {
+	if p, err := exec.LookPath("leyline"); err == nil {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	bundled := filepath.Join(home, ".mache", "bin", "leyline")
+	if _, err := os.Stat(bundled); err == nil {
+		return bundled, nil
+	}
+	if !allowDownload {
+		return "", fmt.Errorf("leyline not on PATH and not at %s", bundled)
+	}
+	if os.Getenv("MACHE_NO_LEYLINE") != "" {
+		return "", fmt.Errorf("leyline not available and MACHE_NO_LEYLINE is set; install leyline or unset MACHE_NO_LEYLINE to auto-download")
+	}
+	return downloadLeyline(bundled)
+}
+
 func downloadLeyline(destPath string) (string, error) {
 	osName := runtime.GOOS // "darwin" or "linux"
 	arch := runtime.GOARCH // "arm64" or "amd64"


### PR DESCRIPTION
## `mache build` auto-provisions leyline (LLO in the build path)

Bead **mache-0ed19b** (advances epic **mache-33dc5f**). Makes `mache build` acquire leyline the same way `mache serve` already does, so the W6.1 find-smells composite action — and any consumer — gets **LLO for free** (all 10 rules + accurate refs) instead of silently degrading to tree-sitter (5 rules) on a runner without leyline.

### The gap this closes
`mache serve`/`DiscoverOrStart` already auto-downloads leyline (ley-line-open v0.5.7, incl. linux) when absent. But `mache build` only *checked* PATH + `~/.mache/bin` (`leylineAvailable`) and never fetched — so `--backend auto` fell back to tree-sitter. That's why the find-smells action ran tree-sitter on CI.

### Change
- New exported **`leyline.ResolveBinary(allowDownload)`** — the single provisioning chokepoint: PATH → `~/.mache/bin/leyline` → auto-download. Reuses the existing `downloadLeyline`.
- `autoInvokeLeylineParse` + `build.go --backend=auto` route through it; removed the now-dead `leylineAvailable()`.
- Hermetic tests (`resolve_binary_test.go`): on-PATH, bundled, disallowed-no-download, `MACHE_NO_LEYLINE` opt-out, and a swapped-URL httptest download.

### ⚠️ Behavior change (deliberate, ADR-0012 direction)
Default `mache build` now **prefers leyline, downloading it if needed**. Graceful: download failure (offline) or `MACHE_NO_LEYLINE=1` falls back to tree-sitter; the binary caches to `~/.mache/bin`. mache's own `task smells` gate uses explicit `--backend tree-sitter`, so it's unaffected and deterministic.

### Verified E2E
With leyline hidden (restricted PATH, temp HOME), `mache build` downloaded `leyline-darwin-arm64` from ley-line-open v0.5.7, produced an `_ast`-bearing db, and `magic_int_in_comparison` (an `_ast`-only rule) fired. `MACHE_NO_LEYLINE=1` still builds via tree-sitter (no `_ast`).

Also closes **mache-9051f0** (download URL was already fixed in code + regression-tested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
