### PR TITLE
feat(actions): default find-smells action to mache v0.13.0 (LLO / all 10 rules)

### DIFF
--- a/.github/actions/find-smells/README.md
+++ b/.github/actions/find-smells/README.md
@@ -36,10 +36,10 @@ Without it the action fails with the exact command above.
 
 ## Inputs
 
-| Input           | Default                    | Description                                                            |
-| --------------- | -------------------------- | ---------------------------------------------------------------------- |
-| `mache-version` | `v0.12.0`                  | Release tag for the `mache-linux-amd64` binary (>= v0.12.0 for SARIF). |
-| `schema`        | *(FCA infer)*              | Path to a mache topology schema.                                       |
-| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor.                                               |
-| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                      |
-| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                  |
+| Input           | Default                    | Description                                                                                                                                             |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mache-version` | `v0.13.0`                  | Release tag for the `mache-linux-amd64` binary. >= v0.13.0 auto-provisions leyline (all 10 rules / LLO); >= v0.12.0 is SARIF + the 5 tree-sitter rules. |
+| `schema`        | *(FCA infer)*              | Path to a mache topology schema.                                                                                                                        |
+| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor.                                                                                                                                |
+| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                                                                                                       |
+| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                                                                                                   |

--- a/.github/actions/find-smells/action.yml
+++ b/.github/actions/find-smells/action.yml
@@ -3,9 +3,9 @@ description: 'Run the mache structural smell ratchet gate over the caller''s che
 
 inputs:
   mache-version:
-    description: 'mache release tag to download mache-linux-amd64 from. Must include `find-smells --format sarif` (>= v0.12.0).'
+    description: 'mache release tag to download mache-linux-amd64 from. >= v0.13.0 auto-provisions leyline so the build runs all 10 find_smells rules (LLO); >= v0.12.0 supports SARIF but runs the 5 tree-sitter rules only.'
     required: false
-    default: 'v0.12.0'
+    default: 'v0.13.0'
   schema:
     description: 'Path to a mache topology schema. Empty uses FCA schema inference.'
     required: false


### PR DESCRIPTION
Bumps the find-smells composite action's `mache-version` default v0.12.0 → v0.13.0. Since v0.13.0's `mache build` auto-provisions leyline, the action now runs the full 10-rule `find_smells` set (LLO) on CI instead of the 5 tree-sitter rules — and baseline-gen + CI enforcement both use LLO, resolving the earlier backend-parity mismatch. No live consumers yet, so low-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)