### PR TITLE
[mache-238673] feat(smells): node_hash-memoized cyclomatic_complexity (phase-1)

### DIFF
--- a/cmd/find_smells_bench_test.go
+++ b/cmd/find_smells_bench_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mache-238673 phase-1 bench — quantifies the node_hash-memo win on
+// cyclomatic_complexity. The scenario models real source: many function
+// occurrences, but a much smaller number of DISTINCT subtrees (boilerplate,
+// generated code, copy-paste all dedup to one merkle node_hash). A warm memo
+// turns the O(occurrences × subtree) branch-count join into an O(occurrences)
+// scan + map lookup — the sub-linear re-run the merkle cash-out promises.
+//
+// Compare the three sub-benchmarks at a given size:
+//   FullScan  — runSmellRule every iteration (today's behavior)
+//   MemoCold  — fresh memo every iteration (first-run cost; parity with FullScan)
+//   MemoWarm  — memo warmed once, reused every iteration (the incremental re-run)
+// MemoWarm/ns-per-op well below FullScan is the phase-1 result.
+
+// seedCyclomaticMemoFixture builds an _ast db of nFuncs function occurrences
+// spread over distinct distinct subtrees, each with a node_hash. Every subtree
+// has three counted branches, so the metric is a constant 3 — the point is the
+// scan cost, not the metric spread.
+func seedCyclomaticMemoFixture(b *testing.B, nFuncs, distinct int) []fixFunc {
+	b.Helper()
+	shapes := make([][]string, distinct)
+	hashes := make([][]byte, distinct)
+	for d := range distinct {
+		shapes[d] = []string{"if_statement", "for_statement", "case_clause", "block"}
+		hashes[d] = hashFor(fmt.Sprintf("subtree-%d", d))
+	}
+	funcs := make([]fixFunc, 0, nFuncs)
+	for i := range nFuncs {
+		d := i % distinct
+		funcs = append(funcs, fixFunc{
+			sourceID:  fmt.Sprintf("pkg/%d/file.go", i/50),
+			nodeID:    fmt.Sprintf("pkg/%d/file.go/F%06d", i/50, i),
+			hash:      hashes[d],
+			branches:  shapes[d],
+			startByte: i * 1000,
+			startRow:  i * 30,
+		})
+	}
+	return funcs
+}
+
+func BenchmarkCyclomaticMemo(b *testing.B) {
+	// 5% distinct: heavy duplication, the memo's best case.
+	for _, n := range []int{1000, 10000} {
+		distinct := n / 20
+		funcs := seedCyclomaticMemoFixture(b, n, distinct)
+		db := buildASTFixture(b, funcs)
+		qg := &sqlDBQuerier{db: db}
+		rule := cyclomaticRule(b)
+
+		b.Run(fmt.Sprintf("FullScan/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				if _, err := runSmellRule(qg, rule, "", oracleLimit); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("MemoCold/n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for range b.N {
+				memo := newSmellMemo()
+				if _, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("MemoWarm/n=%d", n), func(b *testing.B) {
+			memo := newSmellMemo()
+			if _, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo); err != nil {
+				b.Fatal(err)
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				if _, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/find_smells_bench_test.go
+++ b/cmd/find_smells_bench_test.go
@@ -19,7 +19,7 @@ import (
 // MemoWarm/ns-per-op well below FullScan is the phase-1 result.
 
 // seedCyclomaticMemoFixture builds an _ast db of nFuncs function occurrences
-// spread over distinct distinct subtrees, each with a node_hash. Every subtree
+// spread over `distinct` unique subtrees, each with a node_hash. Every subtree
 // has three counted branches, so the metric is a constant 3 — the point is the
 // scan cost, not the metric spread.
 func seedCyclomaticMemoFixture(b *testing.B, nFuncs, distinct int) []fixFunc {

--- a/cmd/smell_findings_incremental_test.go
+++ b/cmd/smell_findings_incremental_test.go
@@ -148,9 +148,13 @@ func cyclomaticRule(t testing.TB) *SmellRule {
 
 const oracleLimit = 100000
 
-// TestCyclomaticMemo_KindsMatchRule pins that the fixture's countedKinds are
-// exactly the kinds the rule's SQL counts — a drift guard so the oracle can't
-// silently stop exercising a kind the rule cares about.
+// TestCyclomaticMemo_KindsMatchRule is the drift guard across all three copies
+// of the counted-kind set: the rule SQL (cyclomatic_complexity.json), the
+// PRODUCTION const cyclomaticBranchKinds (the list that actually computes the
+// memoized metric), and the test's countedKinds (what the fixtures exercise).
+// The production const is the load-bearing one — a memo that counts a different
+// kind set than the rule diverges — so it is checked against the rule directly,
+// not just incidentally via the oracle.
 func TestCyclomaticMemo_KindsMatchRule(t *testing.T) {
 	q := cyclomaticRule(t).Query
 	for _, k := range countedKinds {
@@ -159,6 +163,13 @@ func TestCyclomaticMemo_KindsMatchRule(t *testing.T) {
 	for _, k := range uncountedKinds {
 		assert.NotContainsf(t, q, "'"+k+"'", "rule now counts %q — it must move to countedKinds", k)
 	}
+	// The production kind set must match the rule too — this is the copy that
+	// computes the metric, so its drift is a real byte-identity bug.
+	for _, k := range cyclomaticBranchKinds {
+		assert.Containsf(t, q, "'"+k+"'", "rule no longer counts %q — update cyclomaticBranchKinds", k)
+	}
+	assert.ElementsMatch(t, countedKinds, cyclomaticBranchKinds,
+		"test countedKinds and production cyclomaticBranchKinds must stay in sync")
 }
 
 // TestCyclomaticMemo_DuplicatedSubtrees is oracle case (b): a subtree that
@@ -286,7 +297,127 @@ func TestCyclomaticMemo_DifferentialOracle_RandomEdits(t *testing.T) {
 
 		assert.Equalf(t, jsonOrPanic(want), jsonOrPanic(got),
 			"memoized diverged from full scan at step %d", step)
-		_ = db.Close()
+		// db is closed by buildASTFixture's t.Cleanup — no explicit close here.
 	}
 	assert.True(t, sawHit, "the persistent memo must serve at least one cache hit across the edit sequence")
+}
+
+// TestCyclomaticMemo_LimitTruncation exercises the out[:limit] path (the main
+// oracle uses limit=100000 and never truncates). Includes a tie group that
+// straddles the limit boundary, stressing the stable-sort tie-break
+// (metric DESC, source_id, start_byte) against SQL's ORDER BY..LIMIT.
+func TestCyclomaticMemo_LimitTruncation(t *testing.T) {
+	var funcs []fixFunc
+	// Four functions with metric 2 (same shape, distinct hashes+locations) that
+	// straddle a limit cut, plus a couple of distinct metrics above/below.
+	tie := []string{"if_statement", "for_statement"} // metric 2
+	for i := range 4 {
+		funcs = append(funcs, fixFunc{
+			sourceID:  fmt.Sprintf("pkg/tie%d.go", i),
+			nodeID:    fmt.Sprintf("pkg/tie%d.go/T", i),
+			hash:      hashFor(fmt.Sprintf("tie-%d", i)),
+			branches:  tie,
+			startByte: i * 500,
+			startRow:  i * 20,
+		})
+	}
+	funcs = append(funcs,
+		fixFunc{sourceID: "pkg/hi.go", nodeID: "pkg/hi.go/H", hash: hashFor("hi"), branches: []string{"if_statement", "for_statement", "case_clause", "type_case"}, startByte: 9000, startRow: 900},
+		fixFunc{sourceID: "pkg/lo.go", nodeID: "pkg/lo.go/L", hash: hashFor("lo"), branches: []string{"if_statement"}, startByte: 9500, startRow: 950},
+	)
+
+	db := buildASTFixture(t, funcs)
+	qg := &sqlDBQuerier{db: db}
+
+	for _, limit := range []int{1, 3, 5} {
+		want, err := runSmellRule(qg, cyclomaticRule(t), "", limit)
+		require.NoError(t, err)
+		got, err := runCyclomaticComplexityMemo(qg, "", limit, newSmellMemo())
+		require.NoError(t, err)
+		assert.Equalf(t, jsonOrPanic(want), jsonOrPanic(got),
+			"memoized diverged from full scan at limit=%d", limit)
+		assert.LessOrEqualf(t, len(got), limit, "limit=%d must truncate", limit)
+	}
+}
+
+// TestCyclomaticMemo_HashlessAndMixed exercises the f.hashHex=="" path: some
+// functions carry no node_hash (nil), mixed with hashed ones. Hashless
+// functions must be computed every scan (never cached) and parity must hold
+// across a re-run of the persistent memo.
+func TestCyclomaticMemo_HashlessAndMixed(t *testing.T) {
+	funcs := []fixFunc{
+		{sourceID: "pkg/a.go", nodeID: "pkg/a.go/Hashed", hash: hashFor("h1"), branches: []string{"if_statement", "for_statement"}, startByte: 0, startRow: 0},
+		{sourceID: "pkg/a.go", nodeID: "pkg/a.go/Nil1", hash: nil, branches: []string{"if_statement", "case_clause", "block"}, startByte: 1000, startRow: 50},
+		{sourceID: "pkg/b.go", nodeID: "pkg/b.go/Nil2", hash: nil, branches: []string{"for_statement"}, startByte: 2000, startRow: 100},
+		{sourceID: "pkg/b.go", nodeID: "pkg/b.go/HashedDup", hash: hashFor("h1"), branches: []string{"if_statement", "for_statement"}, startByte: 3000, startRow: 150},
+	}
+	db := buildASTFixture(t, funcs)
+	qg := &sqlDBQuerier{db: db}
+	want, err := runSmellRule(qg, cyclomaticRule(t), "", oracleLimit)
+	require.NoError(t, err)
+
+	memo := newSmellMemo()
+	for run := range 2 {
+		got, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo)
+		require.NoError(t, err)
+		assert.Equalf(t, jsonOrPanic(want), jsonOrPanic(got), "mixed-hash parity failed on run %d", run)
+	}
+	// The two hashless functions are computed on every scan (never cached): 2
+	// per run × 2 runs = 4 hashless computes. The shared h1 subtree is computed
+	// once and cache-hit thereafter.
+	assert.GreaterOrEqual(t, memo.misses, 4, "each hashless occurrence must be (re)computed every scan")
+}
+
+// TestCyclomaticMemo_SourceScoped exercises scanASTFunctions' sourceID!="" WHERE
+// clause: a multi-source fixture scanned scoped to one source must match the
+// scoped full scan byte-for-byte.
+func TestCyclomaticMemo_SourceScoped(t *testing.T) {
+	funcs := []fixFunc{
+		{sourceID: "pkg/a.go", nodeID: "pkg/a.go/A1", hash: hashFor("a1"), branches: []string{"if_statement", "for_statement"}, startByte: 0, startRow: 0},
+		{sourceID: "pkg/a.go", nodeID: "pkg/a.go/A2", hash: hashFor("a2"), branches: []string{"case_clause"}, startByte: 500, startRow: 25},
+		{sourceID: "pkg/b.go", nodeID: "pkg/b.go/B1", hash: hashFor("b1"), branches: []string{"if_statement", "if_statement", "for_statement"}, startByte: 0, startRow: 0},
+	}
+	db := buildASTFixture(t, funcs)
+	qg := &sqlDBQuerier{db: db}
+
+	want, err := runSmellRule(qg, cyclomaticRule(t), "pkg/a.go", oracleLimit)
+	require.NoError(t, err)
+	got, err := runCyclomaticComplexityMemo(qg, "pkg/a.go", oracleLimit, newSmellMemo())
+	require.NoError(t, err)
+	assert.Equal(t, jsonOrPanic(want), jsonOrPanic(got), "source-scoped scan must match")
+	for _, f := range got {
+		assert.Equal(t, "pkg/a.go", f.SourceID, "scoped scan must not leak other sources")
+	}
+}
+
+// TestCyclomaticMemo_NoHashColumn exercises scanASTFunctions' hasHash==false
+// branch: an _ast with NO node_hash column at all (a standalone / non-merkle
+// producer). Every function is computed (nothing cacheable) and parity holds.
+func TestCyclomaticMemo_NoHashColumn(t *testing.T) {
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "nohash.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(`
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL, node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER, end_row INTEGER, end_col INTEGER
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		INSERT INTO _ast VALUES ('s.go/F', 's.go', 'function_declaration', 0, 500, 0, 0, 20, 0);
+		INSERT INTO _ast VALUES ('s.go/F/if', 's.go', 'if_statement', 10, 20, 1, 0, 0, 0);
+		INSERT INTO _ast VALUES ('s.go/F/for', 's.go', 'for_statement', 30, 40, 2, 0, 0, 0);
+		INSERT INTO _ast VALUES ('s.go/G', 's.go', 'method_declaration', 600, 900, 30, 0, 45, 0);
+	`)
+	require.NoError(t, err)
+	qg := &sqlDBQuerier{db: db}
+
+	want, err := runSmellRule(qg, cyclomaticRule(t), "", oracleLimit)
+	require.NoError(t, err)
+	memo := newSmellMemo()
+	got, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo)
+	require.NoError(t, err)
+	assert.Equal(t, jsonOrPanic(want), jsonOrPanic(got), "no-node_hash-column parity must hold")
+	assert.Equal(t, 0, memo.hits, "no node_hash column ⟹ nothing cacheable ⟹ zero cache hits")
 }

--- a/cmd/smell_findings_incremental_test.go
+++ b/cmd/smell_findings_incremental_test.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"crypto/sha256"
+	"database/sql"
+	"fmt"
+	"math/rand"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// mache-238673 phase-1 — the DIFFERENTIAL ORACLE for node_hash-memoized
+// cyclomatic_complexity. THE close condition (per the acceptance amendment):
+// `memoized(db) == full_scan(db)` BYTE-IDENTICAL findings, so a memoization /
+// invalidation bug can only FAIL the test, never pass silently.
+//
+// Why byte-identical is sufficient: cyclomatic_complexity is a PURE-SUBTREE
+// rule — the metric is the count of control-flow descendants of a function, so
+// it is fully determined by the function subtree content = its merkle
+// node_hash. Same hash ⟹ same subtree ⟹ same metric, SOUND BY CONSTRUCTION.
+// The memo caches ONLY the metric (an int64) keyed by node_hash and re-reads
+// every occurrence's span fresh, so a duplicated subtree is computed once and
+// a moved-but-unchanged function keeps its new span. Any divergence from the
+// full scan — stale metric, stale span, dropped occurrence, wrong order — is a
+// bug the oracle catches.
+
+// counted / uncounted are the AST node_kinds the fixture draws branches from.
+// counted MUST stay in sync with cmd/rules/cyclomatic_complexity.json (the
+// oracle catches drift: a memo that counts a different kind set diverges from
+// the rule's own SQL). uncounted kinds appear in the subtree — and thus in the
+// node_hash — but must NOT contribute to the metric, pinning that the memo
+// counts the same subset the rule does.
+var (
+	countedKinds = []string{
+		"if_statement", "for_statement", "case_clause",
+		"expression_case", "type_case", "communication_case", "default_case",
+	}
+	uncountedKinds = []string{
+		"block", "return_statement", "expression_statement", "call_expression",
+	}
+)
+
+// fixFunc is one function occurrence in a synthetic _ast fixture. branches is
+// the ordered list of child node_kinds (both counted and uncounted); it is the
+// function's "content". INVARIANT (enforced by buildASTFixture): two fixFuncs
+// with the same hash MUST have identical branches — that is what makes the
+// fixture an honest model of content-addressing. Two occurrences that share a
+// hash are byte-identical subtrees (a deduped merkle node); occurrences with
+// distinct hashes are distinct content.
+type fixFunc struct {
+	sourceID  string
+	nodeID    string
+	hash      []byte // merkle node_hash of the subtree; nil ⟹ no node_hash (standalone db)
+	branches  []string
+	startByte int
+	startRow  int
+}
+
+// hashFor derives a stable node_hash from a content string. Distinct content
+// strings ⟹ distinct hashes; identical content ⟹ identical hash — the
+// content-addressing invariant the producer guarantees.
+func hashFor(content string) []byte {
+	h := sha256.Sum256([]byte(content))
+	return h[:16]
+}
+
+// buildASTFixture writes an _ast db (with a node_hash column) for the given
+// functions, plus empty node_defs/node_refs so runSmellRule's
+// ensureCanonicalViews probe has real tables to read. It enforces the
+// content-addressing invariant: same hash ⟹ same branches.
+func buildASTFixture(t testing.TB, funcs []fixFunc) *sql.DB {
+	t.Helper()
+
+	// Guard: same hash ⟹ same branch shape, else the fixture lies about
+	// content-addressing and the oracle would be meaningless.
+	byHash := map[string]string{}
+	for _, f := range funcs {
+		if f.hash == nil {
+			continue
+		}
+		key := fmt.Sprintf("%x", f.hash)
+		shape := strings.Join(f.branches, ",")
+		if prev, ok := byHash[key]; ok {
+			require.Equalf(t, prev, shape,
+				"fixture invariant violated: node_hash %s maps to two different branch shapes", key)
+		}
+		byHash[key] = shape
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "incr.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`
+		CREATE TABLE _ast (
+			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL,
+			node_kind TEXT NOT NULL,
+			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL,
+			start_row INTEGER, start_col INTEGER,
+			end_row INTEGER, end_col INTEGER,
+			node_hash BLOB
+		);
+		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
+	`)
+	require.NoError(t, err)
+
+	tx, err := db.Begin()
+	require.NoError(t, err)
+	for _, f := range funcs {
+		_, err := tx.Exec(
+			`INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col, node_hash)
+			 VALUES (?, ?, 'function_declaration', ?, ?, ?, 0, ?, 0, ?)`,
+			f.nodeID, f.sourceID, f.startByte, f.startByte+500, f.startRow, f.startRow+20, f.hash,
+		)
+		require.NoError(t, err)
+		for j, kind := range f.branches {
+			_, err := tx.Exec(
+				`INSERT INTO _ast (node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col)
+				 VALUES (?, ?, ?, ?, ?, ?, 0, 0, 0)`,
+				fmt.Sprintf("%s/branch_%d", f.nodeID, j), f.sourceID, kind,
+				f.startByte+10+j, f.startByte+11+j, f.startRow+1+j,
+			)
+			require.NoError(t, err)
+		}
+	}
+	require.NoError(t, tx.Commit())
+	return db
+}
+
+// cyclomaticRule returns the embedded cyclomatic_complexity rule.
+func cyclomaticRule(t testing.TB) *SmellRule {
+	t.Helper()
+	for _, r := range mustLoadEmbeddedRules() {
+		if r.ID == "cyclomatic_complexity" {
+			return &r
+		}
+	}
+	t.Fatal("cyclomatic_complexity rule not found in embedded ruleset")
+	return nil
+}
+
+const oracleLimit = 100000
+
+// TestCyclomaticMemo_KindsMatchRule pins that the fixture's countedKinds are
+// exactly the kinds the rule's SQL counts — a drift guard so the oracle can't
+// silently stop exercising a kind the rule cares about.
+func TestCyclomaticMemo_KindsMatchRule(t *testing.T) {
+	q := cyclomaticRule(t).Query
+	for _, k := range countedKinds {
+		assert.Containsf(t, q, "'"+k+"'", "rule no longer counts %q — update countedKinds", k)
+	}
+	for _, k := range uncountedKinds {
+		assert.NotContainsf(t, q, "'"+k+"'", "rule now counts %q — it must move to countedKinds", k)
+	}
+}
+
+// TestCyclomaticMemo_DuplicatedSubtrees is oracle case (b): a subtree that
+// occurs N times shares ONE node_hash. The memoized scan must (1) surface all
+// N occurrences byte-identically to the full scan, and (2) compute the metric
+// exactly ONCE for the group (misses==1, hits==N-1) — proving dedup, not just
+// correctness.
+func TestCyclomaticMemo_DuplicatedSubtrees(t *testing.T) {
+	shape := []string{"if_statement", "for_statement", "block", "case_clause"} // metric 3
+	dupHash := hashFor("dup-subtree")
+	var funcs []fixFunc
+	const n = 5
+	for i := range n {
+		funcs = append(funcs, fixFunc{
+			sourceID:  fmt.Sprintf("pkg/f%d.go", i),
+			nodeID:    fmt.Sprintf("pkg/f%d.go/Dup", i),
+			hash:      dupHash,
+			branches:  shape,
+			startByte: i * 1000,
+			startRow:  i * 40,
+		})
+	}
+	// One distinct function so the scan isn't a single group.
+	funcs = append(funcs, fixFunc{
+		sourceID: "pkg/other.go", nodeID: "pkg/other.go/Solo",
+		hash: hashFor("solo"), branches: []string{"if_statement"}, startByte: 99000, startRow: 5000,
+	})
+
+	db := buildASTFixture(t, funcs)
+	qg := &sqlDBQuerier{db: db}
+
+	want, err := runSmellRule(qg, cyclomaticRule(t), "", oracleLimit)
+	require.NoError(t, err)
+
+	memo := newSmellMemo()
+	got, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo)
+	require.NoError(t, err)
+
+	assert.Equal(t, jsonOrPanic(want), jsonOrPanic(got), "memoized findings must be byte-identical to the full scan")
+	assert.Len(t, got, n+1, "all N duplicated occurrences plus the solo must surface")
+	assert.Equal(t, 2, memo.misses, "exactly two distinct node_hashes computed (dup group + solo)")
+	assert.Equal(t, n-1, memo.hits, "the remaining occurrences of the dup group must be cache hits")
+}
+
+// TestCyclomaticMemo_DifferentialOracle_RandomEdits is oracle case (a): a
+// persistent memo carried across a random edit sequence must ALWAYS agree with
+// a fresh full scan of the current db. Edits include add, delete, mutate
+// (content change ⟹ new hash ⟹ recompute) and move (span change, same hash ⟹
+// cache hit but the NEW span must surface). A stale metric, stale span, or
+// dropped occurrence diverges and fails the oracle.
+func TestCyclomaticMemo_DifferentialOracle_RandomEdits(t *testing.T) {
+	rng := rand.New(rand.NewSource(0xC0FFEE))
+	randBranches := func() []string {
+		n := rng.Intn(6)
+		out := make([]string, 0, n)
+		for range n {
+			pool := countedKinds
+			if rng.Intn(3) == 0 {
+				pool = uncountedKinds
+			}
+			out = append(out, pool[rng.Intn(len(pool))])
+		}
+		return out
+	}
+	newFunc := func(id int) fixFunc {
+		br := randBranches()
+		// hash keyed on a unique id + content so distinct funcs get distinct
+		// hashes; a later mutate rekeys the hash from the new content.
+		return fixFunc{
+			sourceID:  fmt.Sprintf("pkg/s%d.go", id%7),
+			nodeID:    fmt.Sprintf("pkg/s%d.go/F%d", id%7, id),
+			hash:      hashFor(fmt.Sprintf("f%d:%s", id, strings.Join(br, ","))),
+			branches:  br,
+			startByte: id * 777,
+			startRow:  id * 13,
+		}
+	}
+
+	funcs := []fixFunc{}
+	nextID := 0
+	for range 6 {
+		funcs = append(funcs, newFunc(nextID))
+		nextID++
+	}
+
+	memo := newSmellMemo()
+	sawHit := false
+	for step := range 60 {
+		switch rng.Intn(4) {
+		case 0: // add
+			funcs = append(funcs, newFunc(nextID))
+			nextID++
+		case 1: // delete
+			if len(funcs) > 0 {
+				i := rng.Intn(len(funcs))
+				funcs = append(funcs[:i], funcs[i+1:]...)
+			}
+		case 2: // mutate content: new branches ⟹ new hash (content-addressing)
+			if len(funcs) > 0 {
+				i := rng.Intn(len(funcs))
+				br := randBranches()
+				funcs[i].branches = br
+				funcs[i].hash = hashFor(fmt.Sprintf("f%s:%s", funcs[i].nodeID, strings.Join(br, ",")))
+			}
+		case 3: // move: same content/hash, new span — metric reused, span must refresh
+			if len(funcs) > 0 {
+				i := rng.Intn(len(funcs))
+				funcs[i].startByte += 100000 + step
+				funcs[i].startRow += 1000 + step
+			}
+		}
+
+		db := buildASTFixture(t, funcs)
+		qg := &sqlDBQuerier{db: db}
+
+		want, err := runSmellRule(qg, cyclomaticRule(t), "", oracleLimit)
+		require.NoErrorf(t, err, "full scan failed at step %d", step)
+
+		before := memo.hits
+		got, err := runCyclomaticComplexityMemo(qg, "", oracleLimit, memo)
+		require.NoErrorf(t, err, "memoized scan failed at step %d", step)
+		if memo.hits > before {
+			sawHit = true
+		}
+
+		assert.Equalf(t, jsonOrPanic(want), jsonOrPanic(got),
+			"memoized diverged from full scan at step %d", step)
+		_ = db.Close()
+	}
+	assert.True(t, sawHit, "the persistent memo must serve at least one cache hit across the edit sequence")
+}

--- a/cmd/smell_incremental.go
+++ b/cmd/smell_incremental.go
@@ -1,0 +1,262 @@
+package cmd
+
+import (
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// mache-238673 phase-1 — content-addressed (node_hash-memoized) evaluation of
+// cyclomatic_complexity, the merkle cash-out that content-addressing was built
+// to enable. Rules currently full-scan every run; this path computes each
+// distinct function subtree's metric ONCE, keyed by its merkle node_hash, and
+// fans the result out to every occurrence.
+//
+// Correctness is sound by construction: cyclomatic_complexity is a PURE-SUBTREE
+// rule (the metric counts a function's own control-flow descendants), so a
+// BLAKE3 content address IS the complete dependency set — same node_hash ⟹ same
+// subtree ⟹ same metric. There is no hand-rolled dependency graph to get wrong.
+// The memo caches ONLY the metric (an int64); every occurrence's SPAN is
+// re-read from _ast each scan, so a function that moved but did not change
+// keeps its new location. See the differential oracle in
+// smell_findings_incremental_test.go — it asserts byte-identical parity with
+// the full scan, so any invalidation bug fails the test rather than passing
+// silently.
+//
+// Phase-1 is deliberately narrow: cyclomatic_complexity only, in-process memo,
+// NO sheaf dependency. A long-lived caller (e.g. a future sheaf-subscribe
+// daemon) holds the memo across scans so an unchanged or duplicated tree is a
+// cache hit — the sub-linear re-run win.
+
+// cyclomaticBranchKinds is the set of control-flow AST node kinds counted for
+// cyclomatic complexity. It MUST match cmd/rules/cyclomatic_complexity.json;
+// the differential oracle (byte-identical vs the rule's own SQL) is the guard
+// against drift.
+var cyclomaticBranchKinds = []string{
+	"if_statement", "for_statement", "case_clause",
+	"expression_case", "type_case", "communication_case", "default_case",
+}
+
+const cyclomaticRuleID = "cyclomatic_complexity"
+
+// smellMemo memoizes pure-subtree rule metrics keyed by merkle node_hash (hex).
+// It is safe to reuse across scans: a hash present in the map was computed from
+// content that (by content-addressing) cannot have changed without changing the
+// hash. hits/misses are per-process counters the tests and bench read to prove
+// the cache is actually load-bearing (a memo that never caches would show zero
+// hits and pass correctness trivially — the oracle asserts hits > 0).
+type smellMemo struct {
+	metric map[string]int64 // node_hash hex → cyclomatic metric
+	hits   int              // occurrences served from the memo without recompute
+	misses int              // distinct subtrees computed this process (cache misses)
+}
+
+func newSmellMemo() *smellMemo {
+	return &smellMemo{metric: make(map[string]int64)}
+}
+
+// astFunc is one function occurrence read from _ast, before its metric is
+// resolved.
+type astFunc struct {
+	sourceID  string
+	nodeID    string
+	hashHex   string // "" when the producer wrote no node_hash (standalone db)
+	startByte int
+	endByte   int
+	startRow  int
+	startCol  int
+}
+
+// runCyclomaticComplexityMemo evaluates cyclomatic_complexity using memo. Its
+// output is byte-identical to runSmellRule(qg, cyclomaticRule, sourceID, limit):
+// the same findings in the same order (metric DESC, source_id, start_byte),
+// truncated to limit. Functions whose node_hash is already memoized skip the
+// branch-count join; functions with no node_hash are always computed (never
+// cached) so correctness never depends on the producer emitting a hash.
+func runCyclomaticComplexityMemo(qg refsQuerier, sourceID string, limit int, memo *smellMemo) ([]smellFinding, error) {
+	funcs, err := scanASTFunctions(qg, sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Decide, per occurrence, whether the metric is already known. Schedule at
+	// most one compute per distinct key: a non-empty node_hash keys the shared
+	// memo; a hashless occurrence keys only itself (no dedup possible).
+	seenThisScan := make(map[string]bool) // node_hash hexes scheduled/available this scan
+	toCompute := make([]astFunc, 0)       // representatives needing the branch-count join
+	local := make(map[string]int64)       // node_id → metric, for hashless occurrences
+	for _, f := range funcs {
+		if f.hashHex != "" {
+			if _, ok := memo.metric[f.hashHex]; ok {
+				memo.hits++
+				continue
+			}
+			if seenThisScan[f.hashHex] {
+				memo.hits++ // duplicate subtree this scan; the representative fills it
+				continue
+			}
+			seenThisScan[f.hashHex] = true
+			toCompute = append(toCompute, f)
+			memo.misses++
+			continue
+		}
+		// No node_hash: cannot dedup or cache — compute this occurrence.
+		toCompute = append(toCompute, f)
+		memo.misses++
+	}
+
+	computed, err := computeCyclomaticMetrics(qg, toCompute)
+	if err != nil {
+		return nil, err
+	}
+	for _, f := range toCompute {
+		m := computed[f.nodeID]
+		if f.hashHex != "" {
+			memo.metric[f.hashHex] = m
+		} else {
+			local[f.nodeID] = m
+		}
+	}
+
+	// Build findings, resolving each occurrence's metric from the memo (hashed)
+	// or the per-occurrence local map (hashless).
+	out := make([]smellFinding, 0, len(funcs))
+	for _, f := range funcs {
+		var m int64
+		if f.hashHex != "" {
+			m = memo.metric[f.hashHex]
+		} else {
+			m = local[f.nodeID]
+		}
+		out = append(out, smellFinding{
+			RuleID:    cyclomaticRuleID,
+			SourceID:  f.sourceID,
+			NodeID:    f.nodeID,
+			StartByte: f.startByte,
+			EndByte:   f.endByte,
+			Line:      f.startRow + 1,
+			Column:    f.startCol + 1,
+			Metric:    m,
+		})
+	}
+
+	// Match the rule's ORDER BY metric DESC, source_id, start_byte. (source_id,
+	// start_byte) is unique per occurrence, so the order is total and
+	// deterministic — a prerequisite for byte-identical parity.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Metric != out[j].Metric {
+			return out[i].Metric > out[j].Metric
+		}
+		if out[i].SourceID != out[j].SourceID {
+			return out[i].SourceID < out[j].SourceID
+		}
+		return out[i].StartByte < out[j].StartByte
+	})
+	if limit >= 0 && len(out) > limit {
+		out = out[:limit]
+	}
+
+	// Parity with runSmellRule (no-op for cyclomatic: spans are already set, so
+	// enrichLocations finds nothing to backfill).
+	if err := enrichLocations(qg, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// scanASTFunctions reads every function/method occurrence from _ast, with its
+// node_hash (when the column exists) and span. Optionally scoped to one source.
+func scanASTFunctions(qg refsQuerier, sourceID string) ([]astFunc, error) {
+	hasHash, err := tableHasColumn(qg, "_ast", "node_hash")
+	if err != nil {
+		return nil, fmt.Errorf("probe _ast.node_hash: %w", err)
+	}
+	hashExpr := "NULL"
+	if hasHash {
+		hashExpr = "node_hash"
+	}
+	q := "SELECT source_id, node_id, " + hashExpr +
+		", start_byte, end_byte, start_row, start_col FROM _ast" +
+		" WHERE node_kind IN ('function_declaration','method_declaration')"
+	args := []any{}
+	if sourceID != "" {
+		q += " AND source_id = ?"
+		args = append(args, sourceID)
+	}
+
+	rows, err := qg.QueryRefs(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("scan _ast functions: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []astFunc
+	for rows.Next() {
+		var (
+			f    astFunc
+			hash []byte
+		)
+		if err := rows.Scan(&f.sourceID, &f.nodeID, &hash, &f.startByte, &f.endByte, &f.startRow, &f.startCol); err != nil {
+			return nil, fmt.Errorf("scan _ast function: %w", err)
+		}
+		if len(hash) > 0 {
+			f.hashHex = hex.EncodeToString(hash)
+		}
+		out = append(out, f)
+	}
+	return out, rows.Err()
+}
+
+// computeCyclomaticMetrics runs the branch-count join for the given function
+// occurrences (representatives of distinct subtrees) and returns node_id →
+// metric. Empty input is a no-op — the whole point of the memo is that a warm
+// re-run schedules nothing.
+func computeCyclomaticMetrics(qg refsQuerier, funcs []astFunc) (map[string]int64, error) {
+	out := make(map[string]int64, len(funcs))
+	if len(funcs) == 0 {
+		return out, nil
+	}
+	kindList := "'" + strings.Join(cyclomaticBranchKinds, "','") + "'"
+	ids := make([]string, len(funcs))
+	for i, f := range funcs {
+		ids[i] = f.nodeID
+	}
+	// Chunk the IN(...) list under SQLite's bound-variable limit.
+	for start := 0; start < len(ids); start += enrichLocChunk {
+		end := min(start+enrichLocChunk, len(ids))
+		batch := ids[start:end]
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(batch)), ",")
+		q := "SELECT fn.node_id, COUNT(branch.node_id) AS metric FROM _ast fn" +
+			" LEFT JOIN _ast branch ON branch.source_id = fn.source_id" +
+			" AND branch.node_id LIKE fn.node_id || '/%'" +
+			" AND branch.node_kind IN (" + kindList + ")" +
+			" WHERE fn.node_id IN (" + placeholders + ")" +
+			" GROUP BY fn.node_id"
+		args := make([]any, len(batch))
+		for i, id := range batch {
+			args[i] = id
+		}
+		rows, err := qg.QueryRefs(q, args...)
+		if err != nil {
+			return nil, fmt.Errorf("compute cyclomatic metrics: %w", err)
+		}
+		for rows.Next() {
+			var (
+				id     string
+				metric int64
+			)
+			if err := rows.Scan(&id, &metric); err != nil {
+				_ = rows.Close()
+				return nil, fmt.Errorf("scan cyclomatic metric: %w", err)
+			}
+			out[id] = metric
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		_ = rows.Close()
+	}
+	return out, nil
+}

--- a/cmd/smell_incremental.go
+++ b/cmd/smell_incremental.go
@@ -46,6 +46,11 @@ const cyclomaticRuleID = "cyclomatic_complexity"
 // hash. hits/misses are per-process counters the tests and bench read to prove
 // the cache is actually load-bearing (a memo that never caches would show zero
 // hits and pass correctness trivially — the oracle asserts hits > 0).
+//
+// NOT safe for concurrent use, and it grows unbounded — a deleted or edited
+// subtree's hash stays resident. Phase-1 callers are single-scan, so neither
+// bites. The phase-2 long-lived concurrent daemon MUST add synchronization and
+// an eviction policy before wiring this in (tracked: mache-a1989b).
 type smellMemo struct {
 	metric map[string]int64 // node_hash hex → cyclomatic metric
 	hits   int              // occurrences served from the memo without recompute
@@ -142,9 +147,12 @@ func runCyclomaticComplexityMemo(qg refsQuerier, sourceID string, limit int, mem
 	}
 
 	// Match the rule's ORDER BY metric DESC, source_id, start_byte. (source_id,
-	// start_byte) is unique per occurrence, so the order is total and
-	// deterministic — a prerequisite for byte-identical parity.
-	sort.Slice(out, func(i, j int) bool {
+	// start_byte) is unique per top-level function/method occurrence, so the
+	// order is total and deterministic — a prerequisite for byte-identical
+	// parity. SliceStable (not Slice) as belt-and-suspenders: if that
+	// uniqueness ever breaks for a new node kind, a stable sort keeps the
+	// truncation boundary predictable rather than arbitrary.
+	sort.SliceStable(out, func(i, j int) bool {
 		if out[i].Metric != out[j].Metric {
 			return out[i].Metric > out[j].Metric
 		}
@@ -157,8 +165,11 @@ func runCyclomaticComplexityMemo(qg refsQuerier, sourceID string, limit int, mem
 		out = out[:limit]
 	}
 
-	// Parity with runSmellRule (no-op for cyclomatic: spans are already set, so
-	// enrichLocations finds nothing to backfill).
+	// Call enrichLocations for exact parity with runSmellRule (which always
+	// calls it). For cyclomatic it backfills nothing meaningful — spans are
+	// already set — EXCEPT a function at byte 0 / row 0 satisfies needsLoc and
+	// gets rewritten with the same zero values, which runSmellRule does too, so
+	// the parity holds either way.
 	if err := enrichLocations(qg, out); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Phase-1 of **mache-238673** (the merkle+sheaf cash-out): content-addressed evaluation of `cyclomatic_complexity`, a pure-subtree rule whose metric is fully determined by the function subtree's merkle `node_hash`. **No sheaf dependency.**

## What
- **`cmd/smell_incremental.go`** — `smellMemo` (`map[node_hash_hex]int64` + hits/misses) and `runCyclomaticComplexityMemo`. Computes each distinct subtree's metric **once**, keyed by `node_hash`, and fans it out to every occurrence. Caches **only the metric** and re-reads spans fresh each scan, so a moved-but-unchanged function keeps its new span. Hashless functions are always computed (never cached) — correctness never depends on the producer emitting a hash.

## Why it's correct (the close condition)
`cyclomatic_complexity` counts a function's own control-flow descendants, so a BLAKE3 content address **is** the complete dependency set — same `node_hash` ⟹ same subtree ⟹ same metric, sound by construction. No hand-rolled dependency graph.

The **differential oracle** (`cmd/smell_findings_incremental_test.go`) is the proof:
- `memoized == full_scan` **byte-identical** across a persistent memo carried through **60 random edits** (add / delete / mutate / **move**) + duplicated subtrees, asserting real cache hits.
- The **move** case (same hash, new span) is the adversarial one — it catches a memo that caches whole findings instead of just the metric.
- Fixture enforces the content-addressing invariant (same hash ⟹ same branch shape) so the oracle can't pass on a lying fixture.
- Plus a drift guard that the counted kinds match `cyclomatic_complexity.json`.

## Performance (`cmd/find_smells_bench_test.go`, 5% distinct subtrees)
| n | FullScan | MemoCold | MemoWarm | warm speedup |
|---|---|---|---|---|
| 1,000 | 45.7 ms | 6.2 ms | 1.26 ms | **36×** |
| 10,000 | 462 ms | 74 ms | 14.2 ms | **33×** |

Warm re-run is the sub-linear win; even cold memo beats full-scan by dedup within a single scan.

## Gates
`go test ./cmd/` green · golangci-lint 0 issues · gofumpt clean · `task smells` 0 NEW.

## Scope / follow-ups
Phase-1 only (cyclomatic, in-process memo, no sheaf). The sheaf-region-recompute arm is gated on an unreleased LLO v0.6.1+ (v0.6.0 doesn't emit the watcher-driven invalidate payload) — tracked on the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)