### PR TITLE
chore(image): OCI cleanups — base digest pin, DL3008 rationale, leyline-version guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,6 +130,10 @@ jobs:
           set -euo pipefail
           # Single source of truth: the const mache already downloads by.
           v=$(grep -oE 'leylineBinaryVersion = "v[0-9.]+"' internal/leyline/socket.go | grep -oE 'v[0-9.]+')
+          if [ -z "$v" ]; then
+            echo "::error::could not parse leylineBinaryVersion from internal/leyline/socket.go — the const format may have changed" >&2
+            exit 1
+          fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Download mache linux binaries

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -14,8 +14,14 @@
 #   image/linux-${TARGETARCH}/mache      (release matrix artifact)
 #   image/linux-${TARGETARCH}/leyline    (pinned ley-line-open binary)
 # Multi-arch via buildx; the correct per-arch binaries are copied in.
-FROM ubuntu:24.04
+# Base pinned by manifest-list digest (bump alongside a deliberate base
+# refresh) for reproducibility; the `:24.04` tag is kept for readability.
+FROM ubuntu:24.04@sha256:4fbb8e6a8395de5a7550b33509421a2bafbc0aab6c06ba2cef9ebffbc7092d90
 
+# hadolint ignore=DL3008
+# apt package versions float within the digest-pinned base — the base pin
+# bounds drift, and per-arch version-pinning (amd64 vs arm64 differ) is
+# brittle for these two stable packages. Revisit if reproducibility demands it.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libsqlite3-0 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Small post-OCI-review hardening: pin the image base by digest, document the DL3008 apt decision, and fail-loud on an empty leyline-version parse. Verified via `task image:verify` (leyline still runs on the pinned base). 🤖 Generated with [Claude Code](https://claude.com/claude-code)