### PR TITLE
[mache-46af85] feat(leyline): use ONLY the pinned leyline version (SHA-verified downloads)

### DIFF
--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -1,0 +1,103 @@
+package leyline
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// leylinePinnedSHA256 pins the SHA-256 of each ley-line-open release asset for
+// leylineBinaryVersion, keyed "<GOOS>-<GOARCH>". mache verifies every
+// DOWNLOADED leyline against this: the binary it runs must be byte-identical to
+// the published pinned release, the same supply-chain posture the repo already
+// enforces for GitHub Actions (task actions:lint). It is intentionally NOT
+// applied to a PATH/cached binary — codesigning (macOS) mutates the Mach-O, so a
+// legitimately-installed local copy of the pinned version has a different whole-
+// file hash; those candidates are gated by version instead (see
+// leylineVersionMatchesPin).
+//
+// Regenerate on a leylineBinaryVersion bump:
+//
+//	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
+//	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
+var leylinePinnedSHA256 = map[string]string{
+	"darwin-amd64": "190d1a6e4c5c963670332679f7521c7131578fc85b3990d92425b712d7af5813",
+	"darwin-arm64": "ba26429d5ec11d5e4f51312ce3f3da544a64f59f27d85e170093282e010a29a2",
+	"linux-amd64":  "0b7f82f1baf9625d9918ec43ce2143c88f5f3307e69bd125ac37d28c12655cc7",
+	"linux-arm64":  "9bda95a0d5c2dcd949d9ea48c747950ff536af3a243c9dc1cc22af7e678c34ed",
+}
+
+// leylineVersionMatchesPin runs `<path> --version` and reports whether the
+// binary's major.minor equals leylineBinaryVersion's. Patch floats — per the
+// pin contract, major.minor is the wire/schema surface, and a patch bump is a
+// daemon-only fix (see the leylineBinaryVersion doc). A binary that won't run or
+// whose version can't be parsed does NOT match: mache must refuse an
+// unverifiable leyline rather than let a wrong-version parse silently diverge
+// from CI. This is the guard against "never use the local version / a raw-main
+// build" — only the pinned version is accepted.
+func leylineVersionMatchesPin(path string) bool {
+	out, err := exec.Command(path, "--version").Output()
+	if err != nil {
+		return false
+	}
+	got := extractSemver(string(out))
+	if got == "" {
+		return false
+	}
+	want := parseSemverParts(leylineBinaryVersion)
+	have := parseSemverParts(got)
+	return want[0] == have[0] && want[1] == have[1]
+}
+
+// extractSemver pulls the first "MAJOR.MINOR[.PATCH]" token from a version line
+// such as "leyline 0.7.0 (open)". Returns "" when none is present.
+func extractSemver(s string) string {
+	for tok := range strings.FieldsSeq(s) {
+		t := strings.TrimPrefix(tok, "v")
+		i := strings.IndexByte(t, '.')
+		if i <= 0 {
+			continue
+		}
+		allDigits := true
+		for _, r := range t[:i] {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			return t
+		}
+	}
+	return ""
+}
+
+// verifyLeylineSHA256 checks that the file at path hashes to the pinned SHA-256
+// for the current platform. An unknown platform (no pin) is an error — refuse to
+// trust a binary we can't verify rather than proceed.
+func verifyLeylineSHA256(path string) error {
+	key := runtime.GOOS + "-" + runtime.GOARCH
+	want, ok := leylinePinnedSHA256[key]
+	if !ok {
+		return fmt.Errorf("no pinned leyline SHA-256 for platform %s (leyline %s)", key, leylineBinaryVersion)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	if got := hex.EncodeToString(h.Sum(nil)); got != want {
+		return fmt.Errorf("leyline download SHA-256 mismatch for %s: got %s, pinned %s (leyline %s) — refusing a binary that is not the published pinned release",
+			key, got, want, leylineBinaryVersion)
+	}
+	return nil
+}

--- a/internal/leyline/binary_pin_test.go
+++ b/internal/leyline/binary_pin_test.go
@@ -1,0 +1,125 @@
+package leyline
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pinLeylineSHA pins content's SHA-256 as the leyline release pin for the
+// current platform for the duration of the test (restored on cleanup). Lets
+// download tests serve arbitrary bytes and still pass verifyLeylineSHA256.
+func pinLeylineSHA(t *testing.T, content []byte) {
+	t.Helper()
+	sum := sha256.Sum256(content)
+	key := runtime.GOOS + "-" + runtime.GOARCH
+	orig, had := leylinePinnedSHA256[key]
+	leylinePinnedSHA256[key] = hex.EncodeToString(sum[:])
+	t.Cleanup(func() {
+		if had {
+			leylinePinnedSHA256[key] = orig
+		} else {
+			delete(leylinePinnedSHA256, key)
+		}
+	})
+}
+
+// mache-46af85 — mache must use ONLY the pinned leyline version. A wrong-version
+// leyline on PATH (the recurring "0.5.7 shadows the pin" trap, or a raw-main
+// build) produces different _ast output than the pinned release and silently
+// diverges local runs from CI. These tests capture that: ResolveBinary rejects a
+// non-pinned PATH binary, and accepts a pinned one.
+
+// writeLeylineStub writes an executable stub that reports versionLine on
+// `--version`, and returns its path.
+func writeLeylineStub(t *testing.T, dir, versionLine string) string {
+	t.Helper()
+	p := filepath.Join(dir, "leyline")
+	// #!/bin/sh is an absolute interpreter path, so it runs even with PATH
+	// stripped to just `dir`.
+	require.NoError(t, os.WriteFile(p, []byte("#!/bin/sh\necho '"+versionLine+"'\n"), 0o755))
+	return p
+}
+
+// hermeticEnv points HOME at an empty temp dir (so ~/.mache/bin/leyline can't
+// leak in) and PATH at only pathDir.
+func hermeticEnv(t *testing.T, pathDir string) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", pathDir)
+}
+
+func TestExtractSemver(t *testing.T) {
+	cases := map[string]string{
+		"leyline 0.7.0 (open)": "0.7.0",
+		"leyline v0.7.0":       "0.7.0",
+		"leyline 0.5.7 (open)": "0.5.7",
+		"0.6.0":                "0.6.0",
+		"no version here":      "",
+		"":                     "",
+	}
+	for in, want := range cases {
+		assert.Equalf(t, want, extractSemver(in), "extractSemver(%q)", in)
+	}
+}
+
+func TestLeylineVersionMatchesPin(t *testing.T) {
+	pin := strings.TrimPrefix(leylineBinaryVersion, "v") // e.g. "0.7.0"
+	dir := t.TempDir()
+
+	match := writeLeylineStub(t, filepath.Join(mustMkdir(t, dir, "ok")), "leyline "+pin+" (open)")
+	assert.True(t, leylineVersionMatchesPin(match), "the pinned version must match")
+
+	wrong := writeLeylineStub(t, filepath.Join(mustMkdir(t, dir, "old")), "leyline 0.5.7 (open)")
+	assert.False(t, leylineVersionMatchesPin(wrong), "a wrong version must NOT match")
+
+	garbage := writeLeylineStub(t, filepath.Join(mustMkdir(t, dir, "junk")), "not a version")
+	assert.False(t, leylineVersionMatchesPin(garbage), "unparseable output must NOT match")
+
+	assert.False(t, leylineVersionMatchesPin(filepath.Join(dir, "does-not-exist")),
+		"a non-existent binary must NOT match")
+}
+
+func TestResolveBinary_RejectsWrongVersionOnPath(t *testing.T) {
+	dir := t.TempDir()
+	writeLeylineStub(t, dir, "leyline 0.5.7 (open)") // wrong version on PATH
+	hermeticEnv(t, dir)
+
+	got, err := ResolveBinary(false) // no download
+	require.Error(t, err, "a wrong-version PATH leyline must be rejected, not returned")
+	assert.NotEqual(t, filepath.Join(dir, "leyline"), got, "must not return the wrong-version binary")
+	assert.Contains(t, err.Error(), leylineBinaryVersion, "error should name the pinned version")
+}
+
+func TestResolveBinary_AcceptsPinnedVersionOnPath(t *testing.T) {
+	dir := t.TempDir()
+	pin := strings.TrimPrefix(leylineBinaryVersion, "v")
+	writeLeylineStub(t, dir, "leyline "+pin+" (open)") // pinned version on PATH
+	hermeticEnv(t, dir)
+
+	got, err := ResolveBinary(false)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(dir, "leyline"), got, "the pinned PATH leyline must be used")
+}
+
+func TestVerifyLeylineSHA256_RejectsBadContent(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "leyline")
+	require.NoError(t, os.WriteFile(f, []byte("not the published leyline binary"), 0o755))
+	// On a pinned platform this is a hash mismatch; on an unknown platform it's a
+	// missing-pin error. Either way, an unverifiable binary must be refused.
+	require.Error(t, verifyLeylineSHA256(f))
+}
+
+func mustMkdir(t *testing.T, base, name string) string {
+	t.Helper()
+	p := filepath.Join(base, name)
+	require.NoError(t, os.MkdirAll(p, 0o755))
+	return p
+}

--- a/internal/leyline/resolve_binary_test.go
+++ b/internal/leyline/resolve_binary_test.go
@@ -5,18 +5,25 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// TestResolveBinary_FindsOnPath returns the PATH-resolved binary without
-// downloading, even when download is allowed.
+// pinnedVersionLine is the `leyline --version` line a stub must print to be
+// accepted as the pinned version (mache-46af85).
+func pinnedVersionLine() string {
+	return "leyline " + strings.TrimPrefix(leylineBinaryVersion, "v") + " (open)"
+}
+
+// TestResolveBinary_FindsOnPath returns a PATH leyline WHEN it reports the
+// pinned version, without downloading, even when download is allowed.
 func TestResolveBinary_FindsOnPath(t *testing.T) {
 	dir := t.TempDir()
 	fake := filepath.Join(dir, "leyline")
-	require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(fake, []byte("#!/bin/sh\necho '"+pinnedVersionLine()+"'\n"), 0o755))
 	t.Setenv("PATH", dir)
 	t.Setenv("HOME", t.TempDir())
 
@@ -25,34 +32,33 @@ func TestResolveBinary_FindsOnPath(t *testing.T) {
 	assert.Equal(t, fake, got)
 }
 
-// TestResolveBinary_FindsBundled falls back to ~/.mache/bin/leyline when not
-// on PATH, still without downloading.
+// TestResolveBinary_FindsBundled falls back to ~/.mache/bin/leyline (reporting
+// the pinned version) when not on PATH, still without downloading.
 func TestResolveBinary_FindsBundled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("PATH", t.TempDir()) // no leyline on PATH
 	t.Setenv("HOME", home)
 	bundled := filepath.Join(home, ".mache", "bin", "leyline")
 	require.NoError(t, os.MkdirAll(filepath.Dir(bundled), 0o755))
-	require.NoError(t, os.WriteFile(bundled, []byte("#!/bin/sh\n"), 0o755))
+	require.NoError(t, os.WriteFile(bundled, []byte("#!/bin/sh\necho '"+pinnedVersionLine()+"'\n"), 0o755))
 
 	got, err := ResolveBinary(true)
 	require.NoError(t, err)
 	assert.Equal(t, bundled, got)
 }
 
-// TestResolveBinary_NoDownloadWhenDisallowed errors (no network) when the
-// binary is absent and allowDownload is false.
+// TestResolveBinary_NoDownloadWhenDisallowed errors (no network) when no pinned
+// leyline is present and allowDownload is false; the error names the pin.
 func TestResolveBinary_NoDownloadWhenDisallowed(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 
 	_, err := ResolveBinary(false)
 	require.Error(t, err)
-	assert.NotContains(t, err.Error(), "download", "must not attempt a download when disallowed")
+	assert.Contains(t, err.Error(), leylineBinaryVersion, "error should name the pinned version it needs")
 }
 
-// TestResolveBinary_NoLeylineEnvSkipsDownload honors MACHE_NO_LEYLINE: no
-// download is attempted even when allowDownload is true.
+// TestResolveBinary_NoLeylineEnvSkipsDownload honors MACHE_NO_LEYLINE.
 func TestResolveBinary_NoLeylineEnvSkipsDownload(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
@@ -63,18 +69,23 @@ func TestResolveBinary_NoLeylineEnvSkipsDownload(t *testing.T) {
 	assert.Contains(t, err.Error(), "MACHE_NO_LEYLINE")
 }
 
-// TestResolveBinary_DownloadsWhenMissing fetches the pinned binary to
-// ~/.mache/bin when absent and allowed. Hermetic: swaps the release URL for a
-// local httptest server, so no network is touched.
+// TestResolveBinary_DownloadsWhenMissing fetches the pinned binary when absent
+// and allowed, and SHA-verifies the download. Hermetic: swaps the release URL
+// for an httptest server AND injects the served content's SHA-256 into the pin
+// map for this platform, so no network is touched and the supply-chain check
+// exercises its accept path.
 func TestResolveBinary_DownloadsWhenMissing(t *testing.T) {
+	content := []byte("#!/bin/sh\necho fake-leyline\n")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte("#!/bin/sh\necho fake-leyline\n"))
+		_, _ = w.Write(content)
 	}))
 	defer srv.Close()
 
 	orig := leylineReleaseURLTemplate
 	leylineReleaseURLTemplate = srv.URL + "/%s/%s"
 	defer func() { leylineReleaseURLTemplate = orig }()
+
+	pinLeylineSHA(t, content) // accept the served payload's SHA hermetically
 
 	home := t.TempDir()
 	t.Setenv("PATH", t.TempDir()) // no leyline on PATH
@@ -88,4 +99,24 @@ func TestResolveBinary_DownloadsWhenMissing(t *testing.T) {
 	fi, err := os.Stat(got)
 	require.NoError(t, err, "downloaded leyline must exist")
 	assert.NotZero(t, fi.Mode()&0o111, "downloaded leyline must be executable")
+}
+
+// TestResolveBinary_RejectsTamperedDownload proves the SHA-pin blocks a download
+// whose bytes don't match the pinned release (supply-chain).
+func TestResolveBinary_RejectsTamperedDownload(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("tampered payload not matching the pinned SHA"))
+	}))
+	defer srv.Close()
+	orig := leylineReleaseURLTemplate
+	leylineReleaseURLTemplate = srv.URL + "/%s/%s"
+	defer func() { leylineReleaseURLTemplate = orig }()
+
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("MACHE_NO_LEYLINE", "")
+
+	_, err := ResolveBinary(true)
+	require.Error(t, err, "a download not matching the pinned SHA-256 must be rejected")
+	assert.Contains(t, err.Error(), "SHA-256")
 }

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -846,8 +846,16 @@ var leylineReleaseURLTemplate = "https://github.com/agentic-research/ley-line-op
 // allowDownload is false, or when MACHE_NO_LEYLINE is set (the CI/offline
 // opt-out). A downloaded binary is cached at ~/.mache/bin/leyline for reuse.
 func ResolveBinary(allowDownload bool) (string, error) {
+	// A leyline on PATH is used ONLY if it is the pinned version. A stale local
+	// install (the recurring "0.5.7 shadows the pin" trap) or a raw-main build
+	// reports a different version and produces different _ast output than the
+	// pinned release — silently diverging local runs from CI. Reject it and fall
+	// through rather than trust whatever happens to be on PATH.
 	if p, err := exec.LookPath("leyline"); err == nil {
-		return p, nil
+		if leylineVersionMatchesPin(p) {
+			return p, nil
+		}
+		log.Printf("leyline on PATH (%s) is not the pinned %s — ignoring it; resolving the pinned binary", p, leylineBinaryVersion)
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -855,13 +863,16 @@ func ResolveBinary(allowDownload bool) (string, error) {
 	}
 	bundled := filepath.Join(home, ".mache", "bin", "leyline")
 	if _, err := os.Stat(bundled); err == nil {
-		return bundled, nil
+		if leylineVersionMatchesPin(bundled) {
+			return bundled, nil
+		}
+		log.Printf("cached leyline (%s) is not the pinned %s — re-resolving", bundled, leylineBinaryVersion)
 	}
 	if !allowDownload {
-		return "", fmt.Errorf("leyline not on PATH and not at %s", bundled)
+		return "", fmt.Errorf("no leyline matching the pinned %s found on PATH or at %s (auto-download disabled)", leylineBinaryVersion, bundled)
 	}
 	if os.Getenv("MACHE_NO_LEYLINE") != "" {
-		return "", fmt.Errorf("leyline not available and MACHE_NO_LEYLINE is set; install leyline or unset MACHE_NO_LEYLINE to auto-download")
+		return "", fmt.Errorf("no leyline matching the pinned %s available and MACHE_NO_LEYLINE is set; install leyline %s or unset MACHE_NO_LEYLINE to auto-download", leylineBinaryVersion, leylineBinaryVersion)
 	}
 	return downloadLeyline(bundled)
 }
@@ -916,6 +927,13 @@ func downloadLeyline(destPath string) (string, error) {
 		return "", fmt.Errorf("write: %w", err)
 	}
 	_ = tmp.Close()
+
+	// Supply-chain integrity: the downloaded bytes must match the pinned
+	// release SHA-256 before we install or run them (mache-46af85).
+	if err := verifyLeylineSHA256(tmpPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", err
+	}
 
 	// Make executable
 	if err := os.Chmod(tmpPath, 0o755); err != nil {

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -718,6 +718,7 @@ func swapLeylineReleaseURLTemplate(t *testing.T, replacement string) {
 // uncovered in PR #388; this test closes that gap hermetically.
 func TestDownloadLeyline_HappyPath(t *testing.T) {
 	const wantBody = "fake-leyline-binary-payload"
+	pinLeylineSHA(t, []byte(wantBody)) // accept the served payload's SHA (mache-46af85)
 
 	var gotPath string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
`ResolveBinary` returned the first `leyline` on `PATH` (or the `~/.mache` cache) with **no version check** — so a stale local install (the recurring "0.5.7 shadows the pin" trap) or a raw-main build silently produced different `_ast` output than the pinned release, diverging local runs from CI.

## Fix
- **PATH/cached** candidates are accepted only if `--version` reports `leylineBinaryVersion`'s major.minor (patch floats). Wrong version → rejected; mache resolves the pin instead. *Version-check, not whole-file SHA — codesigning mutates the macOS Mach-O, so a legit local codesigned copy of the pinned version has a different hash.*
- **Downloads** are **SHA-256-verified** against pinned per-OS/arch release checksums (`leylinePinnedSHA256`) before install — the same supply-chain posture the repo enforces for SHA-pinned GitHub Actions.
- **Tests capture the bug**: a wrong-version PATH leyline is rejected (not returned), the pinned one is accepted, a tampered/wrong download is rejected.

Regenerate SHAs on a `leylineBinaryVersion` bump (documented in `binary_pin.go`).

## Split note
The `_ast`-dogfood work that shared this branch was split off (baseline isn't yet reproducible across darwin/linux — tracked separately). This PR is the version/SHA-pin only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)