### PR TITLE
[mache-3dde13] chore(leyline): pin ley-line-open v0.7.5 (SHA-verified)

### DIFF
--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -26,10 +26,10 @@ import (
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "3074ca3457a104bfd6d897f608f89df52faacc905450fba0cd949a76d3d9296b",
-	"darwin-arm64": "55cd54d917bedf2a1bfc5175d67d6c38acca3f8067feaff7d70ae5cb0a0bcd12",
-	"linux-amd64":  "884f7526134f8f914a01c8c8581bc87258eedef0482a19dabe47f5d336e4ad90",
-	"linux-arm64":  "cddcd0743194efc911c9e5ce0fb0f24ec5d493548e7e1ec9b50430b12327136e",
+	"darwin-amd64": "63ba1c9e3559ecb8d492e3e6ed3fabce98a634c6048943c9ef9a45b49432a2a0",
+	"darwin-arm64": "7e6182b16324aa33e43c039d274440b8e9a2c84b8ba8a2a5dce385123003fae1",
+	"linux-amd64":  "3a75973d9ef89a3f1a89ef2d29fdc3d2f0da8345d572981812830ac9bf26bab4",
+	"linux-arm64":  "191e0ee872e095791f8d2f22c019832bcf73b28e6921c960b858d0b97433e69f",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -790,31 +790,45 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, the daemon binary and go.mod's leyline-schema are both
-// v0.7.1 — LLO releases the binary and the Go schema-client in lockstep
-// (SCHEMA_VERSION == BINARY_VERSION in the daemon's version.rs). v0.7.0 raised
-// the daemon's compat_min_schema_version to 0.6.0 and added source_blobs /
-// capnp_blobs / _ast_pointer, the unified daemon.sheaf.invalidate topic (payload
-// key region_ids→invalidated, tolerated by parsing both), and cross-language
-// def/ref extraction (qualified method tokens + Python/JS/TS + populated
-// nodes.source_file, ley-line-open-caf423). v0.7.1 is a WIRE-UNCHANGED sheaf-
-// correctness patch (δ⁰ orientation-invariance, cascade fixed-point, threshold
-// in norm space, stalks-store-rates) — consumers get more accurate invalidation
-// sets, no client changes required.
+// As of this pin, the daemon binary is v0.7.5 while go.mod's leyline-schema
+// stays v0.7.1 — deliberately. The 0.7.1→0.7.5 daemon bumps are all
+// WIRE-UNCHANGED (wire_format_major=1, compat_min_schema_version stays 0.6.0):
+// v0.7.2 added the additive, node_hash-keyed _cfg / _cfg_edge tables (the
+// analysis-substrate CFG scaffold — schema only; row population is deferred to
+// LLO ley-line-open-a0fadd, so the tables come up empty on parse) and fixed the
+// ingest walker to honor .gitignore (LLO PR #178); v0.7.3 was a confinement /
+// cloister fix (v1 BLAKE3 digest); v0.7.4 added the additive node_refs
+// container_node_id column (nearest enclosing def), which closes mache's
+// ref-based smell-rule parity (fan_out_skew / untested_function — bead
+// ley-line-open-b9d1d5); v0.7.5 added the arena-owner sentinel (kills the
+// cross-repo cache-pollution class) and the additive node_defs.canonical_kind
+// column (closed κ vocabulary — lets dead_code filter WHERE canonical_kind IN
+// ('function','method','type'), collapsing its leyline over-report). All
+// additive — mache does not consume the new columns / CFG types yet (that is
+// the LLO-only smell-gate consolidation, mache-608a3c), and the v0.7.2–v0.7.5
+// leyline-schema Go submodule tags are unpublished (clients/go/leyline-schema
+// stops at v0.7.1), so the schema-client pin remains at v0.7.1. The
+// version-parity gate (mache-b8af69) enforces MAJOR.MINOR agreement only —
+// 0.7 == 0.7 — so this is in contract. Earlier context: v0.7.0 raised compat_min
+// to 0.6.0 and added source_blobs / capnp_blobs / _ast_pointer, the unified
+// daemon.sheaf.invalidate topic, and cross-language def/ref extraction
+// (ley-line-open-caf423); v0.7.1 was a sheaf-correctness patch (δ⁰
+// orientation-invariance, cascade fixed-point).
 //
 // The major/minor must still match the schema (wire format); only the patch
-// floats — so version-check (leylineVersionMatchesPin) accepts any 0.7.x. v0.7.1
+// floats — so version-check (leylineVersionMatchesPin) accepts any 0.7.x. v0.7.5
 // ships all four leyline-<os>-<arch> daemon binaries (darwin/linux × amd64/arm64).
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets;
-// bump the go.mod leyline-schema pin too whenever the WIRE format changes.
+// bump the go.mod leyline-schema pin too whenever the WIRE format changes (i.e.
+// wire_format_major or the major.minor moves — a patch-only daemon bump does not).
 //
 // Doubles as this build's leyline schema-client version for the startup
 // wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
 // pin by the version-parity gate (mache-b8af69).
-const leylineBinaryVersion = "v0.7.1"
+const leylineBinaryVersion = "v0.7.5"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private


### PR DESCRIPTION
## What

Bump the pinned ley-line-open daemon binary **v0.7.1 → v0.7.5** (latest published) + refresh the four platform SHA-256s. (Tracked v0.7.2 → v0.7.5 as LLO shipped, per the pin's "latest published release" contract.)

## Why v0.7.5

All 0.7.1→0.7.5 daemon bumps are **wire-unchanged** (`wire_format_major=1`, `compat_min` stays `0.6.0`); cumulative additive gains:
- **v0.7.2**: `_cfg`/`_cfg_edge` scaffold (schema only) + ingest honors `.gitignore`.
- **v0.7.3**: confinement/BLAKE3 fix.
- **v0.7.4**: `node_refs.container_node_id` (nearest enclosing def) — closes ref-based smell-rule parity (verified: `GROUP BY container_node_id` reproduces `fan_out_skew`).
- **v0.7.5**: arena-owner sentinel (kills the cross-repo cache-pollution class) + `node_defs.canonical_kind` (closed κ vocab: `function`/`method`/`type`/`module`… — lets `dead_code` filter by canonical kind, collapsing its leyline over-report).

## go.mod leyline-schema stays v0.7.1 (deliberate)

- v0.7.2–v0.7.5 schema submodule tags are **unpublished** (`clients/go/leyline-schema` stops at v0.7.1).
- Version-parity gate enforces **major.minor** only — `0.7 == 0.7`, in contract.
- mache doesn't consume the new columns/CFG types yet (that's the consolidation, mache-608a3c).

## Verification (local, darwin-arm64)

- Real v0.7.5 asset SHA-matches the pin, reports `leyline 0.7.5 (open)`; forced fresh resolve downloads → SHA-verifies → parses.
- `node_defs.canonical_kind` present (`function|5764, method|1294, type|673, module|200, constant|62`); `container_node_id` carried forward.
- `go test ./internal/leyline/` green (parity gate + SHA tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)