### PR TITLE
[mache-ba3dc6] fix(smells): resolve v_refs.referrer_node_id via node_refs.container_node_id

### DIFF
--- a/cmd/serve_find_smells_views_test.go
+++ b/cmd/serve_find_smells_views_test.go
@@ -123,6 +123,75 @@ func TestEnsureCanonicalViews_HandlesMissingLSPTables(t *testing.T) {
 	assert.Zero(t, bindingRefs, "no _lsp_refs → no binding rows")
 }
 
+// TestEnsureCanonicalViews_ReferrerFromContainerNodeID pins the leyline
+// caller-aggregation fix (mache-ba3dc6): when node_refs carries the additive
+// container_node_id column (ley-line-open v0.7.4+, the nearest enclosing def),
+// v_refs.referrer_node_id resolves to it so caller-aggregating rules
+// (fan_out_skew) group by the real caller instead of the unique call-site
+// node_id. Empty/NULL containers fall back to node_id.
+func TestEnsureCanonicalViews_ReferrerFromContainerNodeID(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "container.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT);
+		CREATE TABLE node_refs (token TEXT, node_id TEXT, container_node_id TEXT);
+		-- two calls from inside the SAME enclosing function (its def node),
+		-- plus one ref whose container is empty (top-level / file scope).
+		INSERT INTO node_refs VALUES
+			('helperA', 'f.go/function_declaration/call_expression_0', 'f.go/function_declaration'),
+			('helperB', 'f.go/function_declaration/call_expression_1', 'f.go/function_declaration'),
+			('toplevel', 'f.go/call_expression_top', '');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	// Both calls resolve to the ONE enclosing def → caller aggregation sees a
+	// fan-out of 2, not two singletons (the bug: call-site node_id is unique).
+	var distinctReferrers, callsFromEnclosing int
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(DISTINCT referrer_node_id) FROM v_refs WHERE fidelity='mention' AND token IN ('helperA','helperB')`).Scan(&distinctReferrers))
+	assert.Equal(t, 1, distinctReferrers, "both calls resolve to the one enclosing def via container_node_id")
+	require.NoError(t, db.QueryRow(
+		`SELECT COUNT(*) FROM v_refs WHERE referrer_node_id='f.go/function_declaration'`).Scan(&callsFromEnclosing))
+	assert.Equal(t, 2, callsFromEnclosing)
+
+	// Empty container falls back to the call-site node_id.
+	var topReferrer string
+	require.NoError(t, db.QueryRow(
+		`SELECT referrer_node_id FROM v_refs WHERE token='toplevel'`).Scan(&topReferrer))
+	assert.Equal(t, "f.go/call_expression_top", topReferrer, "empty container_node_id falls back to node_id")
+}
+
+// TestEnsureCanonicalViews_ReferrerFallsBackWithoutContainer pins the
+// legacy/tree-sitter shape: node_refs WITHOUT a container_node_id column →
+// referrer_node_id is node_id (the mache-schema caller construct), unchanged.
+func TestEnsureCanonicalViews_ReferrerFallsBackWithoutContainer(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "legacy_refs.db")
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	_, err = db.Exec(`
+		CREATE TABLE node_defs (token TEXT, node_id TEXT);
+		CREATE TABLE node_refs (token TEXT, node_id TEXT);
+		INSERT INTO node_refs VALUES ('Foo', 'functions/Caller/source');
+	`)
+	require.NoError(t, err)
+
+	qg := &sqlDBQuerier{db: db}
+	require.NoError(t, ensureCanonicalViews(qg))
+
+	var referrer string
+	require.NoError(t, db.QueryRow(
+		`SELECT referrer_node_id FROM v_refs WHERE token='Foo'`).Scan(&referrer))
+	assert.Equal(t, "functions/Caller/source", referrer, "no container_node_id column → referrer is node_id")
+}
+
 func TestEnsureCanonicalViews_HandlesLegacyLSPTables(t *testing.T) {
 	// Pre-Step-1 _lsp_* schema (no def_token / referrer_node_id /
 	// ref_token columns). The probe must detect the absence and fall

--- a/cmd/smell_refs_views.go
+++ b/cmd/smell_refs_views.go
@@ -73,6 +73,23 @@ func ensureCanonicalViews(qg refsQuerier) error {
 		return fmt.Errorf("probe node_refs.node_hash: %w", err)
 	}
 
+	// referrer_node_id is meant to be the ENCLOSING definition of each ref
+	// (its caller), so caller-aggregating rules group by the real caller.
+	// The mache-schema/tree-sitter projection puts the enclosing construct in
+	// node_refs.node_id directly. The leyline AST-native projection puts the
+	// call-SITE path there (a unique leaf per call) and instead emits the
+	// enclosing def as a separate additive column, node_refs.container_node_id
+	// (ley-line-open v0.7.4+, bead ley-line-open-b9d1d5). Without this, GROUP BY
+	// referrer_node_id yields n=1 per call site and fan_out_skew returns 0 on
+	// leyline. Probe for the column and prefer it; NULLIF falls back to node_id
+	// for the ~1% of leyline refs (top-level / file scope) with no enclosing
+	// def, and the whole expression degrades to node_id on legacy dbs lacking
+	// the column — so tree-sitter/mache-schema behavior is unchanged. (mache-ba3dc6)
+	hasRefsContainer, err := tableHasColumn(qg, "node_refs", "container_node_id")
+	if err != nil {
+		return fmt.Errorf("probe node_refs.container_node_id: %w", err)
+	}
+
 	defsHashExpr := "NULL"
 	if hasDefsNodeHash {
 		defsHashExpr = "node_hash"
@@ -100,7 +117,11 @@ func ensureCanonicalViews(qg refsQuerier) error {
 	if hasRefsNodeHash {
 		refsHashExpr = "node_hash"
 	}
-	refsBody := `SELECT node_id AS referrer_node_id,
+	refsReferrerExpr := "node_id"
+	if hasRefsContainer {
+		refsReferrerExpr = "COALESCE(NULLIF(container_node_id, ''), node_id)"
+	}
+	refsBody := `SELECT ` + refsReferrerExpr + ` AS referrer_node_id,
 	       token,
 	       NULL  AS target_node_id,
 	       NULL  AS ref_uri,


### PR DESCRIPTION
## Problem

`fan_out_skew` groups refs by `referrer_node_id` to count distinct callees per caller. mache's `v_refs` view aliased `referrer_node_id := node_refs.node_id` — but on the **leyline** AST-native projection `node_refs.node_id` is the **call-SITE path** (a unique leaf per call), so `GROUP BY referrer_node_id` yielded `n=1` everywhere and `fan_out_skew` returned **0** on leyline (vs 33 on tree-sitter). Same root gap that made ref-based rules blind on the leyline projection.

## Fix

ley-line-open **v0.7.4+** emits the nearest enclosing def as an additive `node_refs.container_node_id` column (bead `ley-line-open-b9d1d5`, shipped + pinned via #519). This PR probes for it and sets:

```
referrer_node_id := COALESCE(NULLIF(container_node_id, ''), node_id)
```

`fan_out_skew` now returns **94** on leyline — cross-language, since it also sees Rust/Python functions the Go-focused tree-sitter backend never parsed. No rule-file edit needed; the fix is entirely in the view.

## Safety

- **Probe-guarded + backward-compatible**: legacy / tree-sitter dbs have no `container_node_id` column → falls back to `node_id`, unchanged.
- **Zero regression proven**: `find-smells --rule '*'` output is **byte-identical** to `main` on a tree-sitter db (diffed).
- **Tests**: pin both the container-aggregation path (two calls → one caller) and the no-column fallback.

## Scope

This is the first piece of the LLO-only smell-gate consolidation (`mache-608a3c`). It does **not** flip the gate — `canonical_kind` wiring + the `untested_function`/`dead_code` cross-language ports (`mache-ba24f3` + follow-up) land separately, since those rules need careful Go-scoping and over-report on the raw leyline projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)