### PR TITLE
[mache-46af85] fix(build): add go:embed'd assets to build-task sources (no stale binary)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,21 @@ tools/KNOWN_ISSUES.md
 
 # transient OCI build context (release image job + task image:verify)
 /image/
+
+# runtime embedding model cache (fastembed) — regenerated on demand
+**/.fastembed_cache/
+
+# session resume scratch (RESUME.md's own header: gitignore or delete when stale)
+/RESUME.md
+
+# stale README restructure artifacts (the WIP is recoverable from git stash)
+/README.md.bak
+/README.md.diff
+
+# local scratch / probe tools (uncommitted experiments from prior sessions)
+/tools/listchildren-probe/
+/tools/phaseb-validate/
+/tools/sheaf-probe/
+/tools/sheaf-subscribe-probe/
+/tools/sheaf-wire-check/
+/tools/uds-smoke/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -52,6 +52,16 @@ tasks:
       - go.mod
       - go.sum
       - entitlements.plist
+      # go:embed'd assets are baked into the binary — a change to any of them
+      # yields a different binary, but Task's up-to-date check skips the rebuild
+      # unless they're listed here. Omitting them left a STALE binary on a
+      # rule-only edit, which the smell gate (deps:[build]) then ran against —
+      # producing phantom "NEW findings" and masking an incomplete rule fix
+      # (mache-46af85). Keep this list in sync with the //go:embed directives.
+      - "cmd/rules/*.json"
+      - "cmd/schemas/*.json"
+      - "cmd/schemas/sarif.tmpl"
+      - "internal/buildinfo/version.txt"
     generates:
       - "{{.BINARY_NAME}}"
 


### PR DESCRIPTION
Closes the acute half of `mache-46af85` — the stale-binary trap that bit us **twice** this session.

## Bug
The `build` task's `sources:` fingerprinted `**/*.go` + `go.mod`/`go.sum`/`entitlements.plist` — but **not** the `go:embed`'d assets (`cmd/rules/*.json`, `cmd/schemas/*.json`, `cmd/schemas/sarif.tmpl`, `internal/buildinfo/version.txt`). So a **rule-only edit** left Task's up-to-date check unchanged → build **skipped** → the smell gate (`deps:[build]`) ran a **stale binary** with the old embedded rules. Symptoms seen this session: phantom "98 NEW findings" (stale rules vs moved baseline), and a stale binary masking an incomplete `dead_code` fix.

## Fix
Add the embedded assets to `sources`. Verified: a rule content change now forces `task build` to rebuild (was skipped).

## Hygiene (bundled)
The working tree had accumulated cruft fouling `git status`. Gitignored `**/.fastembed_cache/` (runtime model cache), `RESUME.md` (session scratch per its own header), the stale `README.md.bak`/`.diff` (May restructure WIP, recoverable from `git stash`), and `tools/*-probe/` scratch tools. Also resolved a **leftover unresolved `git stash pop` conflict in `README.md`** back to HEAD (it had live conflict markers).

## Remaining (follow-up)
The other half of `mache-46af85` — **dogfood the `_ast`-requiring rules** (`cyclomatic_complexity`, `long_function`, `magic_int_in_comparison`, `duplicate_code`) on mache's own source via a leyline-built `.db` — is now viable with LLO v0.7.0 and tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)