### PR TITLE
[mache-9cd0f5] fix(ci): raise go test -timeout to 20m (macOS integration flake)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -96,7 +96,12 @@ tasks:
   test:
     desc: Run all tests
     cmds:
-      - go test -tags boltdb -race -gcflags=all=-d=checkptr=0 -v ./...
+      # -timeout 20m (go test defaults to 10m/package): the cmd integration
+      # suite runs right at the 10m boundary on the slower macOS CI runner and
+      # intermittently trips `panic: test timed out after 10m0s` (mache-9cd0f5).
+      # This target is the single source CI invokes (ci.yml + integration.yml
+      # both `task test`), so the bump keeps local == CI.
+      - go test -tags boltdb -race -gcflags=all=-d=checkptr=0 -timeout 20m -v ./...
 
   test-coverage:
     desc: Run tests with coverage


### PR DESCRIPTION
Fixes the macOS-integration timeout flake that hit nearly every PR this session.

## Bug
The `cmd` integration suite runs right at go test's **default 10m/package** timeout on the slower macOS CI runner and intermittently trips `panic: test timed out after 10m0s` → `FAIL .../cmd 600s`. It passed on re-run each time (~10m27s), confirming a boundary issue, not a hang.

## Fix
Add `-timeout 20m` to the `task test` command. Both CI jobs (`ci.yml` + `integration.yml`) invoke `task test`, so this **single source keeps local == CI** (taskfile-ci-parity) and gives 2× headroom.

Verified the resolved command (`go test … -timeout 20m -v ./...`) and that CI's `-- -run … ./tests/` args still compose after the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)