### PR TITLE
[mache-3ac299] feat(action): reconverge with the v0.17.0 gate — adopt --tags=gate, bump default

### DIFF
--- a/.github/actions/find-smells/README.md
+++ b/.github/actions/find-smells/README.md
@@ -45,13 +45,13 @@ agree on it. If you keep your baseline elsewhere, pass the `baseline` input.
 
 ## Inputs
 
-| Input           | Default                    | Description                                                                                                                                                                                                          |
-| --------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mache-version` | `v0.16.2`                  | Release tag for the `mache-linux-amd64` binary. >= v0.13.0 auto-provisions leyline, so the `_ast`-backed rules run too; >= v0.12.0 is SARIF + the cross-reference rules only. Absent-table rules skip automatically. |
-| `schema`        | *(FCA infer)*              | Path to a mache topology schema. Setting it forces `--backend tree-sitter` (leyline ignores build-time schemas).                                                                                                     |
-| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor (see above).                                                                                                                                                                                 |
-| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                                                                                                                                                                    |
-| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                                                                                                                                                                |
+| Input           | Default                    | Description                                                                                                                                                                                                                                 |
+| --------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mache-version` | `v0.17.0`                  | Release tag for the `mache-linux-amd64` binary. >= v0.17.0 ships gate-tagged rules (required — the gate runs `--tags=gate`); >= v0.13.0 auto-provisions leyline, so the `_ast`-backed rules run too. Absent-table rules skip automatically. |
+| `schema`        | *(FCA infer)*              | Path to a mache topology schema. Setting it forces `--backend tree-sitter` (leyline ignores build-time schemas).                                                                                                                            |
+| `baseline`      | `docs/smell-baseline.json` | Committed ratchet floor (see above).                                                                                                                                                                                                        |
+| `fail-on-new`   | `true`                     | Fail the job on new findings; `false` = advisory.                                                                                                                                                                                           |
+| `upload-sarif`  | `true`                     | Emit + upload SARIF to code-scanning.                                                                                                                                                                                                       |
 
 ## Contract with mache's own gate
 
@@ -67,13 +67,11 @@ Two intentional differences from mache's own gate (mache-608a3c
 consolidated it onto a single leyline build + single baseline, so the
 builds now match):
 
-1. mache's Taskfile gate scopes to `--tags=gate` — the ratchet rule set,
-   excluding the min-0 firehose rules (`cyclomatic_complexity`,
-   `magic_int_in_comparison`). The action runs `--rule '*'` because its
-   pinned release predates the `gate` retag of the embedded rules;
-   `--tags=gate` will be adopted when the default `mache-version` is
-   bumped to a release that ships them (the parity test encodes this
-   reconvergence condition).
+1. Both gates scope to `--tags=gate` — the ratchet rule set, excluding
+   the min-0 firehose rules (`cyclomatic_complexity`,
+   `magic_int_in_comparison`). Reconverged at v0.17.0, the first
+   release shipping gate-tagged rules; the parity test pins the shared
+   shape on both sides.
 1. mache's gate builds from the tracked tree (`git archive HEAD`); the
    action builds from the checkout, which is equivalent on a clean CI
    checkout.

--- a/.github/actions/find-smells/action.yml
+++ b/.github/actions/find-smells/action.yml
@@ -5,23 +5,27 @@ inputs:
   mache-version:
     description: >-
       mache release tag to download mache-linux-amd64 from.
-      >= v0.13.0 auto-provisions leyline during `mache build` (backend
-      auto), so the _ast-backed rules (long_function, long_file,
-      duplicate_code, cyclomatic_complexity, ...) run in addition to the
-      cross-reference rules; rules whose required tables are absent are
-      skipped automatically by --rule '*'. >= v0.12.0 supports SARIF but
-      has no leyline auto-provisioning, so only the cross-reference
-      (nodes/node_defs/node_refs) rules run.
+      >= v0.17.0 ships gate-tagged rules, so the ratchet runs the same
+      `--tags=gate` selection as mache's own Taskfile gate (min-0
+      firehose rules like cyclomatic_complexity are excluded from the
+      gate but still available ad hoc). >= v0.13.0 auto-provisions
+      leyline during `mache build` (backend auto), so the _ast-backed
+      rules run in addition to the cross-reference rules; absent-table
+      rules are skipped automatically. Versions below v0.17.0 have no
+      gate-tagged rules and fail with 'no rules match' — pin an older
+      action revision instead of overriding this downward.
     required: false
-    default: 'v0.16.2'
+    default: 'v0.17.0'
   schema:
     description: >-
       Path to a mache topology schema. Empty uses FCA schema inference.
-      When set, the build is forced to --backend tree-sitter: the
-      leyline backend (preferred by backend auto) does not honor
-      build-time schemas, so without the override the build would only
-      WARN (a log line CI never fails on) and produce a .db that lacks
-      the schema.
+      When set, the build is forced to --backend tree-sitter for
+      LANGUAGE COVERAGE: since v0.17.0 the leyline backend honors
+      build-time schemas, but the pinned leyline parses ~11 of the 28
+      registry languages while the in-process tree-sitter tier covers
+      all 28. The forcing goes away when the CGO tree-sitter backend is
+      deleted (mache-37ae8b); unparseable schema languages then fail
+      loudly via the coverage guard.
     required: false
     default: ''
   baseline:
@@ -68,21 +72,17 @@ runs:
         if [ ! -f "$BASELINE" ]; then
           echo "::error::mache find-smells: no baseline at '${BASELINE}'."
           echo "::error::Bootstrap it once and commit the file, then re-run:"
-          echo "::error::  mache build . smells.db && mache find-smells --db smells.db --rule '*' --limit 100000 --baseline-root \"\$PWD\" --write-baseline ${BASELINE}"
+          echo "::error::  mache build . smells.db && mache find-smells --db smells.db --rule '*' --tags=gate --limit 100000 --baseline-root \"\$PWD\" --write-baseline ${BASELINE}"
           exit 1
         fi
 
     # Core invocation contract: the find-smells calls below mirror the
     # `smells` target in mache's own Taskfile (build, then
-    # `find-smells --rule '*' --limit 100000 --baseline-root --baseline`).
+    # `find-smells --rule '*' --tags=gate --limit 100000 --baseline-root --baseline`).
     # cmd/find_smells_action_test.go asserts the two invocation shapes
-    # stay in sync — change them together. Known temporary divergence
-    # (mache-608a3c): the Taskfile gate adds the gate-tag rule filter
-    # (the ratchet set, excluding the min-0 firehoses); this action pins
-    # a released mache whose embedded rules predate the gate retag, so
-    # that filter here would match zero rules. Adopt it when the default
-    # mache-version above is bumped to a release shipping gate-tagged
-    # rules — the parity test enforces exactly this reconvergence.
+    # stay in sync — change them together. Reconverged at v0.17.0
+    # (mache-3ac299): both gates run the `--tags=gate` ratchet rule set
+    # (min-0 firehoses excluded).
     - name: Build index
       shell: bash
       env:
@@ -103,7 +103,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --limit 100000 \
+        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --tags=gate --limit 100000 \
           --baseline-root "$PWD" --format sarif > "${RUNNER_TEMP}/mache.sarif"
 
     - name: Upload SARIF
@@ -116,7 +116,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --limit 100000 \
+        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --tags=gate --limit 100000 \
           --baseline-root "$PWD" --format md >> "$GITHUB_STEP_SUMMARY"
 
     - name: Ratchet gate
@@ -126,7 +126,7 @@ runs:
         FAIL_ON_NEW: ${{ inputs.fail-on-new }}
       run: |
         set -uo pipefail
-        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --limit 100000 \
+        mache find-smells --db "${RUNNER_TEMP}/repo.db" --rule '*' --tags=gate --limit 100000 \
           --baseline-root "$PWD" --baseline "$BASELINE"
         code=$?
         if [ "$FAIL_ON_NEW" != "true" ] && [ "$code" -eq 1 ]; then

--- a/cmd/find_smells_action_test.go
+++ b/cmd/find_smells_action_test.go
@@ -79,24 +79,16 @@ func TestFindSmellsAction_TaskfileParity(t *testing.T) {
 	require.NoError(t, err)
 	action, taskfile := string(actionRaw), string(taskRaw)
 
-	// The core invocation shape: run every rule (auto-skipping
-	// absent-table rules), uncapped in practice, with a portable
-	// baseline root. TEMPORARY divergence (mache-608a3c): mache's own
-	// Taskfile gate additionally scopes to `--tags=gate` — the ratchet
-	// rule set, excluding the min-0 firehoses — but the action pins a
-	// RELEASED mache whose embedded rules predate the `gate` retag, so
-	// `--tags=gate` there would match zero rules and exit 3. Once the
-	// action's default mache-version is bumped to a release that ships
-	// gate-tagged rules, add `--tags=gate` to the action's invocations
-	// and collapse these two constants back into one.
-	const actionShape = "--rule '*' --limit 100000"
-	const taskfileShape = "--rule '*' --tags=gate --limit 100000"
-	assert.Contains(t, action, actionShape,
-		"action must run the documented rule-selection + limit shape")
-	assert.NotContains(t, action, "--tags=",
-		"the action must not use --tags until its pinned mache release ships gate-tagged rules — bump the default mache-version first, then reconverge the shapes (mache-608a3c)")
-	assert.Contains(t, taskfile, taskfileShape,
-		"Taskfile smells gate must run the gate-tagged ratchet shape")
+	// The core invocation shape, RECONVERGED at v0.17.0 (mache-3ac299):
+	// both gates run the `--tags=gate` ratchet rule set (min-0
+	// firehoses excluded), uncapped in practice, with a portable
+	// baseline root. If either side changes selection, both files and
+	// the action README's contract section move together.
+	const coreShape = "--rule '*' --tags=gate --limit 100000"
+	assert.Contains(t, action, coreShape,
+		"action must run the same gate-tagged rule-selection + limit shape as `task smells`")
+	assert.Contains(t, taskfile, coreShape,
+		"Taskfile smells gate must run the same gate-tagged rule-selection + limit shape as the action")
 	assert.Contains(t, action, "--baseline-root")
 	assert.Contains(t, taskfile, "--baseline-root")
 
@@ -114,15 +106,15 @@ func TestFindSmellsAction_TaskfileParity(t *testing.T) {
 		"Taskfile smells gate must gate on the documented baseline path")
 
 	// The action's default mache-version must be a well-formed release
-	// tag at or above v0.13.0 — the floor its input description documents
-	// (leyline auto-provisioning; below that the description's behavior
-	// notes would be wrong for the default).
+	// tag at or above v0.17.0 — the first release shipping gate-tagged
+	// rules; below that `--tags=gate` matches zero rules and the gate
+	// exits 3 ('no rules match').
 	m := regexp.MustCompile(`default: 'v(\d+)\.(\d+)\.\d+'`).FindStringSubmatch(action)
 	require.NotNil(t, m, "action must declare a semver default for mache-version")
 	major, err := strconv.Atoi(m[1])
 	require.NoError(t, err)
 	minor, err := strconv.Atoi(m[2])
 	require.NoError(t, err)
-	assert.True(t, major > 0 || minor >= 13,
-		"default mache-version %s predates v0.13.0 leyline auto-provisioning; the input description would be stale", m[0])
+	assert.True(t, major > 0 || minor >= 17,
+		"default mache-version %s predates v0.17.0 gate-tagged rules; --tags=gate would match nothing", m[0])
 }


### PR DESCRIPTION
## Summary
Closes the two tripwires deliberately encoded in `TestFindSmellsAction_TaskfileParity` now that v0.17.0 (the first release shipping gate-tagged rules) is published:

- Default `mache-version` → **v0.17.0**; input description documents the new floor (below it `--tags=gate` matches zero rules).
- Every find-smells invocation (bootstrap hint, SARIF, MD summary, ratchet gate) adopts **`--tags=gate`** — consumers gate on the same ratchet rule set as mache's own Taskfile gate, and code-scanning SARIF stays free of the min-0 firehoses.
- Parity test collapses back to a single `coreShape` (`--rule '*' --tags=gate --limit 100000` asserted in BOTH files); semver floor assertion rises to v0.17.0.
- Schema input **keeps** forcing `--backend tree-sitter`, with the rationale corrected: leyline honors schemas since v0.17.0, but parses ~11/28 registry languages vs tree-sitter's 28 — the forcing is about coverage now, and is removed with the CGO deletion (mache-37ae8b).
- Action README contract section updated (divergence paragraph → reconverged).

## Verification
`go test ./cmd/ -run TestFindSmellsAction` pass; `task docs:lint` / `lint:yaml` / `lint:actions` clean. v0.17.0 release assets verified present (mache-linux-amd64 + checksums).

🤖 Generated with [Claude Code](https://claude.com/claude-code)