### PR TITLE
[mache-2350ec] chore(deps): adopt ley-line-open v0.7.1 (sheaf-correctness patch)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.1
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.0
 	github.com/go-task/task/v3 v3.52.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0 h1:9csEr3PhpoKLgrZrIF4FUf4JhwRF4kcuJtk7tLlVAEk=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.1 h1:2s8fA+9BZVF5uWh2U+2EzH9bAvfYgUpp9cDU6DmoXBQ=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -26,10 +26,10 @@ import (
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "190d1a6e4c5c963670332679f7521c7131578fc85b3990d92425b712d7af5813",
-	"darwin-arm64": "ba26429d5ec11d5e4f51312ce3f3da544a64f59f27d85e170093282e010a29a2",
-	"linux-amd64":  "0b7f82f1baf9625d9918ec43ce2143c88f5f3307e69bd125ac37d28c12655cc7",
-	"linux-arm64":  "9bda95a0d5c2dcd949d9ea48c747950ff536af3a243c9dc1cc22af7e678c34ed",
+	"darwin-amd64": "3074ca3457a104bfd6d897f608f89df52faacc905450fba0cd949a76d3d9296b",
+	"darwin-arm64": "55cd54d917bedf2a1bfc5175d67d6c38acca3f8067feaff7d70ae5cb0a0bcd12",
+	"linux-amd64":  "884f7526134f8f914a01c8c8581bc87258eedef0482a19dabe47f5d336e4ad90",
+	"linux-arm64":  "cddcd0743194efc911c9e5ce0fb0f24ec5d493548e7e1ec9b50430b12327136e",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -791,18 +791,20 @@ func (c *SocketClient) Prioritize(files []string) error {
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
 // As of this pin, the daemon binary and go.mod's leyline-schema are both
-// v0.7.0 — LLO releases the binary and the Go schema-client in lockstep
+// v0.7.1 — LLO releases the binary and the Go schema-client in lockstep
 // (SCHEMA_VERSION == BINARY_VERSION in the daemon's version.rs). v0.7.0 raised
-// the daemon's compat_min_schema_version to 0.6.0 and added the source_blobs /
-// capnp_blobs / _ast_pointer tables, the unified daemon.sheaf.invalidate topic
-// (payload key region_ids→invalidated, which mache tolerates by parsing both),
-// and cross-language def/ref extraction with qualified method tokens + Python/
-// JS/TS coverage + populated nodes.source_file — the fidelity fixes that
-// mache's own smell rules first surfaced (ley-line-open-caf423).
+// the daemon's compat_min_schema_version to 0.6.0 and added source_blobs /
+// capnp_blobs / _ast_pointer, the unified daemon.sheaf.invalidate topic (payload
+// key region_ids→invalidated, tolerated by parsing both), and cross-language
+// def/ref extraction (qualified method tokens + Python/JS/TS + populated
+// nodes.source_file, ley-line-open-caf423). v0.7.1 is a WIRE-UNCHANGED sheaf-
+// correctness patch (δ⁰ orientation-invariance, cascade fixed-point, threshold
+// in norm space, stalks-store-rates) — consumers get more accurate invalidation
+// sets, no client changes required.
 //
 // The major/minor must still match the schema (wire format); only the patch
-// floats. v0.7.0 ships all four leyline-<os>-<arch> daemon binaries
-// (darwin/linux × amd64/arm64).
+// floats — so version-check (leylineVersionMatchesPin) accepts any 0.7.x. v0.7.1
+// ships all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64).
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets;
 // bump the go.mod leyline-schema pin too whenever the WIRE format changes.
@@ -812,7 +814,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
 // pin by the version-parity gate (mache-b8af69).
-const leylineBinaryVersion = "v0.7.0"
+const leylineBinaryVersion = "v0.7.1"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
Bumps the leyline pin **v0.7.0 → v0.7.1**. Remote pin, no local `replace`.

## Changes
- `go.mod` leyline-schema **v0.7.0 → v0.7.1** (+ `go.sum`).
- `internal/leyline/socket.go` `leylineBinaryVersion` → v0.7.1 + refreshed comment.
- `internal/leyline/binary_pin.go` `leylinePinnedSHA256` → the four v0.7.1 release digests.

## What v0.7.1 is
A **wire-unchanged sheaf-correctness patch** (math-friend audit) — no client code needed:
- δ⁰ orientation-invariance (a `<= EPS` signed filter passed severe violations)
- cascade fixed-point (a hardcoded depth-3 cap **under-invalidated** mache's Louvain topologies of diameter > 3)
- δ⁰ threshold moved to norm space; sheaf stalks store rates not raw counts

Net: more accurate invalidation sets — directly improves the substrate the dataflow/sheaf direction (ADR-0024) rides on.

Verified: `go build`, `go test ./internal/leyline/` (the version-pin tests), `go vet` clean; module resolves the remote v0.7.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)