### PR TITLE
feat(sheaf): consume LLO v0.6+ watcher-driven invalidate payload (bead e4c4ea)

### DIFF
--- a/cmd/sheaf_subscribe.go
+++ b/cmd/sheaf_subscribe.go
@@ -86,18 +86,59 @@ func (r *sheafEventRouter) dispatch(ev leyline.SheafInvalidateEvent) { // covera
 } // coverage:ignore — subscriber handler shim; reduction tracked in mache-89b5dd.
 
 // routeSheafEvent is the pure routing function. Given an event and a
-// slice of invalidators, it asks each invalidator to invalidate the
-// nodes belonging to any region in ev.Invalidated. Invalidators with
-// no CommunityResult (or no matching regions) silently no-op.
+// slice of invalidators, it dispatches on the event's Scope
+// (LLO v0.6+ coarse-v1 payload contract, LLO PR #140):
 //
-// If NO invalidator claims any region in the event, the event is
-// logged + skipped per the c14c43 contract (question 4) — we do not
-// buffer events waiting for a CommunityResult to appear. The cascade
-// math the event reports is only meaningful relative to the topology
-// that produced it; by the time a future get_communities install
-// runs, the topology will have been re-pushed and the daemon will
-// re-cascade from there.
+//   - [leyline.ScopeChangedOnly] or empty (pre-v0.6 consumer-driven
+//     topic): fine-grained per-region eviction. Each invalidator
+//     invalidates the nodes whose community IDs appear in
+//     ev.Invalidated. Invalidators with no CommunityResult (or no
+//     matching regions) silently no-op. Empty scope maps here because
+//     the pre-v0.6 wire didn't carry the field.
+//
+//   - [leyline.ScopeAllKnown] (LLO v0.6+ watcher-driven coarse-v1):
+//     evict every sheaf-scoped cache entry each invalidator holds.
+//     The daemon has told us its whole working set is stale;
+//     re-cascading region-by-region against the daemon would be
+//     redundant chatter, so we invalidate locally via
+//     [graph.SheafInvalidator.InvalidateAllScoped].
+//
+//   - Any other non-empty Scope: log a warning and treat as
+//     ScopeAllKnown. Over-invalidating is always safe; the failure
+//     mode we refuse is silently serving stale data because we
+//     didn't recognise a new sentinel.
+//
+// If NO invalidator claims any region under changed-only, the event
+// is logged + skipped per the c14c43 contract (question 4) — we do
+// not buffer events waiting for a CommunityResult to appear. The
+// cascade math the event reports is only meaningful relative to the
+// topology that produced it; by the time a future get_communities
+// install runs, the topology will have been re-pushed and the daemon
+// will re-cascade from there. The all-known path skips this guard
+// because it invalidates via membership, not via specific IDs.
 func routeSheafEvent(ev leyline.SheafInvalidateEvent, invalidators []*graph.SheafInvalidator) {
+	switch ev.Scope {
+	case "", leyline.ScopeChangedOnly:
+		routeSheafEventChangedOnly(ev, invalidators)
+	case leyline.ScopeAllKnown:
+		routeSheafEventAllKnown(ev, invalidators)
+	default:
+		// Unknown scope — future LLO release added a value we don't
+		// know. Log at the level agents will actually see, then fall
+		// through to the safest behavior. This is the SAFE-DEFAULT
+		// gate; if we ever add a scope that intentionally requires
+		// less-than-all invalidation, do NOT reuse ScopeAllKnown as
+		// its fallback here — add an explicit case for it.
+		log.Printf("sheaf event: unknown scope %q (generation=%d count=%d); treating as %q (over-invalidating rather than serve stale)",
+			ev.Scope, ev.Generation, ev.Count, leyline.ScopeAllKnown)
+		routeSheafEventAllKnown(ev, invalidators)
+	}
+}
+
+// routeSheafEventChangedOnly is the fine-grained per-region path.
+// Extracted from the prior routeSheafEvent body verbatim so the
+// dispatcher above stays a pure switch.
+func routeSheafEventChangedOnly(ev leyline.SheafInvalidateEvent, invalidators []*graph.SheafInvalidator) {
 	if len(ev.Invalidated) == 0 { // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
 		return // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
 	} // coverage:ignore — defensive guard; reduction tracked in mache-89b5dd.
@@ -115,6 +156,25 @@ func routeSheafEvent(ev leyline.SheafInvalidateEvent, invalidators []*graph.Shea
 	if !matched {
 		log.Printf("sheaf event skipped (no invalidator claims any of regions %v): generation=%d count=%d",
 			ev.Invalidated, ev.Generation, ev.Count)
+	}
+}
+
+// routeSheafEventAllKnown is the coarse-v1 "invalidate everything"
+// path. For each invalidator with an installed CommunityResult, evict
+// every node in its Membership. Invalidators without a result no-op
+// (nothing to invalidate — the cascade for that window is unreachable
+// until a get_communities install runs).
+//
+// We deliberately do NOT emit the "no invalidator matched" log the
+// changed-only path emits: coarse-v1 events fire on every watcher
+// cycle regardless of whether mache has a result yet, and an early
+// serve session where get_communities hasn't run would spam the log.
+func routeSheafEventAllKnown(ev leyline.SheafInvalidateEvent, invalidators []*graph.SheafInvalidator) {
+	for _, si := range invalidators {
+		if !si.HasResult() {
+			continue
+		}
+		si.InvalidateAllScoped()
 	}
 }
 

--- a/cmd/sheaf_subscribe_test.go
+++ b/cmd/sheaf_subscribe_test.go
@@ -116,6 +116,139 @@ func TestRouteSheafEvent_MultipleRegionsInOneEvent(t *testing.T) {
 		"every region in the event must invalidate its members")
 }
 
+// TestRouteSheafEvent_AllKnownScopeEvictsEverything pins the coarse-v1
+// behavior of the LLO v0.6+ watcher-driven `daemon.sheaf.invalidate`
+// topic (LLO PR #140, bead `ley-line-open-3b3476`). When the daemon
+// declares its whole working set stale via `scope: "all-known"`, the
+// routing layer must evict EVERY node the invalidator's CommunityResult
+// claims membership for — not just the ones listed in the payload's
+// region_ids field.
+//
+// The distinction matters because the daemon's watcher-driven emit
+// lists every currently-known region regardless of what actually
+// changed (there's no file→region map on the daemon side pre-fine-
+// grained, LLO bead `e40566`). Treating that list as a whitelist under
+// changed-only semantics would let the routing layer silently under-
+// invalidate: a region present in mache's Membership but omitted from
+// the daemon's snapshot (e.g. the daemon lost the complex during a
+// crash-recover window) would be treated as fresh.
+//
+// The test constructs a CommunityResult with THREE regions, then fires
+// an all-known event whose payload lists only ONE region ID. All
+// three region members must be invalidated — proving the routing
+// layer read Scope, not region_ids.
+func TestRouteSheafEvent_AllKnownScopeEvictsEverything(t *testing.T) {
+	g := &fakeGraph{}
+	si := graph.NewSheafInvalidator(g, nil, &graph.CommunityResult{
+		Communities: []graph.Community{
+			{ID: 1, Members: []string{"a"}},
+			{ID: 2, Members: []string{"b"}},
+			{ID: 3, Members: []string{"c"}},
+		},
+		Membership: map[string]int{"a": 1, "b": 2, "c": 3},
+	})
+
+	// Payload lists only region 1, but scope=all-known says
+	// "everything is stale". All three members must be evicted.
+	routeSheafEvent(leyline.SheafInvalidateEvent{
+		Invalidated: []int{1},
+		Scope:       leyline.ScopeAllKnown,
+		Generation:  100,
+	}, []*graph.SheafInvalidator{si})
+
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, g.Invalidated(),
+		"all-known scope must evict every node in Membership, not just those in the payload's region_ids")
+}
+
+// TestRouteSheafEvent_UnknownScopeFallsBackToAllKnown pins the safe-
+// default contract: any scope value the router doesn't recognise MUST
+// be treated as coarse-v1 all-known. Over-invalidating is safe; under-
+// invalidating is not. If a future LLO release ships a new scope value
+// (e.g. "delta-only") before mache has learned to parse it, the
+// existing router will still evict every cached entry — never serve
+// stale data because it didn't recognise a sentinel.
+//
+// Complements the log line the router emits — this test doesn't
+// assert the log (would couple to log format) but proves the behavior
+// the log describes.
+func TestRouteSheafEvent_UnknownScopeFallsBackToAllKnown(t *testing.T) {
+	g := &fakeGraph{}
+	si := graph.NewSheafInvalidator(g, nil, &graph.CommunityResult{
+		Communities: []graph.Community{
+			{ID: 5, Members: []string{"x", "y"}},
+		},
+		Membership: map[string]int{"x": 5, "y": 5},
+	})
+
+	routeSheafEvent(leyline.SheafInvalidateEvent{
+		Invalidated: []int{5},
+		Scope:       "future-scope-mache-does-not-know",
+		Generation:  200,
+	}, []*graph.SheafInvalidator{si})
+
+	assert.ElementsMatch(t, []string{"x", "y"}, g.Invalidated(),
+		"unknown scope must fall through to all-known (evict everything) — over-invalidate rather than serve stale")
+}
+
+// TestRouteSheafEvent_ChangedOnlyExplicitBehavesLikeEmpty pins that
+// the explicit `scope: "changed-only"` sentinel produces the same
+// per-region dispatch as the pre-v0.6 empty-scope shape. Once LLO
+// bead `e40566` ships fine-grained mode, the watcher-driven emit
+// will populate this field; mache must route it through the SAME
+// path as the current empty-scope consumer-driven emit.
+//
+// The pin is behavioral: given identical region lists, empty scope
+// and explicit "changed-only" scope must invalidate the same
+// members. If they diverge, the routing switch has drifted.
+func TestRouteSheafEvent_ChangedOnlyExplicitBehavesLikeEmpty(t *testing.T) {
+	cr := &graph.CommunityResult{
+		Communities: []graph.Community{{ID: 7, Members: []string{"a", "b"}}},
+		Membership:  map[string]int{"a": 7, "b": 7},
+	}
+
+	// Explicit "changed-only".
+	explicitG := &fakeGraph{}
+	explicitSI := graph.NewSheafInvalidator(explicitG, nil, cr)
+	routeSheafEvent(leyline.SheafInvalidateEvent{
+		Invalidated: []int{7},
+		Scope:       leyline.ScopeChangedOnly,
+	}, []*graph.SheafInvalidator{explicitSI})
+
+	// Empty (pre-v0.6).
+	emptyG := &fakeGraph{}
+	emptySI := graph.NewSheafInvalidator(emptyG, nil, cr)
+	routeSheafEvent(leyline.SheafInvalidateEvent{
+		Invalidated: []int{7},
+		Scope:       "",
+	}, []*graph.SheafInvalidator{emptySI})
+
+	assert.ElementsMatch(t, explicitG.Invalidated(), emptyG.Invalidated(),
+		"explicit changed-only scope and empty scope must produce identical invalidations")
+}
+
+// TestRouteSheafEvent_AllKnownNoResultNoOps pins the graceful-degradation
+// contract when the coarse-v1 event fires before any get_communities
+// install: with no CommunityResult, there's nothing to iterate, so the
+// router silently no-ops. This matters because the LLO watcher fires
+// on EVERY successful enrichment tick, including during the startup
+// window before mache has run community detection. Emitting a log
+// line per tick under those conditions would spam the operator — the
+// c14c43 contract says "log + skip" for changed-only, but coarse-v1
+// skips silently.
+func TestRouteSheafEvent_AllKnownNoResultNoOps(t *testing.T) {
+	g := &fakeGraph{}
+	// No CommunityResult installed yet.
+	si := graph.NewSheafInvalidator(g, nil, nil)
+
+	routeSheafEvent(leyline.SheafInvalidateEvent{
+		Invalidated: []int{1, 2, 3},
+		Scope:       leyline.ScopeAllKnown,
+	}, []*graph.SheafInvalidator{si})
+
+	assert.Empty(t, g.Invalidated(),
+		"all-known event before any CommunityResult install must no-op silently")
+}
+
 // fakeGraph is a minimal graph.Graph that records Invalidate calls
 // for assertion. Mirrors the mockGraph in internal/graph but lives
 // here so the cmd-package routing test isn't coupled to that file's

--- a/internal/graph/sheaf_invalidate.go
+++ b/internal/graph/sheaf_invalidate.go
@@ -119,6 +119,51 @@ func (si *SheafInvalidator) CommunityResultForRouting() *CommunityResult { // co
 	return si.result      // coverage:ignore — read-only accessor; reduction tracked in mache-89b5dd.
 }
 
+// InvalidateAllScoped evicts every node the invalidator's
+// CommunityResult claims membership for, WITHOUT calling the sheaf
+// backend to compute a cascade. Returns the number of nodes evicted.
+//
+// This is the coarse-v1 "invalidate everything" path used by the
+// watcher-driven `daemon.sheaf.invalidate` topic (LLO PR #140, LLO
+// v0.6+). The daemon has already declared its entire working set
+// stale by the time it emits `scope: "all-known"`, so re-cascading
+// per-region against the daemon would be redundant chatter — we
+// know the answer is "all of them". A future fine-grained
+// (`scope: "changed-only"`) emit path exists (LLO bead `e40566`); it
+// stays on the per-region cascade path via InvalidateNodesWithCascade.
+//
+// No-op when the invalidator, graph, or CommunityResult is nil (same
+// null-safety contract as InvalidateNodesWithCascade). Skipping the
+// backend also means this method does not touch si.sheaf, so it's
+// safe to call even when no SheafBackend is installed — the
+// membership snapshot is enough.
+func (si *SheafInvalidator) InvalidateAllScoped() int {
+	if si == nil || si.graph == nil {
+		return 0
+	}
+
+	// Snapshot Membership under the read lock, then release it before
+	// touching the graph — Graph.Invalidate can hold its own lock and
+	// we don't want to nest.
+	si.mu.RLock()
+	storedResult := si.result
+	si.mu.RUnlock()
+
+	if storedResult == nil {
+		return 0
+	}
+
+	invalidated := make(map[string]struct{}, len(storedResult.Membership))
+	for nodeID := range storedResult.Membership {
+		if _, seen := invalidated[nodeID]; seen {
+			continue
+		}
+		si.graph.Invalidate(nodeID)
+		invalidated[nodeID] = struct{}{}
+	}
+	return len(invalidated)
+}
+
 // InvalidateNodesWithCascade is the batched-by-region variant of
 // InvalidateWithCascade. The watcher passes every node touched by a
 // file edit; this method dedupes them to the underlying set of unique

--- a/internal/graph/sheaf_invalidate_test.go
+++ b/internal/graph/sheaf_invalidate_test.go
@@ -650,3 +650,63 @@ func TestSheafInvalidator_InvalidateNodesWithCascade_FallbackPaths(t *testing.T)
 		assert.Empty(t, g.Invalidated())
 	})
 }
+
+// TestSheafInvalidator_InvalidateAllScoped pins the coarse-v1
+// "invalidate every sheaf-scoped node" path used by the LLO v0.6+
+// watcher-driven `daemon.sheaf.invalidate` topic (LLO PR #140).
+//
+// Contract:
+//  1. Every node in Membership is passed to graph.Invalidate exactly
+//     once (dedup by node ID).
+//  2. The SheafBackend is NOT called. The daemon has already declared
+//     everything stale — re-cascading region-by-region would be
+//     redundant chatter.
+//  3. nil receiver / nil graph / nil CommunityResult all no-op with
+//     zero return (same null-safety contract as InvalidateNodesWithCascade).
+func TestSheafInvalidator_InvalidateAllScoped(t *testing.T) {
+	t.Run("evicts_every_membership_entry_without_calling_backend", func(t *testing.T) {
+		g := &mockGraph{}
+		backend := &mockSheafBackend{}
+		cr := &CommunityResult{
+			Communities: []Community{
+				{ID: 1, Members: []string{"a", "b"}},
+				{ID: 2, Members: []string{"c"}},
+			},
+			Membership: map[string]int{"a": 1, "b": 1, "c": 2},
+		}
+		si := NewSheafInvalidator(g, backend, cr)
+
+		count := si.InvalidateAllScoped()
+
+		assert.Equal(t, 3, count, "every node in Membership must be evicted exactly once")
+		assert.ElementsMatch(t, []string{"a", "b", "c"}, g.Invalidated(),
+			"all three membership entries invalidated")
+		assert.Empty(t, backend.Calls(),
+			"backend must NOT be called under all-known — daemon already did the work")
+	})
+
+	t.Run("no_result_no_ops", func(t *testing.T) {
+		g := &mockGraph{}
+		si := NewSheafInvalidator(g, nil, nil)
+
+		count := si.InvalidateAllScoped()
+
+		assert.Equal(t, 0, count)
+		assert.Empty(t, g.Invalidated(),
+			"no CommunityResult → nothing to iterate → silent no-op (matches route layer's pre-topology contract)")
+	})
+
+	t.Run("nil_receiver_safe", func(t *testing.T) {
+		var nilSi *SheafInvalidator
+		assert.Equal(t, 0, nilSi.InvalidateAllScoped(),
+			"nil receiver must be safe (matches HasResult/InvalidateNodesWithCascade contract)")
+	})
+
+	t.Run("nil_graph_no_ops", func(t *testing.T) {
+		cr := &CommunityResult{Membership: map[string]int{"a": 1}}
+		si := NewSheafInvalidator(nil, nil, cr)
+
+		assert.Equal(t, 0, si.InvalidateAllScoped(),
+			"nil graph short-circuits — the invalidator has no target to evict against")
+	})
+}

--- a/internal/leyline/sheaf_subscriber.go
+++ b/internal/leyline/sheaf_subscriber.go
@@ -7,8 +7,22 @@ import (
 	"time"
 )
 
-// SheafSubscriber owns a long-lived `subscribe` connection to the ley-line
-// daemon, dispatching pushed `sheaf.invalidate` events to a handler.
+// SheafSubscriber owns a long-lived `subscribe` connection to the
+// ley-line daemon, dispatching pushed sheaf-invalidate events to a
+// handler.
+//
+// Two topics feed the same handler:
+//
+//   - `sheaf.invalidate` — pre-v0.6 consumer-driven emit from
+//     `op_sheaf_invalidate` (mache calls this from its own watcher via
+//     [SheafClient.Invalidate]).
+//   - `daemon.sheaf.invalidate` — LLO v0.6+ watcher-driven emit from
+//     the daemon's own enrichment cycle (LLO PR #140 / bead
+//     `ley-line-open-3b3476`), carrying the coarse-v1 payload shape
+//     documented on [SheafInvalidateEvent].
+//
+// Both variants decode to a single [SheafInvalidateEvent]; the routing
+// layer in cmd/sheaf_subscribe.go dispatches on the Scope field.
 //
 // FIXED UPSTREAM (LLO v0.4.3, ley-line-open-5caa59): pre-v0.4.3 LLO
 // daemons did NOT actually deliver sheaf.invalidate events to UDS
@@ -92,19 +106,98 @@ type SheafSubscriber struct {
 // implementations must guard their own state.
 type EventHandler func(SheafInvalidateEvent)
 
-// SheafInvalidateEvent is the parsed shape of a sheaf.invalidate event
-// pushed by the daemon. Generation is parsed from the wire's quoted-
-// string Int64 (capnp-json convention, see PR #382's parseUint64).
+// Sheaf-invalidation scope values carried on the wire.
+//
+// The scope field is emitted by LLO v0.6+ on the watcher-driven
+// `daemon.sheaf.invalidate` topic (LLO PR #140, bead
+// `ley-line-open-3b3476`). The pre-v0.6 consumer-driven
+// `sheaf.invalidate` topic does not carry the field — mache treats
+// its absence as [ScopeChangedOnly] (the historical per-region
+// behavior) so existing callers keep working unchanged.
+const (
+	// ScopeChangedOnly is the fine-grained per-region contract:
+	// invalidate only the caches for regions listed in RegionIDs.
+	// Emitted by:
+	//   - the consumer-driven `sheaf.invalidate` topic (payload has
+	//     no `scope` field; mache infers this variant),
+	//   - the future fine-grained daemon-driven emit (LLO bead
+	//     `e40566`, not yet shipped).
+	ScopeChangedOnly = "changed-only"
+
+	// ScopeAllKnown is the coarse-v1 contract shipped by LLO v0.6:
+	// evict every sheaf-scoped cache entry. Region IDs are still
+	// carried (they list every known region) but callers should NOT
+	// treat them as a whitelist — the daemon is reporting the whole
+	// working set as stale.
+	ScopeAllKnown = "all-known"
+)
+
+// SheafInvalidateEvent is the parsed shape of a sheaf-invalidate event
+// pushed by the daemon. Two on-wire variants collapse to this struct:
+//
+//   - Topic `sheaf.invalidate` (LLO ≤ v0.5, consumer-driven — emitted
+//     from `op_sheaf_invalidate` when a client calls it):
+//     `{invalidated, count, generation, prior_generation}`.
+//   - Topic `daemon.sheaf.invalidate` (LLO v0.6+, watcher-driven —
+//     emitted from the daemon's enrichment cycle, LLO PR #140):
+//     `{region_ids, count, scope, changed_files, current_root,
+//     generation, prior_generation, timestamp_ms}`.
+//
+// `Generation` and `PriorGeneration` are parsed from either raw JSON
+// numbers or capnp-json quoted-string Int64 (see parseUint64) so a
+// single struct handles both encodings without a per-topic parse.
 type SheafInvalidateEvent struct {
-	// Invalidated region IDs the cascade marked stale.
+	// Invalidated carries the region identifiers the daemon named in
+	// the payload. Populated from `invalidated` (consumer-driven) or
+	// `region_ids` (watcher-driven). Interpretation depends on Scope
+	// (see the constants above): under ScopeChangedOnly this is a
+	// whitelist to invalidate; under ScopeAllKnown it's a snapshot of
+	// every known region and callers should evict everything.
+	//
+	// The field keeps its pre-v0.6 name (rather than being renamed to
+	// `RegionIDs`) to preserve the public-API contract of the mache
+	// event surface. The `region_ids` wire field is decoded into it
+	// too.
 	Invalidated []int
-	// Generation is the daemon's monotonic counter at the time of the
-	// cascade. Agents compare this to a previously-cached value to
-	// decide whether their snapshot is still fresh.
+
+	// Generation is the daemon's monotonic counter after the emit.
+	// Agents compare this to a previously-cached value to decide
+	// whether their snapshot is still fresh.
 	Generation uint64
+
+	// PriorGeneration is the counter value before this event's bump.
+	// Populated on both topics.
+	PriorGeneration uint64
+
 	// Count mirrors len(Invalidated); kept as a separate wire field
 	// because the daemon emits it that way.
 	Count int
+
+	// Scope classifies the event: [ScopeChangedOnly] or [ScopeAllKnown].
+	// See the constants for semantics + wire-emission provenance. The
+	// dispatcher treats an unknown non-empty value as ScopeAllKnown
+	// (over-invalidate rather than serve stale) and logs a warning so
+	// a new future scope value isn't silently dropped.
+	//
+	// Empty when parsed from the consumer-driven topic (which
+	// pre-dates the field) — cmd routing infers ScopeChangedOnly for
+	// the empty case.
+	Scope string
+
+	// ChangedFiles lists the files whose reparse triggered the emit.
+	// Watcher-driven topic only; empty from the consumer-driven topic
+	// (which has no file context — the caller decides which regions
+	// to poke).
+	ChangedFiles []string
+
+	// CurrentRoot is the 64-hex BLAKE3 root of the substrate state
+	// after the emit. Watcher-driven topic only; may be empty when
+	// the daemon's controller read failed (best-effort, degrades
+	// honestly per LLO PR #140).
+	CurrentRoot string
+
+	// TimestampMs is now_ms() at emit time. Watcher-driven topic only.
+	TimestampMs int64
 }
 
 // SubscriberState classifies the subscriber's connection state.
@@ -268,7 +361,22 @@ func (s *SheafSubscriber) run(ctx context.Context) {
 		}
 
 		// Subscribe.
-		evCh, err := sock.Subscribe([]string{"sheaf.invalidate"})
+		//
+		// Two topics feed the same dispatch:
+		//   - `sheaf.invalidate` — pre-v0.6 consumer-driven emit
+		//     (from `op_sheaf_invalidate` on client-triggered ops).
+		//   - `daemon.sheaf.invalidate` — LLO v0.6+ watcher-driven
+		//     emit (from the daemon's own file-change enrichment,
+		//     LLO PR #140 / bead `ley-line-open-3b3476`). Closes the
+		//     sheaf-invalidation loop end-to-end so mache no longer
+		//     needs to poke the daemon after every observed file
+		//     change.
+		//
+		// The subscribe response replays historical events, so
+		// resubscribing over an existing conn will re-drain topics
+		// that had events during the disconnect window — safe under
+		// the daemon's dedup on generation counter.
+		evCh, err := sock.Subscribe([]string{"sheaf.invalidate", "daemon.sheaf.invalidate"})
 		if err != nil { // coverage:ignore — Subscribe error path (post-dial); reduction tracked in mache-89b5dd.
 			s.setState(StateDisconnected, fmt.Sprintf("subscribe: %v", err)) // coverage:ignore — Subscribe error path; reduction tracked in mache-89b5dd.
 			_ = sock.Close()                                                 // coverage:ignore — Subscribe error path; reduction tracked in mache-89b5dd.
@@ -318,30 +426,43 @@ func (s *SheafSubscriber) consume(ctx context.Context, evCh <-chan map[string]an
 }
 
 // dispatch parses a single event map and calls the handler. Events
-// with a non-matching topic are silently dropped — they're structurally
-// impossible from the daemon side (we only subscribed to one topic),
-// so reaching them indicates a daemon-side bug rather than a runtime
-// condition agents need to observe. Updated from the prior "logged
-// and skipped" docstring (PR #384 Copilot #2) to match what the code
-// actually does; the runtime log line would just be noise on a
-// subscribed-topic stream.
+// with a topic mache did not subscribe to are silently dropped —
+// they're structurally impossible from the daemon side (we only
+// subscribed to two topics), so reaching them indicates a daemon-side
+// bug rather than a runtime condition agents need to observe. Updated
+// from the prior "logged and skipped" docstring (PR #384 Copilot #2)
+// to match what the code actually does; the runtime log line would
+// just be noise on a subscribed-topic stream.
 //
-// Wire shape (pinned against LLO v0.4.3 via
-// tools/sheaf-subscribe-probe/main.go):
+// Two wire shapes are unified here:
 //
-//	{"event": true, "seq": N, "source": "leyline",
-//	 "topic": "sheaf.invalidate",
-//	 "data": {"invalidated": [...], "generation": N, "count": N,
-//	          "prior_generation": N}}
+//  1. Consumer-driven `sheaf.invalidate` (LLO ≤ v0.5, pinned against
+//     LLO v0.4.3 via tools/sheaf-subscribe-probe/main.go):
+//
+//     {"event": true, "seq": N, "source": "leyline",
+//     "topic": "sheaf.invalidate",
+//     "data": {"invalidated": [...], "generation": N, "count": N,
+//     "prior_generation": N}}
+//
+//  2. Watcher-driven `daemon.sheaf.invalidate` (LLO v0.6+, LLO
+//     PR #140 / bead `ley-line-open-3b3476`):
+//
+//     {"event": true, "seq": N, "source": "leyline",
+//     "topic": "daemon.sheaf.invalidate",
+//     "data": {"region_ids": [...], "count": N, "scope": "all-known",
+//     "changed_files": [...], "current_root": "<hex>",
+//     "generation": "N", "prior_generation": "N",
+//     "timestamp_ms": "N"}}
 //
 // Payload fields are nested under `data`. Pre-v0.4.3 the daemon
 // never delivered the event at all (ley-line-open-5caa59), so the
 // envelope wasn't observable from mache's side until the fix shipped.
 func (s *SheafSubscriber) dispatch(ev map[string]any) {
 	topic, _ := ev["topic"].(string)
-	if topic != "sheaf.invalidate" { // coverage:ignore — defensive guard for structurally-impossible topic; reduction tracked in mache-89b5dd.
-		// Only sheaf.invalidate is subscribed; silently ignore the
-		// impossible case rather than emit log noise per event.
+	if topic != "sheaf.invalidate" && topic != "daemon.sheaf.invalidate" { // coverage:ignore — defensive guard for structurally-impossible topic; reduction tracked in mache-89b5dd.
+		// Only the two sheaf-invalidate topics are subscribed;
+		// silently ignore the impossible case rather than emit log
+		// noise per event.
 		return // coverage:ignore — defensive guard for structurally-impossible topic; reduction tracked in mache-89b5dd.
 	} // coverage:ignore — defensive guard for structurally-impossible topic; reduction tracked in mache-89b5dd.
 
@@ -351,9 +472,20 @@ func (s *SheafSubscriber) dispatch(ev map[string]any) {
 	// the topic-was-delivered signal and can decide what to do.
 	data, _ := ev["data"].(map[string]any)
 
+	// Region IDs live in `region_ids` on the watcher-driven topic and
+	// `invalidated` on the consumer-driven topic. Read both — the one
+	// that's present wins; if both are somehow present the
+	// watcher-driven `region_ids` takes precedence (its emit is the
+	// canonical source of "here's what's stale").
+	regions := parseIntSlice(data["region_ids"])
+	if len(regions) == 0 {
+		regions = parseIntSlice(data["invalidated"])
+	}
+
 	parsed := SheafInvalidateEvent{
-		Invalidated: parseIntSlice(data["invalidated"]),
-		Generation:  parseUint64(data["generation"]),
+		Invalidated:     regions,
+		Generation:      parseUint64(data["generation"]),
+		PriorGeneration: parseUint64(data["prior_generation"]),
 	}
 	if v, ok := data["count"].(float64); ok {
 		parsed.Count = int(v)
@@ -361,12 +493,62 @@ func (s *SheafSubscriber) dispatch(ev map[string]any) {
 		parsed.Count = len(parsed.Invalidated) // coverage:ignore — defensive fallback when daemon omits count; reduction tracked in mache-89b5dd.
 	} // coverage:ignore — defensive fallback when daemon omits count; reduction tracked in mache-89b5dd.
 
+	// New coarse-v1 fields (watcher-driven topic). Absent on the
+	// consumer-driven topic; the zero values are the correct default
+	// for the routing layer to infer ScopeChangedOnly.
+	if scope, ok := data["scope"].(string); ok {
+		parsed.Scope = scope
+	}
+	parsed.ChangedFiles = parseStringSlice(data["changed_files"])
+	if root, ok := data["current_root"].(string); ok {
+		parsed.CurrentRoot = root
+	}
+	parsed.TimestampMs = parseInt64(data["timestamp_ms"])
+
 	s.mu.Lock()
 	s.lastEvent = time.Now()
 	s.lastGeneration = parsed.Generation
 	s.mu.Unlock()
 
 	s.handler(parsed)
+}
+
+// parseStringSlice extracts []string from a JSON-decoded []any.
+// Returns nil for a nil / non-slice input, and skips non-string
+// entries within the slice (rather than aborting) so a malformed
+// entry doesn't drop otherwise-valid file paths.
+func parseStringSlice(v any) []string {
+	arr, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// parseInt64 accepts a float64 (raw JSON number) or a string (capnp-
+// json's quoted-Int64 rendering) and returns the corresponding int64.
+// Returns 0 for any other shape. Timestamp fields cross the 2^53
+// safe-integer ceiling around year 2255, so the quoted-string form
+// isn't strictly needed today, but LLO emits timestamps as strings
+// (see PR #140's `now_ms().to_string()`) for consistency with the
+// generation counters, and this helper matches that shape.
+func parseInt64(v any) int64 {
+	switch x := v.(type) {
+	case float64:
+		return int64(x)
+	case string:
+		var n int64
+		_, _ = fmt.Sscanf(x, "%d", &n)
+		return n
+	default:
+		return 0
+	}
 }
 
 // setState updates the connection state under the write lock. Reason

--- a/internal/leyline/sheaf_subscriber_test.go
+++ b/internal/leyline/sheaf_subscriber_test.go
@@ -265,6 +265,163 @@ func TestSheafSubscriber_StopIdempotentAndAlwaysWaits(t *testing.T) {
 		"after Stop returns, state MUST be Disconnected")
 }
 
+// TestSheafSubscriber_DispatchesWatcherDrivenEvent pins the LLO v0.6+
+// coarse-v1 payload contract (LLO PR #140, bead
+// `ley-line-open-3b3476`). The watcher-driven `daemon.sheaf.invalidate`
+// topic carries an extended payload:
+//
+//	{"topic": "daemon.sheaf.invalidate",
+//	 "data": {"region_ids": [...],
+//	          "count": N,
+//	          "scope": "all-known",
+//	          "changed_files": [...],
+//	          "current_root": "<64-hex>",
+//	          "generation": "N", "prior_generation": "N",
+//	          "timestamp_ms": "N"}}
+//
+// All the numeric fields (generation, prior_generation, timestamp_ms)
+// arrive as quoted strings on the wire per capnp-json convention,
+// matching what LLO's `emit_watcher_sheaf_invalidate` emits (see
+// PR #140).
+//
+// This test drives the parser directly through the mock daemon path:
+// push the exact envelope, assert every field parses onto the shared
+// SheafInvalidateEvent struct. Without this pin, a future LLO wire
+// change (e.g. dropping the timestamp field, or renaming a key)
+// would break silently — the mock daemon happily pushes whatever we
+// give it and the routing layer only cares about Scope + Invalidated.
+func TestSheafSubscriber_DispatchesWatcherDrivenEvent(t *testing.T) {
+	sockPath := startSubscribeMockServer(t, mockBehavior{
+		acceptSubscribe: true,
+		pushEvents: []map[string]any{
+			{
+				"event":  true,
+				"seq":    1.0,
+				"source": "leyline",
+				"topic":  "daemon.sheaf.invalidate",
+				"data": map[string]any{
+					"region_ids":       []any{4.0, 5.0, 6.0},
+					"count":            3.0,
+					"scope":            "all-known",
+					"changed_files":    []any{"pkg/a.rs", "pkg/b.rs"},
+					"current_root":     strings.Repeat("a", 64),
+					"generation":       "12", // quoted-string Int64
+					"prior_generation": "11",
+					"timestamp_ms":     "1720000000000",
+				},
+			},
+		},
+	})
+
+	var (
+		handled  atomic.Int32
+		gotEvent SheafInvalidateEvent
+		eventMu  sync.Mutex
+	)
+	handler := func(ev SheafInvalidateEvent) {
+		eventMu.Lock()
+		gotEvent = ev
+		eventMu.Unlock()
+		handled.Add(1)
+	}
+
+	sub := NewSheafSubscriber(sockPath, handler)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sub.Start(ctx)
+	t.Cleanup(sub.Stop)
+
+	require.Eventually(t, func() bool {
+		return handled.Load() > 0
+	}, 2*time.Second, 25*time.Millisecond, "handler must fire on daemon.sheaf.invalidate")
+
+	eventMu.Lock()
+	got := gotEvent
+	eventMu.Unlock()
+
+	assert.Equal(t, []int{4, 5, 6}, got.Invalidated,
+		"region_ids must decode into Invalidated (shared field with pre-v0.6 shape)")
+	assert.Equal(t, uint64(12), got.Generation, "quoted-string generation parses")
+	assert.Equal(t, uint64(11), got.PriorGeneration, "quoted-string prior_generation parses")
+	assert.Equal(t, 3, got.Count, "count round-trips")
+	assert.Equal(t, ScopeAllKnown, got.Scope, "coarse-v1 scope decodes verbatim")
+	assert.Equal(t, []string{"pkg/a.rs", "pkg/b.rs"}, got.ChangedFiles, "changed_files decode")
+	assert.Equal(t, strings.Repeat("a", 64), got.CurrentRoot, "current_root decodes")
+	assert.Equal(t, int64(1720000000000), got.TimestampMs, "quoted-string timestamp_ms parses")
+
+	assert.Equal(t, uint64(12), sub.Status().LastGeneration,
+		"Status.LastGeneration mirrors the new topic's generation counter")
+}
+
+// TestSheafSubscriber_PreV06PayloadUnaffected pins the backward-compat
+// half of the LLO v0.6+ rollout: the pre-v0.6 `sheaf.invalidate` topic
+// (consumer-driven, emitted from `op_sheaf_invalidate`) has no
+// `scope`, `region_ids`, `changed_files`, `current_root`, or
+// `timestamp_ms` fields, and its region list lives in `invalidated`.
+// The subscriber must still parse it — mache's own calls to
+// `op_sheaf_invalidate` (via SheafInvalidator.InvalidateNodesWithCascade)
+// generate exactly this event flow.
+//
+// The zero values for the new fields are the correct signal for the
+// routing layer to infer ScopeChangedOnly (see cmd/sheaf_subscribe.go's
+// routeSheafEvent switch).
+func TestSheafSubscriber_PreV06PayloadUnaffected(t *testing.T) {
+	sockPath := startSubscribeMockServer(t, mockBehavior{
+		acceptSubscribe: true,
+		pushEvents: []map[string]any{
+			{
+				"event":  true,
+				"seq":    1.0,
+				"source": "leyline",
+				"topic":  "sheaf.invalidate",
+				"data": map[string]any{
+					"invalidated":      []any{9.0},
+					"count":            1.0,
+					"generation":       42.0, // pre-v0.6 emitted raw numbers
+					"prior_generation": 41.0,
+				},
+			},
+		},
+	})
+
+	var (
+		handled  atomic.Int32
+		gotEvent SheafInvalidateEvent
+		eventMu  sync.Mutex
+	)
+	handler := func(ev SheafInvalidateEvent) {
+		eventMu.Lock()
+		gotEvent = ev
+		eventMu.Unlock()
+		handled.Add(1)
+	}
+
+	sub := NewSheafSubscriber(sockPath, handler)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	sub.Start(ctx)
+	t.Cleanup(sub.Stop)
+
+	require.Eventually(t, func() bool {
+		return handled.Load() > 0
+	}, 2*time.Second, 25*time.Millisecond, "handler must still fire on pre-v0.6 sheaf.invalidate")
+
+	eventMu.Lock()
+	got := gotEvent
+	eventMu.Unlock()
+
+	assert.Equal(t, []int{9}, got.Invalidated,
+		"pre-v0.6 `invalidated` field must still decode into Invalidated")
+	assert.Equal(t, uint64(42), got.Generation, "raw-number generation still parses")
+	assert.Equal(t, uint64(41), got.PriorGeneration, "raw-number prior_generation still parses")
+	assert.Equal(t, "", got.Scope,
+		"pre-v0.6 event has no scope — leave empty so router infers changed-only")
+	assert.Nil(t, got.ChangedFiles,
+		"pre-v0.6 event has no changed_files — must decode to nil, not a fabricated slice")
+	assert.Equal(t, "", got.CurrentRoot, "pre-v0.6 event has no current_root")
+	assert.Equal(t, int64(0), got.TimestampMs, "pre-v0.6 event has no timestamp_ms")
+}
+
 // TestSheafSubscriber_StopHaltsLoop pins clean shutdown: Stop()
 // terminates the subscribe goroutine + closes the underlying socket.
 // Under -race, any leaked goroutine writing through the conn after


### PR DESCRIPTION
## Summary

Wires mache's `SheafSubscriber` to the new `daemon.sheaf.invalidate`
topic shipped by LLO v0.6+ ([LLO PR #140](https://github.com/agentic-research/ley-line-open/pull/140), bead
`ley-line-open-3b3476`). Closes bead `mache-e4c4ea`.

Before this PR the subscriber only listened on the pre-v0.6
consumer-driven `sheaf.invalidate` topic (fired from
`op_sheaf_invalidate` when mache pokes the daemon after observing its
own file changes). LLO PR #140 closed the loop on the daemon side —
the daemon's watcher fires `daemon.sheaf.invalidate` on every
successful enrichment tick, so mache no longer has to observe file
changes itself to keep its cache honest. This PR is the mache-side
subscription update.

## Wire contract (from [LLO PR #140](https://github.com/agentic-research/ley-line-open/pull/140))

Same topic naming pattern as existing daemon.* events. Payload
extends the pre-v0.6 shape with coarse-v1 fields:

```json
{
  "region_ids": [1, 2, 3],
  "count": 3,
  "scope": "all-known",
  "changed_files": ["pkg/a.rs", "pkg/b.rs"],
  "current_root": "<64-char BLAKE3 hex>",
  "generation": "12",         // quoted-string Int64
  "prior_generation": "11",
  "timestamp_ms": "1720000000000"
}
```

The pre-v0.6 `sheaf.invalidate` topic still carries the old shape
(`{invalidated, count, generation, prior_generation}`) — both feed
the same `SheafInvalidateEvent` struct.

## Scope dispatch (coarse vs fine + safe unknown-value fallback)

`routeSheafEvent` now switches on the event's `Scope`:

- `"changed-only"` (or empty, for pre-v0.6 backward-compat):
  per-region eviction via the existing
  `SheafInvalidator.InvalidateNodesWithCascade` path.
- `"all-known"` (LLO v0.6+ coarse-v1): evict every sheaf-scoped
  cache entry via a new `SheafInvalidator.InvalidateAllScoped`. The
  new method walks `Membership` and calls `graph.Invalidate` directly
  WITHOUT calling the sheaf backend — the daemon has already declared
  everything stale, so re-cascading region-by-region would be
  redundant chatter.
- Any other non-empty scope: log a warning and fall through to
  `"all-known"`. Over-invalidating is always safe; under-invalidating
  because we didn't recognise a future sentinel is not.

Once LLO bead `e40566` ships fine-grained mode (payload with
`scope: "changed-only"` from the watcher path), no mache-side change
is needed — the routing already treats explicit `"changed-only"`
identically to the pre-v0.6 empty-scope shape.

## Test coverage

- **`internal/leyline/sheaf_subscriber_test.go`** — parser pins for
  both wire shapes:
  - `TestSheafSubscriber_DispatchesWatcherDrivenEvent` fires a fake
    `daemon.sheaf.invalidate` payload with every coarse-v1 field
    (including the quoted-string Int64 encoding LLO uses) and
    asserts each field parses onto the shared struct.
  - `TestSheafSubscriber_PreV06PayloadUnaffected` fires the
    pre-v0.6 `sheaf.invalidate` payload and asserts the new fields
    default to zero values (empty scope → router infers
    changed-only; nil ChangedFiles; empty CurrentRoot; zero
    TimestampMs).
- **`cmd/sheaf_subscribe_test.go`** — dispatch pins:
  - `TestRouteSheafEvent_AllKnownScopeEvictsEverything`: with a
    three-region CommunityResult and a payload listing only one
    region, all three members must be evicted (proves the router
    reads `Scope`, not `region_ids`, under coarse-v1).
  - `TestRouteSheafEvent_UnknownScopeFallsBackToAllKnown`: unknown
    sentinel → evict everything.
  - `TestRouteSheafEvent_ChangedOnlyExplicitBehavesLikeEmpty`:
    explicit `"changed-only"` and empty scope produce identical
    invalidations.
  - `TestRouteSheafEvent_AllKnownNoResultNoOps`: coarse-v1 event
    before any get_communities install silently no-ops (no log
    spam during the startup window).
- **`internal/graph/sheaf_invalidate_test.go`** —
  `InvalidateAllScoped` correctness + null-safety (nil receiver,
  nil graph, no CommunityResult, backend never called).

Full E2E against a live LLO daemon is out of scope for this PR —
existing `sheaf_subscriber_e2e_test.go` still guards the wire path
for the consumer-driven topic; a follow-up gate can extend it to
push a watcher-driven event once LLO v0.6+ is a release dependency.

## Backward compat

- `SheafSubscriber` public API: unchanged.
- `SheafInvalidateEvent`: new fields added; existing
  `Invalidated`/`Generation`/`Count` field names retained (rather
  than renamed to `RegionIDs`) so downstream callers keep compiling.
- `sheaf.invalidate` (pre-v0.6 consumer-driven) topic: still
  subscribed, still parsed, still dispatched via the same per-region
  path. Mache's own calls to `op_sheaf_invalidate` (via
  `SheafInvalidator.InvalidateNodesWithCascade`) still fire this
  event flow.

## Test plan

- [x] `task fmt:check` clean
- [x] `task vet` clean
- [x] `task lint` clean (0 issues)
- [x] `task parity` green
- [x] `task validate` green
- [x] `task docs:lint` green
- [x] `task actions:lint` green
- [x] `task test` green (full `go test -race` suite)
- [x] Targeted `-race` runs on affected packages
      (`internal/leyline`, `internal/graph`, `cmd`) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152aGbbyPQkbj4qz1bqXDQL