### PR TITLE
ci(docs): gate docs:lint in CI + refresh 6 docs to v0.12.0 (mache-27347d)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,14 @@ jobs:
         # Fail if any workflow `uses:` ref isn't SHA-pinned (mache-b8900d).
         run: task actions:lint
 
+      - name: Docs lint
+        # Fail if a top-level doc's covers-version drifts from the latest
+        # CHANGELOG release, or a mache language-count claim goes stale
+        # (mache-27347d). Same `task docs:lint` a developer runs locally —
+        # this closes the local==CI gap that let the v0.12.0 release ship
+        # with six stale covers-version markers undetected.
+        run: task docs:lint
+
       - name: Smell gate
         # Build a .db of the repo + fail on NEW structural findings vs the
         # committed baseline (W5 ratchet, mache-4da90e). Local == CI: the same

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.11.0
-last-verified: 2026-05-10
+covers-version: v0.12.0
+last-verified: 2026-07-03
 sources-of-truth:
   - internal/lang/lang.go
   - cmd/serve_handlers.go

--- a/docs/ARENA.md
+++ b/docs/ARENA.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.11.0
-last-verified: 2026-05-10
+covers-version: v0.12.0
+last-verified: 2026-07-03
 sources-of-truth:
   - scripts/arena.sh
 audience: [contributors, evaluators, agent developers]

--- a/docs/PRIOR_ART.md
+++ b/docs/PRIOR_ART.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.11.0
-last-verified: 2026-05-10
+covers-version: v0.12.0
+last-verified: 2026-07-03
 sources-of-truth:
   - CHANGELOG.md
   - docs/ROADMAP.md

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.11.0
-last-verified: 2026-05-10
+covers-version: v0.12.0
+last-verified: 2026-07-03
 sources-of-truth:
   - CHANGELOG.md
   - .beads/

--- a/docs/competitive-landscape-2026.md
+++ b/docs/competitive-landscape-2026.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.11.0
-last-verified: 2026-05-10
+covers-version: v0.12.0
+last-verified: 2026-07-03
 sources-of-truth:
   - CHANGELOG.md
   - docs/ROADMAP.md

--- a/docs/smell-debt-baseline-2026-06-24.md
+++ b/docs/smell-debt-baseline-2026-06-24.md
@@ -1,6 +1,6 @@
 ---
 status: current
-covers-version: v0.11.0
+covers-version: v0.12.0
 last-verified: 2026-06-24
 ---
 


### PR DESCRIPTION
## Gate `docs:lint` in CI + refresh 6 stale docs

Closes **mache-27347d**. Makes the docs-freshness check a real PR gate and clears the staleness it was already catching locally.

### Why
`docs:lint` is a Taskfile target that `task check` runs locally, but **CI never invoked it** — a local==CI parity gap. That's exactly how the **v0.12.0 release shipped with 6 stale `covers-version` markers undetected**: W6.1's `task check` failed earlier at `gen:server-json:check` and never reached `docs:lint`, and CI didn't run it at all.

### Changes
- **CI gate:** new "Docs lint" step in the `ci.yml` checks job runs `task docs:lint` (taskfile-ci-parity — CI invokes the Taskfile target, doesn't reimplement it).
- **Refresh:** `covers-version` v0.11.0 → v0.12.0 on the 6 flagged docs; `last-verified` → 2026-07-03 on the 5 non-snapshot docs (`smell-debt-baseline-2026-06-24.md` keeps its snapshot date). Skimmed each against v0.12.0 — no contradictions (v0.12.0 is additive: `find-smells --format sarif`, the composite action, LLO build auto-download).

### Safe as a gate — no time-bomb
Only `covers-version` mismatch, missing frontmatter, and stale mache lang-count **FAIL**. The `last-verified` 90-day check is **WARN-only**, so docs aging past 90 days won't spontaneously turn CI red on unrelated PRs.

### Out of scope (noted)
Pre-existing content drift observed: docs say "`find_smells` 9 rules" but the registry now has 14. Not gated by docs:lint (version + lang-count only) and predates v0.12.0 — tracked separately for a real content pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
