### PR TITLE
[mache-2350ec] chore(deps): adopt ley-line-open v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-task/task/v3 v3.52.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0 h1:KG/8AT4u6l/CtR5qRtUmpYo0EaSMHihAH+JGIY1CL6I=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.6.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0 h1:9csEr3PhpoKLgrZrIF4FUf4JhwRF4kcuJtk7tLlVAEk=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -790,23 +790,19 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, the daemon binary is v0.5.7 while go.mod's leyline-schema
-// stays at v0.5.5: v0.5.6 and v0.5.7 are BOTH daemon-only LSP fixes with no
-// wire/schema change, so the v0.5.5 Go schema-client decodes a v0.5.7
-// daemon's responses identically.
-//   - v0.5.6: gopls workspace init (workspaceFolders + per-language
-//     initializationOptions).
-//   - v0.5.7: the LSP client now answers server→client requests
-//     (workspace/configuration, window/workDoneProgress/create) — without
-//     this gopls blocked indefinitely and Go enrichment produced 0 hovers;
-//     with it, get_type_info returns real Go hover end-to-end (mache-6584a0).
+// As of this pin, the daemon binary and go.mod's leyline-schema are both
+// v0.7.0 — LLO releases the binary and the Go schema-client in lockstep
+// (SCHEMA_VERSION == BINARY_VERSION in the daemon's version.rs). v0.7.0 raised
+// the daemon's compat_min_schema_version to 0.6.0 and added the source_blobs /
+// capnp_blobs / _ast_pointer tables, the unified daemon.sheaf.invalidate topic
+// (payload key region_ids→invalidated, which mache tolerates by parsing both),
+// and cross-language def/ref extraction with qualified method tokens + Python/
+// JS/TS coverage + populated nodes.source_file — the fidelity fixes that
+// mache's own smell rules first surfaced (ley-line-open-caf423).
 //
 // The major/minor must still match the schema (wire format); only the patch
-// floats. v0.5.7 ships all four leyline-<os>-<arch> daemon binaries
-// (darwin/linux × amd64/arm64). (The release omits the
-// libleyline_fs-darwin-amd64 *staticlib* — same gap as v0.5.0–v0.5.6 — but
-// mache doesn't link the cgo FFI: internal/leyline/client.go is //go:build
-// leyline, off in releases, so the download path is unaffected.)
+// floats. v0.7.0 ships all four leyline-<os>-<arch> daemon binaries
+// (darwin/linux × amd64/arm64).
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets;
 // bump the go.mod leyline-schema pin too whenever the WIRE format changes.
@@ -816,7 +812,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
 // pin by the version-parity gate (mache-b8af69).
-const leylineBinaryVersion = "v0.6.0"
+const leylineBinaryVersion = "v0.7.0"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
Adopts LLO **v0.7.0** (released today). Pins the remote module — no local `replace`/`../`.

## Changes
- `go.mod` leyline-schema pin **v0.6.0 → v0.7.0** (+ `go.sum`).
- `internal/leyline/socket.go` `leylineBinaryVersion` **v0.6.0 → v0.7.0**; refreshed the stale v0.5.7-era doc comment.

## What v0.7.0 brings (relevant to mache)
- **Def/ref extraction gains Python/JS/TS, qualified method tokens (Go+Rust), populated `nodes.source_file`** — the fidelity fixes mache's own smell rules surfaced (`ley-line-open-caf423`, LLO PR #165).
- `compat_min_schema_version` 0.4.1→0.6.0 (mache pins exactly at the floor — handshake OK).
- Unified `daemon.sheaf.invalidate` topic, payload key `region_ids`→`invalidated` (mache tolerates both).
- Additive `source_blobs`/`capnp_blobs`/`_ast_pointer` tables.

## Verification
- `go mod tidy` + `go build ./...` + `go vet` clean; **`task test` green** against the new schema module (no capnp API breakage).
- Installed v0.7.0 daemon parses Go/Rust/Python/JS with qualified tokens + populated `source_file` (verified empirically).

## Follow-up (separate PR)
The v0.7.0 extraction fix **confirmed** `mache-caaae9` rather than obviating it: `duplicate_definitions` still false-positives on Python/JS, and `dead_code` now *runs* (source_file populated) and false-positives on types. Fix incoming on its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)