### PR TITLE
[mache-fe3a4a] feat(examples): smell-rules starter kit + composite-action drift fixes (v0.16.2, schema-input bug)

### DIFF
--- a/.github/actions/find-smells/README.md
+++ b/.github/actions/find-smells/README.md
@@ -5,6 +5,11 @@ Runs the [mache](https://github.com/agentic-research/mache) structural smell
 committed baseline (existing debt is grandfathered), and uploads all findings
 to your repo's code-scanning tab as SARIF.
 
+New to mache smell rules entirely? Start with
+[`examples/smell-rules/README.md`](../../../examples/smell-rules/README.md) —
+it explains what a rule is, how the baseline/ratchet model works, and how to
+wire this action, in one read.
+
 ## Usage
 
 ```yaml
@@ -34,12 +39,33 @@ mache find-smells --db smells.db --rule '*' --limit 100000 \
 
 Without it the action fails with the exact command above.
 
+`docs/smell-baseline.json` is the single documented default baseline path —
+the action input, this README, and mache's own Taskfile `smells` gate all
+agree on it. If you keep your baseline elsewhere, pass the `baseline` input.
+
 ## Inputs
 
-| Input           | Default                    | Description                                                                                                                                             |
-| --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mache-version` | `v0.13.0`                  | Release tag for the `mache-linux-amd64` binary. >= v0.13.0 auto-provisions leyline (all 10 rules / LLO); >= v0.12.0 is SARIF + the 5 tree-sitter rules. |
-| `schema`        | *(FCA infer)*              | Path to a mache topology schema.                                                                                                                        |
-| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor.                                                                                                                                |
-| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                                                                                                       |
-| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                                                                                                   |
+| Input           | Default                    | Description                                                                                                                                                                                                          |
+| --------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mache-version` | `v0.16.2`                  | Release tag for the `mache-linux-amd64` binary. >= v0.13.0 auto-provisions leyline, so the `_ast`-backed rules run too; >= v0.12.0 is SARIF + the cross-reference rules only. Absent-table rules skip automatically. |
+| `schema`        | *(FCA infer)*              | Path to a mache topology schema. Setting it forces `--backend tree-sitter` (leyline ignores build-time schemas).                                                                                                     |
+| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor (see above).                                                                                                                                                                                 |
+| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                                                                                                                                                                    |
+| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                                                                                                                                                                |
+
+## Contract with mache's own gate
+
+The action's core invocation
+(`mache build`, then `find-smells --rule '*' --limit 100000 --baseline-root "$PWD" --baseline <path>`) deliberately mirrors the `smells`
+target in mache's own [Taskfile](../../../Taskfile.yml) — the gate a mache PR
+runs is the gate you consume. `cmd/find_smells_action_test.go`
+(`TestFindSmellsAction_TaskfileParity`) asserts the two invocation shapes and
+the default baseline path stay in sync, so drift fails mache's CI rather than
+surprising a consuming repo.
+
+One intentional difference: mache's own repo splits the gate into two
+baselines (`task smells` with a forced tree-sitter backend +
+`task smells:ast` over a leyline build) for parity reasons internal to this
+repo. The action uses a single build (backend auto) and a single baseline —
+bootstrap the baseline with the same mache version the action runs and the
+two always agree.

--- a/.github/actions/find-smells/action.yml
+++ b/.github/actions/find-smells/action.yml
@@ -19,8 +19,9 @@ inputs:
       Path to a mache topology schema. Empty uses FCA schema inference.
       When set, the build is forced to --backend tree-sitter: the
       leyline backend (preferred by backend auto) does not honor
-      build-time schemas, so without the override the schema would be
-      silently ignored.
+      build-time schemas, so without the override the build would only
+      WARN (a log line CI never fails on) and produce a .db that lacks
+      the schema.
     required: false
     default: ''
   baseline:

--- a/.github/actions/find-smells/action.yml
+++ b/.github/actions/find-smells/action.yml
@@ -3,15 +3,35 @@ description: 'Run the mache structural smell ratchet gate over the caller''s che
 
 inputs:
   mache-version:
-    description: 'mache release tag to download mache-linux-amd64 from. >= v0.13.0 auto-provisions leyline so the build runs all 10 find_smells rules (LLO); >= v0.12.0 supports SARIF but runs the 5 tree-sitter rules only.'
+    description: >-
+      mache release tag to download mache-linux-amd64 from.
+      >= v0.13.0 auto-provisions leyline during `mache build` (backend
+      auto), so the _ast-backed rules (long_function, long_file,
+      duplicate_code, cyclomatic_complexity, ...) run in addition to the
+      cross-reference rules; rules whose required tables are absent are
+      skipped automatically by --rule '*'. >= v0.12.0 supports SARIF but
+      has no leyline auto-provisioning, so only the cross-reference
+      (nodes/node_defs/node_refs) rules run.
     required: false
-    default: 'v0.13.0'
+    default: 'v0.16.2'
   schema:
-    description: 'Path to a mache topology schema. Empty uses FCA schema inference.'
+    description: >-
+      Path to a mache topology schema. Empty uses FCA schema inference.
+      When set, the build is forced to --backend tree-sitter: the
+      leyline backend (preferred by backend auto) does not honor
+      build-time schemas, so without the override the schema would be
+      silently ignored.
     required: false
     default: ''
   baseline:
-    description: 'Path to the committed smell baseline (the ratchet floor).'
+    description: >-
+      Path to the committed smell baseline (the ratchet floor). This
+      default is THE documented baseline location — mache's own
+      Taskfile `smells` gate uses the same path, and
+      cmd/find_smells_action_test.go asserts the two stay in sync. If
+      the gate-consolidation workstream renames the baseline file,
+      change it here, in the Taskfile, and in this action's README
+      together.
     required: false
     default: 'docs/smell-baseline.json'
   fail-on-new:
@@ -51,6 +71,11 @@ runs:
           exit 1
         fi
 
+    # Core invocation contract: the find-smells calls below mirror the
+    # `smells` target in mache's own Taskfile (build, then
+    # `find-smells --rule '*' --limit 100000 --baseline-root --baseline`).
+    # cmd/find_smells_action_test.go asserts the two invocation shapes
+    # stay in sync — change them together.
     - name: Build index
       shell: bash
       env:
@@ -58,7 +83,10 @@ runs:
       run: |
         set -euo pipefail
         if [ -n "$SCHEMA" ]; then
-          mache build --schema "$SCHEMA" . "${RUNNER_TEMP}/repo.db"
+          # The leyline backend (preferred by the default backend=auto)
+          # ignores build-time schemas; force the in-process tree-sitter
+          # backend so the caller's schema is actually honored.
+          mache build --schema "$SCHEMA" --backend tree-sitter . "${RUNNER_TEMP}/repo.db"
         else
           mache build . "${RUNNER_TEMP}/repo.db"
         fi

--- a/cmd/find_smells_action_test.go
+++ b/cmd/find_smells_action_test.go
@@ -12,29 +12,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// moduleRoot walks up from the test's working directory to the
-// directory containing go.mod.
-func moduleRoot(t *testing.T) string {
-	t.Helper()
-	dir, err := os.Getwd()
-	require.NoError(t, err)
-	for {
-		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return dir
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			t.Fatal("go.mod not found walking up from cwd")
-		}
-		dir = parent
-	}
-}
-
 // actionYAMLPath locates .github/actions/find-smells/action.yml from the
 // module root.
 func actionYAMLPath(t *testing.T) string {
 	t.Helper()
-	return filepath.Join(moduleRoot(t), ".github", "actions", "find-smells", "action.yml")
+	return filepath.Join(macheRepoRoot(t), ".github", "actions", "find-smells", "action.yml")
 }
 
 // TestFindSmellsAction_Contract asserts the composite action exists, is a
@@ -90,7 +72,7 @@ func TestFindSmellsAction_Contract(t *testing.T) {
 // the note in .github/actions/find-smells/README.md ("Contract with
 // mache's own gate").
 func TestFindSmellsAction_TaskfileParity(t *testing.T) {
-	root := moduleRoot(t)
+	root := macheRepoRoot(t)
 	actionRaw, err := os.ReadFile(actionYAMLPath(t))
 	require.NoError(t, err)
 	taskRaw, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))

--- a/cmd/find_smells_action_test.go
+++ b/cmd/find_smells_action_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -10,15 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// actionYAMLPath locates .github/actions/find-smells/action.yml from the
-// module root.
-func actionYAMLPath(t *testing.T) string {
+// moduleRoot walks up from the test's working directory to the
+// directory containing go.mod.
+func moduleRoot(t *testing.T) string {
 	t.Helper()
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	for {
 		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
-			return filepath.Join(dir, ".github", "actions", "find-smells", "action.yml")
+			return dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -26,6 +28,13 @@ func actionYAMLPath(t *testing.T) string {
 		}
 		dir = parent
 	}
+}
+
+// actionYAMLPath locates .github/actions/find-smells/action.yml from the
+// module root.
+func actionYAMLPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(moduleRoot(t), ".github", "actions", "find-smells", "action.yml")
 }
 
 // TestFindSmellsAction_Contract asserts the composite action exists, is a
@@ -68,4 +77,57 @@ func TestFindSmellsAction_Contract(t *testing.T) {
 	assert.Contains(t, src, "--format sarif")
 	assert.Contains(t, src, "--write-baseline")
 	assert.Contains(t, src, "--baseline ")
+}
+
+// TestFindSmellsAction_TaskfileParity asserts the composite action's core
+// gate invocation matches the Taskfile `smells` target's invocation shape
+// (taskfile-ci-parity: the action is the CONSUMER-facing twin of the gate
+// mache's own CI runs via `task smells`). It doesn't compare the scripts
+// byte-for-byte — the action adds download/SARIF/summary steps by design —
+// it pins the shared contract: same rule selection, same limit, same
+// baseline-root portability trick, and the SAME documented default
+// baseline path. Any deliberate divergence must update both files plus
+// the note in .github/actions/find-smells/README.md ("Contract with
+// mache's own gate").
+func TestFindSmellsAction_TaskfileParity(t *testing.T) {
+	root := moduleRoot(t)
+	actionRaw, err := os.ReadFile(actionYAMLPath(t))
+	require.NoError(t, err)
+	taskRaw, err := os.ReadFile(filepath.Join(root, "Taskfile.yml"))
+	require.NoError(t, err)
+	action, taskfile := string(actionRaw), string(taskRaw)
+
+	// The shared core invocation shape. Both gates must run every rule
+	// (auto-skipping absent-table rules), uncapped in practice, with a
+	// portable baseline root.
+	const coreShape = "--rule '*' --limit 100000"
+	assert.Contains(t, action, coreShape,
+		"action must run the same rule-selection + limit shape as `task smells`")
+	assert.Contains(t, taskfile, coreShape,
+		"Taskfile smells gate must run the same rule-selection + limit shape as the action")
+	assert.Contains(t, action, "--baseline-root")
+	assert.Contains(t, taskfile, "--baseline-root")
+
+	// The single documented default baseline path. The action input
+	// default and the Taskfile gate must name the same file; the
+	// consuming-repo docs (action README, examples/smell-rules/README.md)
+	// reference this default rather than inventing their own.
+	const defaultBaseline = "docs/smell-baseline.json"
+	assert.Contains(t, action, "default: '"+defaultBaseline+"'",
+		"action baseline input default must be the documented path")
+	assert.Contains(t, taskfile, "--baseline "+defaultBaseline,
+		"Taskfile smells gate must gate on the documented baseline path")
+
+	// The action's default mache-version must be a well-formed release
+	// tag at or above v0.13.0 — the floor its input description documents
+	// (leyline auto-provisioning; below that the description's behavior
+	// notes would be wrong for the default).
+	m := regexp.MustCompile(`default: 'v(\d+)\.(\d+)\.\d+'`).FindStringSubmatch(action)
+	require.NotNil(t, m, "action must declare a semver default for mache-version")
+	major, err := strconv.Atoi(m[1])
+	require.NoError(t, err)
+	minor, err := strconv.Atoi(m[2])
+	require.NoError(t, err)
+	assert.True(t, major > 0 || minor >= 13,
+		"default mache-version %s predates v0.13.0 leyline auto-provisioning; the input description would be stale", m[0])
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,28 +1,38 @@
-# Mache Example Schemas
+# Mache Examples
 
-This directory contains example topologies (schemas) for Mache, demonstrating how to project various data sources into filesystem hierarchies.
+This directory is a flat mix of four different kinds of artifact. Use
+this map:
 
-## Table of Contents
+| You want to...                                                     | Go to                                                                  |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Project a data source or codebase as a filesystem (write a schema) | [Topology schemas](#topology-schemas) below                            |
+| Adopt the structural smell gate / write custom smell rules         | [`smell-rules/`](smell-rules/README.md) — a self-contained starter kit |
+| See the agent-audit projection pattern (markdown → JSON → mount)   | [Audit tooling](#audit-tooling)                                        |
+| Find the sample inputs the schemas are tested against              | [Test fixtures](#test-fixtures)                                        |
 
-- [Data Sources (JSON/SQLite)](#data-sources-jsonsqlite)
-  - [NVD Schema (`nvd-schema.json`)](#nvd-schema)
-  - [KEV Schema (`kev-schema.json`)](#kev-schema)
-  - [LLM Conversations (`llm-conversations-schema.json`)](#llm-conversations)
-- [MCP (Model Context Protocol)](#mcp-model-context-protocol)
-  - [MCP Server Manifest (`mcp-schema.json`)](#mcp-server-manifest)
-  - [MCP Registry (`mcp-registry-schema.json`)](#mcp-registry)
-- [Source Code (Tree-sitter)](#source-code-tree-sitter)
-  - [Go Schema (`go-schema.json`)](#go-schema)
-  - [Python Schema (`python-schema.json`)](#python-schema)
-  - [SQL Schema (`sql-schema.json`)](#sql-schema)
-  - [Cobra CLI Schema (`cli-schema.json`)](#cobra-cli-schema)
-- [Testing](#testing)
+**Start here** if you're new: read a small schema
+([`kev-schema.json`](kev-schema.json) for JSON data,
+[`go-schema.json`](go-schema.json) for source code) alongside its
+section below — every schema is the same pattern: `nodes` describe
+directories, `files`/`file_sets` describe the rendered leaf files, and
+selectors (JSONPath for data, tree-sitter queries for code) pick what
+lands where. Smell rules are a separate mechanism (SQL over the built
+`.db`, not schemas) — see
+[`smell-rules/README.md`](smell-rules/README.md).
 
-## Data Sources (JSON/SQLite)
+## Topology schemas
 
-These schemas map structured JSON data into navigable directory trees. They use the `.item.` accessor because the primary data source is Venturi SQLite databases where records are wrapped as `{"schema":"...", "identifier":"...", "item":{...}}`.
+Declarative JSON schemas that drive `mache mount` / `mache build` /
+`mache serve`, projecting a data source into a navigable tree.
 
-### NVD Schema
+### Data sources (JSON / SQLite)
+
+These schemas map structured JSON data into directory trees. They use
+the `.item.` accessor because the primary data source is Venturi
+SQLite databases where records are wrapped as
+`{"schema":"...", "identifier":"...", "item":{...}}`.
+
+#### NVD Schema
 
 [`nvd-schema.json`](nvd-schema.json) — Maps the National Vulnerability Database (NVD) JSON feed into a hierarchy of `Year/Month/ID`.
 
@@ -34,7 +44,7 @@ These schemas map structured JSON data into navigable directory trees. They use 
         - `/:cve_id` (e.g., `CVE-2024-1234`)
           - `description`, `published`, `status`, `raw.json`
 
-### KEV Schema
+#### KEV Schema
 
 [`kev-schema.json`](kev-schema.json) — Maps the CISA Known Exploited Vulnerabilities catalog.
 
@@ -44,7 +54,7 @@ These schemas map structured JSON data into navigable directory trees. They use 
     - `/:cve_id` (e.g., `CVE-2021-1234`)
       - `vendor`, `product`, `description`, `date-added`, `due-date`, `raw.json`
 
-### LLM Conversations
+#### LLM Conversations
 
 [`llm-conversations-schema.json`](llm-conversations-schema.json) — Projects LLM conversation exports into a structured archive.
 
@@ -56,11 +66,17 @@ These schemas map structured JSON data into navigable directory trees. They use 
         - `/:conversation_id`
           - `title`, `transcript`, `system-prompt`, `token-usage`, `raw.json`
 
-## MCP (Model Context Protocol)
+#### Other data schemas
+
+- [`bdr-schema.json`](bdr-schema.json) / [`bdr-hierarchy-schema.json`](bdr-hierarchy-schema.json) — Project a beads issue database (`issues` table) as flat and dependency-hierarchy trees respectively (`title`, `description`, `status`, `priority` per bead).
+- [`notion-schema.json`](notion-schema.json) / [`notion-repos-schema.json`](notion-repos-schema.json) — Project Notion page exports: a flat pages view, and a layered repo-catalog view (`/repos/:layer/:name` with `purpose`/`path` leaves).
+- [`trivy-ghsa-schema.json`](trivy-ghsa-schema.json) — Projects Venturi GitHub Advisory data into the trivy-db BoltDB layout (`--format boltdb` output path).
+
+### MCP (Model Context Protocol)
 
 These schemas project MCP server capabilities into browsable filesystem trees. MCP is a JSON-RPC 2.0 protocol for connecting AI agents to external tools, resources, and prompts.
 
-### MCP Server Manifest
+#### MCP Server Manifest
 
 [`mcp-schema.json`](mcp-schema.json) — Projects a single MCP server's `tools/list` response into a navigable tree of tools, resources, and prompts.
 
@@ -78,7 +94,7 @@ These schemas project MCP server capabilities into browsable filesystem trees. M
 
 The `input-schema.json` file is the key artifact — it contains the JSON Schema for a tool's parameters, making the capability space greppable without loading everything into context.
 
-### MCP Registry
+#### MCP Registry
 
 [`mcp-registry-schema.json`](mcp-registry-schema.json) — Projects the MCP server registry (thousands of servers) into a namespace/server hierarchy.
 
@@ -91,11 +107,12 @@ The `input-schema.json` file is the key artifact — it contains the JSON Schema
 
 This schema uses `Refs` cross-references on server names, enabling the `callers/` virtual directory to answer "which namespaces provide servers with similar names."
 
-## Source Code (Tree-sitter)
+### Source code (tree-sitter)
 
-These schemas use Tree-sitter S-expression queries to project source code ASTs into logical views.
+These schemas use tree-sitter S-expression queries to project source
+code ASTs into logical views.
 
-### Go Schema
+#### Go Schema
 
 [`go-schema.json`](go-schema.json) — Projects Go source into package-organized views.
 
@@ -105,7 +122,7 @@ These schemas use Tree-sitter S-expression queries to project source code ASTs i
     - `imports/`, `functions/`, `methods/`, `types/`, `constants/`, `variables/`
 - **Sample Data:** [`testdata/go_sample.go`](testdata/go_sample.go)
 
-### Python Schema
+#### Python Schema
 
 [`python-schema.json`](python-schema.json) — Projects Python source into classes, functions, and imports.
 
@@ -116,7 +133,7 @@ These schemas use Tree-sitter S-expression queries to project source code ASTs i
   - `functions/` — top-level functions
 - **Sample Data:** [`testdata/python_sample.py`](testdata/python_sample.py)
 
-### SQL Schema
+#### SQL Schema
 
 [`sql-schema.json`](sql-schema.json) — Projects SQL DDL into tables and views.
 
@@ -126,7 +143,7 @@ These schemas use Tree-sitter S-expression queries to project source code ASTs i
   - `views/` — `CREATE VIEW` statements
 - **Sample Data:** [`testdata/sql_sample.sql`](testdata/sql_sample.sql)
 
-### Cobra CLI Schema
+#### Cobra CLI Schema
 
 [`cli-schema.json`](cli-schema.json) — Extracts CLI command structure from Go code using the [Cobra](https://github.com/spf13/cobra) library.
 
@@ -137,11 +154,64 @@ These schemas use Tree-sitter S-expression queries to project source code ASTs i
     - `flags/` — flag definitions with `info` details
 - **Sample Data:** [`testdata/cli_sample.go`](testdata/cli_sample.go)
 
+#### Other source schemas
+
+- [`rust-schema.json`](rust-schema.json) — Rust functions/types with LSP-backed leaves (`hover`, `diagnostics`, `definitions`, `references` from the `_lsp*` tables a ley-line build produces).
+- [`terraform-schema.json`](terraform-schema.json) — Terraform/HCL resources with the same LSP file set.
+- [`markdown-schema.json`](markdown-schema.json) — Markdown sections by heading (tree-sitter `markdown` grammar).
+
+## Smell rules
+
+[`smell-rules/`](smell-rules/README.md) is a **copyable starter kit**
+for the structural smell gate: example custom rules (the JSON DSL the
+built-in `cmd/rules/*.json` rules also use), plus a README that walks
+a brand-new repo through the whole surface — rule shape, how custom
+rules overlay the built-ins (`MACHE_SMELL_RULES_DIR`), bootstrapping a
+baseline, wiring the
+[`find-smells` composite action](../.github/actions/find-smells/README.md)
+in CI, and the ratchet model. Unlike everything else in `examples/`,
+smell rules are not topology schemas — they're SQL queries over the
+`.db` that `mache build` produces.
+
+## Audit tooling
+
+A worked example of projecting agent-coordination markdown as a
+queryable filesystem:
+
+- [`audit-indexer.py`](audit-indexer.py) — Parses an `.audit/`
+  directory of coordination files (`STATUS.md`, `MASTER-TRIAGE.md`,
+  `SCORECARD.md`, `BEAD-PLAN.md`, per-dimension audits) into a single
+  `.index.json`.
+- [`audit-schema.json`](audit-schema.json) — The topology schema that
+  mounts that index (`findings/` with `title`/`severity`/`status`/`dimension`
+  leaves).
+- [`test-audit/`](test-audit) — Sample `.audit/` input files for
+  trying the indexer end-to-end:
+
+```bash
+python examples/audit-indexer.py examples/test-audit/
+mache mount examples/test-audit/.index.json --schema examples/audit-schema.json /tmp/audit
+```
+
+## Test fixtures
+
+- [`testdata/`](testdata) — Sample source files (`go_sample.go`,
+  `python_sample.py`, `sql_sample.sql`, `cli_sample.go`) the
+  tree-sitter schemas are validated against.
+- [`mcp-sample-manifest.json`](mcp-sample-manifest.json),
+  [`llm-conversations-sample.json`](llm-conversations-sample.json) —
+  Sample JSON inputs for the MCP and LLM-conversation schemas.
+
 ## Testing
 
-Tree-sitter examples are validated by [`examples_test.go`](examples_test.go) using the sample data in `testdata/`. JSON/SQLite schemas are tested by the integration tests in `internal/ingest/`.
+Tree-sitter examples are validated by
+[`examples_test.go`](examples_test.go) using the sample data in
+`testdata/`. JSON/SQLite schemas are tested by the integration tests
+in `internal/ingest/`. The example smell rules are load-tested by
+`cmd/serve_find_smells_load_test.go`.
 
 ```bash
 task test -- -run TestTreeSitterExamples ./examples/...
 task test -- -run TestSchemasParse ./examples/...
+go test ./cmd/ -run TestLoadExternalSmellRules_ShippedExamplesLoadCleanly
 ```

--- a/examples/smell-rules/README.md
+++ b/examples/smell-rules/README.md
@@ -1,46 +1,58 @@
-# External smell rules
+# Smell rules — a copyable starter
 
-Drop-in `*.json` files that define additional `find_smells` rules,
-loaded at process start when `MACHE_SMELL_RULES_DIR` points at the
-directory containing them.
+This directory is a working starter kit for mache's structural smell
+gate. If you have never seen mache before, read this file top to
+bottom: it covers what a rule is, how custom rules compose with the
+built-ins, how to bootstrap a baseline, how to wire the CI gate into
+your own repo, and how the ratchet model keeps a codebase from getting
+structurally worse.
 
-```bash
-export MACHE_SMELL_RULES_DIR=$(pwd)/examples/smell-rules
-mache serve --http :7532
-```
+Background in one paragraph: `mache build <src> <out.db>` parses a
+source tree into a SQLite database of code structure — construct nodes
+(`nodes`), definitions (`node_defs`), references (`node_refs`), and,
+when the leyline backend is used, raw AST spans (`_ast`). A **smell
+rule** is a SQL query over that database. `mache find-smells` runs
+rules and reports each row they return as a *finding*: a (file, node,
+span, metric) tuple describing one structural problem.
 
-Each external rule shows up in `find_smells` discovery (the no-arg
-listing) and as a runnable rule (`find_smells rule=<id>`) the same
-way built-ins do.
+## 1. What a rule is
 
-## File layout
+One JSON object per file. The example rules in this directory are
+copy-paste templates:
 
-One rule per file. The filename has no semantic meaning beyond
-sort order during load — pick something that matches the rule ID
-for clarity.
+| File                                                             | Demonstrates                                                                                          |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| [`fatal_call_in_library.json`](fatal_call_in_library.json)       | Binary rule (`0 AS metric`), cross-reference tables only, `%%` escaping, the empty-`source_file` trap |
+| [`long_test_function.json`](long_test_function.json)             | Metric rule with `DefaultMinMetric`, `_ast`-backed, auto-skips on backends without `_ast`             |
+| [`long_unexported_function.json`](long_unexported_function.json) | Joining `_ast` spans to `nodes` for name-based filtering                                              |
 
-## Rule shape
+The shape:
 
 ```json
 {
-  "ID": "long_unexported_function",
-  "Description": "Unexported Go functions whose body exceeds 200 lines.",
-  "Requires": ["_ast", "nodes"],
+  "ID": "long_test_function",
+  "Description": "What it flags, why it matters, and known false positives.",
+  "Requires": ["_ast"],
   "ScopeColumn": "fn.source_id",
-  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn JOIN nodes n ON n.id = fn.node_id WHERE ... %s ORDER BY metric DESC"
+  "DefaultMinMetric": 121,
+  "Severity": "warn",
+  "Tags": ["tests"],
+  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn WHERE ... %s ORDER BY metric DESC"
 }
 ```
 
-| Field              | Required    | Notes                                                                                                                                                                                                                                                                                                                                                                                                 |
-| ------------------ | ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ID`               | yes         | Stable identifier. Must not collide with a built-in.                                                                                                                                                                                                                                                                                                                                                  |
-| `Description`      | recommended | Shown in the rule listing — agents read this.                                                                                                                                                                                                                                                                                                                                                         |
-| `Requires`         | recommended | SQL tables the query reads. Used for the pre-flight "this rule needs `_ast`, your backend doesn't have it" diagnostic.                                                                                                                                                                                                                                                                                |
-| `ScopeColumn`      | optional    | SQL expression compared to `source_id` when callers pass a `source_id` arg. Leave blank to disable scoping.                                                                                                                                                                                                                                                                                           |
-| `Query`            | yes         | SQL with **exactly one `%s`** placeholder for the scope clause.                                                                                                                                                                                                                                                                                                                                       |
-| `DefaultMinMetric` | optional    | Integer threshold the handler applies when the caller omits `min_metric`. Use for metric-bearing rules where the natural query output has a long tail of low-metric noise (e.g. `long_function` defaults to 81 lines). An explicit `min_metric=0` from the caller still overrides — agents that want everything sorted can opt out. Omit the field to leave threshold control entirely to the caller. |
+| Field              | Required    | Notes                                                                                                                                                                              |
+| ------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ID`               | yes         | Stable identifier. Must not collide with a built-in or another custom rule.                                                                                                        |
+| `Description`      | recommended | Shown in the rule listing — agents and humans read this to decide whether to run the rule. Document known false positives here.                                                    |
+| `Requires`         | recommended | SQL tables the query reads. Powers the pre-flight "this rule needs `_ast`, your backend doesn't have it" diagnostic (and the auto-skip under `--rule '*'`).                        |
+| `ScopeColumn`      | optional    | SQL expression compared to the caller's `source_id` arg to scope a run to one file. Leave blank to disable scoping.                                                                |
+| `Query`            | yes         | SQL with **exactly one `%s`** placeholder where the scope clause is spliced in.                                                                                                    |
+| `DefaultMinMetric` | optional    | Threshold applied when the caller omits `min_metric`. Use for metric rules whose natural output has a long tail of low-metric noise. An explicit `min_metric` (even 0) overrides.  |
+| `Severity`         | optional    | `off` / `warn` / `error` (ESLint precedent, ADR-0018). Empty means `warn`. The gate decision is made at invocation via `--fail-on`; the rule only states how serious a finding is. |
+| `Tags`             | optional    | Free-form labels for `--tags=a,b` selection (union semantics). Keep it to 3–5 per rule.                                                                                            |
 
-## The query contract
+### The query contract
 
 Every query MUST select these seven columns in this order:
 
@@ -48,53 +60,185 @@ Every query MUST select these seven columns in this order:
 source_id, node_id, start_byte, end_byte, start_row, start_col, metric
 ```
 
-- `source_id` — the source file path, used for filtering.
-- `node_id` — the construct dir or AST node ID being flagged.
-- `start_byte`, `end_byte` — byte range of the offending span.
-- `start_row`, `start_col` — 0-based line/column (the handler converts to 1-based for the response).
-- `metric` — integer score. Use `0` for binary rules with no metric.
+- `source_id` — the source file path.
+- `node_id` — the construct dir or AST node being flagged.
+- `start_byte`, `end_byte` — byte range of the offending span (0 if unknown).
+- `start_row`, `start_col` — 0-based line/column (the handler converts to 1-based).
+- `metric` — integer score, descending sort recommended. Use `0 AS metric` for binary rules.
 
-Any rule that doesn't match this column shape will produce a SQL
-error at run time and the agent will get a tool error.
+A rule that doesn't match this column shape produces a SQL error at run
+time.
 
-## SQL caveats
+## 2. How built-ins and custom rules compose
 
-- **Escape `%` chars.** The query is `fmt.Sprintf`'d at run time
-  to splice in the optional scope clause. Any `%` that isn't part
-  of `%s` must be escaped as `%%`. The loader rejects rules with
-  unescaped `%` at startup (regression: a stray `%` in a `LIKE`
-  pattern would corrupt the query at the first call).
-- **Table availability.** Built-in mache produces `nodes`,
-  `node_refs`, `node_defs`. ley-line-parsed `.db` files
-  additionally have `_ast`, `_source`, `_imports`, and `_lsp*`.
-  Declare in `Requires` so the pre-flight check catches missing
-  tables before the SQL runs.
+Mache ships built-in rules embedded in the binary (`cmd/rules/*.json`
+in this repo — same JSON format, same validation). Run
+`mache find-smells` with no `--rule` to list everything that's
+registered.
 
-## Common pitfalls
+Custom rules live in a directory of `*.json` files — like this one —
+and are **merged with the built-ins on every invocation**. The
+directory is resolved with this precedence:
 
-A few schema quirks bite first-time rule authors. The built-in rules
-work around them, so consult `cmd/serve_find_smells.go` for prior art
-before assuming a "natural" SQL query will do what you expect.
+1. `--rules-dir <dir>` flag
+1. `MACHE_SMELL_RULES_DIR` environment variable
+1. `smellRulesDir` in the project's `.mache.json` (relative paths are
+   project-relative and containment-checked)
+1. none — built-ins only
+
+```bash
+# Point mache at this directory and list the merged rule set:
+mache find-smells --rules-dir examples/smell-rules
+
+# Or via the environment (also honored by `mache serve` / MCP):
+export MACHE_SMELL_RULES_DIR="$PWD/examples/smell-rules"
+mache find-smells --db repo.db --rule long_test_function
+```
+
+Once loaded, custom rules are indistinguishable from built-ins: they
+appear in the listing, run under `--rule '*'` globs and `--tags`
+filters, participate in baselines, and hit the same pre-flight table
+check. The directory is re-scanned per invocation (and per MCP
+request), so dropping in a new file needs no restart. Loading is
+fail-fast: one malformed rule aborts the whole custom set — the CLI
+surfaces the error; `mache serve` logs it and falls back to built-ins.
+
+## 3. Bootstrapping a baseline
+
+An existing codebase will have findings on day one. You don't fix them
+all first — you **grandfather** them into a committed baseline and gate
+only on *new* debt:
+
+```bash
+# 1. Index your repo (downloads/uses leyline automatically when available):
+mache build . smells.db
+
+# 2. Record the current findings as the floor and commit the file:
+mache find-smells --db smells.db --rule '*' --limit 100000 \
+  --baseline-root "$PWD" --write-baseline docs/smell-baseline.json
+git add docs/smell-baseline.json
+```
+
+Notes:
+
+- `docs/smell-baseline.json` is the conventional default path — the
+  composite action below defaults to it. Any path works as long as the
+  action's `baseline` input agrees.
+- `--baseline-root "$PWD"` relativizes recorded file paths so the
+  baseline is portable across machines and CI.
+- `--rule '*'` runs every registered rule and silently skips rules
+  whose `Requires` tables aren't in the .db — so the same command works
+  on any backend.
+- Regenerate the baseline with the same mache version (and the same
+  custom-rules dir) your CI uses, or counts can differ.
+
+## 4. Wiring the CI gate in your repo
+
+Mache ships a composite GitHub Action
+([`.github/actions/find-smells`](../../.github/actions/find-smells/README.md))
+that downloads a pinned mache release, indexes the checkout, gates
+against your committed baseline, and uploads SARIF to the
+code-scanning tab. Complete minimal workflow:
+
+```yaml
+# .github/workflows/smells.yml
+name: smells
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  security-events: write   # for the SARIF upload; drop with upload-sarif: false
+
+jobs:
+  smells:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: agentic-research/mache/.github/actions/find-smells@main   # pin a SHA in production
+        with:
+          baseline: docs/smell-baseline.json   # the default; shown for clarity
+```
+
+To include the custom rules from a directory in your repo, export the
+env var for the job:
+
+```yaml
+    env:
+      MACHE_SMELL_RULES_DIR: ${{ github.workspace }}/smell-rules
+```
+
+(Custom rules change the finding set — regenerate the baseline with the
+same env var set.)
+
+## 5. The ratchet model
+
+The gate is a **ratchet**, not a linter with a fixed zero-findings bar:
+
+- The committed baseline records, per (rule, file), how many findings
+  existed when it was written.
+- `find-smells --baseline <path>` exits non-zero **only when a
+  (rule, file) count exceeds its baseline entry** — brand-new findings
+  in new files, or extra findings in known files, fail; grandfathered
+  debt passes.
+- Fixing debt makes the next `--write-baseline` strictly smaller — the
+  ratchet only tightens.
+- When a PR deliberately adds a finding (rare, but legitimate),
+  regenerate and commit the baseline in the same PR so the review sees
+  the decision.
+
+Mache dogfoods this exact loop on itself: the `smells` target in
+[`Taskfile.yml`](../../Taskfile.yml) runs the same
+`find-smells --rule '*' --limit 100000 --baseline-root --baseline`
+invocation the composite action uses (a Go test,
+`TestFindSmellsAction_TaskfileParity`, keeps the two in sync), and
+`task smells:baseline` regenerates the floor.
+
+______________________________________________________________________
+
+## Appendix: authoring caveats
+
+### Escape `%` chars
+
+The query is `fmt.Sprintf`'d at run time to splice in the optional
+scope clause. Any `%` that isn't the single `%s` placeholder must be
+escaped as `%%` — SQL `LIKE '%foo%'` becomes `LIKE '%%foo%%'`. The
+loader rejects rules with unescaped `%` at startup.
+
+### Which tables exist depends on the build backend
+
+`mache build` dispatches to leyline when available (backend `auto`),
+else the in-process tree-sitter backend:
+
+- **Both backends**: `nodes`, `node_defs`, `node_refs` (plus the
+  `v_defs` / `v_refs` canonical views).
+- **leyline only**: `_ast`, `_source`, `_imports`, `_lsp*`.
+
+Declare every table your query reads in `Requires` so the pre-flight
+check reports "rule X needs table Y" instead of a raw
+`no such table: _ast` — and so `--rule '*'` can skip the rule cleanly.
+To see which backend produced a `.db`:
+
+```bash
+sqlite3 my.db "SELECT key, value FROM _mache_meta"
+```
 
 ### `nodes.source_file` is empty for construct dirs
 
-The schema engine attaches `source_file` to the leaf rendered files
+The schema engine attaches `source_file` to leaf rendered files
 (`source`, `ast.json`, `doc`) but **not** to the wrapping construct
-directory itself. So a query like
+directory. So:
 
 ```sql
 SELECT id FROM nodes WHERE source_file NOT LIKE '%test.go'
 ```
 
-won't filter construct dirs the way you'd expect. Every dir's
-`source_file` is `''`, and `'' NOT LIKE '%test.go'` evaluates true,
-so construct dirs are **included** in the result — *the predicate
-doesn't filter them at all*. The "is this construct in a test file?"
-question can only be answered by walking the dir's child rows (where
-`source_file` is non-empty) and projecting the answer up.
-
-Use the COALESCE-via-child idiom the built-in `dead_code` rule uses
-(`cmd/serve_find_smells.go:241`):
+does not exclude construct dirs — their `source_file` is `''`, and
+`'' NOT LIKE '%test.go'` is true, so they all pass the predicate. Add a
+non-empty guard (see `fatal_call_in_library.json`), or resolve the
+file via child leaves with the COALESCE idiom the built-in `dead_code`
+rule uses:
 
 ```sql
 WITH child_source AS (
@@ -110,62 +254,24 @@ LEFT JOIN child_source cs ON cs.node_id = n.id
 ```
 
 The `NULLIF(..., '')` is load-bearing — `COALESCE` only skips NULLs,
-not empty strings, so without it the empty `n.source_file` shadows
-the resolved child `source_file`.
+not empty strings.
 
 ### Joining `node_defs` to an `_ast` row
 
-`node_defs.node_id` is the construct dir (`functions/Foo`), while the
-matching `_ast` row's `node_id` is the AST path under the source
-(`<type_decl>/type_spec` or similar). A `=` join
-
-```sql
-SELECT ... FROM node_defs d JOIN _ast a ON a.node_id = d.node_id
-```
-
-returns nothing because the two columns refer to different things.
-Use a `LIKE` join with the construct-dir path as a prefix:
+`node_defs.node_id` is the construct dir (`functions/Foo`) while the
+matching `_ast` row's `node_id` is the AST path under the source. A
+`=` join returns nothing; use a prefix `LIKE` join:
 
 ```sql
 SELECT ... FROM node_defs d
 JOIN _ast a ON a.node_id LIKE d.node_id || '/%%'
 ```
 
-(Remember to escape the SQL `%` as `%%` — see SQL caveats below.)
+### Validation
 
-### Backend produced different tables
-
-`mache build` may dispatch to leyline or the in-process tree-sitter
-backend depending on what's on PATH. Leyline produces `_ast`,
-`_source`, `_imports`, `_lsp*` in addition to the shared
-`nodes` / `node_defs` / `node_refs` tables; the in-process backend
-produces `v_defs` / `v_refs` / `_index_coverage` and no `_ast`.
-
-Declare every table your query reads in `Requires` so the pre-flight
-check returns a friendly "rule X needs table Y" error instead of a
-raw `no such table: _ast`. To check which backend produced an
-existing `.db`, look at the `_mache_meta` table:
-
-```bash
-sqlite3 my.db "SELECT key, value FROM _mache_meta"
-```
-
-## Validation
-
-The loader validates every rule at startup:
-
-- Non-empty `ID`, no collision with a built-in or another external
-- Non-empty `Query` with exactly one `%s` placeholder
-- `fmt.Sprintf` over the query produces no `%!` error markers
-  (catches unescaped `%` chars in `LIKE` patterns and similar)
-
-A validation failure aborts the load and logs a warning — mache
-starts without external rules rather than failing to boot. Tests
-call `LoadExternalSmellRules` directly and assert errors loudly.
-
-## Example rule
-
-[`long_unexported_function.json`](long_unexported_function.json) is
-an example rule that flags Go functions with lowercase names whose
-body spans more than 200 source lines. Drop the file in your
-`MACHE_SMELL_RULES_DIR` and call `find_smells rule=long_unexported_function`.
+The loader validates every rule at load time: non-empty `ID` with no
+collisions, non-empty `Query` with exactly one `%s`, no unescaped `%`,
+and a whitelist check on `ScopeColumn` characters. The rules in this
+directory are load-tested by `cmd/serve_find_smells_load_test.go`
+(`TestLoadExternalSmellRules_ShippedExamplesLoadCleanly`), so they
+can't rot silently.

--- a/examples/smell-rules/README.md
+++ b/examples/smell-rules/README.md
@@ -126,9 +126,9 @@ Notes:
   action's `baseline` input agrees.
 - `--baseline-root "$PWD"` relativizes recorded file paths so the
   baseline is portable across machines and CI.
-- `--rule '*'` runs every registered rule and silently skips rules
-  whose `Requires` tables aren't in the .db — so the same command works
-  on any backend.
+- `--rule '*'` runs every registered rule and skips rules whose
+  `Requires` tables aren't in the .db without failing (a `skipping rule ...` notice goes to stderr) — so the same command works on any
+  backend.
 - Regenerate the baseline with the same mache version (and the same
   custom-rules dir) your CI uses, or counts can differ.
 

--- a/examples/smell-rules/fatal_call_in_library.json
+++ b/examples/smell-rules/fatal_call_in_library.json
@@ -1,0 +1,9 @@
+{
+  "ID": "fatal_call_in_library",
+  "Description": "Calls to Fatal / Fatalf / Fatalln outside main.go and test files. log.Fatal in library code exits the whole process from a place the caller can't intercept — return an error instead and let main decide. BINARY rule: it has no meaningful magnitude, so it emits 0 AS metric (the query contract still requires the metric column). Works on every backend (node_refs + nodes only, no _ast needed). Heuristic caveat: node_refs stores the bare call token, so a custom Fatalf method on your own logger type is a false positive — same documented divergence as the built-in sleep_in_test rule. This rule also demonstrates the two classic authoring traps: (1) every SQL '%' is escaped as '%%' because the query is fmt.Sprintf'd to splice the scope clause; (2) NOT LIKE needs a non-empty source_file guard, because construct dirs carry source_file = '' and '' NOT LIKE pattern is TRUE — without the guard every construct dir in the repo would be flagged.",
+  "Requires": ["node_refs", "nodes"],
+  "ScopeColumn": "COALESCE(n.source_file, '')",
+  "Severity": "warn",
+  "Tags": ["errors", "library-hygiene"],
+  "Query": "SELECT COALESCE(n.source_file, n.id) AS source_id, n.id AS node_id, 0 AS start_byte, 0 AS end_byte, 0 AS start_row, 0 AS start_col, 0 AS metric FROM node_refs r JOIN nodes n ON n.id = r.node_id WHERE r.token IN ('Fatal', 'Fatalf', 'Fatalln') AND COALESCE(n.source_file, '') != '' AND n.source_file NOT LIKE '%%_test.go' AND n.source_file NOT LIKE '%%/main.go' AND n.source_file != 'main.go' %s ORDER BY source_id, node_id"
+}

--- a/examples/smell-rules/long_test_function.json
+++ b/examples/smell-rules/long_test_function.json
@@ -1,0 +1,10 @@
+{
+  "ID": "long_test_function",
+  "Description": "Go test-file functions sorted descending by body line count (end_row - start_row). A 120+ line test usually bundles several behaviors into one function; split it into subtests or table cases so a failure names the behavior that broke. METRIC rule with a DefaultMinMetric of 121: callers who omit min_metric get only the 121+ line offenders, an explicit --min-metric (including 0) overrides — that's the standard threshold pattern for any rule whose natural output has a long tail of small, uninteresting rows. Requires the _ast table (produced by leyline / ley-line-open builds; the pure tree-sitter backend doesn't emit it), so on a .db without _ast the rule is skipped automatically under --rule '*'. Deliberately more lenient than the built-in long_function (81): test length is a softer signal than production-function length.",
+  "Requires": ["_ast"],
+  "ScopeColumn": "fn.source_id",
+  "DefaultMinMetric": 121,
+  "Severity": "warn",
+  "Tags": ["tests"],
+  "Query": "SELECT fn.source_id, fn.node_id, fn.start_byte, fn.end_byte, fn.start_row, fn.start_col, (fn.end_row - fn.start_row) AS metric FROM _ast fn WHERE fn.node_kind IN ('function_declaration', 'method_declaration') AND fn.source_id LIKE '%%_test.go' %s ORDER BY metric DESC, fn.source_id, fn.start_byte"
+}


### PR DESCRIPTION
## Summary
Unifies the smell-gate consumption surface so a new repo can adopt the scan in one read, and fixes real drift in the composite action.

### Composite action (.github/actions/find-smells)
- Default `mache-version` bumped **v0.13.0 → v0.16.2**; stale rule-count claims in input descriptions replaced with mechanism descriptions that don't rot.
- **Bug fix:** the `schema` input was silently ignored on ≥ v0.13.0 — `mache build` defaults to `--backend auto`, which prefers leyline, and the leyline path warns-and-ignores `--schema`. The action now forces `--backend tree-sitter` when a schema is provided.
- All find-smells flags the action uses verified against `cmd/find_smells_cli.go`.

### Action ↔ Taskfile contract
New `TestFindSmellsAction_TaskfileParity` asserts the action's core gate invocation matches the Taskfile `smells` target's shape (rule selection, limit, baseline-root, and the single documented default baseline path). Intentional divergence documented in the action README.

### examples/
- `examples/smell-rules/` is now a copyable starter kit: 2 new fully-annotated example rules (`fatal_call_in_library` — binary/node_refs; `long_test_function` — _ast metric with DefaultMinMetric) + a newcomer README covering the rule JSON shape, builtin/overlay composition (verified against the loader's precedence), baseline bootstrap, a complete minimal workflow YAML, and the ratchet model.
- `examples/README.md` restructured into sections (topology schemas / smell rules / audit tooling / fixtures) with a start-here map.

## Verification
- `go test ./cmd/ ./examples/`: ok; targeted action/example-rule tests pass post-commit.
- `task lint` 0 issues; `task vet`, `task fmt`, `task lint:yaml`, `task lint:actions`, `task docs:lint`, `task smells`: pass.

## Merge order
After #521. **Note for the leyline gate PR (mache-608a3c):** that branch changes the Taskfile gate to `--rule '*' --tags=gate --limit 100000`; when it lands it must update the action to adopt `--tags=gate` and adjust this PR's `coreShape` assertion — noted on both beads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)