### PR TITLE
[mache-466a65] feat(ci): actionlint + yamllint gates, wired 1:1 with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,18 @@ jobs:
       - name: Vet
         run: task vet
 
-      - name: Actions SHA-pin check
-        # Fail if any workflow `uses:` ref isn't SHA-pinned (mache-b8900d).
-        run: task actions:lint
+      - name: Actions lint (actionlint + SHA-pin)
+        # actionlint (workflow semantics + shellcheck of `run:` blocks) plus the
+        # SHA-pin supply-chain gate. Same `task lint:actions` a developer runs
+        # locally (mache-466a65 / mache-b8900d). actionlint runs via `go run`.
+        run: task lint:actions
+
+      - name: YAML lint
+        # yamllint over tracked CI/build YAML (relaxed .yamllint). Same
+        # `task lint:yaml` a developer runs; CI provides the tool (mache-466a65).
+        run: |
+          python3 -m pip install --quiet yamllint
+          task lint:yaml
 
       - name: Docs lint
         # Fail if a top-level doc's covers-version drifts from the latest

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+# yamllint config for mache CI/build YAML (mache-466a65). Style rules that add
+# noise without catching real bugs are disabled; actionlint handles workflow
+# semantics + shellcheck. yamllint enforces structural validity + basic hygiene.
+extends: relaxed
+rules:
+  line-length: disable
+  document-start: disable
+  comments: disable
+  truthy: disable
+ignore: |
+  /testdata/
+  /packages/
+  /image/
+  /node_modules/
+  /.task/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -399,6 +399,27 @@ tasks:
     cmds:
       - bash scripts/actions-pin-lint.sh
 
+  lint:actions:
+    desc: "Lint GitHub Actions workflows — actionlint (semantics + shellcheck) + the SHA-pin gate (mache-466a65)"
+    deps: [actions:lint]
+    cmds:
+      # actionlint: prefer an installed binary (fast local dev), else `go run`
+      # the pinned module — go-toolchain-safe, so CI needs no separate install.
+      - >-
+        command -v actionlint >/dev/null 2>&1 && actionlint
+        || go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+
+  lint:yaml:
+    desc: "Lint tracked CI/build YAML with yamllint (relaxed .yamllint config; mache-466a65)"
+    cmds:
+      # Guard (gate-preflight): require yamllint, with an install hint. Lint only
+      # TRACKED yaml (excludes gitignored scratch + testdata fixtures by
+      # construction) so the gate is stable regardless of local scratch.
+      - >-
+        command -v yamllint >/dev/null 2>&1
+        || { echo "yamllint required — install: pip install yamllint"; exit 1; };
+        git ls-files '*.yml' '*.yaml' | grep -vE 'testdata/' | xargs yamllint -c .yamllint
+
   smells:
     desc: "Structural smell gate — fail on NEW findings vs docs/smell-baseline.json (W5 local-first gate, mache-4da90e)"
     deps: [build]
@@ -525,7 +546,8 @@ tasks:
       - task: test
       - task: validate
       - task: docs:lint
-      - task: actions:lint
+      - task: lint:actions
+      - task: lint:yaml
       - task: smells
       - task: gates:preflight
       - task: gen:server-json:check
@@ -550,7 +572,8 @@ tasks:
       - task: test
       - task: validate
       - task: docs:lint
-      - task: actions:lint
+      - task: lint:actions
+      - task: lint:yaml
       - task: smells
       - task: gates:preflight
       - task: gen:server-json:check


### PR DESCRIPTION
The repo linted Go but not its own **CI/build YAML** — a malformed workflow or drifted action only surfaced when CI itself broke. Adds real linting, wired per the taskfile-ci-parity discipline (CI invokes the task target; no re-implemented commands).

## Targets
- **`lint:actions`** — `actionlint` (workflow semantics + shellcheck of `run:` blocks) via `command -v` guard else `go run` (CI-portable, no separate install), composed with the existing SHA-pin gate (`actions:lint`).
- **`lint:yaml`** — `yamllint` over **tracked** CI/build YAML only (`git ls-files`, so gitignored scratch + `testdata/` fixtures are excluded by construction), with a relaxed `.yamllint` (style noise off; actionlint owns workflow semantics). **0 issues** on the current 15 tracked files.
- Both folded into **`task check`** *and* **`task ci`** (the pre-push gate).

## CI
Upgraded the "Actions SHA-pin check" step to `task lint:actions` (now real actionlint too) and added a "YAML lint" step (`pip install yamllint` + `task lint:yaml`).

## Verified
`gates:preflight` OK (both targets' external tools guarded) · `actionlint` clean on all workflows incl. this edit · `yamllint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)