### PR TITLE
feat(merkle): read node_hash (B4/B6) + consume merkle IR producer (leyline v0.6.0)

### DIFF
--- a/cmd/serve_find_smells_fanout_test.go
+++ b/cmd/serve_find_smells_fanout_test.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// One-to-many node_hash fan-out guard (B6, mache-ffabd1).
+//
+// INVARIANT: node_hash is ONE-TO-MANY. A deduped subtree is stored once
+// (one node_content row, one node_hash) but appears at MANY occurrences,
+// so the same node_hash recurs across many (token, node_id) rows.
+// Resolution always targets an occurrence (node_id), NEVER a node_hash;
+// a JOIN/GROUP BY on node_hash assuming a single row is a fan-out bug
+// (mirror of be6136). These tests pin that consumers surface EVERY
+// occurrence of a duplicated subtree — no silent loss.
+
+// b6RealDefHash is a real 32-byte merkle node_hash from the ground-truth
+// mergeperfix.db: the def subtree of token `searchResult`, which the
+// producer deduped to one node_content row that multiple node_defs
+// occurrences point at.
+var b6RealDefHash = []byte{
+	0xF1, 0xD5, 0xD2, 0x29, 0xEC, 0x89, 0x46, 0x33,
+	0xA3, 0x10, 0x92, 0x8B, 0xFC, 0x52, 0xAA, 0xE5,
+	0x96, 0xC2, 0x6D, 0xE9, 0xC8, 0x7B, 0x1A, 0xB1,
+	0xC9, 0x46, 0x5B, 0x08, 0x9E, 0x2C, 0x4E, 0xE6,
+}
+
+// b6RealTopASTHash is the most-duplicated _ast subtree in mergeperfix.db
+// (occurs 11,179× across 187 sources) — the strongest available fan-out
+// witness.
+var b6RealTopASTHash = []byte{
+	0x17, 0x7D, 0x27, 0x84, 0x2E, 0x5A, 0xC6, 0x6E,
+	0xD6, 0x98, 0x3A, 0x8E, 0x97, 0x40, 0xB3, 0x9B,
+	0xF7, 0x32, 0xA7, 0x23, 0x4A, 0xAC, 0x51, 0x4A,
+	0x65, 0x71, 0x0D, 0x07, 0x48, 0x8E, 0xEE, 0xE4,
+}
+
+// TestEnsureCanonicalViews_NodeHashFanOut (B6 unit) pins the one-to-many
+// invariant through the v_defs path: a token whose def subtree is
+// deduped to ONE node_hash but occurs at MULTIPLE node_ids must surface
+// ALL its occurrences. A consumer that (wrongly) grouped by node_hash
+// would collapse them to one — this test would catch that.
+func TestEnsureCanonicalViews_NodeHashFanOut(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "fanout.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Three occurrences of `dup` share ONE node_hash (a deduped
+	// subtree) but live at three distinct node_ids. One unrelated def
+	// `solo` carries its own hash.
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL,
+			source_id TEXT NOT NULL, node_hash BLOB
+		);
+		CREATE TABLE node_refs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL,
+			source_id TEXT NOT NULL, node_hash BLOB
+		);
+		INSERT INTO node_defs VALUES ('dup', 'a/dup', 'a.go', X'DEAD');
+		INSERT INTO node_defs VALUES ('dup', 'b/dup', 'b.go', X'DEAD');
+		INSERT INTO node_defs VALUES ('dup', 'c/dup', 'c.go', X'DEAD');
+		INSERT INTO node_defs VALUES ('solo', 'd/solo', 'd.go', X'BEEF');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// The duplicated node_hash must map to THREE distinct occurrences.
+	rows, err := db.Query(
+		`SELECT node_id FROM v_defs WHERE token='dup' AND node_hash=X'DEAD' ORDER BY node_id`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var got []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		got = append(got, id)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"a/dup", "b/dup", "c/dup"}, got,
+		"one node_hash → many occurrences; v_defs must not collapse the fan-out")
+
+	// Sanity: grouping BY node_hash would wrongly report 1 row for the
+	// duplicated subtree — pin that the raw occurrence count is 3.
+	var occurrences int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM v_defs WHERE node_hash=X'DEAD'`).Scan(&occurrences))
+	assert.Equal(t, 3, occurrences, "node_hash is one-to-many, not one-to-one")
+}
+
+// TestNodeHashFanOut_GroundTruthDB (B6 integration-flavored) reads the
+// real merkle-produced mergeperfix.db and asserts the fan-out survives
+// end-to-end: the deduped def subtree of `searchResult` is stored once
+// (one node_hash) yet resolves to multiple distinct occurrences, and
+// the most-duplicated _ast subtree resolves to many source_id/node_id
+// rows — a JOIN on node_hash assuming a single row would be a bug.
+//
+// Skips when the ground-truth db is absent (CI / other machines).
+func TestNodeHashFanOut_GroundTruthDB(t *testing.T) {
+	const gtPath = "/private/tmp/b5-verify/mergeperfix.db"
+	db, err := sql.Open("sqlite", "file:"+gtPath+"?mode=ro")
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	// A missing file surfaces on first query, not on Open — probe and
+	// skip rather than fail on machines without the ground-truth db.
+	if err := db.QueryRow(`SELECT 1 FROM sqlite_master LIMIT 1`).Scan(new(int)); err != nil {
+		t.Skipf("ground-truth db unavailable (%s): %v", gtPath, err)
+	}
+
+	// The `searchResult` def subtree deduped to one node_hash but has
+	// >1 occurrence. find_definition keys on token → must return ALL.
+	var defOccurrences int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM node_defs WHERE token='searchResult' AND node_hash=?`,
+		b6RealDefHash,
+	).Scan(&defOccurrences))
+	assert.Greater(t, defOccurrences, 1,
+		"searchResult's deduped def subtree must occur at multiple node_defs rows")
+
+	// _ast: the most-duplicated subtree resolves to MANY (source_id,
+	// node_id) rows — one node_hash, many occurrences. Resolving to a
+	// single row here would be the be6136-class fan-out bug.
+	var astRows, distinctNodes int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*), COUNT(DISTINCT node_id) FROM _ast WHERE node_hash=?`,
+		b6RealTopASTHash,
+	).Scan(&astRows, &distinctNodes))
+	assert.Greater(t, astRows, 1,
+		"most-duplicated _ast subtree must resolve to multiple occurrences")
+	assert.Equal(t, astRows, distinctNodes,
+		"each occurrence is a distinct node_id — node_hash is one-to-many over node_id")
+}

--- a/cmd/serve_find_smells_nodehash_test.go
+++ b/cmd/serve_find_smells_nodehash_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// Additive node_hash passthrough (B4, mache-ff9a9d).
+//
+// ensureCanonicalViews surfaces node_hash as a trailing additive column
+// on v_defs / v_refs when the occurrence tables (node_defs / node_refs)
+// carry it — the merkle-AST producer dedups identical subtrees to one
+// node_content row keyed by a 32-byte node_hash and stamps a pointer
+// onto each occurrence. When the column is absent (standalone-mache db)
+// the views emit `NULL AS node_hash`, keeping a stable trailing-column
+// shape and behaving exactly as today. The token/node_id keying is
+// untouched.
+
+// TestEnsureCanonicalViews_NodeHashPassthrough (B4a) pins that when
+// node_defs / node_refs carry an additive node_hash column, v_defs /
+// v_refs expose it, and the existing token/node_id/fidelity columns
+// stay byte-identical.
+func TestEnsureCanonicalViews_NodeHashPassthrough(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "nodehash.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Mirror the merkle-producer schema: node_defs / node_refs with the
+	// additive node_hash BLOB column referencing node_content.
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL,
+			source_id TEXT NOT NULL, node_hash BLOB
+		);
+		CREATE TABLE node_refs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL,
+			source_id TEXT NOT NULL, node_hash BLOB
+		);
+		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo', 'pkg.go', X'AABB');
+		INSERT INTO node_refs VALUES ('Foo', 'pkg/Bar', 'pkg.go', X'CCDD');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// v_defs: existing columns unchanged, node_hash exposed.
+	var (
+		token, nodeID, fidelity string
+		nodeHash                []byte
+	)
+	require.NoError(t, db.QueryRow(
+		`SELECT token, node_id, fidelity, node_hash FROM v_defs WHERE fidelity='mention'`,
+	).Scan(&token, &nodeID, &fidelity, &nodeHash))
+	assert.Equal(t, "Foo", token)
+	assert.Equal(t, "pkg/Foo", nodeID)
+	assert.Equal(t, "mention", fidelity)
+	assert.Equal(t, []byte{0xAA, 0xBB}, nodeHash, "v_defs must passthrough node_defs.node_hash")
+
+	// v_refs: existing columns unchanged, node_hash exposed.
+	var (
+		refReferrer, refToken, refQualifier string
+		refHash                             []byte
+	)
+	require.NoError(t, db.QueryRow(
+		`SELECT referrer_node_id, token, qualifier, node_hash FROM v_refs WHERE fidelity='mention'`,
+	).Scan(&refReferrer, &refToken, &refQualifier, &refHash))
+	assert.Equal(t, "pkg/Bar", refReferrer)
+	assert.Equal(t, "Foo", refToken)
+	assert.Equal(t, "", refQualifier)
+	assert.Equal(t, []byte{0xCC, 0xDD}, refHash, "v_refs must passthrough node_refs.node_hash")
+}
+
+// TestEnsureCanonicalViews_NodeHashAbsentBackCompat (B4b) is the
+// backward-compat regression: a standalone-mache db has no node_hash
+// column. The views must still build, the token/node_id rows must be
+// identical to today, and node_hash must read as NULL (stable trailing
+// column shape) rather than erroring with "no such column".
+func TestEnsureCanonicalViews_NodeHashAbsentBackCompat(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "no_nodehash.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// Legacy standalone shape: no node_hash column at all.
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo');
+		INSERT INTO node_refs VALUES ('Foo', 'pkg/Bar');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// Existing rows byte-identical to today.
+	var token, nodeID string
+	require.NoError(t, db.QueryRow(
+		`SELECT token, node_id FROM v_defs WHERE fidelity='mention'`,
+	).Scan(&token, &nodeID))
+	assert.Equal(t, "Foo", token)
+	assert.Equal(t, "pkg/Foo", nodeID)
+
+	// node_hash column present in shape, resolves to NULL (not an error).
+	var defHash, refHash []byte
+	require.NoError(t, db.QueryRow(`SELECT node_hash FROM v_defs WHERE fidelity='mention'`).Scan(&defHash))
+	require.NoError(t, db.QueryRow(`SELECT node_hash FROM v_refs WHERE fidelity='mention'`).Scan(&refHash))
+	assert.Nil(t, defHash, "no node_defs.node_hash → NULL, not an error")
+	assert.Nil(t, refHash, "no node_refs.node_hash → NULL, not an error")
+
+	// Row counts identical to today's mention-only behavior.
+	var defCount, refCount int
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_defs`).Scan(&defCount))
+	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs`).Scan(&refCount))
+	assert.Equal(t, 1, defCount)
+	assert.Equal(t, 1, refCount)
+}

--- a/cmd/smell_refs_views.go
+++ b/cmd/smell_refs_views.go
@@ -41,11 +41,51 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		return fmt.Errorf("probe _lsp_defs: %w", err)
 	}
 
-	defsBody := `SELECT token, node_id, 'mention' AS fidelity FROM node_defs`
+	// Additive node_hash passthrough (mache-ff9a9d). The merkle-AST
+	// producer (LLO) writes an additive node_hash BLOB column onto the
+	// occurrence tables (node_defs / node_refs / _ast): identical
+	// subtrees dedup to one node_content row keyed by that 32-byte
+	// hash, and each OCCURRENCE carries a pointer back to it. mache
+	// reads the occurrence layer unchanged (keyed on token / node_id);
+	// we surface node_hash as a trailing additive column so downstream
+	// consumers can group/annotate by content identity WITHOUT changing
+	// the token/node_id keying.
+	//
+	// INVARIANT: node_hash is ONE-TO-MANY — a deduped subtree appears at
+	// many occurrences, so the same node_hash recurs across many
+	// (token, node_id) rows. Resolution always targets an occurrence
+	// (node_id), NEVER a node_hash; a JOIN on node_hash assuming a
+	// single row is a fan-out bug (mirror of be6136).
+	//
+	// Standalone-mache .db files (written by NewSQLiteWriter, no merkle
+	// producer) have no node_hash column. We probe and emit `NULL AS
+	// node_hash` in that case — same trailing-column shape on every db,
+	// mirroring how `qualifier` is always present in v_refs. Existing
+	// consumers select explicit column lists (never SELECT *), so the
+	// added trailing column is transparent to them; the rows they read
+	// are byte-identical to before.
+	hasDefsNodeHash, err := tableHasColumn(qg, "node_defs", "node_hash")
+	if err != nil {
+		return fmt.Errorf("probe node_defs.node_hash: %w", err)
+	}
+	hasRefsNodeHash, err := tableHasColumn(qg, "node_refs", "node_hash")
+	if err != nil {
+		return fmt.Errorf("probe node_refs.node_hash: %w", err)
+	}
+
+	defsHashExpr := "NULL"
+	if hasDefsNodeHash {
+		defsHashExpr = "node_hash"
+	}
+	defsBody := `SELECT token, node_id, 'mention' AS fidelity, ` +
+		defsHashExpr + ` AS node_hash FROM node_defs`
 	if hasLSPDefsToken {
+		// Binding-fidelity def rows come from _lsp_defs, which has no
+		// merkle node_hash concept — emit NULL to keep UNION arity.
 		defsBody += `
 			UNION ALL
-			SELECT def_token AS token, node_id, 'binding' AS fidelity
+			SELECT def_token AS token, node_id, 'binding' AS fidelity,
+			       NULL AS node_hash
 			FROM _lsp_defs
 			WHERE def_token != ''`
 	}
@@ -56,13 +96,18 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	// doesn't populate it) and for pre-T8.7 capnp records (default
 	// '' per schema-evolution invariant). See mache-6c0d07 for the
 	// fan_out_skew metric that consumes it.
+	refsHashExpr := "NULL"
+	if hasRefsNodeHash {
+		refsHashExpr = "node_hash"
+	}
 	refsBody := `SELECT node_id AS referrer_node_id,
 	       token,
 	       NULL  AS target_node_id,
 	       NULL  AS ref_uri,
 	       NULL  AS ref_line,
 	       'mention' AS fidelity,
-	       ''    AS qualifier
+	       ''    AS qualifier,
+	       ` + refsHashExpr + ` AS node_hash
 	FROM node_refs`
 	// Binding-fidelity rows come from the per-connection
 	// _capnp_binding_refs TEMP table, populated from the sibling
@@ -78,6 +123,8 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	// between LLO writer and mache reader (rather than only
 	// preventing them by flag). LLO continues writing _lsp_refs in
 	// the transition window; mache no longer reads it.
+	// _capnp_binding_refs has no merkle node_hash concept — emit NULL
+	// to keep UNION arity with the mention arm's trailing node_hash.
 	refsBody += `
 		UNION ALL
 		SELECT referrer_node_id,
@@ -86,7 +133,8 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		       ref_uri,
 		       ref_line,
 		       'binding' AS fidelity,
-		       qualifier
+		       qualifier,
+		       NULL AS node_hash
 		FROM _capnp_binding_refs`
 
 	stmts := []string{

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.6
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/hashicorp/hcl/v2 v2.24.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk
 github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.6 h1:B4c4GodlWlI+LsB+7VFDosJwaw4KuOjZPBp//8owZTs=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.5.6/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0 h1:KG/8AT4u6l/CtR5qRtUmpYo0EaSMHihAH+JGIY1CL6I=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/graph/sqlite_graph_nodehash_test.go
+++ b/internal/graph/sqlite_graph_nodehash_test.go
@@ -1,0 +1,128 @@
+package graph
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// One-to-many node_hash fan-out guard on the reader path (B6,
+// mache-ffabd1).
+//
+// The merkle-AST producer dedups identical subtrees to one node_content
+// row keyed by a 32-byte node_hash and stamps an additive node_hash
+// pointer onto each OCCURRENCE in node_defs / node_refs. mache reads the
+// occurrence layer keyed on token / node_id — node_hash is never a key.
+//
+// INVARIANT: node_hash is ONE-TO-MANY. A token whose def (or ref)
+// subtree is duplicated has the SAME node_hash across MANY distinct
+// node_ids. find_definition / find_callers must return ALL of them —
+// keying/deduping on node_hash would silently drop occurrences (the
+// be6136-class fan-out bug). These tests seed a duplicated node_hash and
+// assert no occurrence is lost. The additive column must also not
+// disturb the existing token/node_id read path.
+
+// TestSQLiteGraph_LookupDef_NodeHashFanOut pins that LookupDef returns
+// every occurrence of a token whose def subtree deduped to a single
+// node_hash. The reader keys on token; the additive node_hash column is
+// along for the ride and must not collapse the result set.
+func TestSQLiteGraph_LookupDef_NodeHashFanOut(t *testing.T) {
+	dir, err := os.MkdirTemp("", "lookupdef-nodehash-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	// node_defs / node_refs carry the additive node_hash BLOB column,
+	// as the merkle producer writes it.
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON
+		);
+		CREATE TABLE node_refs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL, node_hash BLOB
+		);
+		CREATE TABLE node_defs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL, node_hash BLOB
+		);
+
+		-- Three occurrences of searchResult share ONE deduped node_hash
+		-- (X'DEAD') at three distinct node_ids. A JOIN/GROUP BY on
+		-- node_hash would collapse these to one.
+		INSERT INTO node_defs VALUES ('searchResult', 'a/searchResult', X'DEAD');
+		INSERT INTO node_defs VALUES ('searchResult', 'b/searchResult', X'DEAD');
+		INSERT INTO node_defs VALUES ('searchResult', 'c/searchResult', X'DEAD');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	g, err := OpenSQLiteGraph(dbPath, &api.Topology{}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = g.Close() })
+
+	ids := g.LookupDef("searchResult")
+	require.ElementsMatch(t,
+		[]string{"a/searchResult", "b/searchResult", "c/searchResult"}, ids,
+		"LookupDef must return ALL occurrences of a token whose def subtree "+
+			"deduped to one node_hash — no silent loss to the fan-out")
+
+	// DefsMap (bulk snapshot path) must preserve the same fan-out.
+	got := g.DefsMap()
+	require.Len(t, got["searchResult"], 3,
+		"DefsMap must hydrate all node_hash-duplicated occurrences")
+}
+
+// TestSQLiteGraph_GetCallers_NodeHashFanOut pins the same invariant on
+// the refs/find_callers path: a duplicated ref subtree (one node_hash,
+// many referrers) must surface every caller.
+func TestSQLiteGraph_GetCallers_NodeHashFanOut(t *testing.T) {
+	dir, err := os.MkdirTemp("", "getcallers-nodehash-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	dbPath := filepath.Join(dir, "test.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	_, err = db.Exec(`
+		CREATE TABLE nodes (
+			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+			kind INTEGER NOT NULL, size INTEGER DEFAULT 0, mtime INTEGER NOT NULL,
+			record_id TEXT, record JSON
+		);
+		CREATE TABLE node_refs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL, node_hash BLOB
+		);
+		CREATE TABLE node_defs (
+			token TEXT NOT NULL, node_id TEXT NOT NULL, node_hash BLOB
+		);
+
+		-- Two call sites reference Validate from identical (deduped)
+		-- ref subtrees — same node_hash, distinct referrer node_ids.
+		INSERT INTO node_refs VALUES ('Validate', 'billing/Charge', X'CAFE');
+		INSERT INTO node_refs VALUES ('Validate', 'auth/Login',    X'CAFE');
+	`)
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	g, err := OpenSQLiteGraph(dbPath, &api.Topology{}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = g.Close() })
+
+	callers, err := g.GetCallers("Validate")
+	require.NoError(t, err)
+	ids := make([]string, len(callers))
+	for i, n := range callers {
+		ids[i] = n.ID
+	}
+	require.ElementsMatch(t, []string{"billing/Charge", "auth/Login"}, ids,
+		"GetCallers must return every referrer even when their ref subtrees "+
+			"deduped to a single node_hash")
+}

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -816,7 +816,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
 // pin by the version-parity gate (mache-b8af69).
-const leylineBinaryVersion = "v0.5.7"
+const leylineBinaryVersion = "v0.6.0"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
## Summary

mache-side **merkle enablement**: read the content-addressed `node_hash` the LLO v0.6.0 merkle-AST IR producer emits, and consume that producer. Two additive reader beads + the release pin.

## B4 — additive `node_hash` passthrough (mache-ff9a9d)

`ensureCanonicalViews` now probes `node_defs`/`node_refs` for a `node_hash` column (via the existing `tableHasColumn`) and, when present, exposes it as a **trailing additive** column on `v_defs`/`v_refs`. When absent (a standalone-mache db with no merkle producer), the views emit `NULL AS node_hash` — so **existing output is byte-identical and every current consumer keeps working**. token/node_id keying is untouched.

## B6 — one-to-many fan-out guard (mache-ffabd1)

`node_hash` is **one-to-many** (a deduped subtree appears at many occurrences); resolving on it would silently collapse two distinct callees with identical bodies. Adds tests pinning that the reader path (`v_defs`/`v_refs`, `LookupDef`/`GetCallers`) returns **all** occurrences of a duplicated subtree — no silent fan-out loss. Includes a real-db assertion: the most-duplicated subtree (11,179×) resolves to `COUNT(*) == COUNT(DISTINCT node_id)`.

## v0.6.0 pin bump (mache-3f0d59)

LLO v0.6.0 ships the merkle producer (`node_content`/`node_child`/`node_hash`; `symbols`/`fact_edges` removed). Bump both pins, keeping the version-parity gate (mache-b8af69) satisfied at major.minor **0.6**:
- `go.mod`: `leyline-schema` v0.5.6 → **v0.6.0**
- `internal/leyline/socket.go`: `leylineBinaryVersion` v0.5.7 → **v0.6.0**

mache **compiles clean** against the v0.6.0 Go bindings (capnp content unchanged); `TestLeylineSchemaBinaryVersionParity` + the leyline version-compat suite green.

## Verification

- Full `task ci` green on the combined state (`cmd/`, `internal/graph/`, `internal/leyline/`, smells gate, server-json drift).
- Backward-compat proven: views build + rows byte-identical on a no-`node_hash` db.

Beads: mache-ff9a9d, mache-ffabd1, mache-3f0d59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
