### PR TITLE
fix(leyline): de-flake TestProvenance_RecordAndReport under -race (overridable probe timeout)

### DIFF
--- a/internal/leyline/provenance.go
+++ b/internal/leyline/provenance.go
@@ -78,11 +78,19 @@ func versionContainsTag(version, tag string) bool {
 	}), tag)
 }
 
+// probeTimeout bounds the `<bin> --version` probe so a hung binary can't
+// block the spawn path. 2s is ample in prod (resolving a local binary's
+// version); it's a package var only so tests can widen it — under
+// `go test -race ./...` the fake-binary subprocess can be starved past 2s by
+// cross-package contention, which is a test-environment artifact, not a prod
+// concern (mache-3a0da5).
+var probeTimeout = 2 * time.Second
+
 // queryBinaryVersion runs `<bin> --version` and returns the trimmed output
 // (best-effort, "" on any error). Bounded so a hung binary can't block the
 // spawn path; provenance is informational, never load-bearing.
 func queryBinaryVersion(bin string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
 	defer cancel()
 	out, err := exec.CommandContext(ctx, bin, "--version").Output()
 	if err != nil {

--- a/internal/leyline/provenance_test.go
+++ b/internal/leyline/provenance_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestProvenance_RecordAndReport verifies the resolved-leyline provenance
@@ -21,6 +22,15 @@ func TestProvenance_RecordAndReport(t *testing.T) {
 	}
 	resetResolved()
 	t.Cleanup(resetResolved)
+
+	// The 2s prod probe timeout is too tight for this test's fake-binary
+	// subprocess under full-suite -race contention (mache-3a0da5); widen it so
+	// the test still exercises the real exec+parse path without deadline
+	// flakiness. Package tests are sequential (no t.Parallel), so overriding
+	// the package var is race-safe.
+	origTimeout := probeTimeout
+	probeTimeout = 30 * time.Second
+	t.Cleanup(func() { probeTimeout = origTimeout })
 
 	// Before any resolution: ok=false, but expected version still reported.
 	if p, ok := Provenance(); ok || p.ExpectedVersion != leylineBinaryVersion {
@@ -72,4 +82,30 @@ func writeFakeLeyline(t *testing.T, versionLine string) string {
 		t.Fatalf("write fake leyline: %v", err)
 	}
 	return p
+}
+
+// TestQueryBinaryVersion_HonorsProbeTimeout proves probeTimeout is load-bearing:
+// a binary that only prints its version after sleeping past a tiny deadline
+// yields "" (deadline fired), while a generous deadline resolves the same
+// binary. Falsifiable — if the probe ignored probeTimeout, the tiny-deadline
+// case would still return the version and this test would fail (mache-3a0da5).
+func TestQueryBinaryVersion_HonorsProbeTimeout(t *testing.T) {
+	orig := probeTimeout
+	t.Cleanup(func() { probeTimeout = orig })
+
+	slow := filepath.Join(t.TempDir(), "leyline")
+	script := "#!/bin/sh\nsleep 1\necho 'leyline " + leylineBinaryVersion + " (open)'\n"
+	if err := os.WriteFile(slow, []byte(script), 0o755); err != nil {
+		t.Fatalf("write slow fake leyline: %v", err)
+	}
+
+	probeTimeout = 50 * time.Millisecond
+	if v := queryBinaryVersion(slow); v != "" {
+		t.Errorf("deadline should fire: got %q, want empty", v)
+	}
+
+	probeTimeout = 5 * time.Second
+	if v := queryBinaryVersion(slow); v == "" {
+		t.Error("generous deadline should resolve the version, got empty")
+	}
 }


### PR DESCRIPTION
## Summary

`internal/leyline/TestProvenance_RecordAndReport` flaked intermittently under the full `task ci` / `go test -tags boltdb -race ./...` suite, while passing 100% in isolation (`-run … -count=3`) and package-alone (`./internal/leyline/ -count=5`).

## Root cause

`queryBinaryVersion` bounded the `<bin> --version` probe with a hardcoded **2s** deadline. Under `-race ./...`, many package test binaries run concurrently and starve subprocess spawning — the fake-binary probe exceeds 2s → `exec …Output()` errors → empty version → the `VersionMatches` assertion fails. (Observed ~5.6s test wall time under contention vs ~0.4s isolated — subprocess starvation, not a logic bug.)

## Fix

Extract the 2s literal to a package var `probeTimeout` (**prod behavior unchanged**). The test widens it to 30s, so it still exercises the real exec+parse path without being deadline-fragile under load. Adds `TestQueryBinaryVersion_HonorsProbeTimeout` as a falsifiable anchor: a tiny deadline yields `""`, a generous one resolves the same binary — so the test fails if the probe ever stops honoring `probeTimeout`.

## Verification

- `go test -tags boltdb -race -count=5 ./internal/leyline/` — green.
- Full `task ci` — green (validated on the combined merkle+flake-fix state).

Closes mache-3a0da5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
