### PR TITLE
feat(smells): source v_defs/v_refs mention arm from fact_edges — ADR-0023 step 2 (IR reader)

### DIFF
--- a/cmd/serve_find_smells_views_test.go
+++ b/cmd/serve_find_smells_views_test.go
@@ -123,6 +123,110 @@ func TestEnsureCanonicalViews_HandlesMissingLSPTables(t *testing.T) {
 	assert.Zero(t, bindingRefs, "no _lsp_refs → no binding rows")
 }
 
+// canonicalViewRows runs ensureCanonicalViews on a fresh db built by
+// setup() and returns the mention-fidelity v_defs and v_refs rows as
+// stable, ordered string slices for equality comparison.
+func canonicalViewRows(t *testing.T, name, setup string) (defs, refs []string) {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), name)
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(setup)
+	require.NoError(t, err)
+
+	require.NoError(t, ensureCanonicalViews(&sqlDBQuerier{db: db}))
+
+	dRows, err := db.Query(`SELECT token, node_id, fidelity FROM v_defs
+		WHERE fidelity = 'mention' ORDER BY token, node_id`)
+	require.NoError(t, err)
+	for dRows.Next() {
+		var tok, nid, fid string
+		require.NoError(t, dRows.Scan(&tok, &nid, &fid))
+		defs = append(defs, tok+"|"+nid+"|"+fid)
+	}
+	require.NoError(t, dRows.Close())
+
+	// Include every v_refs column so the parity assertion catches any
+	// shape drift (target_node_id, ref_uri, ref_line, qualifier).
+	rRows, err := db.Query(`SELECT referrer_node_id, token,
+		COALESCE(target_node_id, 'NULL'), COALESCE(ref_uri, 'NULL'),
+		COALESCE(CAST(ref_line AS TEXT), 'NULL'), fidelity, qualifier
+		FROM v_refs WHERE fidelity = 'mention' ORDER BY referrer_node_id, token`)
+	require.NoError(t, err)
+	for rRows.Next() {
+		var rn, tok, tgt, uri, line, fid, qual string
+		require.NoError(t, rRows.Scan(&rn, &tok, &tgt, &uri, &line, &fid, &qual))
+		refs = append(refs, rn+"|"+tok+"|"+tgt+"|"+uri+"|"+line+"|"+fid+"|"+qual)
+	}
+	require.NoError(t, rRows.Close())
+	return defs, refs
+}
+
+// TestEnsureCanonicalViews_FactEdgesByteParityWithLegacy is the ADR-0023
+// step 2 de-risk: the same logical defs/refs, sourced two ways, must yield
+// byte-identical v_defs / v_refs mention rows.
+//
+//   - legacy: node_defs / node_refs populated, no IR tables.
+//   - IR: fact_edges / symbols populated, node_defs / node_refs EMPTY — so
+//     any row that appears MUST have come through the fact_edges arm.
+//
+// Identical output proves the substrate swap is transparent to consumers.
+func TestEnsureCanonicalViews_FactEdgesByteParityWithLegacy(t *testing.T) {
+	// Two defs and two refs — enough to catch a bad join or a dropped row.
+	legacy := `
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO node_defs VALUES ('add', 'util.go/func'), ('main', 'main.go/func');
+		INSERT INTO node_refs VALUES ('add', 'main.go/call'), ('println', 'main.go/call2');`
+
+	// IR db: node_defs / node_refs exist but are EMPTY; fact_edges + symbols
+	// carry the same logical data. symbol_id blobs are arbitrary-but-distinct;
+	// the join is on symbol_id equality, not on any 32-byte invariant.
+	ir := `
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE symbols (symbol_id BLOB NOT NULL, node_id TEXT NOT NULL);
+		CREATE TABLE fact_edges (src BLOB NOT NULL, dst BLOB, kind TEXT NOT NULL, token TEXT);
+		INSERT INTO symbols (symbol_id, node_id) VALUES
+			(X'01', 'util.go/func'), (X'02', 'main.go/func'),
+			(X'03', 'main.go/call'), (X'04', 'main.go/call2');
+		INSERT INTO fact_edges (src, dst, kind, token) VALUES
+			(X'01', NULL, 'defines', 'add'),
+			(X'02', NULL, 'defines', 'main'),
+			(X'03', X'01', 'references', 'add'),
+			(X'04', NULL, 'references', 'println');`
+
+	legacyDefs, legacyRefs := canonicalViewRows(t, "legacy.db", legacy)
+	irDefs, irRefs := canonicalViewRows(t, "ir.db", ir)
+
+	require.Len(t, legacyDefs, 2, "sanity: two mention defs")
+	require.Len(t, legacyRefs, 2, "sanity: two mention refs")
+	assert.Equal(t, legacyDefs, irDefs,
+		"v_defs mention rows must be byte-identical whether sourced from node_defs or fact_edges")
+	assert.Equal(t, legacyRefs, irRefs,
+		"v_refs mention rows must be byte-identical whether sourced from node_refs or fact_edges "+
+			"(target_node_id held NULL even though fact_edges.dst is resolved)")
+}
+
+// TestEnsureCanonicalViews_FactEdgesTakesPrecedenceOverEmptyLegacy pins the
+// probe: with the IR tables present, an EMPTY node_defs/node_refs must not
+// suppress the fact_edges-sourced rows (i.e. the swap engages, it doesn't
+// merely UNION).
+func TestEnsureCanonicalViews_FactEdgesTakesPrecedenceOverEmptyLegacy(t *testing.T) {
+	defs, refs := canonicalViewRows(t, "ir_only.db", `
+		CREATE TABLE node_defs (token TEXT, node_id TEXT);
+		CREATE TABLE node_refs (token TEXT, node_id TEXT);
+		CREATE TABLE symbols (symbol_id BLOB NOT NULL, node_id TEXT NOT NULL);
+		CREATE TABLE fact_edges (src BLOB NOT NULL, dst BLOB, kind TEXT NOT NULL, token TEXT);
+		INSERT INTO symbols (symbol_id, node_id) VALUES (X'0a', 'a.go/f');
+		INSERT INTO fact_edges (src, dst, kind, token) VALUES (X'0a', NULL, 'defines', 'F');`)
+	assert.Equal(t, []string{"F|a.go/f|mention"}, defs,
+		"def must be sourced from fact_edges, not the empty node_defs")
+	assert.Empty(t, refs, "no references edges → no mention refs")
+}
+
 func TestEnsureCanonicalViews_HandlesLegacyLSPTables(t *testing.T) {
 	// Pre-Step-1 _lsp_* schema (no def_token / referrer_node_id /
 	// ref_token columns). The probe must detect the absence and fall

--- a/cmd/smell_refs_views.go
+++ b/cmd/smell_refs_views.go
@@ -41,7 +41,38 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		return fmt.Errorf("probe _lsp_defs: %w", err)
 	}
 
-	defsBody := `SELECT token, node_id, 'mention' AS fidelity FROM node_defs`
+	// Unified code-fact IR (ADR-0023 step 2): when the db carries the IR
+	// tables (ley-line-open's `fact_edges` + `symbols`), source the
+	// mention arm from `fact_edges` instead of `node_defs`/`node_refs`.
+	// The producer derives `fact_edges`' defines/references arms from the
+	// same tree-sitter extraction that feeds `node_defs`/`node_refs`, so
+	// the swap is byte-parity by construction; the probe falls back to the
+	// legacy tables on dbs without the IR (older producers). `symbols`
+	// carries `node_id`, so the join re-attaches the parse-run locator the
+	// mention views expose. Same dual-read discipline as the T8.8 capnp
+	// migration — probe the producer's shape, keep the consumer SQL fixed.
+	// Requires both tables: an edges-without-symbols db falls back rather
+	// than emit an empty (unjoinable) view.
+	hasFactEdges, err := tableHasColumn(qg, "fact_edges", "kind")
+	if err != nil {
+		return fmt.Errorf("probe fact_edges: %w", err)
+	}
+	if hasFactEdges {
+		hasSymbols, err := tableHasColumn(qg, "symbols", "node_id")
+		if err != nil {
+			return fmt.Errorf("probe symbols: %w", err)
+		}
+		hasFactEdges = hasSymbols
+	}
+
+	defsMentionArm := `SELECT token, node_id, 'mention' AS fidelity FROM node_defs`
+	if hasFactEdges {
+		defsMentionArm = `SELECT fe.token AS token, s.node_id AS node_id, 'mention' AS fidelity
+			FROM fact_edges fe JOIN symbols s ON s.symbol_id = fe.src
+			WHERE fe.kind = 'defines'`
+	}
+
+	defsBody := defsMentionArm
 	if hasLSPDefsToken {
 		defsBody += `
 			UNION ALL
@@ -56,7 +87,7 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	// doesn't populate it) and for pre-T8.7 capnp records (default
 	// '' per schema-evolution invariant). See mache-6c0d07 for the
 	// fan_out_skew metric that consumes it.
-	refsBody := `SELECT node_id AS referrer_node_id,
+	refsMentionArm := `SELECT node_id AS referrer_node_id,
 	       token,
 	       NULL  AS target_node_id,
 	       NULL  AS ref_uri,
@@ -64,6 +95,23 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	       'mention' AS fidelity,
 	       ''    AS qualifier
 	FROM node_refs`
+	if hasFactEdges {
+		// target_node_id is held NULL to match the node_refs mention shape
+		// byte-for-byte. `fact_edges` DOES carry the resolved `dst`, but
+		// surfacing it is a binding-fidelity enhancement for a later slice;
+		// forcing NULL here keeps this a pure, provable substrate swap.
+		refsMentionArm = `SELECT s.node_id AS referrer_node_id,
+		       fe.token AS token,
+		       NULL  AS target_node_id,
+		       NULL  AS ref_uri,
+		       NULL  AS ref_line,
+		       'mention' AS fidelity,
+		       ''    AS qualifier
+		FROM fact_edges fe JOIN symbols s ON s.symbol_id = fe.src
+		WHERE fe.kind = 'references'`
+	}
+
+	refsBody := refsMentionArm
 	// Binding-fidelity rows come from the per-connection
 	// _capnp_binding_refs TEMP table, populated from the sibling
 	// .bindings.capnp event log by LoadCapnpBindings (mache-190508).


### PR DESCRIPTION
## What

The mache reader over the unified code-fact IR (ADR-0023 step 2 — "the whole thesis in working code"). When a `.db` carries ley-line-open's `fact_edges` + `symbols` tables (the [producer PR](https://github.com/agentic-research/ley-line-open/pull/126)), `ensureCanonicalViews` sources the **mention** arm of `v_defs`/`v_refs` from `fact_edges` (JOIN `symbols` for `node_id`) instead of `node_defs`/`node_refs`.

Probe-and-fall-back: dbs without the IR (older producers) keep the legacy source. Same dual-read discipline as the T8.8 capnp migration — probe the producer's shape, keep the consumer SQL fixed.

- `v_defs` mention: `fact_edges WHERE kind='defines' JOIN symbols` → `(token, node_id)`
- `v_refs` mention: `fact_edges WHERE kind='references' JOIN symbols` → referrer. `target_node_id` held NULL to match the `node_refs` shape byte-for-byte (the resolved `fact_edges.dst` is a binding-fidelity enhancement for a later slice).
- Requires **both** `fact_edges` AND `symbols`; an edges-without-symbols db falls back rather than emit an empty view. Binding arms (`_lsp_defs`, `_capnp_binding_refs`) untouched.

## Why it's safe

**Byte-parity by construction:** the producer derives `fact_edges`' defines/references arms from the *same* tree-sitter extraction that feeds `node_defs`/`node_refs`. The tests prove it — the same logical data sourced two ways (legacy `node_defs`/`node_refs` vs `fact_edges` with the legacy tables **emptied**) yields byte-identical `v_defs`/`v_refs` mention rows; a precedence test confirms the `fact_edges` arm engages over an empty `node_defs`.

Full `cmd` package green (89s); gofumpt / vet / golangci-lint clean.

## Notes
- Depends on ley-line-open#126 for a real `fact_edges`-bearing `.db`; an end-to-end integration test against a producer-built db lands once that merges + mache pins the new leyline version.
- ADR-0023 doc merged separately in #488.

Draft — no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)