### PR TITLE
[mache-73b885] refactor(writeback): validate + lint via leyline v0.7.8 validate op — drop in-process tree-sitter from the write path

### DIFF
--- a/cmd/mount_nfs.go
+++ b/cmd/mount_nfs.go
@@ -35,8 +35,11 @@ func mountNFS(schema *api.Topology, g graph.Graph, engine *ingest.Engine, mountP
 				return fmt.Errorf("node not found: %w", err)
 			}
 
-			// 1. Validate syntax before touching source file
-			if err := writeback.Validate(content, origin.FilePath); err != nil {
+			// 1. Validate syntax before touching source file. ONE leyline
+			// parse serves both validation and (for Go) the lint rules
+			// below via the returned AST payload — no second parse.
+			astPayload, err := writeback.ValidateWithAST(content, origin.FilePath)
+			if err != nil {
 				log.Printf("writeback: validation failed for %s: %v (saving draft)", origin.FilePath, err)
 				// Store diagnostic for _diagnostics/ virtual dir
 				if isMemStore {
@@ -52,9 +55,12 @@ func mountNFS(schema *api.Topology, g graph.Graph, engine *ingest.Engine, mountP
 			// 2. Format in-process (gofumpt for Go, hclwrite for HCL/Terraform)
 			formatted := writeback.FormatBuffer(content, origin.FilePath)
 
-			// Linting (Warning only)
+			// Linting (Warning only). Runs on the pre-format AST — for the
+			// snippet writes this path receives, FormatBuffer is a no-op
+			// (format.Source needs a whole file), so line numbers agree;
+			// any residual drift is acceptable for a warning-only signal.
 			if strings.HasSuffix(origin.FilePath, ".go") {
-				if diags, err := linter.Lint(formatted, "go"); err == nil && len(diags) > 0 {
+				if diags, err := linter.LintAST(astPayload); err == nil && len(diags) > 0 {
 					var sb strings.Builder
 					for _, d := range diags {
 						sb.WriteString(d.String() + "\n")

--- a/cmd/mount_nfs.go
+++ b/cmd/mount_nfs.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -40,10 +41,20 @@ func mountNFS(schema *api.Topology, g graph.Graph, engine *ingest.Engine, mountP
 			// below via the returned AST payload — no second parse.
 			astPayload, err := writeback.ValidateWithAST(content, origin.FilePath)
 			if err != nil {
+				// Syntax failure and validator-infra failure (daemon
+				// unreachable / too old) both draft — the pre-existing
+				// contract — but the _diagnostics message distinguishes
+				// them so an editor user can tell "my code is broken"
+				// from "the validator is down" (#527 review).
+				diag := err.Error()
+				var ve *writeback.ValidationError
+				if !errors.As(err, &ve) {
+					diag = "validator unavailable (draft saved, source untouched): " + diag
+				}
 				log.Printf("writeback: validation failed for %s: %v (saving draft)", origin.FilePath, err)
 				// Store diagnostic for _diagnostics/ virtual dir
 				if isMemStore {
-					store.WriteStatus.Store(filepath.Dir(nodeID), err.Error())
+					store.WriteStatus.Store(filepath.Dir(nodeID), diag)
 					// Save as Draft
 					draft := make([]byte, len(content))
 					copy(draft, content)

--- a/cmd/serve_write.go
+++ b/cmd/serve_write.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -63,8 +64,17 @@ func makeWriteFileHandler(g graph.Graph) server.ToolHandlerFunc {
 				Path   string `json:"path"`
 				File   string `json:"file"`
 			}
+			// Syntax failures ("your code is broken") and validator-infra
+			// failures (daemon unreachable / too old) are different facts;
+			// the status field must not claim validation_error for the
+			// latter (#527 review).
+			status := "validation_error"
+			var ve *writeback.ValidationError
+			if !errors.As(err, &ve) {
+				status = "validator_unavailable"
+			}
 			data, _ := json.MarshalIndent(valResult{
-				Status: "validation_error",
+				Status: status,
 				Error:  err.Error(),
 				Path:   path,
 				File:   origin.FilePath,

--- a/cmd/serve_write_test.go
+++ b/cmd/serve_write_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/lltest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -19,12 +20,36 @@ import (
 // hclwrite) with validation. These tests pin the new contract:
 // validation always runs; formatting is opt-out via format=false.
 
+// fakeValidateDaemon wires a plumbing-fake leyline daemon (mache-73b885:
+// syntax validation rides the daemon's validate op). These tests exercise
+// format/splice mechanics, not parsing, so a brace-balance heuristic is a
+// sufficient verdict for the fixtures here; the real parser is covered by
+// internal/writeback's gated e2e suite.
+func fakeValidateDaemon(t *testing.T) {
+	t.Helper()
+	sock := lltest.FakeDaemon(t, func(req map[string]any) any {
+		content, _ := req["content"].(string)
+		if strings.Count(content, "{") != strings.Count(content, "}") {
+			return map[string]any{
+				"ok": false,
+				"errors": []any{map[string]any{
+					"row": 0, "col": 0, "byte_start": 0, "byte_end": 0, "message": "syntax error",
+				}},
+				"diagnostics": []any{},
+			}
+		}
+		return map[string]any{"ok": true, "errors": []any{}, "diagnostics": []any{}}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+}
+
 // buildWriteGraph creates a MemoryStore plus a real source file on disk
 // so the splice pipeline (validate → optional format → splice → update)
 // has something to write into. Returns the graph, the node path, and
 // the source file path.
 func buildWriteGraph(t *testing.T) (*graph.MemoryStore, string, string) {
 	t.Helper()
+	fakeValidateDaemon(t)
 
 	// Source file with deliberately-unformatted Go that gofumpt will
 	// rewrite (extra blank lines + tabs vs spaces in the body).
@@ -196,6 +221,7 @@ func TestWriteFile_ValidationStillRunsWhenFormatFalse(t *testing.T) {
 // write_file must surface that to the caller via "ok_graph_stale" plus
 // a graph_warning, not silently report "ok".
 func TestWriteFile_SurfacesStaleGraphAfterSplice(t *testing.T) {
+	fakeValidateDaemon(t)
 	original := "package main\n\nfunc Hello() {}\n"
 	srcPath := filepath.Join(t.TempDir(), "main.go")
 	require.NoError(t, os.WriteFile(srcPath, []byte(original), 0o644))

--- a/cmd/serve_write_test.go
+++ b/cmd/serve_write_test.go
@@ -371,3 +371,36 @@ func TestWriteFile_FormatChangedFalseWhenAlreadyClean(t *testing.T) {
 	assert.True(t, resp.FormatApplied)
 	assert.False(t, resp.FormatChanged, "clean input must not be reported as format-changed")
 }
+
+// TestServeWriteFile_InfraFailureStatusDistinct pins the #527 review fix:
+// when the validator INFRASTRUCTURE is unavailable (vs the content being
+// broken), write_file must report status "validator_unavailable" — not
+// falsely claim "validation_error". A dead socket + MACHE_NO_LEYLINE +
+// empty HOME guarantees no daemon can be acquired.
+func TestServeWriteFile_InfraFailureStatusDistinct(t *testing.T) {
+	store, nodePath, _ := buildWriteGraph(t)
+
+	// Kill the daemon acquisition path AFTER the graph was built (the
+	// builder wires a working fake; override it).
+	deadSock := filepath.Join(t.TempDir(), "dead.sock")
+	t.Setenv("LEYLINE_SOCKET", deadSock)
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "/nonexistent-for-test")
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+
+	handler := makeWriteFileHandler(store)
+	result, err := handler(context.Background(), makeRequest(map[string]any{
+		"path":    nodePath,
+		"content": "package main\n\nfunc Hello() {\n\treturn\n}\n",
+	}))
+	require.NoError(t, err)
+
+	var resp struct {
+		Status string `json:"status"`
+		Error  string `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &resp))
+	assert.Equal(t, "validator_unavailable", resp.Status,
+		"infra failure must not be reported as a validation_error")
+	assert.NotEmpty(t, resp.Error)
+}

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -3,52 +3,12 @@
   "counts": [
     {
       "rule_id": "dead_code",
-      "source_id": "cmd/all_tools_e2e_test.go",
-      "count": 2
-    },
-    {
-      "rule_id": "dead_code",
       "source_id": "cmd/config.go",
-      "count": 2
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "cmd/init.go",
-      "count": 1
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "cmd/pack.go",
-      "count": 1
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "cmd/serve.go",
-      "count": 1
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "cmd/serve_resolve_ref.go",
-      "count": 1
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "internal/graph/graph_suite_test.go",
-      "count": 4
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "internal/graph/sqlite_resolver_test.go",
       "count": 1
     },
     {
       "rule_id": "dead_code",
       "source_id": "internal/ingest/benchmark_test.go",
-      "count": 1
-    },
-    {
-      "rule_id": "dead_code",
-      "source_id": "internal/lang/lang.go",
       "count": 1
     },
     {
@@ -1234,12 +1194,12 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/cache.go",
-      "count": 5
+      "count": 7
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/cache_oci.go",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
@@ -1249,16 +1209,21 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/leyline.go",
-      "count": 1
+      "count": 3
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/mount_control.go",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/mount_nfs.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/pack.go",
       "count": 1
     },
     {
@@ -1278,12 +1243,32 @@
     },
     {
       "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_find_smells_load.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_find_callees.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_find_definition.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
       "source_id": "cmd/serve_handler_get_communities.go",
       "count": 1
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/serve_handler_list_directory.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "cmd/serve_handler_read_file.go",
       "count": 1
     },
     {
@@ -1314,7 +1299,7 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "cmd/serve_registry.go",
-      "count": 2
+      "count": 3
     },
     {
       "rule_id": "fan_out_skew",
@@ -1328,7 +1313,7 @@
     },
     {
       "rule_id": "fan_out_skew",
-      "source_id": "graph/sqlite.go",
+      "source_id": "internal/control/control.go",
       "count": 1
     },
     {
@@ -1338,8 +1323,18 @@
     },
     {
       "rule_id": "fan_out_skew",
+      "source_id": "internal/graph/memstore_callees.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
       "source_id": "internal/graph/memstore_refsdb.go",
       "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/graph/memstore_write.go",
+      "count": 1
     },
     {
       "rule_id": "fan_out_skew",
@@ -1368,7 +1363,17 @@
     },
     {
       "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/address_refs.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/engine_ingest.go",
       "count": 1
     },
     {
@@ -1384,7 +1389,7 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_walk.go",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
@@ -1393,7 +1398,27 @@
     },
     {
       "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/sitter_walker.go",
+      "count": 4
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/lattice/greedy.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/lattice/project_ast.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
       "source_id": "internal/leyline/socket.go",
+      "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/leyline/trigger.go",
       "count": 1
     },
     {
@@ -1409,6 +1434,16 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "internal/materialize/json.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/nfsmount/graphfs.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/refsvtab/refs_module.go",
       "count": 1
     },
     {
@@ -1434,21 +1469,11 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/mod.rs",
-      "count": 3
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/providers.rs",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/dolt/mod.rs",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "testdata/snapshots/medium-rust-rosary/src/github_mirror.rs",
       "count": 1
     },
     {
@@ -1464,17 +1489,12 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/reconcile/mod.rs",
-      "count": 3
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/reconcile/orchestration.rs",
-      "count": 2
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "testdata/snapshots/medium-rust-rosary/src/reconcile/threading.rs",
-      "count": 2
+      "count": 1
     },
     {
       "rule_id": "fan_out_skew",
@@ -1494,22 +1514,17 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/serve/handlers.rs",
-      "count": 7
+      "count": 4
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/serve/ipc.rs",
-      "count": 3
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/serve/mod.rs",
-      "count": 3
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "testdata/snapshots/medium-rust-rosary/src/serve/webhook.rs",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
@@ -1523,18 +1538,18 @@
     },
     {
       "rule_id": "fan_out_skew",
-      "source_id": "testdata/snapshots/medium-rust-rosary/tests/cli_integration.rs",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
       "source_id": "tools/coverage-gate/main.go",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "tools/fixtures-rebaseline/main.go",
       "count": 2
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "tools/fixtures-snapshot/main.go",
+      "count": 1
     },
     {
       "rule_id": "fan_out_skew",

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -26,10 +26,10 @@ import (
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "63ba1c9e3559ecb8d492e3e6ed3fabce98a634c6048943c9ef9a45b49432a2a0",
-	"darwin-arm64": "7e6182b16324aa33e43c039d274440b8e9a2c84b8ba8a2a5dce385123003fae1",
-	"linux-amd64":  "3a75973d9ef89a3f1a89ef2d29fdc3d2f0da8345d572981812830ac9bf26bab4",
-	"linux-arm64":  "191e0ee872e095791f8d2f22c019832bcf73b28e6921c960b858d0b97433e69f",
+	"darwin-amd64": "54b21072d3c0e362304b93f82065d21451619751d9b66ad4291de0a64b1a5f3e",
+	"darwin-arm64": "c20ae5ed2b89b7693463240fcba25285c019502b3f29d0476ed3b3430e6430cb",
+	"linux-amd64":  "34cc851f744f3f2662d89473be1bc6a175b9777747e2922fd3efd88292b9fcb2",
+	"linux-arm64":  "c48b64041a68744d66274cd18d5b0996d0e4db07c51af8430c8b31fe7ddffe79",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -250,36 +250,26 @@ func DiscoverOrStart() (string, error) {
 		managed.discard()
 	}
 
-	// Find the leyline binary: PATH → ~/.mache/bin/ → auto-download
+	// Find the leyline binary through the SAME pin-checked chokepoint as
+	// the build path (ResolveBinary: PATH → ~/.mache/bin → SHA-verified
+	// download, each candidate accepted only on the exact pinned version).
+	// This block previously did a raw LookPath + unchecked cache stat —
+	// the drift ResolveBinary was built to kill (mache-0acdf6): a stale
+	// PATH leyline would be SPAWNED as the daemon, and with the write-back
+	// validate op requiring >= v0.7.8 every write would draft with a
+	// daemon-too-old diagnostic. An already-RUNNING daemon (fast paths
+	// above) is still honored as-is — it is the user's own; the wire
+	// handshake and per-op probes cover that case. ResolveBinary respects
+	// MACHE_NO_LEYLINE before downloading.
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
-
-	leylineBin, err := exec.LookPath("leyline")
-	source := "PATH"
+	leylineBin, err := ResolveBinary(true)
 	if err != nil {
-		// Fallback: check ~/.mache/bin/leyline
-		localBin := filepath.Join(home, ".mache", "bin", "leyline")
-		if _, statErr := os.Stat(localBin); statErr == nil {
-			leylineBin = localBin
-			source = "cached" // ~/.mache/bin — un-versioned, can shadow the pin (mache-0acdf6)
-		} else if os.Getenv("MACHE_NO_LEYLINE") != "" {
-			// CI / bundle deployments set this to opt out of the
-			// network-fetch path entirely. Surface a clear error
-			// rather than attempting a download that's likely to
-			// 404 against an unpublished ley-line-open release.
-			return "", fmt.Errorf("leyline not on PATH and MACHE_NO_LEYLINE is set; install leyline or unset MACHE_NO_LEYLINE")
-		} else {
-			// Auto-download from GitHub releases
-			downloaded, dlErr := downloadLeyline(localBin)
-			if dlErr != nil {
-				return "", fmt.Errorf("leyline not on PATH and auto-download failed: %w", dlErr)
-			}
-			leylineBin = downloaded
-			source = "downloaded"
-		}
+		return "", fmt.Errorf("no pinned leyline to spawn: %w", err)
 	}
+	source := "resolved-pinned"
 	// Record which binary won, from which tier, at what version — so the
 	// resolution is visible in logs AND via get_sheaf_status (mache-0dcd98).
 	// This was invisible before, which made the stale-cached-0.4.1 skew

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -830,7 +830,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch. Its major.minor is kept in lockstep with the go.mod leyline-schema
 // pin by the version-parity gate (mache-b8af69).
-const leylineBinaryVersion = "v0.7.5"
+const leylineBinaryVersion = "v0.7.8"
 
 // leylineReleaseURLTemplate is the GitHub releases URL for the public
 // ley-line-open repository. The earlier URL pointed at the private

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -982,13 +982,17 @@ func TestDiscoverOrStart_LocalBinFallback_SocketTimeout(t *testing.T) {
 	// on the sleep) and uses an absolute PATH for `sleep` because the test
 	// nukes PATH — otherwise `sleep` isn't found and the process would exit
 	// (taking the crash branch instead of the timeout branch).
-	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'fake leyline'; exit 0;; esac\nPATH=/bin:/usr/bin exec sleep 30\n"
+	// Must report the PINNED version: DiscoverOrStart's spawn path now goes
+	// through ResolveBinary (exact pin), so an unversioned stub would be
+	// rejected and trigger a download instead of exercising the timeout.
+	pin := strings.TrimPrefix(leylineBinaryVersion, "v")
+	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'leyline " + pin + " (open)'; exit 0;; esac\nPATH=/bin:/usr/bin exec sleep 30\n"
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "leyline"), []byte(fake), 0o755))
 
 	t.Setenv("HOME", home)
 	t.Setenv("LEYLINE_SOCKET", "")
 	t.Setenv("PATH", "/nonexistent-path-for-test")
-	t.Setenv("MACHE_NO_LEYLINE", "")
+	t.Setenv("MACHE_NO_LEYLINE", "1") // belt-and-braces: never download in tests
 	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "1s")
 
 	_, err := DiscoverOrStart()
@@ -1021,12 +1025,17 @@ func TestDiscoverOrStart_DaemonExitsDuringStartup(t *testing.T) {
 	home := e2eHome(t)
 	binDir := filepath.Join(home, ".mache", "bin")
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
-	require.NoError(t, os.Symlink("/bin/sh", filepath.Join(binDir, "leyline")))
+	// Pin-versioned stub (spawn path is ResolveBinary-gated) that exits
+	// non-zero for the daemon invocation — stands in for a leyline that
+	// dies on startup. The former /bin/sh symlink can't answer --version.
+	pin := strings.TrimPrefix(leylineBinaryVersion, "v")
+	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'leyline " + pin + " (open)'; exit 0;; esac\nexit 2\n"
+	require.NoError(t, os.WriteFile(filepath.Join(binDir, "leyline"), []byte(fake), 0o755))
 
 	t.Setenv("HOME", home)
 	t.Setenv("LEYLINE_SOCKET", "")
 	t.Setenv("PATH", "/nonexistent-path-for-test")
-	t.Setenv("MACHE_NO_LEYLINE", "")
+	t.Setenv("MACHE_NO_LEYLINE", "1") // belt-and-braces: never download in tests
 	// Generous timeout so the assertion proves we returned on exit-detection,
 	// not because the wait elapsed.
 	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "30s")
@@ -1062,13 +1071,14 @@ func TestDiscoverOrStart_DaemonExitsCleanlyDuringStartup(t *testing.T) {
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 	// Answers --version fast, then exits 0 for the daemon invocation without
 	// binding a socket.
-	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'fake leyline'; exit 0;; esac\nexit 0\n"
+	pin := strings.TrimPrefix(leylineBinaryVersion, "v")
+	fake := "#!/bin/sh\ncase \"$1\" in --version) echo 'leyline " + pin + " (open)'; exit 0;; esac\nexit 0\n"
 	require.NoError(t, os.WriteFile(filepath.Join(binDir, "leyline"), []byte(fake), 0o755))
 
 	t.Setenv("HOME", home)
 	t.Setenv("LEYLINE_SOCKET", "")
 	t.Setenv("PATH", "/nonexistent-path-for-test")
-	t.Setenv("MACHE_NO_LEYLINE", "")
+	t.Setenv("MACHE_NO_LEYLINE", "1") // belt-and-braces: never download in tests
 	t.Setenv("MACHE_LEYLINE_START_TIMEOUT", "30s")
 
 	_, err := DiscoverOrStart()

--- a/internal/leyline/validate.go
+++ b/internal/leyline/validate.go
@@ -1,0 +1,193 @@
+package leyline
+
+// Client for the daemon's `validate` op (ley-line-open >= v0.7.8).
+//
+// Request wire (rs/ll-open/cli-lib/src/daemon/wire.rs ValidateRequest):
+//
+//	{"op":"validate", "content":"<utf8 source>", "language":"go",
+//	 "path":"main.go", "emit_ast":true}
+//
+// `language` is an extension key (go|py|js|ts|tsx|rs|ex|exs); `path` lets the
+// daemon infer the language from the extension. When both are present,
+// `language` wins. When `emit_ast` is true, `path` doubles as the source_id
+// stamped on every emitted AST row.
+//
+// Response wire (rs/ll-open/cli-lib/src/daemon/ops.rs op_validate):
+//
+//	{"ok": bool,
+//	 "errors": [{"row":N,"col":N,"byte_start":N,"byte_end":N,"message":"..."}],
+//	 "diagnostics": [legacy first-error-only shape — ignored here],
+//	 "ast": {...}}   // only when emit_ast was requested
+//
+// `errors` enumerates EVERY ERROR/MISSING node in document order; row/col are
+// 0-based (col = byte offset within the row), byte_start == byte_end for
+// zero-width MISSING nodes, message is "syntax error" or "missing <kind>".
+// Daemons older than v0.7.7 lack the `errors` key entirely — that is treated
+// as a hard "daemon too old" error, never a silent fallback (the mache binary
+// pin guarantees v0.7.8 for daemons mache spawns, but LEYLINE_SOCKET may point
+// at a user-supplied older daemon).
+
+import (
+	"fmt"
+)
+
+// ValidateSyntaxError is one ERROR/MISSING node from the daemon's validate
+// op. Row and Col are 0-based; Col is the byte offset within the row.
+// ByteStart == ByteEnd for zero-width MISSING nodes.
+type ValidateSyntaxError struct {
+	Row       uint32 `json:"row"`
+	Col       uint32 `json:"col"`
+	ByteStart uint32 `json:"byte_start"`
+	ByteEnd   uint32 `json:"byte_end"`
+	Message   string `json:"message"`
+}
+
+// ASTRow mirrors one `_ast` table row emitted by the daemon's emit_ast
+// extension. NodeID is the hierarchical merkle-AST path (parent node_id +
+// "/" + child kind, with a `_N` index suffix when a parent has multiple
+// same-kind named children), rooted at the request's source_id.
+type ASTRow struct {
+	NodeID    string `json:"node_id"`
+	SourceID  string `json:"source_id"`
+	NodeKind  string `json:"node_kind"`
+	StartByte uint32 `json:"start_byte"`
+	EndByte   uint32 `json:"end_byte"`
+	StartRow  uint32 `json:"start_row"`
+	StartCol  uint32 `json:"start_col"`
+	EndRow    uint32 `json:"end_row"`
+	EndCol    uint32 `json:"end_col"`
+	NodeHash  string `json:"node_hash"`
+}
+
+// ASTDef mirrors one `node_defs` row from emit_ast.
+type ASTDef struct {
+	Token           string  `json:"token"`
+	NodeID          string  `json:"node_id"`
+	SourceID        string  `json:"source_id"`
+	ContainerNodeID *string `json:"container_node_id"`
+	CanonicalKind   *string `json:"canonical_kind"`
+}
+
+// ASTRef mirrors one `node_refs` row from emit_ast.
+type ASTRef struct {
+	Token           string  `json:"token"`
+	NodeID          string  `json:"node_id"`
+	SourceID        string  `json:"source_id"`
+	ContainerNodeID *string `json:"container_node_id"`
+}
+
+// ASTImport mirrors one `_imports` row from emit_ast.
+type ASTImport struct {
+	Alias    string `json:"alias"`
+	Path     string `json:"path"`
+	SourceID string `json:"source_id"`
+}
+
+// ASTPayload is the `ast` object the daemon folds into a validate response
+// when emit_ast is requested: SQL-shaped `_ast`/`node_defs`/`node_refs`/
+// `_imports` rows from the SAME parse that produced the syntax verdict.
+type ASTPayload struct {
+	SourceID    string      `json:"source_id"`
+	Language    string      `json:"language"`
+	ContentHash string      `json:"content_hash"`
+	AST         []ASTRow    `json:"ast"`
+	Defs        []ASTDef    `json:"defs"`
+	Refs        []ASTRef    `json:"refs"`
+	Imports     []ASTImport `json:"imports"`
+}
+
+// ValidateResult is the decoded validate response.
+type ValidateResult struct {
+	OK     bool
+	Errors []ValidateSyntaxError
+	AST    *ASTPayload // non-nil only when emit_ast was requested and honored
+}
+
+// validateResponse is the raw wire shape. Errors is a *pointer* to a slice so
+// key-absence (old daemon) is distinguishable from an empty array (clean
+// parse) — the v0.7.8 contract always includes "errors", even when empty.
+type validateResponse struct {
+	OK     *bool                  `json:"ok"`
+	Error  *string                `json:"error,omitempty"`
+	Errors *[]ValidateSyntaxError `json:"errors"`
+	AST    *ASTPayload            `json:"ast,omitempty"`
+}
+
+// Validate runs the daemon's validate op on caller-supplied content.
+// language is a leyline extension key ("go", "py", ...); path is optional and
+// (a) lets the daemon infer the language when language is empty, (b) becomes
+// the source_id on emitted AST rows. emitAST folds ONE parse into both the
+// syntax verdict and SQL-shaped AST rows (ValidateResult.AST).
+//
+// A daemon response without the `errors` key, or without the `ast` payload
+// when emitAST was requested on a clean parse, is a hard error: the daemon
+// predates the v0.7.8 wire contract and mache must not silently skip
+// validation or linting.
+func (c *SocketClient) Validate(content []byte, language, path string, emitAST bool) (*ValidateResult, error) {
+	req := map[string]any{
+		"op":      "validate",
+		"content": string(content),
+	}
+	if language != "" {
+		req["language"] = language
+	}
+	if path != "" {
+		req["path"] = path
+	}
+	if emitAST {
+		req["emit_ast"] = true
+	}
+
+	var resp validateResponse
+	if err := c.SendOpInto(req, &resp); err != nil {
+		return nil, fmt.Errorf("leyline validate op: %w", err)
+	}
+	if resp.Error != nil {
+		// Structured daemon error envelope: unknown op (pre-v0.7.7 daemon),
+		// unknown language, or missing language+path. All are hard errors —
+		// the caller gates supported languages client-side, so none of these
+		// is a legitimate pass-through.
+		return nil, fmt.Errorf("leyline validate: %s (daemon must be ley-line-open >= %s)", *resp.Error, leylineBinaryVersion)
+	}
+	if resp.Errors == nil {
+		return nil, fmt.Errorf("leyline validate response has no `errors` field — daemon too old, need ley-line-open >= %s (refusing to treat the write as validated)", leylineBinaryVersion)
+	}
+
+	res := &ValidateResult{
+		OK:     resp.OK != nil && *resp.OK,
+		Errors: *resp.Errors,
+		AST:    resp.AST,
+	}
+	if emitAST && res.AST == nil {
+		return nil, fmt.Errorf("leyline validate did not return the `ast` payload for emit_ast — daemon too old, need ley-line-open >= %s", leylineBinaryVersion)
+	}
+	return res, nil
+}
+
+// ValidateContent is the write-back path's convenience wrapper: it acquires a
+// daemon via DiscoverOrStart (reusing a live socket when one exists — env
+// LEYLINE_SOCKET or ~/.mache/default.sock — else lazily spawning a managed
+// daemon), dials, runs one validate op, and closes the connection.
+//
+// Latency: the UDS dial + round trip is sub-millisecond when a daemon is
+// already running. The FIRST write after mount may pay a cold daemon spawn
+// (typically 0.5–2s: arena init + socket bind); subsequent writes reuse that
+// daemon via the well-known socket. Dial-per-call is deliberate — it avoids a
+// cached client going stale when the daemon restarts between writes.
+func ValidateContent(content []byte, language, path string, emitAST bool) (*ValidateResult, error) {
+	sock, err := DiscoverOrStart()
+	if err != nil {
+		return nil, fmt.Errorf("acquire leyline daemon for validate: %w", err)
+	}
+	c, err := DialSocket(sock)
+	if err != nil {
+		return nil, fmt.Errorf("dial leyline daemon %s: %w", sock, err)
+	}
+	defer func() { _ = c.Close() }()
+	return c.Validate(content, language, path, emitAST)
+}
+
+// PinnedBinaryVersion returns the ley-line-open release tag this mache build
+// pins (e.g. "v0.7.8"). Exported for test gates that must verify a local
+// leyline binary matches the pin without ever downloading one.
+func PinnedBinaryVersion() string { return leylineBinaryVersion }

--- a/internal/leyline/validate_op_test.go
+++ b/internal/leyline/validate_op_test.go
@@ -1,0 +1,112 @@
+package leyline_test
+
+// External test package (leyline_test) so these tests can use
+// lltest.FakeDaemon, which imports internal/leyline — an in-package test file
+// would create an import cycle. What is under test is the package-level
+// ValidateContent path: daemon acquisition via LEYLINE_SOCKET, one dial, one
+// op, typed decode.
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/agentic-research/mache/internal/lltest"
+)
+
+func TestValidateContent_DecodesVerdictAndAST(t *testing.T) {
+	var gotReq map[string]any
+	sock := lltest.FakeDaemon(t, func(req map[string]any) any {
+		gotReq = req
+		return map[string]any{
+			"ok":          true,
+			"errors":      []any{},
+			"diagnostics": []any{},
+			"ast": map[string]any{
+				"source_id":    "main.go",
+				"language":     "go",
+				"content_hash": "cafe",
+				"ast": []any{map[string]any{
+					"node_id": "main.go", "source_id": "main.go", "node_kind": "source_file",
+					"start_byte": 0, "end_byte": 13, "start_row": 0, "start_col": 0,
+					"end_row": 1, "end_col": 0, "node_hash": "beef",
+				}},
+				"defs":    []any{map[string]any{"token": "f", "node_id": "main.go/function_declaration", "source_id": "main.go", "container_node_id": nil, "canonical_kind": "function"}},
+				"refs":    []any{},
+				"imports": []any{},
+			},
+		}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	res, err := leyline.ValidateContent([]byte("package main\n"), "go", "main.go", true)
+	require.NoError(t, err)
+	assert.True(t, res.OK)
+	assert.Empty(t, res.Errors)
+	require.NotNil(t, res.AST)
+	assert.Equal(t, "go", res.AST.Language)
+	require.Len(t, res.AST.AST, 1)
+	assert.Equal(t, "source_file", res.AST.AST[0].NodeKind)
+	require.Len(t, res.AST.Defs, 1)
+	assert.Equal(t, "f", res.AST.Defs[0].Token)
+	require.NotNil(t, res.AST.Defs[0].CanonicalKind)
+	assert.Equal(t, "function", *res.AST.Defs[0].CanonicalKind)
+
+	require.NotNil(t, gotReq)
+	assert.Equal(t, "validate", gotReq["op"])
+	assert.Equal(t, "go", gotReq["language"])
+	assert.Equal(t, "main.go", gotReq["path"])
+	assert.Equal(t, true, gotReq["emit_ast"])
+}
+
+func TestValidateContent_SyntaxErrorsDecoded(t *testing.T) {
+	sock := lltest.FakeDaemon(t, func(map[string]any) any {
+		return map[string]any{
+			"ok": false,
+			"errors": []any{
+				map[string]any{"row": 2, "col": 12, "byte_start": 26, "byte_end": 41, "message": "syntax error"},
+			},
+			"diagnostics": []any{},
+		}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	res, err := leyline.ValidateContent([]byte("package main\nbroken"), "go", "", false)
+	require.NoError(t, err, "a not-ok verdict is a RESULT, not a client error")
+	assert.False(t, res.OK)
+	require.Len(t, res.Errors, 1)
+	assert.Equal(t, uint32(2), res.Errors[0].Row)
+	assert.Equal(t, uint32(12), res.Errors[0].Col)
+	assert.Equal(t, uint32(26), res.Errors[0].ByteStart)
+	assert.Equal(t, uint32(41), res.Errors[0].ByteEnd)
+}
+
+func TestValidateContent_MissingErrorsKey_DaemonTooOld(t *testing.T) {
+	sock := lltest.FakeDaemon(t, func(map[string]any) any {
+		return map[string]any{"ok": true, "diagnostics": []any{}}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	_, err := leyline.ValidateContent([]byte("package main\n"), "go", "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), leyline.PinnedBinaryVersion())
+}
+
+func TestValidateContent_ErrorEnvelope(t *testing.T) {
+	sock := lltest.FakeDaemon(t, func(map[string]any) any {
+		return map[string]any{"ok": false, "error": "unknown language id: `xyz`"}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	_, err := leyline.ValidateContent([]byte("x"), "xyz", "", false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown language id")
+}
+
+func TestPinnedBinaryVersion_IsSemverTag(t *testing.T) {
+	assert.Regexp(t, regexp.MustCompile(`^v\d+\.\d+\.\d+$`), leyline.PinnedBinaryVersion(),
+		"pin must be an exact semver tag — test gates compare local binaries against it")
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -1,14 +1,20 @@
+// Package linter runs warning-only static-analysis rules on write-back
+// content. Since mache-73b885 the rules are SQL over the leyline daemon's
+// emit_ast payload (SQL-shaped `_ast` rows from the SAME parse that
+// validated the write) — no in-process tree-sitter.
 package linter
 
 import (
-	"context"
+	"database/sql"
 	"fmt"
 	"strings"
 
-	"github.com/agentic-research/mache/internal/lang"
-	sitter "github.com/smacker/go-tree-sitter"
+	_ "modernc.org/sqlite" // pure-Go SQLite driver for the in-memory rule DB
+
+	"github.com/agentic-research/mache/internal/leyline"
 )
 
+// Diagnostic is one warning-only lint finding. Line is 0-indexed.
 type Diagnostic struct {
 	Message string
 	Line    uint32
@@ -18,77 +24,106 @@ func (d Diagnostic) String() string {
 	return fmt.Sprintf("line %d: %s", d.Line+1, d.Message)
 }
 
-// Lint checks the content for static analysis issues.
-// Currently supports Go only.
+const nilSliceMessage = "Nil slice declaration. Consider 'make([]T, 0)' for JSON compatibility."
+
+// nilSliceSQL flags `var x []T` declarations with no initializer.
+//
+// Structure over `_ast` rows: a `var_spec` node whose DIRECT child is a
+// `slice_type` (the declared type) and which has NO direct `expression_list`
+// child (the initializer). Direct-child is expressed through the hierarchical
+// node_id path the daemon emits (child id = parent id + "/" + segment): the
+// child's id extends the parent's by exactly one segment. That excludes e.g.
+// the slice_type inside `var w []int = []int{1}`'s composite literal, which
+// sits under expression_list/composite_literal — two extra segments.
+const nilSliceSQL = `
+SELECT v.start_row
+FROM _ast v
+WHERE v.node_kind = 'var_spec'
+  AND EXISTS (
+    SELECT 1 FROM _ast c
+    WHERE c.node_kind = 'slice_type'
+      AND substr(c.node_id, 1, length(v.node_id) + 1) = v.node_id || '/'
+      AND instr(substr(c.node_id, length(v.node_id) + 2), '/') = 0
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM _ast c
+    WHERE c.node_kind = 'expression_list'
+      AND substr(c.node_id, 1, length(v.node_id) + 1) = v.node_id || '/'
+      AND instr(substr(c.node_id, length(v.node_id) + 2), '/') = 0
+  )
+ORDER BY v.start_row`
+
+// Lint checks the content for static analysis issues. Currently supports Go
+// only; other languages return (nil, nil). It costs one leyline validate
+// (emit_ast) round trip — callers that already hold an ASTPayload from the
+// write path's validation should call LintAST instead to reuse that parse.
 func Lint(content []byte, langName string) ([]Diagnostic, error) {
 	if langName != "go" && !strings.HasSuffix(langName, ".go") {
 		return nil, nil
 	}
-
-	parser := sitter.NewParser()
-	parser.SetLanguage(lang.ForName("go").Grammar())
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
+	res, err := leyline.ValidateContent(content, "go", "", true)
 	if err != nil {
 		return nil, err
 	}
+	return LintAST(res.AST)
+}
+
+// LintAST runs the SQL rules over an already-parsed emit_ast payload — no
+// daemon round trip. A nil payload (pass-through language, or a caller that
+// validated without emit_ast) yields no diagnostics. Non-Go payloads yield no
+// diagnostics: every current rule is Go-specific.
+func LintAST(ast *leyline.ASTPayload) ([]Diagnostic, error) {
+	if ast == nil || ast.Language != "go" || len(ast.AST) == 0 {
+		return nil, nil
+	}
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		return nil, fmt.Errorf("open in-memory lint db: %w", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.Exec(`CREATE TABLE _ast (node_id TEXT PRIMARY KEY, node_kind TEXT NOT NULL, start_row INTEGER NOT NULL)`); err != nil {
+		return nil, fmt.Errorf("create lint _ast table: %w", err)
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("begin lint insert: %w", err)
+	}
+	stmt, err := tx.Prepare(`INSERT INTO _ast (node_id, node_kind, start_row) VALUES (?, ?, ?)`)
+	if err != nil {
+		_ = tx.Rollback()
+		return nil, fmt.Errorf("prepare lint insert: %w", err)
+	}
+	for _, row := range ast.AST {
+		if _, err := stmt.Exec(row.NodeID, row.NodeKind, row.StartRow); err != nil {
+			_ = stmt.Close()
+			_ = tx.Rollback()
+			return nil, fmt.Errorf("insert lint _ast row %s: %w", row.NodeID, err)
+		}
+	}
+	_ = stmt.Close()
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit lint insert: %w", err)
+	}
+
+	rows, err := db.Query(nilSliceSQL)
+	if err != nil {
+		return nil, fmt.Errorf("run nil-slice rule: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
 
 	var diags []Diagnostic
-
-	// Rule 1: Nil Slice declaration
-	// var x []T (without initialization)
-	// Query: (var_declaration (var_spec name: (identifier) type: (slice_type) !value))
-	// Tree-sitter query syntax for "missing field" is slightly different depending on grammar.
-	// For Go: var_spec has 'name', 'type', 'value'.
-	// If 'value' is missing, it's a nil slice.
-
-	// Query to find slice declarations without values
-	query := `
-		(var_declaration
-			(var_spec
-				name: (identifier)
-				type: (slice_type)
-			) @decl
-		)
-	`
-	q, qerr := sitter.NewQuery([]byte(query), lang.ForName("go").Grammar())
-	if qerr != nil {
-		return nil, fmt.Errorf("compile lint query: %w", qerr)
-	}
-	qc := sitter.NewQueryCursor()
-	defer qc.Close()
-	qc.Exec(q, tree.RootNode())
-
-	for {
-		m, ok := qc.NextMatch()
-		if !ok {
-			break
+	for rows.Next() {
+		var startRow uint32
+		if err := rows.Scan(&startRow); err != nil {
+			return nil, fmt.Errorf("scan nil-slice row: %w", err)
 		}
-		for _, c := range m.Captures {
-			// Check if the var_spec has a value child
-			// The query finds var_spec with name and type.
-			// We need to verify it does NOT have a value.
-			// var_spec structure: name, type, [value]
-
-			// Simple check: iterate children of var_spec
-			hasValue := false
-			count := int(c.Node.ChildCount())
-			for i := range count {
-				// In Go grammar, the value is usually an expression list?
-				// Field names: name, type, value
-				if c.Node.FieldNameForChild(i) == "value" {
-					hasValue = true
-					break
-				}
-			}
-
-			if !hasValue {
-				diags = append(diags, Diagnostic{
-					Message: "Nil slice declaration. Consider 'make([]T, 0)' for JSON compatibility.",
-					Line:    c.Node.StartPoint().Row,
-				})
-			}
-		}
+		diags = append(diags, Diagnostic{Message: nilSliceMessage, Line: startRow})
 	}
-
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate nil-slice rows: %w", err)
+	}
 	return diags, nil
 }

--- a/internal/linter/linter_e2e_test.go
+++ b/internal/linter/linter_e2e_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestE2E_Lint_NilSlice_Flagged(t *testing.T) {
-	sock := lltest.StartPinnedDaemon(t)
-	t.Setenv("LEYLINE_SOCKET", sock)
+	lltest.UsePinnedDaemon(t)
 
 	src := []byte("package main\n\nvar x []int\n\nfunc f() {\n\tvar z []byte\n\t_ = z\n}\n")
 	diags, err := Lint(src, "go")
@@ -29,8 +28,7 @@ func TestE2E_Lint_NilSlice_Flagged(t *testing.T) {
 }
 
 func TestE2E_Lint_InitializedSlices_Clean(t *testing.T) {
-	sock := lltest.StartPinnedDaemon(t)
-	t.Setenv("LEYLINE_SOCKET", sock)
+	lltest.UsePinnedDaemon(t)
 
 	src := []byte("package main\n\nvar y []string = nil\n\nfunc f() {\n\tw := []int{1}\n\t_ = w\n\t_ = y\n}\n")
 	diags, err := Lint(src, "go")
@@ -41,8 +39,7 @@ func TestE2E_Lint_InitializedSlices_Clean(t *testing.T) {
 func TestE2E_Lint_FunctionSnippet_Parses(t *testing.T) {
 	// NFS write-back sends function-body snippets without a package clause;
 	// tree-sitter-go accepts them, so lint must work on snippets too.
-	sock := lltest.StartPinnedDaemon(t)
-	t.Setenv("LEYLINE_SOCKET", sock)
+	lltest.UsePinnedDaemon(t)
 
 	src := []byte("func HelloWorld() {\n\tvar s []int\n\t_ = s\n}\n")
 	diags, err := Lint(src, "go")

--- a/internal/linter/linter_e2e_test.go
+++ b/internal/linter/linter_e2e_test.go
@@ -1,0 +1,52 @@
+//go:build unix
+
+package linter
+
+// Gated e2e: the full Lint path (one leyline validate emit_ast round trip +
+// SQL rules) against the REAL pinned daemon. Skips when the pinned binary is
+// absent; never downloads.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/lltest"
+)
+
+func TestE2E_Lint_NilSlice_Flagged(t *testing.T) {
+	sock := lltest.StartPinnedDaemon(t)
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	src := []byte("package main\n\nvar x []int\n\nfunc f() {\n\tvar z []byte\n\t_ = z\n}\n")
+	diags, err := Lint(src, "go")
+	require.NoError(t, err)
+	require.Len(t, diags, 2, "both uninitialized slice declarations must be flagged")
+	assert.Equal(t, uint32(2), diags[0].Line, "top-level var x []int (0-based row 2)")
+	assert.Equal(t, uint32(5), diags[1].Line, "in-function var z []byte (0-based row 5)")
+	assert.Contains(t, diags[0].Message, "Nil slice declaration")
+}
+
+func TestE2E_Lint_InitializedSlices_Clean(t *testing.T) {
+	sock := lltest.StartPinnedDaemon(t)
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	src := []byte("package main\n\nvar y []string = nil\n\nfunc f() {\n\tw := []int{1}\n\t_ = w\n\t_ = y\n}\n")
+	diags, err := Lint(src, "go")
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+}
+
+func TestE2E_Lint_FunctionSnippet_Parses(t *testing.T) {
+	// NFS write-back sends function-body snippets without a package clause;
+	// tree-sitter-go accepts them, so lint must work on snippets too.
+	sock := lltest.StartPinnedDaemon(t)
+	t.Setenv("LEYLINE_SOCKET", sock)
+
+	src := []byte("func HelloWorld() {\n\tvar s []int\n\t_ = s\n}\n")
+	diags, err := Lint(src, "go")
+	require.NoError(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t, uint32(1), diags[0].Line)
+}

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -25,47 +25,53 @@ func goPayload(rows ...leyline.ASTRow) *leyline.ASTPayload {
 	return &leyline.ASTPayload{SourceID: "main.go", Language: "go", AST: rows}
 }
 
-func TestLintAST_NilSliceRule(t *testing.T) {
-	tests := []struct {
-		name      string
+// varSpecRows emits the _ast rows for one `var_declaration/var_spec` subtree
+// at the given node_id prefix and line: the declared-type row (typeKind, with
+// a nested type_identifier) plus, when initialized, an expression_list child
+// — the daemon shapes the nil-slice rule discriminates on.
+func varSpecRows(prefix string, line uint32, typeKind string, initialized bool) []leyline.ASTRow {
+	spec := prefix + "/var_spec"
+	rows := []leyline.ASTRow{
+		astRow(prefix, "var_declaration", line),
+		astRow(spec, "var_spec", line),
+		astRow(spec+"/identifier", "identifier", line),
+		astRow(spec+"/"+typeKind, typeKind, line),
+		astRow(spec+"/"+typeKind+"/type_identifier", "type_identifier", line),
+	}
+	if initialized {
+		rows = append(rows,
+			astRow(spec+"/expression_list", "expression_list", line),
+			astRow(spec+"/expression_list/nil", "nil", line),
+		)
+	}
+	return rows
+}
+
+func nilSliceRuleCases() map[string]struct {
+	rows      []leyline.ASTRow
+	wantLines []uint32
+} {
+	root := astRow("main.go", "source_file", 0)
+	return map[string]struct {
 		rows      []leyline.ASTRow
 		wantLines []uint32
 	}{
-		{
-			// var x []int → var_spec with a direct slice_type child, no value
-			name: "uninitialized slice flagged",
-			rows: []leyline.ASTRow{
-				astRow("main.go", "source_file", 0),
-				astRow("main.go/var_declaration", "var_declaration", 2),
-				astRow("main.go/var_declaration/var_spec", "var_spec", 2),
-				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 2),
-				astRow("main.go/var_declaration/var_spec/slice_type", "slice_type", 2),
-				astRow("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 2),
-			},
+		// var x []int → var_spec with a direct slice_type child, no value
+		"uninitialized slice flagged": {
+			rows:      append([]leyline.ASTRow{root}, varSpecRows("main.go/var_declaration", 2, "slice_type", false)...),
 			wantLines: []uint32{2},
 		},
-		{
-			// var y []string = nil → var_spec has a direct expression_list child
-			name: "initialized slice not flagged",
-			rows: []leyline.ASTRow{
-				astRow("main.go", "source_file", 0),
-				astRow("main.go/var_declaration", "var_declaration", 4),
-				astRow("main.go/var_declaration/var_spec", "var_spec", 4),
-				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 4),
-				astRow("main.go/var_declaration/var_spec/slice_type", "slice_type", 4),
-				astRow("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 4),
-				astRow("main.go/var_declaration/var_spec/expression_list", "expression_list", 4),
-				astRow("main.go/var_declaration/var_spec/expression_list/nil", "nil", 4),
-			},
+		// var y []string = nil → var_spec has a direct expression_list child
+		"initialized slice not flagged": {
+			rows:      append([]leyline.ASTRow{root}, varSpecRows("main.go/var_declaration", 4, "slice_type", true)...),
 			wantLines: nil,
 		},
-		{
-			// var w = []int{1} → the slice_type sits under expression_list/
-			// composite_literal, NOT as a direct var_spec child. The
-			// direct-child predicate (one path segment) must exclude it.
-			name: "composite literal slice type not a direct child",
+		// var w = []int{1} → the slice_type sits under expression_list/
+		// composite_literal, NOT as a direct var_spec child. The
+		// direct-child predicate (one path segment) must exclude it.
+		"composite literal slice type not a direct child": {
 			rows: []leyline.ASTRow{
-				astRow("main.go", "source_file", 0),
+				root,
 				astRow("main.go/var_declaration", "var_declaration", 1),
 				astRow("main.go/var_declaration/var_spec", "var_spec", 1),
 				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 1),
@@ -75,44 +81,39 @@ func TestLintAST_NilSliceRule(t *testing.T) {
 			},
 			wantLines: nil,
 		},
-		{
-			// var m map[string][]int → declared type is map_type; the
-			// slice_type is a grandchild and must not trigger the rule.
-			name: "map of slices not flagged",
-			rows: []leyline.ASTRow{
-				astRow("main.go", "source_file", 0),
-				astRow("main.go/var_declaration", "var_declaration", 1),
-				astRow("main.go/var_declaration/var_spec", "var_spec", 1),
-				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 1),
-				astRow("main.go/var_declaration/var_spec/map_type", "map_type", 1),
-				astRow("main.go/var_declaration/var_spec/map_type/type_identifier", "type_identifier", 1),
+		// var m map[string][]int → declared type is map_type; the slice_type
+		// grandchild under it must not trigger the rule.
+		"map of slices not flagged": {
+			rows: append(
+				append([]leyline.ASTRow{root}, varSpecRows("main.go/var_declaration", 1, "map_type", false)...),
 				astRow("main.go/var_declaration/var_spec/map_type/slice_type", "slice_type", 1),
-			},
+			),
 			wantLines: nil,
 		},
-		{
-			// Same-kind siblings carry _N suffixes on node_id (daemon
-			// behavior for >1 named children of one kind) — the rule must
-			// still see them, in document order.
-			name: "multiple nil slices all flagged in order",
-			rows: []leyline.ASTRow{
-				astRow("main.go", "source_file", 0),
-				astRow("main.go/function_declaration", "function_declaration", 0),
-				astRow("main.go/function_declaration/block", "block", 0),
-				astRow("main.go/function_declaration/block/statement_list", "statement_list", 1),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_0", "var_declaration", 1),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec", "var_spec", 1),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec/slice_type", "slice_type", 1),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_1", "var_declaration", 3),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec", "var_spec", 3),
-				astRow("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec/slice_type", "slice_type", 3),
-			},
+		// Same-kind siblings carry _N suffixes on node_id (daemon behavior
+		// for >1 named children of one kind) — the rule must still see them,
+		// in document order.
+		"multiple nil slices all flagged in order": {
+			rows: append(
+				append(
+					[]leyline.ASTRow{
+						root,
+						astRow("main.go/function_declaration", "function_declaration", 0),
+						astRow("main.go/function_declaration/block", "block", 0),
+						astRow("main.go/function_declaration/block/statement_list", "statement_list", 1),
+					},
+					varSpecRows("main.go/function_declaration/block/statement_list/var_declaration_0", 1, "slice_type", false)...,
+				),
+				varSpecRows("main.go/function_declaration/block/statement_list/var_declaration_1", 3, "slice_type", false)...,
+			),
 			wantLines: []uint32{1, 3},
 		},
 	}
+}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+func TestLintAST_NilSliceRule(t *testing.T) {
+	for name, tc := range nilSliceRuleCases() {
+		t.Run(name, func(t *testing.T) {
 			diags, err := LintAST(goPayload(tc.rows...))
 			require.NoError(t, err)
 			var gotLines []uint32

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/agentic-research/mache/internal/leyline"
 )
 
-// row is a shorthand _ast row constructor for rule tests (only the columns
+// astRow is a shorthand _ast row constructor for rule tests (only the columns
 // the rules consult are populated).
-func row(nodeID, kind string, startRow uint32) leyline.ASTRow {
+func astRow(nodeID, kind string, startRow uint32) leyline.ASTRow {
 	return leyline.ASTRow{NodeID: nodeID, SourceID: "main.go", NodeKind: kind, StartRow: startRow}
 }
 
@@ -25,96 +25,109 @@ func goPayload(rows ...leyline.ASTRow) *leyline.ASTPayload {
 	return &leyline.ASTPayload{SourceID: "main.go", Language: "go", AST: rows}
 }
 
-func TestLintAST_NilSliceDeclaration_Flagged(t *testing.T) {
-	// var x []int   → var_spec with a direct slice_type child, no value
-	ast := goPayload(
-		row("main.go", "source_file", 0),
-		row("main.go/var_declaration", "var_declaration", 2),
-		row("main.go/var_declaration/var_spec", "var_spec", 2),
-		row("main.go/var_declaration/var_spec/identifier", "identifier", 2),
-		row("main.go/var_declaration/var_spec/slice_type", "slice_type", 2),
-		row("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 2),
-	)
-	diags, err := LintAST(ast)
-	require.NoError(t, err)
-	require.Len(t, diags, 1)
-	assert.Equal(t, uint32(2), diags[0].Line)
-	assert.Contains(t, diags[0].Message, "Nil slice declaration")
-	assert.Contains(t, diags[0].String(), "line 3:", "String() renders 1-based")
+func TestLintAST_NilSliceRule(t *testing.T) {
+	tests := []struct {
+		name      string
+		rows      []leyline.ASTRow
+		wantLines []uint32
+	}{
+		{
+			// var x []int → var_spec with a direct slice_type child, no value
+			name: "uninitialized slice flagged",
+			rows: []leyline.ASTRow{
+				astRow("main.go", "source_file", 0),
+				astRow("main.go/var_declaration", "var_declaration", 2),
+				astRow("main.go/var_declaration/var_spec", "var_spec", 2),
+				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 2),
+				astRow("main.go/var_declaration/var_spec/slice_type", "slice_type", 2),
+				astRow("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 2),
+			},
+			wantLines: []uint32{2},
+		},
+		{
+			// var y []string = nil → var_spec has a direct expression_list child
+			name: "initialized slice not flagged",
+			rows: []leyline.ASTRow{
+				astRow("main.go", "source_file", 0),
+				astRow("main.go/var_declaration", "var_declaration", 4),
+				astRow("main.go/var_declaration/var_spec", "var_spec", 4),
+				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 4),
+				astRow("main.go/var_declaration/var_spec/slice_type", "slice_type", 4),
+				astRow("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 4),
+				astRow("main.go/var_declaration/var_spec/expression_list", "expression_list", 4),
+				astRow("main.go/var_declaration/var_spec/expression_list/nil", "nil", 4),
+			},
+			wantLines: nil,
+		},
+		{
+			// var w = []int{1} → the slice_type sits under expression_list/
+			// composite_literal, NOT as a direct var_spec child. The
+			// direct-child predicate (one path segment) must exclude it.
+			name: "composite literal slice type not a direct child",
+			rows: []leyline.ASTRow{
+				astRow("main.go", "source_file", 0),
+				astRow("main.go/var_declaration", "var_declaration", 1),
+				astRow("main.go/var_declaration/var_spec", "var_spec", 1),
+				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 1),
+				astRow("main.go/var_declaration/var_spec/expression_list", "expression_list", 1),
+				astRow("main.go/var_declaration/var_spec/expression_list/composite_literal", "composite_literal", 1),
+				astRow("main.go/var_declaration/var_spec/expression_list/composite_literal/slice_type", "slice_type", 1),
+			},
+			wantLines: nil,
+		},
+		{
+			// var m map[string][]int → declared type is map_type; the
+			// slice_type is a grandchild and must not trigger the rule.
+			name: "map of slices not flagged",
+			rows: []leyline.ASTRow{
+				astRow("main.go", "source_file", 0),
+				astRow("main.go/var_declaration", "var_declaration", 1),
+				astRow("main.go/var_declaration/var_spec", "var_spec", 1),
+				astRow("main.go/var_declaration/var_spec/identifier", "identifier", 1),
+				astRow("main.go/var_declaration/var_spec/map_type", "map_type", 1),
+				astRow("main.go/var_declaration/var_spec/map_type/type_identifier", "type_identifier", 1),
+				astRow("main.go/var_declaration/var_spec/map_type/slice_type", "slice_type", 1),
+			},
+			wantLines: nil,
+		},
+		{
+			// Same-kind siblings carry _N suffixes on node_id (daemon
+			// behavior for >1 named children of one kind) — the rule must
+			// still see them, in document order.
+			name: "multiple nil slices all flagged in order",
+			rows: []leyline.ASTRow{
+				astRow("main.go", "source_file", 0),
+				astRow("main.go/function_declaration", "function_declaration", 0),
+				astRow("main.go/function_declaration/block", "block", 0),
+				astRow("main.go/function_declaration/block/statement_list", "statement_list", 1),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_0", "var_declaration", 1),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec", "var_spec", 1),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec/slice_type", "slice_type", 1),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_1", "var_declaration", 3),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec", "var_spec", 3),
+				astRow("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec/slice_type", "slice_type", 3),
+			},
+			wantLines: []uint32{1, 3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			diags, err := LintAST(goPayload(tc.rows...))
+			require.NoError(t, err)
+			var gotLines []uint32
+			for _, d := range diags {
+				assert.Contains(t, d.Message, "Nil slice declaration")
+				gotLines = append(gotLines, d.Line)
+			}
+			assert.Equal(t, tc.wantLines, gotLines)
+		})
+	}
 }
 
-func TestLintAST_InitializedSlice_NotFlagged(t *testing.T) {
-	// var y []string = nil → var_spec has a direct expression_list child
-	ast := goPayload(
-		row("main.go", "source_file", 0),
-		row("main.go/var_declaration", "var_declaration", 4),
-		row("main.go/var_declaration/var_spec", "var_spec", 4),
-		row("main.go/var_declaration/var_spec/identifier", "identifier", 4),
-		row("main.go/var_declaration/var_spec/slice_type", "slice_type", 4),
-		row("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 4),
-		row("main.go/var_declaration/var_spec/expression_list", "expression_list", 4),
-		row("main.go/var_declaration/var_spec/expression_list/nil", "nil", 4),
-	)
-	diags, err := LintAST(ast)
-	require.NoError(t, err)
-	assert.Empty(t, diags)
-}
-
-func TestLintAST_CompositeLiteralSliceType_NotDirectChild_NotFlagged(t *testing.T) {
-	// var w = []int{1} → the slice_type sits under expression_list/
-	// composite_literal, NOT as a direct var_spec child. The direct-child
-	// predicate (one path segment) must exclude it.
-	ast := goPayload(
-		row("main.go", "source_file", 0),
-		row("main.go/var_declaration", "var_declaration", 1),
-		row("main.go/var_declaration/var_spec", "var_spec", 1),
-		row("main.go/var_declaration/var_spec/identifier", "identifier", 1),
-		row("main.go/var_declaration/var_spec/expression_list", "expression_list", 1),
-		row("main.go/var_declaration/var_spec/expression_list/composite_literal", "composite_literal", 1),
-		row("main.go/var_declaration/var_spec/expression_list/composite_literal/slice_type", "slice_type", 1),
-	)
-	diags, err := LintAST(ast)
-	require.NoError(t, err)
-	assert.Empty(t, diags)
-}
-
-func TestLintAST_MapOfSlices_NotFlagged(t *testing.T) {
-	// var m map[string][]int → declared type is map_type; the slice_type is
-	// a grandchild and must not trigger the rule.
-	ast := goPayload(
-		row("main.go", "source_file", 0),
-		row("main.go/var_declaration", "var_declaration", 1),
-		row("main.go/var_declaration/var_spec", "var_spec", 1),
-		row("main.go/var_declaration/var_spec/identifier", "identifier", 1),
-		row("main.go/var_declaration/var_spec/map_type", "map_type", 1),
-		row("main.go/var_declaration/var_spec/map_type/type_identifier", "type_identifier", 1),
-		row("main.go/var_declaration/var_spec/map_type/slice_type", "slice_type", 1),
-	)
-	diags, err := LintAST(ast)
-	require.NoError(t, err)
-	assert.Empty(t, diags)
-}
-
-func TestLintAST_MultipleNilSlices_AllFlaggedInOrder(t *testing.T) {
-	// Same-kind siblings carry _N suffixes on node_id (daemon behavior for
-	// >1 named children of one kind) — the rule must still see them.
-	ast := goPayload(
-		row("main.go", "source_file", 0),
-		row("main.go/function_declaration", "function_declaration", 0),
-		row("main.go/function_declaration/block", "block", 0),
-		row("main.go/function_declaration/block/statement_list", "statement_list", 1),
-		row("main.go/function_declaration/block/statement_list/var_declaration_0", "var_declaration", 1),
-		row("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec", "var_spec", 1),
-		row("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec/slice_type", "slice_type", 1),
-		row("main.go/function_declaration/block/statement_list/var_declaration_1", "var_declaration", 3),
-		row("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec", "var_spec", 3),
-		row("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec/slice_type", "slice_type", 3),
-	)
-	diags, err := LintAST(ast)
-	require.NoError(t, err)
-	require.Len(t, diags, 2)
-	assert.Equal(t, uint32(1), diags[0].Line)
-	assert.Equal(t, uint32(3), diags[1].Line)
+func TestDiagnostic_String_Renders1Based(t *testing.T) {
+	d := Diagnostic{Message: "Nil slice declaration.", Line: 2}
+	assert.Equal(t, "line 3: Nil slice declaration.", d.String())
 }
 
 func TestLintAST_NilPayload_NoDiagnostics(t *testing.T) {
@@ -125,7 +138,7 @@ func TestLintAST_NilPayload_NoDiagnostics(t *testing.T) {
 
 func TestLintAST_NonGoPayload_NoDiagnostics(t *testing.T) {
 	ast := &leyline.ASTPayload{SourceID: "lib.rs", Language: "rust", AST: []leyline.ASTRow{
-		row("lib.rs", "source_file", 0),
+		astRow("lib.rs", "source_file", 0),
 	}}
 	diags, err := LintAST(ast)
 	require.NoError(t, err)

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -1,0 +1,141 @@
+package linter
+
+// Unit tests for the SQL-over-emit_ast lint rules. LintAST is pure (no
+// daemon): payloads here are hand-built to mirror the exact node_id/node_kind
+// shapes the v0.7.8 daemon emits (verified against a live daemon — see the
+// e2e file for the real-parse path).
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/leyline"
+)
+
+// row is a shorthand _ast row constructor for rule tests (only the columns
+// the rules consult are populated).
+func row(nodeID, kind string, startRow uint32) leyline.ASTRow {
+	return leyline.ASTRow{NodeID: nodeID, SourceID: "main.go", NodeKind: kind, StartRow: startRow}
+}
+
+// goPayload wraps rows in a Go-language payload.
+func goPayload(rows ...leyline.ASTRow) *leyline.ASTPayload {
+	return &leyline.ASTPayload{SourceID: "main.go", Language: "go", AST: rows}
+}
+
+func TestLintAST_NilSliceDeclaration_Flagged(t *testing.T) {
+	// var x []int   → var_spec with a direct slice_type child, no value
+	ast := goPayload(
+		row("main.go", "source_file", 0),
+		row("main.go/var_declaration", "var_declaration", 2),
+		row("main.go/var_declaration/var_spec", "var_spec", 2),
+		row("main.go/var_declaration/var_spec/identifier", "identifier", 2),
+		row("main.go/var_declaration/var_spec/slice_type", "slice_type", 2),
+		row("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 2),
+	)
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	require.Len(t, diags, 1)
+	assert.Equal(t, uint32(2), diags[0].Line)
+	assert.Contains(t, diags[0].Message, "Nil slice declaration")
+	assert.Contains(t, diags[0].String(), "line 3:", "String() renders 1-based")
+}
+
+func TestLintAST_InitializedSlice_NotFlagged(t *testing.T) {
+	// var y []string = nil → var_spec has a direct expression_list child
+	ast := goPayload(
+		row("main.go", "source_file", 0),
+		row("main.go/var_declaration", "var_declaration", 4),
+		row("main.go/var_declaration/var_spec", "var_spec", 4),
+		row("main.go/var_declaration/var_spec/identifier", "identifier", 4),
+		row("main.go/var_declaration/var_spec/slice_type", "slice_type", 4),
+		row("main.go/var_declaration/var_spec/slice_type/type_identifier", "type_identifier", 4),
+		row("main.go/var_declaration/var_spec/expression_list", "expression_list", 4),
+		row("main.go/var_declaration/var_spec/expression_list/nil", "nil", 4),
+	)
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+}
+
+func TestLintAST_CompositeLiteralSliceType_NotDirectChild_NotFlagged(t *testing.T) {
+	// var w = []int{1} → the slice_type sits under expression_list/
+	// composite_literal, NOT as a direct var_spec child. The direct-child
+	// predicate (one path segment) must exclude it.
+	ast := goPayload(
+		row("main.go", "source_file", 0),
+		row("main.go/var_declaration", "var_declaration", 1),
+		row("main.go/var_declaration/var_spec", "var_spec", 1),
+		row("main.go/var_declaration/var_spec/identifier", "identifier", 1),
+		row("main.go/var_declaration/var_spec/expression_list", "expression_list", 1),
+		row("main.go/var_declaration/var_spec/expression_list/composite_literal", "composite_literal", 1),
+		row("main.go/var_declaration/var_spec/expression_list/composite_literal/slice_type", "slice_type", 1),
+	)
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+}
+
+func TestLintAST_MapOfSlices_NotFlagged(t *testing.T) {
+	// var m map[string][]int → declared type is map_type; the slice_type is
+	// a grandchild and must not trigger the rule.
+	ast := goPayload(
+		row("main.go", "source_file", 0),
+		row("main.go/var_declaration", "var_declaration", 1),
+		row("main.go/var_declaration/var_spec", "var_spec", 1),
+		row("main.go/var_declaration/var_spec/identifier", "identifier", 1),
+		row("main.go/var_declaration/var_spec/map_type", "map_type", 1),
+		row("main.go/var_declaration/var_spec/map_type/type_identifier", "type_identifier", 1),
+		row("main.go/var_declaration/var_spec/map_type/slice_type", "slice_type", 1),
+	)
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	assert.Empty(t, diags)
+}
+
+func TestLintAST_MultipleNilSlices_AllFlaggedInOrder(t *testing.T) {
+	// Same-kind siblings carry _N suffixes on node_id (daemon behavior for
+	// >1 named children of one kind) — the rule must still see them.
+	ast := goPayload(
+		row("main.go", "source_file", 0),
+		row("main.go/function_declaration", "function_declaration", 0),
+		row("main.go/function_declaration/block", "block", 0),
+		row("main.go/function_declaration/block/statement_list", "statement_list", 1),
+		row("main.go/function_declaration/block/statement_list/var_declaration_0", "var_declaration", 1),
+		row("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec", "var_spec", 1),
+		row("main.go/function_declaration/block/statement_list/var_declaration_0/var_spec/slice_type", "slice_type", 1),
+		row("main.go/function_declaration/block/statement_list/var_declaration_1", "var_declaration", 3),
+		row("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec", "var_spec", 3),
+		row("main.go/function_declaration/block/statement_list/var_declaration_1/var_spec/slice_type", "slice_type", 3),
+	)
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	require.Len(t, diags, 2)
+	assert.Equal(t, uint32(1), diags[0].Line)
+	assert.Equal(t, uint32(3), diags[1].Line)
+}
+
+func TestLintAST_NilPayload_NoDiagnostics(t *testing.T) {
+	diags, err := LintAST(nil)
+	require.NoError(t, err)
+	assert.Nil(t, diags)
+}
+
+func TestLintAST_NonGoPayload_NoDiagnostics(t *testing.T) {
+	ast := &leyline.ASTPayload{SourceID: "lib.rs", Language: "rust", AST: []leyline.ASTRow{
+		row("lib.rs", "source_file", 0),
+	}}
+	diags, err := LintAST(ast)
+	require.NoError(t, err)
+	assert.Nil(t, diags)
+}
+
+func TestLint_NonGoLanguage_NoDaemonContact(t *testing.T) {
+	// Lint's language gate must short-circuit before any daemon work.
+	t.Setenv("LEYLINE_SOCKET", "/nonexistent/sock")
+	diags, err := Lint([]byte("resource {}"), "terraform")
+	require.NoError(t, err)
+	assert.Nil(t, diags)
+}

--- a/internal/lltest/lltest.go
+++ b/internal/lltest/lltest.go
@@ -1,0 +1,82 @@
+// Package lltest provides test doubles for the leyline daemon wire: an
+// in-process fake speaking the line-delimited JSON UDS protocol, and a gated
+// spawner for the SHA-pinned real binary. Tests point mache at either via
+// t.Setenv("LEYLINE_SOCKET", sock) — leyline.DiscoverOrStart honors that env
+// var before any spawn/download logic runs.
+package lltest
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Handler produces the response object for one decoded request. The returned
+// value is JSON-marshalled and written back as a single line.
+type Handler func(req map[string]any) any
+
+// FakeDaemon starts a Unix-domain-socket server that speaks the daemon's
+// line-delimited JSON protocol, answering every request via handler. It
+// returns the socket path; callers wire it up with
+// t.Setenv("LEYLINE_SOCKET", sock). The server tolerates probe connections
+// that close without sending (DiscoverOrStart's liveness check does exactly
+// that). Shutdown is registered via t.Cleanup.
+func FakeDaemon(t *testing.T, handler Handler) string {
+	t.Helper()
+
+	// os.MkdirTemp("", ...) uses $TMPDIR which stays under the ~104-byte
+	// sun_path limit on macOS, unlike t.TempDir()'s deeply nested paths.
+	dir, err := os.MkdirTemp("", "llfake")
+	if err != nil {
+		t.Fatalf("lltest: create fake daemon dir: %v", err)
+	}
+	sock := filepath.Join(dir, "d.sock")
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("lltest: listen on %s: %v", sock, err)
+	}
+	t.Cleanup(func() {
+		_ = ln.Close()
+		_ = os.RemoveAll(dir)
+	})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed
+			}
+			go serveConn(conn, handler)
+		}
+	}()
+
+	return sock
+}
+
+func serveConn(conn net.Conn, handler Handler) {
+	defer func() { _ = conn.Close() }()
+	rd := bufio.NewReader(conn)
+	for {
+		line, err := rd.ReadBytes('\n')
+		if err != nil {
+			return // EOF: client closed (liveness probes do this immediately)
+		}
+		var req map[string]any
+		if err := json.Unmarshal(line, &req); err != nil {
+			return
+		}
+		resp, err := json.Marshal(handler(req))
+		if err != nil {
+			return
+		}
+		resp = append(resp, '\n')
+		if _, err := conn.Write(resp); err != nil {
+			return
+		}
+	}
+}

--- a/internal/lltest/lltest_test.go
+++ b/internal/lltest/lltest_test.go
@@ -1,0 +1,79 @@
+package lltest
+
+import (
+	"bufio"
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sendLine dials the fake daemon, writes one JSON line, and decodes the
+// single-line response — the exact protocol leyline.SocketClient speaks.
+func sendLine(t *testing.T, sock string, req map[string]any) map[string]any {
+	t.Helper()
+	conn, err := net.Dial("unix", sock)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+	_, err = conn.Write(append(data, '\n'))
+	require.NoError(t, err)
+
+	line, err := bufio.NewReader(conn).ReadBytes('\n')
+	require.NoError(t, err)
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(line, &resp))
+	return resp
+}
+
+func TestFakeDaemon_RoundTripsHandlerResponse(t *testing.T) {
+	sock := FakeDaemon(t, func(req map[string]any) any {
+		return map[string]any{"ok": true, "echo": req["op"]}
+	})
+
+	resp := sendLine(t, sock, map[string]any{"op": "validate"})
+	assert.Equal(t, true, resp["ok"])
+	assert.Equal(t, "validate", resp["echo"])
+}
+
+func TestFakeDaemon_SurvivesProbeConnections(t *testing.T) {
+	// DiscoverOrStart's liveness check dials and immediately closes; the
+	// fake must keep serving afterwards.
+	sock := FakeDaemon(t, func(map[string]any) any {
+		return map[string]any{"ok": true}
+	})
+
+	probe, err := net.Dial("unix", sock)
+	require.NoError(t, err)
+	require.NoError(t, probe.Close())
+
+	resp := sendLine(t, sock, map[string]any{"op": "anything"})
+	assert.Equal(t, true, resp["ok"])
+}
+
+func TestFakeDaemon_ServesMultipleRequestsPerConnection(t *testing.T) {
+	calls := 0
+	sock := FakeDaemon(t, func(map[string]any) any {
+		calls++
+		return map[string]any{"n": calls}
+	})
+
+	conn, err := net.Dial("unix", sock)
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	rd := bufio.NewReader(conn)
+
+	for i := 1; i <= 2; i++ {
+		_, err = conn.Write([]byte(`{"op":"x"}` + "\n"))
+		require.NoError(t, err)
+		line, err := rd.ReadBytes('\n')
+		require.NoError(t, err)
+		var resp map[string]any
+		require.NoError(t, json.Unmarshal(line, &resp))
+		assert.EqualValues(t, i, resp["n"])
+	}
+}

--- a/internal/lltest/pinned_unix.go
+++ b/internal/lltest/pinned_unix.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package lltest
+
+import (
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/agentic-research/mache/internal/leyline"
+)
+
+// StartPinnedDaemon spawns the SHA-pinned leyline binary from
+// ~/.mache/bin/leyline as a PRIVATE daemon (own arena/control/socket in a
+// short-lived temp dir — no interference with the shared ~/.mache arena) and
+// returns its socket path for t.Setenv("LEYLINE_SOCKET", ...).
+//
+// Gated, never downloads: the test SKIPS when the binary is absent or its
+// --version does not match leyline.PinnedBinaryVersion(). It deliberately
+// does NOT fall back to a leyline on PATH — an unpinned binary produces
+// different wire behavior than CI's SHA-verified release (mache-608a3c).
+func StartPinnedDaemon(t *testing.T) string {
+	t.Helper()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("lltest: no home dir, cannot locate pinned leyline: %v", err)
+	}
+	bin := filepath.Join(home, ".mache", "bin", "leyline")
+	out, err := exec.Command(bin, "--version").Output()
+	if err != nil {
+		t.Skipf("lltest: pinned leyline not runnable at %s (never downloading in tests): %v", bin, err)
+	}
+	want := strings.TrimPrefix(leyline.PinnedBinaryVersion(), "v")
+	if !strings.Contains(string(out), want) {
+		t.Skipf("lltest: leyline at %s reports %q, want pinned %s — skipping (never downloading in tests)", bin, strings.TrimSpace(string(out)), want)
+	}
+
+	// /tmp keeps the socket path under the ~104-byte sun_path limit; the
+	// daemon binds <control-stem>.sock next to the control file.
+	dir, err := os.MkdirTemp("/tmp", "llpin")
+	if err != nil {
+		t.Fatalf("lltest: create pinned daemon dir: %v", err)
+	}
+	sock := filepath.Join(dir, "d.sock")
+
+	cmd := exec.Command(bin, "daemon",
+		"--arena", filepath.Join(dir, "d.arena"),
+		"--arena-size-mib", "64",
+		"--control", filepath.Join(dir, "d.ctrl"),
+	) // headless: no --mount, no --source — validate is content-supplied
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(dir)
+		t.Fatalf("lltest: start pinned leyline daemon: %v", err)
+	}
+	t.Cleanup(func() {
+		// Group-kill so any child the daemon spawned is reaped with it.
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_, _ = cmd.Process.Wait()
+		_ = os.RemoveAll(dir)
+	})
+
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if conn, err := net.Dial("unix", sock); err == nil {
+			_ = conn.Close()
+			return sock
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("lltest: pinned leyline daemon socket %s did not appear within 15s", sock)
+	return "" // unreachable
+}

--- a/internal/lltest/pinned_unix.go
+++ b/internal/lltest/pinned_unix.go
@@ -15,10 +15,18 @@ import (
 	"github.com/agentic-research/mache/internal/leyline"
 )
 
+// UsePinnedDaemon spawns a private pinned daemon (see StartPinnedDaemon) and
+// points LEYLINE_SOCKET at it for the remainder of the test, which is how
+// every gated e2e consumer wires the daemon into mache's discovery path.
+func UsePinnedDaemon(t *testing.T) {
+	t.Helper()
+	t.Setenv("LEYLINE_SOCKET", StartPinnedDaemon(t))
+}
+
 // StartPinnedDaemon spawns the SHA-pinned leyline binary from
 // ~/.mache/bin/leyline as a PRIVATE daemon (own arena/control/socket in a
 // short-lived temp dir — no interference with the shared ~/.mache arena) and
-// returns its socket path for t.Setenv("LEYLINE_SOCKET", ...).
+// returns its socket path.
 //
 // Gated, never downloads: the test SKIPS when the binary is absent or its
 // --version does not match leyline.PinnedBinaryVersion(). It deliberately
@@ -27,19 +35,7 @@ import (
 func StartPinnedDaemon(t *testing.T) string {
 	t.Helper()
 
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("lltest: no home dir, cannot locate pinned leyline: %v", err)
-	}
-	bin := filepath.Join(home, ".mache", "bin", "leyline")
-	out, err := exec.Command(bin, "--version").Output()
-	if err != nil {
-		t.Skipf("lltest: pinned leyline not runnable at %s (never downloading in tests): %v", bin, err)
-	}
-	want := strings.TrimPrefix(leyline.PinnedBinaryVersion(), "v")
-	if !strings.Contains(string(out), want) {
-		t.Skipf("lltest: leyline at %s reports %q, want pinned %s — skipping (never downloading in tests)", bin, strings.TrimSpace(string(out)), want)
-	}
+	bin := pinnedBinaryOrSkip(t)
 
 	// /tmp keeps the socket path under the ~104-byte sun_path limit; the
 	// daemon binds <control-stem>.sock next to the control file.
@@ -47,7 +43,6 @@ func StartPinnedDaemon(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("lltest: create pinned daemon dir: %v", err)
 	}
-	sock := filepath.Join(dir, "d.sock")
 
 	cmd := exec.Command(bin, "daemon",
 		"--arena", filepath.Join(dir, "d.arena"),
@@ -66,6 +61,33 @@ func StartPinnedDaemon(t *testing.T) string {
 		_ = os.RemoveAll(dir)
 	})
 
+	return awaitSocket(t, filepath.Join(dir, "d.sock"))
+}
+
+// pinnedBinaryOrSkip resolves ~/.mache/bin/leyline and verifies it reports
+// the pinned version, skipping the test otherwise.
+func pinnedBinaryOrSkip(t *testing.T) string {
+	t.Helper()
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("lltest: no home dir, cannot locate pinned leyline: %v", err)
+	}
+	bin := filepath.Join(home, ".mache", "bin", "leyline")
+	out, err := exec.Command(bin, "--version").Output()
+	if err != nil {
+		t.Skipf("lltest: pinned leyline not runnable at %s (never downloading in tests): %v", bin, err)
+	}
+	want := strings.TrimPrefix(leyline.PinnedBinaryVersion(), "v")
+	if !strings.Contains(string(out), want) {
+		t.Skipf("lltest: leyline at %s reports %q, want pinned %s — skipping (never downloading in tests)", bin, strings.TrimSpace(string(out)), want)
+	}
+	return bin
+}
+
+// awaitSocket polls until a UDS listener answers at sock or the deadline
+// passes.
+func awaitSocket(t *testing.T, sock string) string {
+	t.Helper()
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		if conn, err := net.Dial("unix", sock); err == nil {

--- a/internal/lltest/pinned_unix_test.go
+++ b/internal/lltest/pinned_unix_test.go
@@ -1,0 +1,25 @@
+//go:build unix
+
+package lltest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartPinnedDaemon_AnswersValidateOp(t *testing.T) {
+	// Gated on the pinned binary (skips when absent, never downloads).
+	// Pins the contract every consumer relies on: the spawned daemon is
+	// private, live, and speaks the v0.7.8 validate wire (errors key
+	// present even on a clean parse).
+	sock := StartPinnedDaemon(t)
+
+	resp := sendLine(t, sock, map[string]any{
+		"op": "validate", "content": "package main\n", "language": "go",
+	})
+	assert.Equal(t, true, resp["ok"])
+	errs, hasErrors := resp["errors"]
+	assert.True(t, hasErrors, "v0.7.8 wire always includes the errors key")
+	assert.Empty(t, errs)
+}

--- a/internal/writeback/validate.go
+++ b/internal/writeback/validate.go
@@ -21,6 +21,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+
 	"github.com/agentic-research/mache/internal/leyline"
 )
 
@@ -61,9 +64,14 @@ func langKeyForPath(filePath string) string {
 }
 
 // SupportedPath reports whether filePath's extension is syntax-validated on
-// the write path (i.e. recognized by the leyline daemon's validate op).
+// write-back — by the leyline daemon (Go/Python/JS/TS/TSX/Rust/Elixir) or
+// in-process (HCL/Terraform via hclsyntax). Everything else — including
+// .sql/.yaml/.md/.toml/.json and the C-family/JVM/scripting extensions the
+// old in-process grammar set covered — passes through UNVALIDATED and
+// splices as written; there is no structural check for those until leyline
+// grows the grammars.
 func SupportedPath(filePath string) bool {
-	return langKeyForPath(filePath) != ""
+	return isHCLPath(filePath) || langKeyForPath(filePath) != ""
 }
 
 // Validate checks content for syntax errors via the leyline daemon and
@@ -93,6 +101,14 @@ func ValidateWithAST(content []byte, filePath string) (*leyline.ASTPayload, erro
 // emit_ast pipeline covers fewer languages than the validator; requesting it
 // for an uncovered language is a daemon-side hard error).
 func validateRemote(content []byte, filePath string, wantAST bool) (*leyline.ASTPayload, error) {
+	// HCL/Terraform validates IN-PROCESS via hclsyntax (pure Go, same
+	// hashicorp/hcl module hclwrite comes from) — restoring the pre-73b885
+	// draft behavior. Without this, broken HCL passed through unvalidated
+	// AND FormatBuffer's hclwrite.Format (a token formatter, NOT a
+	// validator) MANGLED it before splicing to disk (#527 review).
+	if isHCLPath(filePath) {
+		return nil, validateHCL(content, filePath)
+	}
 	key := langKeyForPath(filePath)
 	if key == "" {
 		return nil, nil // not validated — pass through
@@ -118,6 +134,43 @@ func validateRemote(content []byte, filePath string, wantAST bool) (*leyline.AST
 		return nil, &ValidationError{FilePath: filePath, Message: "AST contains errors"}
 	}
 	return res.AST, nil
+}
+
+// isHCLPath reports whether filePath is HCL/Terraform — validated
+// in-process (see validateRemote) rather than via the leyline daemon.
+func isHCLPath(filePath string) bool {
+	switch strings.ToLower(filepath.Ext(filePath)) {
+	case ".tf", ".hcl":
+		return true
+	}
+	return false
+}
+
+// validateHCL syntax-checks HCL/Terraform content with hclsyntax.ParseConfig.
+// hcl positions are 1-based; ValidationError is 0-based (Error() re-renders
+// 1-based), so subtract one. Returns the first error diagnostic as a
+// *ValidationError, matching the Go path's first-error contract.
+func validateHCL(content []byte, filePath string) error {
+	_, diags := hclsyntax.ParseConfig(content, filePath, hcl.InitialPos)
+	if !diags.HasErrors() {
+		return nil
+	}
+	for _, d := range diags {
+		if d.Severity != hcl.DiagError {
+			continue
+		}
+		ve := &ValidationError{FilePath: filePath, Message: d.Summary}
+		if d.Subject != nil {
+			if d.Subject.Start.Line > 0 {
+				ve.Line = uint32(d.Subject.Start.Line - 1) // #nosec G115 -- hcl lines are small positive ints
+			}
+			if d.Subject.Start.Column > 0 {
+				ve.Column = uint32(d.Subject.Start.Column - 1) // #nosec G115
+			}
+		}
+		return ve
+	}
+	return &ValidationError{FilePath: filePath, Message: "HCL contains errors"}
 }
 
 // ASTErrors returns all ERROR/MISSING node locations in the content for

--- a/internal/writeback/validate.go
+++ b/internal/writeback/validate.go
@@ -1,19 +1,34 @@
 package writeback
 
+// Syntax validation for the write-back pipeline.
+//
+// Since mache-73b885 this package holds NO in-process tree-sitter: validation
+// is delegated to the pinned leyline daemon's `validate` op (ley-line-open >=
+// v0.7.8), which runs the same grammars the `_ast` producer uses. The daemon
+// is acquired lazily per call via leyline.ValidateContent (DiscoverOrStart);
+// see that function's doc for the latency profile (sub-ms with a live daemon,
+// a one-off spawn cost on the first write otherwise).
+//
+// Language coverage CHANGED with the migration: the daemon validates the
+// extension keys in leylineValidateLangs below. Extensions that mache's old
+// in-process grammar set covered but the daemon does not (e.g. .tf/.hcl,
+// .yaml, .sql, .md, .toml) now PASS THROUGH unvalidated — same contract as an
+// unknown extension. For HCL/Terraform, FormatBuffer's hclwrite step remains
+// the only structural check on the write path.
+
 import (
-	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
-	sitter "github.com/smacker/go-tree-sitter"
-
-	"github.com/agentic-research/mache/internal/lang"
+	"github.com/agentic-research/mache/internal/leyline"
 )
 
 // ValidationError contains structured information about a syntax error.
 type ValidationError struct {
 	FilePath string
 	Line     uint32 // 0-indexed
-	Column   uint32 // 0-indexed
+	Column   uint32 // 0-indexed (byte offset within the line)
 	Message  string
 }
 
@@ -21,119 +36,112 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("%s:%d:%d: %s", e.FilePath, e.Line+1, e.Column+1, e.Message)
 }
 
-// Validate parses content with tree-sitter and returns an error if the AST
-// contains syntax errors. Files with no known tree-sitter language pass
-// through without validation (returns nil).
+// leylineValidateLangs is the set of extension keys the pinned leyline
+// daemon's validate op accepts (ley-line-open rs/ll-open/fs/src/validate.rs
+// language_for_extension). The key doubles as the wire `language` value.
+var leylineValidateLangs = map[string]bool{
+	"go":  true,
+	"py":  true,
+	"js":  true,
+	"ts":  true,
+	"tsx": true,
+	"rs":  true,
+	"ex":  true,
+	"exs": true,
+}
+
+// langKeyForPath maps a file path to the leyline validate language key, or ""
+// when the extension is not validated (pass-through).
+func langKeyForPath(filePath string) string {
+	ext := strings.TrimPrefix(strings.ToLower(filepath.Ext(filePath)), ".")
+	if leylineValidateLangs[ext] {
+		return ext
+	}
+	return ""
+}
+
+// SupportedPath reports whether filePath's extension is syntax-validated on
+// the write path (i.e. recognized by the leyline daemon's validate op).
+func SupportedPath(filePath string) bool {
+	return langKeyForPath(filePath) != ""
+}
+
+// Validate checks content for syntax errors via the leyline daemon and
+// returns a *ValidationError for the first ERROR/MISSING node. Files whose
+// extension the daemon does not validate pass through (returns nil).
+// Daemon-acquisition failures and daemon-too-old responses are returned as
+// ordinary (non-ValidationError) errors so callers can distinguish "your code
+// is broken" from "the validator is unavailable".
 func Validate(content []byte, filePath string) error {
-	grammar := LanguageForPath(filePath)
-	if grammar == nil {
-		return nil // unknown language — pass through
-	}
-
-	parser := sitter.NewParser()
-	parser.SetLanguage(grammar)
-
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
-	if err != nil {
-		return fmt.Errorf("tree-sitter parse failed for %s: %w", filePath, err)
-	}
-
-	root := tree.RootNode()
-	if root == nil {
-		return fmt.Errorf("tree-sitter returned nil root for %s", filePath)
-	}
-
-	if !root.HasError() {
-		return nil
-	}
-
-	// Walk tree to find first ERROR node for a useful error message
-	errNode := findFirstError(root)
-	if errNode != nil {
-		return &ValidationError{
-			FilePath: filePath,
-			Line:     uint32(errNode.StartPoint().Row),
-			Column:   uint32(errNode.StartPoint().Column),
-			Message:  "syntax error in AST",
-		}
-	}
-
-	return &ValidationError{
-		FilePath: filePath,
-		Line:     0,
-		Column:   0,
-		Message:  "AST contains errors",
-	}
+	_, err := validateRemote(content, filePath, false)
+	return err
 }
 
-// ASTErrors returns all ERROR node locations in the content for diagnostic reporting.
-// Returns nil if no errors or unknown language.
-func ASTErrors(content []byte, filePath string) []ValidationError {
-	grammar := LanguageForPath(filePath)
-	if grammar == nil {
-		return nil
-	}
-
-	parser := sitter.NewParser()
-	parser.SetLanguage(grammar)
-
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
-	if err != nil {
-		return nil
-	}
-
-	root := tree.RootNode()
-	if root == nil || !root.HasError() {
-		return nil
-	}
-
-	var errs []ValidationError
-	collectErrors(root, filePath, &errs)
-	return errs
+// ValidateWithAST is Validate plus AST rows from the SAME parse: for
+// languages with an emit_ast-capable extractor that mache lints (Go today),
+// a clean validation also returns the daemon's SQL-shaped AST payload so the
+// linter can run without a second parse. For every other validated language
+// it behaves exactly like Validate and returns (nil, nil) on success.
+// Pass-through extensions return (nil, nil).
+func ValidateWithAST(content []byte, filePath string) (*leyline.ASTPayload, error) {
+	return validateRemote(content, filePath, true)
 }
 
-// findFirstError does a depth-first search for the first ERROR node.
-func findFirstError(node *sitter.Node) *sitter.Node {
-	if node.IsError() || node.IsMissing() {
-		return node
+// validateRemote runs one daemon validate round trip. wantAST requests
+// emit_ast, which is only sent for Go — the only language mache has AST lint
+// rules for, and a member of the daemon extractor's supported subset (the
+// emit_ast pipeline covers fewer languages than the validator; requesting it
+// for an uncovered language is a daemon-side hard error).
+func validateRemote(content []byte, filePath string, wantAST bool) (*leyline.ASTPayload, error) {
+	key := langKeyForPath(filePath)
+	if key == "" {
+		return nil, nil // not validated — pass through
 	}
-	for i := 0; i < int(node.ChildCount()); i++ {
-		child := node.Child(i)
-		if child.HasError() || child.IsError() || child.IsMissing() {
-			found := findFirstError(child)
-			if found != nil {
-				return found
+	emit := wantAST && key == "go"
+
+	res, err := leyline.ValidateContent(content, key, filePath, emit)
+	if err != nil {
+		return nil, fmt.Errorf("validate %s: %w", filePath, err)
+	}
+	if !res.OK {
+		if len(res.Errors) > 0 {
+			first := res.Errors[0]
+			return nil, &ValidationError{
+				FilePath: filePath,
+				Line:     first.Row,
+				Column:   first.Col,
+				Message:  first.Message,
 			}
 		}
+		// Defensive: the daemon reports ok=false with a populated errors
+		// array; an empty one still must not validate the write.
+		return nil, &ValidationError{FilePath: filePath, Message: "AST contains errors"}
 	}
-	return nil
+	return res.AST, nil
 }
 
-// collectErrors gathers all ERROR/MISSING nodes in the tree.
-func collectErrors(node *sitter.Node, filePath string, errs *[]ValidationError) {
-	if node.IsError() || node.IsMissing() {
-		*errs = append(*errs, ValidationError{
-			FilePath: filePath,
-			Line:     uint32(node.StartPoint().Row),
-			Column:   uint32(node.StartPoint().Column),
-			Message:  "syntax error in AST",
-		})
-		return // don't recurse into error children
-	}
-	for i := 0; i < int(node.ChildCount()); i++ {
-		child := node.Child(i)
-		if child.HasError() || child.IsError() || child.IsMissing() {
-			collectErrors(child, filePath, errs)
-		}
-	}
-}
-
-// LanguageForPath maps file extensions to tree-sitter languages.
-// Delegates to the lang registry — supports all 18 languages automatically.
-func LanguageForPath(filePath string) *sitter.Language {
-	l := lang.ForPath(filePath)
-	if l == nil {
+// ASTErrors returns all ERROR/MISSING node locations in the content for
+// diagnostic reporting (0-based positions, straight off the daemon wire).
+// Returns nil if the content is clean, the extension is not validated, or the
+// daemon is unavailable — this is the diagnostic-rendering flavor and has no
+// error channel, matching the historical contract.
+func ASTErrors(content []byte, filePath string) []ValidationError {
+	key := langKeyForPath(filePath)
+	if key == "" {
 		return nil
 	}
-	return l.Grammar()
+	res, err := leyline.ValidateContent(content, key, filePath, false)
+	if err != nil || res.OK {
+		return nil
+	}
+	errs := make([]ValidationError, 0, len(res.Errors))
+	for _, e := range res.Errors {
+		errs = append(errs, ValidationError{
+			FilePath: filePath,
+			Line:     e.Row,
+			Column:   e.Col,
+			Message:  e.Message,
+		})
+	}
+	return errs
 }

--- a/internal/writeback/validate.go
+++ b/internal/writeback/validate.go
@@ -10,11 +10,13 @@ package writeback
 // a one-off spawn cost on the first write otherwise).
 //
 // Language coverage CHANGED with the migration: the daemon validates the
-// extension keys in leylineValidateLangs below. Extensions that mache's old
-// in-process grammar set covered but the daemon does not (e.g. .tf/.hcl,
-// .yaml, .sql, .md, .toml) now PASS THROUGH unvalidated — same contract as an
-// unknown extension. For HCL/Terraform, FormatBuffer's hclwrite step remains
-// the only structural check on the write path.
+// extension keys in leylineValidateLangs below, and HCL/Terraform validates
+// IN-PROCESS via hclsyntax (hclwrite.Format is a token formatter, NOT a
+// validator — it mangles broken input, which is why the in-process check
+// exists). Every other extension the old in-process grammar set covered
+// (.sql/.yaml/.md/.toml/.json plus the C-family/JVM/scripting set) passes
+// through UNVALIDATED — same contract as an unknown extension — until
+// leyline grows the grammars (ley-line-open-e5addb).
 
 import (
 	"fmt"
@@ -151,15 +153,28 @@ func isHCLPath(filePath string) bool {
 // 1-based), so subtract one. Returns the first error diagnostic as a
 // *ValidationError, matching the Go path's first-error contract.
 func validateHCL(content []byte, filePath string) error {
+	errs := hclErrors(content, filePath)
+	if len(errs) == 0 {
+		return nil
+	}
+	first := errs[0]
+	return &first
+}
+
+// hclErrors returns every hclsyntax error diagnostic as a ValidationError
+// (0-based positions; hcl's are 1-based). Shared by validateHCL (first-error
+// contract) and ASTErrors (all-errors diagnostics flavor).
+func hclErrors(content []byte, filePath string) []ValidationError {
 	_, diags := hclsyntax.ParseConfig(content, filePath, hcl.InitialPos)
 	if !diags.HasErrors() {
 		return nil
 	}
+	var errs []ValidationError
 	for _, d := range diags {
 		if d.Severity != hcl.DiagError {
 			continue
 		}
-		ve := &ValidationError{FilePath: filePath, Message: d.Summary}
+		ve := ValidationError{FilePath: filePath, Message: d.Summary}
 		if d.Subject != nil {
 			if d.Subject.Start.Line > 0 {
 				ve.Line = uint32(d.Subject.Start.Line - 1) // #nosec G115 -- hcl lines are small positive ints
@@ -168,9 +183,12 @@ func validateHCL(content []byte, filePath string) error {
 				ve.Column = uint32(d.Subject.Start.Column - 1) // #nosec G115
 			}
 		}
-		return ve
+		errs = append(errs, ve)
 	}
-	return &ValidationError{FilePath: filePath, Message: "HCL contains errors"}
+	if len(errs) == 0 {
+		errs = append(errs, ValidationError{FilePath: filePath, Message: "HCL contains errors"})
+	}
+	return errs
 }
 
 // ASTErrors returns all ERROR/MISSING node locations in the content for
@@ -179,6 +197,11 @@ func validateHCL(content []byte, filePath string) error {
 // daemon is unavailable — this is the diagnostic-rendering flavor and has no
 // error channel, matching the historical contract.
 func ASTErrors(content []byte, filePath string) []ValidationError {
+	// HCL mirrors validateRemote's in-process branch — ALL error
+	// diagnostics, not just the first (this is the diagnostics flavor).
+	if isHCLPath(filePath) {
+		return hclErrors(content, filePath)
+	}
 	key := langKeyForPath(filePath)
 	if key == "" {
 		return nil

--- a/internal/writeback/validate_e2e_test.go
+++ b/internal/writeback/validate_e2e_test.go
@@ -1,0 +1,103 @@
+//go:build unix
+
+package writeback
+
+// Gated end-to-end tests against the REAL pinned leyline daemon
+// (~/.mache/bin/leyline, version-checked against the binary pin; skipped when
+// absent, never downloaded). These verify the actual tree-sitter verdicts and
+// positions the daemon produces — the unit suite only pins the client-side
+// wire contract.
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/lltest"
+)
+
+func usePinnedDaemon(t *testing.T) {
+	t.Helper()
+	sock := lltest.StartPinnedDaemon(t)
+	t.Setenv("LEYLINE_SOCKET", sock)
+}
+
+func TestE2E_Validate_ValidGo(t *testing.T) {
+	usePinnedDaemon(t)
+	assert.NoError(t, Validate([]byte("package main\n\nfunc hello() string {\n\treturn \"world\"\n}\n"), "test.go"))
+}
+
+func TestE2E_Validate_BrokenGo_Positions(t *testing.T) {
+	usePinnedDaemon(t)
+
+	// Verified against the v0.7.8 daemon: the first ERROR node for this
+	// buffer is at 0-based row 2, col 12 (the `{ BROKEN SYNTAX` region).
+	err := Validate([]byte("package main\n\nfunc main() { BROKEN SYNTAX "), "test.go")
+	require.Error(t, err)
+
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve)
+	assert.Equal(t, "test.go", ve.FilePath)
+	assert.Equal(t, uint32(2), ve.Line)
+	assert.Equal(t, uint32(12), ve.Column)
+	assert.Contains(t, ve.Message, "syntax error")
+}
+
+func TestE2E_Validate_BrokenGo_MissingBrace(t *testing.T) {
+	usePinnedDaemon(t)
+	err := Validate([]byte("package main\n\nfunc hello() string {\n\treturn \"world\"\n// missing closing brace\n"), "test.go")
+	require.Error(t, err)
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve)
+}
+
+func TestE2E_Validate_BrokenPython(t *testing.T) {
+	usePinnedDaemon(t)
+	err := Validate([]byte("def hello(\n    return \"world\"\n"), "test.py")
+	require.Error(t, err)
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve)
+}
+
+func TestE2E_Validate_ValidPython(t *testing.T) {
+	usePinnedDaemon(t)
+	assert.NoError(t, Validate([]byte("def hello():\n    return \"world\"\n"), "test.py"))
+}
+
+func TestE2E_Validate_TerraformPassThrough(t *testing.T) {
+	// Preserved-and-documented behavior: .tf is not in the daemon's
+	// validate set, so even syntactically broken HCL passes validation
+	// (FormatBuffer's hclwrite is the remaining structural check).
+	usePinnedDaemon(t)
+	assert.NoError(t, Validate([]byte(`resource "x" { broken {{{`), "main.tf"))
+}
+
+func TestE2E_ValidateWithAST_ReturnsRowsFromSameParse(t *testing.T) {
+	usePinnedDaemon(t)
+
+	src := []byte("package main\n\nvar x []int\n\nfunc f() {\n\tvar y []string = nil\n\t_ = y\n}\n")
+	ast, err := ValidateWithAST(src, "main.go")
+	require.NoError(t, err)
+	require.NotNil(t, ast, "clean Go parse with emit must return the AST payload")
+	assert.Equal(t, "go", ast.Language)
+	assert.Equal(t, "main.go", ast.SourceID, "path must ride as source_id on emitted rows")
+	assert.NotEmpty(t, ast.ContentHash)
+
+	kinds := map[string]int{}
+	for _, r := range ast.AST {
+		kinds[r.NodeKind]++
+		assert.Equal(t, "main.go", r.SourceID)
+	}
+	assert.GreaterOrEqual(t, kinds["var_spec"], 2, "both var declarations must appear as _ast rows")
+	assert.GreaterOrEqual(t, kinds["function_declaration"], 1)
+	require.NotEmpty(t, ast.Defs, "func f must be extracted as a def")
+	assert.Equal(t, "f", ast.Defs[0].Token)
+}
+
+func TestE2E_ASTErrors_EnumeratesAll(t *testing.T) {
+	usePinnedDaemon(t)
+	errs := ASTErrors([]byte("package main\n\nfunc hello() {\n\tx :=\n}\n"), "test.go")
+	require.NotEmpty(t, errs)
+	assert.Equal(t, "test.go", errs[0].FilePath)
+}

--- a/internal/writeback/validate_e2e_test.go
+++ b/internal/writeback/validate_e2e_test.go
@@ -30,10 +30,10 @@ func TestE2E_Validate_Verdicts(t *testing.T) {
 		{"broken go missing brace", "test.go", "package main\n\nfunc hello() string {\n\treturn \"world\"\n// missing closing brace\n", true},
 		{"valid python", "test.py", "def hello():\n    return \"world\"\n", false},
 		{"broken python", "test.py", "def hello(\n    return \"world\"\n", true},
-		// Preserved-and-documented behavior: .tf is not in the daemon's
-		// validate set, so even syntactically broken HCL passes validation
-		// (FormatBuffer's hclwrite is the remaining structural check).
-		{"terraform pass-through", "main.tf", `resource "x" { broken {{{`, false},
+		// .tf is not in the daemon's validate set — it validates
+		// IN-PROCESS via hclsyntax, so broken HCL still drafts.
+		{"terraform broken drafts", "main.tf", `resource "x" { broken {{{`, true},
+		{"terraform valid passes", "ok.tf", "resource \"x\" \"y\" {\n  count = 1\n}\n", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/writeback/validate_e2e_test.go
+++ b/internal/writeback/validate_e2e_test.go
@@ -17,19 +17,41 @@ import (
 	"github.com/agentic-research/mache/internal/lltest"
 )
 
-func usePinnedDaemon(t *testing.T) {
-	t.Helper()
-	sock := lltest.StartPinnedDaemon(t)
-	t.Setenv("LEYLINE_SOCKET", sock)
-}
+func TestE2E_Validate_Verdicts(t *testing.T) {
+	lltest.UsePinnedDaemon(t)
 
-func TestE2E_Validate_ValidGo(t *testing.T) {
-	usePinnedDaemon(t)
-	assert.NoError(t, Validate([]byte("package main\n\nfunc hello() string {\n\treturn \"world\"\n}\n"), "test.go"))
+	tests := []struct {
+		name    string
+		path    string
+		src     string
+		wantErr bool
+	}{
+		{"valid go", "test.go", "package main\n\nfunc hello() string {\n\treturn \"world\"\n}\n", false},
+		{"broken go missing brace", "test.go", "package main\n\nfunc hello() string {\n\treturn \"world\"\n// missing closing brace\n", true},
+		{"valid python", "test.py", "def hello():\n    return \"world\"\n", false},
+		{"broken python", "test.py", "def hello(\n    return \"world\"\n", true},
+		// Preserved-and-documented behavior: .tf is not in the daemon's
+		// validate set, so even syntactically broken HCL passes validation
+		// (FormatBuffer's hclwrite is the remaining structural check).
+		{"terraform pass-through", "main.tf", `resource "x" { broken {{{`, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Validate([]byte(tc.src), tc.path)
+			if !tc.wantErr {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var ve *ValidationError
+			require.ErrorAs(t, err, &ve, "real syntax failures must surface as ValidationError")
+			assert.Equal(t, tc.path, ve.FilePath)
+		})
+	}
 }
 
 func TestE2E_Validate_BrokenGo_Positions(t *testing.T) {
-	usePinnedDaemon(t)
+	lltest.UsePinnedDaemon(t)
 
 	// Verified against the v0.7.8 daemon: the first ERROR node for this
 	// buffer is at 0-based row 2, col 12 (the `{ BROKEN SYNTAX` region).
@@ -44,37 +66,8 @@ func TestE2E_Validate_BrokenGo_Positions(t *testing.T) {
 	assert.Contains(t, ve.Message, "syntax error")
 }
 
-func TestE2E_Validate_BrokenGo_MissingBrace(t *testing.T) {
-	usePinnedDaemon(t)
-	err := Validate([]byte("package main\n\nfunc hello() string {\n\treturn \"world\"\n// missing closing brace\n"), "test.go")
-	require.Error(t, err)
-	var ve *ValidationError
-	require.ErrorAs(t, err, &ve)
-}
-
-func TestE2E_Validate_BrokenPython(t *testing.T) {
-	usePinnedDaemon(t)
-	err := Validate([]byte("def hello(\n    return \"world\"\n"), "test.py")
-	require.Error(t, err)
-	var ve *ValidationError
-	require.ErrorAs(t, err, &ve)
-}
-
-func TestE2E_Validate_ValidPython(t *testing.T) {
-	usePinnedDaemon(t)
-	assert.NoError(t, Validate([]byte("def hello():\n    return \"world\"\n"), "test.py"))
-}
-
-func TestE2E_Validate_TerraformPassThrough(t *testing.T) {
-	// Preserved-and-documented behavior: .tf is not in the daemon's
-	// validate set, so even syntactically broken HCL passes validation
-	// (FormatBuffer's hclwrite is the remaining structural check).
-	usePinnedDaemon(t)
-	assert.NoError(t, Validate([]byte(`resource "x" { broken {{{`), "main.tf"))
-}
-
 func TestE2E_ValidateWithAST_ReturnsRowsFromSameParse(t *testing.T) {
-	usePinnedDaemon(t)
+	lltest.UsePinnedDaemon(t)
 
 	src := []byte("package main\n\nvar x []int\n\nfunc f() {\n\tvar y []string = nil\n\t_ = y\n}\n")
 	ast, err := ValidateWithAST(src, "main.go")
@@ -96,7 +89,7 @@ func TestE2E_ValidateWithAST_ReturnsRowsFromSameParse(t *testing.T) {
 }
 
 func TestE2E_ASTErrors_EnumeratesAll(t *testing.T) {
-	usePinnedDaemon(t)
+	lltest.UsePinnedDaemon(t)
 	errs := ASTErrors([]byte("package main\n\nfunc hello() {\n\tx :=\n}\n"), "test.go")
 	require.NotEmpty(t, errs)
 	assert.Equal(t, "test.go", errs[0].FilePath)

--- a/internal/writeback/validate_test.go
+++ b/internal/writeback/validate_test.go
@@ -119,13 +119,21 @@ func TestValidate_UnknownExtension_PassThroughWithoutDaemon(t *testing.T) {
 	assert.NoError(t, Validate([]byte(`this is not valid code in any language {{{`), "test.txt"))
 }
 
-func TestValidate_TerraformExtension_PassThroughWithoutDaemon(t *testing.T) {
-	// Documented behavior change (mache-73b885): .tf/.hcl were validated by
-	// the old in-process grammar set but are NOT in the leyline daemon's
-	// validate language set — they now pass through unvalidated (hclwrite
-	// in FormatBuffer remains the only structural check for them).
+func TestValidate_TerraformValidatesInProcess_WithoutDaemon(t *testing.T) {
+	// .tf/.hcl are NOT in the leyline daemon's validate set — they validate
+	// IN-PROCESS via hclsyntax (pure Go), restoring the pre-73b885 draft
+	// behavior. Without this, broken HCL passed through AND hclwrite.Format
+	// (a token formatter, not a validator) mangled it before splicing
+	// (#527 review should-fix). Dead socket proves no daemon contact.
 	useDeadSocket(t)
-	assert.NoError(t, Validate([]byte(`resource "x" { broken {{{`), "main.tf"))
+
+	err := Validate([]byte(`resource "x" { broken {{{`), "main.tf")
+	var ve *ValidationError
+	require.ErrorAs(t, err, &ve, "broken HCL must fail as a ValidationError (draftable)")
+	assert.Equal(t, "main.tf", ve.FilePath)
+
+	assert.NoError(t, Validate([]byte("resource \"x\" \"y\" {\n  count = 1\n}\n"), "main.tf"),
+		"valid HCL must pass without daemon contact")
 }
 
 func TestValidate_DaemonUnreachable_IsErrorNotPass(t *testing.T) {
@@ -262,8 +270,9 @@ func TestSupportedPath(t *testing.T) {
 		{"lib.rs", true},
 		{"app.ex", true},
 		{"script.exs", true},
-		{"MAIN.GO", true}, // extension matching is case-insensitive
-		{"infra.tf", false},
+		{"MAIN.GO", true},  // extension matching is case-insensitive
+		{"infra.tf", true}, // HCL validates in-process via hclsyntax
+		{"mod.hcl", true},
 		{"conf.yaml", false},
 		{"query.sql", false},
 		{"README.md", false},

--- a/internal/writeback/validate_test.go
+++ b/internal/writeback/validate_test.go
@@ -1,95 +1,279 @@
 package writeback
 
+// Unit tests for the leyline-backed validator. These run WITHOUT a real
+// leyline: lltest.FakeDaemon serves canned wire responses over a private UDS
+// socket that LEYLINE_SOCKET points at, so what is under test is the
+// client-side contract — request shape, position mapping (0-based wire →
+// 0-based ValidationError), pass-through gating, and the hard daemon-too-old
+// error. Real-parser behavior is covered by validate_e2e_test.go against the
+// pinned binary.
+
 import (
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/lltest"
 )
 
-func TestValidate_ValidGo(t *testing.T) {
-	src := []byte(`package main
-
-func hello() string {
-	return "world"
+// okValidateResp is a clean-parse validate response per the v0.7.8 wire.
+func okValidateResp() map[string]any {
+	return map[string]any{"ok": true, "errors": []any{}, "diagnostics": []any{}}
 }
-`)
-	err := Validate(src, "test.go")
+
+// useFakeDaemon points the leyline discovery path at a fake daemon.
+func useFakeDaemon(t *testing.T, handler lltest.Handler) {
+	t.Helper()
+	sock := lltest.FakeDaemon(t, handler)
+	t.Setenv("LEYLINE_SOCKET", sock)
+}
+
+// useDeadSocket points LEYLINE_SOCKET at a plain file so any attempt to
+// contact the daemon fails fast (and provably: a pass-through result can
+// only mean the daemon was never contacted).
+func useDeadSocket(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	dead := filepath.Join(dir, "dead.sock")
+	require.NoError(t, os.WriteFile(dead, nil, 0o600))
+	t.Setenv("LEYLINE_SOCKET", dead)
+}
+
+func TestValidate_ValidGo_FakeDaemon(t *testing.T) {
+	var gotReq map[string]any
+	useFakeDaemon(t, func(req map[string]any) any {
+		gotReq = req
+		return okValidateResp()
+	})
+
+	err := Validate([]byte("package main\n"), "test.go")
 	assert.NoError(t, err)
+
+	require.NotNil(t, gotReq, "daemon must be consulted for .go content")
+	assert.Equal(t, "validate", gotReq["op"])
+	assert.Equal(t, "go", gotReq["language"], "language key must be sent (it wins over path)")
+	assert.Equal(t, "test.go", gotReq["path"])
+	assert.Equal(t, "package main\n", gotReq["content"])
+	_, hasEmit := gotReq["emit_ast"]
+	assert.False(t, hasEmit, "plain Validate must not request emit_ast")
 }
 
-func TestValidate_BrokenGo(t *testing.T) {
-	src := []byte(`package main
+func TestValidate_BrokenGo_MapsFirstErrorPosition(t *testing.T) {
+	useFakeDaemon(t, func(map[string]any) any {
+		return map[string]any{
+			"ok": false,
+			"errors": []any{
+				map[string]any{"row": 2, "col": 12, "byte_start": 26, "byte_end": 41, "message": "syntax error"},
+				map[string]any{"row": 4, "col": 0, "byte_start": 50, "byte_end": 50, "message": "missing }"},
+			},
+			"diagnostics": []any{map[string]any{"line": 2, "col": 12, "message": "syntax error"}},
+		}
+	})
 
-func hello() string {
-	return "world"
-// missing closing brace
-`)
-	err := Validate(src, "test.go")
+	err := Validate([]byte("package main\n\nfunc main() { BROKEN SYNTAX \n\n"), "test.go")
 	require.Error(t, err)
 
 	var ve *ValidationError
 	require.ErrorAs(t, err, &ve)
 	assert.Equal(t, "test.go", ve.FilePath)
+	assert.Equal(t, uint32(2), ve.Line, "wire row is 0-based and ValidationError.Line stays 0-based")
+	assert.Equal(t, uint32(12), ve.Column, "wire col is 0-based and ValidationError.Column stays 0-based")
 	assert.Contains(t, ve.Message, "syntax error")
+	// Error() renders 1-based for humans — the historical contract.
+	assert.Contains(t, ve.Error(), "test.go:3:13:")
 }
 
-func TestValidate_ValidPython(t *testing.T) {
-	src := []byte(`def hello():
-    return "world"
-`)
-	err := Validate(src, "test.py")
-	assert.NoError(t, err)
-}
+func TestValidate_DaemonWithoutErrorsKey_IsHardError(t *testing.T) {
+	// A pre-v0.7.7 daemon (user-supplied via LEYLINE_SOCKET) has no
+	// `errors` key. That must be a hard "daemon too old" failure, NOT a
+	// silent pass — otherwise invalid bytes reach the splice.
+	useFakeDaemon(t, func(map[string]any) any {
+		return map[string]any{"ok": true, "diagnostics": []any{}}
+	})
 
-func TestValidate_BrokenPython(t *testing.T) {
-	src := []byte(`def hello(
-    return "world"
-`)
-	err := Validate(src, "test.py")
+	err := Validate([]byte("package main\n"), "test.go")
 	require.Error(t, err)
+	var ve *ValidationError
+	assert.False(t, errors.As(err, &ve), "daemon-too-old must not be a ValidationError")
+	assert.Contains(t, err.Error(), "v0.7.8")
 }
 
-func TestValidate_ValidJS(t *testing.T) {
-	src := []byte(`function hello() { return "world"; }`)
-	err := Validate(src, "test.js")
-	assert.NoError(t, err)
+func TestValidate_DaemonErrorEnvelope_IsHardError(t *testing.T) {
+	useFakeDaemon(t, func(map[string]any) any {
+		return map[string]any{"ok": false, "error": "unknown op `validate`"}
+	})
+
+	err := Validate([]byte("package main\n"), "test.go")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown op")
 }
 
-func TestValidate_UnknownExtension_PassThrough(t *testing.T) {
-	// Unknown extensions should pass through without error
-	src := []byte(`this is not valid code in any language {{{`)
-	err := Validate(src, "test.txt")
-	assert.NoError(t, err)
+func TestValidate_UnknownExtension_PassThroughWithoutDaemon(t *testing.T) {
+	// .txt is never validated; the daemon must not even be contacted —
+	// the dead socket would error if it were.
+	useDeadSocket(t)
+	assert.NoError(t, Validate([]byte(`this is not valid code in any language {{{`), "test.txt"))
+}
+
+func TestValidate_TerraformExtension_PassThroughWithoutDaemon(t *testing.T) {
+	// Documented behavior change (mache-73b885): .tf/.hcl were validated by
+	// the old in-process grammar set but are NOT in the leyline daemon's
+	// validate language set — they now pass through unvalidated (hclwrite
+	// in FormatBuffer remains the only structural check for them).
+	useDeadSocket(t)
+	assert.NoError(t, Validate([]byte(`resource "x" { broken {{{`), "main.tf"))
+}
+
+func TestValidate_DaemonUnreachable_IsErrorNotPass(t *testing.T) {
+	// For a VALIDATED language, an unreachable daemon must surface as an
+	// error (draft mode on the write path), never as a false "valid".
+	useDeadSocket(t)
+	err := Validate([]byte("package main\n"), "test.go")
+	require.Error(t, err)
+	var ve *ValidationError
+	assert.False(t, errors.As(err, &ve), "acquisition failure must not masquerade as a syntax error")
 }
 
 func TestValidate_EmptyContent(t *testing.T) {
-	err := Validate([]byte{}, "test.go")
+	useFakeDaemon(t, func(map[string]any) any { return okValidateResp() })
+	assert.NoError(t, Validate([]byte{}, "test.go"))
+}
+
+func TestValidateWithAST_RequestsEmitForGo(t *testing.T) {
+	var gotReq map[string]any
+	useFakeDaemon(t, func(req map[string]any) any {
+		gotReq = req
+		resp := okValidateResp()
+		resp["ast"] = map[string]any{
+			"source_id":    "test.go",
+			"language":     "go",
+			"content_hash": "abc",
+			"ast": []any{map[string]any{
+				"node_id": "test.go", "source_id": "test.go", "node_kind": "source_file",
+				"start_byte": 0, "end_byte": 13, "start_row": 0, "start_col": 0,
+				"end_row": 1, "end_col": 0, "node_hash": "deadbeef",
+			}},
+			"defs": []any{}, "refs": []any{}, "imports": []any{},
+		}
+		return resp
+	})
+
+	ast, err := ValidateWithAST([]byte("package main\n"), "test.go")
+	require.NoError(t, err)
+	require.NotNil(t, gotReq)
+	assert.Equal(t, true, gotReq["emit_ast"], "ValidateWithAST must fold emit_ast into the same request")
+	require.NotNil(t, ast, "AST payload must round-trip")
+	assert.Equal(t, "go", ast.Language)
+	require.Len(t, ast.AST, 1)
+	assert.Equal(t, "source_file", ast.AST[0].NodeKind)
+	assert.Equal(t, uint32(13), ast.AST[0].EndByte)
+}
+
+func TestValidateWithAST_EmitRequestedButMissing_IsHardError(t *testing.T) {
+	// A v0.7.7 daemon knows `errors` but silently ignores emit_ast. The
+	// missing `ast` payload must be a hard error, not a silent lint skip.
+	useFakeDaemon(t, func(map[string]any) any { return okValidateResp() })
+
+	_, err := ValidateWithAST([]byte("package main\n"), "test.go")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v0.7.8")
+}
+
+func TestValidateWithAST_NonGoValidatedLanguage_NoEmit(t *testing.T) {
+	// Python is validated but has no lint rules — emit_ast must NOT be
+	// requested (the daemon's extractor supports fewer languages than its
+	// validator, and requesting emit for an uncovered one is a daemon-side
+	// hard error).
+	var gotReq map[string]any
+	useFakeDaemon(t, func(req map[string]any) any {
+		gotReq = req
+		return okValidateResp()
+	})
+
+	ast, err := ValidateWithAST([]byte("def f():\n    pass\n"), "test.py")
+	require.NoError(t, err)
+	assert.Nil(t, ast)
+	require.NotNil(t, gotReq)
+	_, hasEmit := gotReq["emit_ast"]
+	assert.False(t, hasEmit)
+	assert.Equal(t, "py", gotReq["language"])
+}
+
+func TestValidateWithAST_PassThroughExtension_NilNil(t *testing.T) {
+	useDeadSocket(t)
+	ast, err := ValidateWithAST([]byte("whatever"), "notes.md")
 	assert.NoError(t, err)
+	assert.Nil(t, ast)
 }
 
-func TestASTErrors_BrokenGo(t *testing.T) {
-	src := []byte(`package main
+func TestASTErrors_MapsAllErrors(t *testing.T) {
+	useFakeDaemon(t, func(map[string]any) any {
+		return map[string]any{
+			"ok": false,
+			"errors": []any{
+				map[string]any{"row": 1, "col": 4, "byte_start": 10, "byte_end": 12, "message": "syntax error"},
+				map[string]any{"row": 3, "col": 0, "byte_start": 30, "byte_end": 30, "message": "missing identifier"},
+			},
+			"diagnostics": []any{},
+		}
+	})
 
-func hello() {
-	x :=
-}
-`)
-	errs := ASTErrors(src, "test.go")
-	require.NotEmpty(t, errs)
-	assert.Equal(t, "test.go", errs[0].FilePath)
+	errs := ASTErrors([]byte("package main\nbroken"), "test.go")
+	require.Len(t, errs, 2, "ASTErrors must surface EVERY wire error, not just the first")
+	assert.Equal(t, uint32(1), errs[0].Line)
+	assert.Equal(t, uint32(4), errs[0].Column)
+	assert.Equal(t, "syntax error", errs[0].Message)
+	assert.Equal(t, uint32(3), errs[1].Line)
+	assert.Equal(t, "missing identifier", errs[1].Message)
+	assert.Equal(t, "test.go", errs[1].FilePath)
 }
 
 func TestASTErrors_ValidGo_ReturnsNil(t *testing.T) {
-	src := []byte(`package main
-
-func hello() {}
-`)
-	errs := ASTErrors(src, "test.go")
-	assert.Nil(t, errs)
+	useFakeDaemon(t, func(map[string]any) any { return okValidateResp() })
+	assert.Nil(t, ASTErrors([]byte("package main\n"), "test.go"))
 }
 
 func TestASTErrors_UnknownExtension_ReturnsNil(t *testing.T) {
-	errs := ASTErrors([]byte(`broken {{{`), "test.txt")
-	assert.Nil(t, errs)
+	useDeadSocket(t)
+	assert.Nil(t, ASTErrors([]byte(`broken {{{`), "test.txt"))
+}
+
+func TestASTErrors_DaemonUnreachable_ReturnsNil(t *testing.T) {
+	// The diagnostic flavor has no error channel — it degrades to nil,
+	// matching the historical parse-failure contract.
+	useDeadSocket(t)
+	assert.Nil(t, ASTErrors([]byte("package main\n"), "test.go"))
+}
+
+func TestSupportedPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"main.go", true},
+		{"app.py", true},
+		{"index.js", true},
+		{"index.ts", true},
+		{"comp.tsx", true},
+		{"lib.rs", true},
+		{"app.ex", true},
+		{"script.exs", true},
+		{"MAIN.GO", true}, // extension matching is case-insensitive
+		{"infra.tf", false},
+		{"conf.yaml", false},
+		{"query.sql", false},
+		{"README.md", false},
+		{"data.json", false},
+		{"no_extension", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.path, func(t *testing.T) {
+			assert.Equal(t, tc.want, SupportedPath(tc.path),
+				"SupportedPath must agree with the leyline daemon's validate language set")
+		})
+	}
 }

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -99,8 +99,7 @@ func setup(t *testing.T) *testFixture {
 // and exposed via LEYLINE_SOCKET so the pipeline under test finds it.
 func requireWriteDaemon(t *testing.T) {
 	t.Helper()
-	sock := lltest.StartPinnedDaemon(t)
-	t.Setenv("LEYLINE_SOCKET", sock)
+	lltest.UsePinnedDaemon(t)
 }
 
 // realWriteBack replicates the cmd/mount_nfs.go NFS write-back pipeline:

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -9,20 +8,19 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentic-research/mache/api"
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/agentic-research/mache/internal/ingest"
-	"github.com/agentic-research/mache/internal/lattice"
 	"github.com/agentic-research/mache/internal/linter"
+	"github.com/agentic-research/mache/internal/lltest"
 	"github.com/agentic-research/mache/internal/nfsmount"
 	"github.com/agentic-research/mache/internal/writeback"
-	sitter "github.com/smacker/go-tree-sitter"
-	"github.com/smacker/go-tree-sitter/golang"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // testFixture bundles the shared state for integration tests:
-// a real Go source file, an inferred schema, a MemoryStore graph,
+// a real Go source file, a schema, a MemoryStore graph,
 // and a GraphFS wired with the real write-back pipeline.
 type testFixture struct {
 	srcDir  string
@@ -42,8 +40,32 @@ func HelloWorld() {
 }
 `
 
-// setup creates a temp dir with a Go source file, infers a schema via FCA,
-// ingests the source into a MemoryStore, and wires up the real write-back
+// goFunctionsSchema projects Go functions as functions/<name>/source —
+// the same layout the FCA-inferred schema used to produce for this fixture.
+// Hand-written since mache-73b885 removed this package's direct tree-sitter
+// fixture parsing (inference itself is covered by internal/lattice and the
+// cmd infer tests).
+func goFunctionsSchema() *api.Topology {
+	return &api.Topology{
+		Version: "v1",
+		Nodes: []api.Node{{
+			Name:     "functions",
+			Selector: "$",
+			Language: "go",
+			Children: []api.Node{{
+				Name:     "{{.name}}",
+				Selector: "(function_declaration name: (identifier) @name) @scope",
+				Files: []api.Leaf{{
+					Name:            "source",
+					ContentTemplate: "{{.scope}}",
+				}},
+			}},
+		}},
+	}
+}
+
+// setup creates a temp dir with a Go source file, ingests it into a
+// MemoryStore under goFunctionsSchema, and wires up the real write-back
 // callback on a GraphFS instance.
 func setup(t *testing.T) *testFixture {
 	t.Helper()
@@ -52,21 +74,7 @@ func setup(t *testing.T) *testFixture {
 	srcFile := filepath.Join(srcDir, "main.go")
 	require.NoError(t, os.WriteFile(srcFile, []byte(testGoSource), 0o644))
 
-	// Infer schema from directory via FCA (replicates cmd/mount.go --infer logic)
-	content, err := os.ReadFile(srcFile)
-	require.NoError(t, err)
-	parser := sitter.NewParser()
-	parser.SetLanguage(golang.GetLanguage())
-	tree, err := parser.ParseCtx(context.Background(), nil, content)
-	require.NoError(t, err)
-	records := ingest.FlattenAST(tree.RootNode())
-	require.NotEmpty(t, records, "FlattenAST should produce records")
-
-	inf := &lattice.Inferrer{Config: lattice.DefaultInferConfig()}
-	inf.Config.Method = "fca"
-	inf.Config.Language = "go" // Set language for proper node tagging
-	schema, err := inf.InferFromRecords(records)
-	require.NoError(t, err, "schema inference failed")
+	schema := goFunctionsSchema()
 
 	// Ingest into MemoryStore
 	store := graph.NewMemoryStore()
@@ -85,8 +93,19 @@ func setup(t *testing.T) *testFixture {
 	}
 }
 
-// realWriteBack replicates the cmd/mount.go NFS write-back pipeline:
-// validate → format (gofumpt) → lint → splice → surgical update.
+// requireWriteDaemon gates tests that exercise the write-back pipeline: since
+// mache-73b885, validation + lint run through the leyline daemon's validate
+// op. A PRIVATE pinned daemon (never downloaded; skip when absent) is spawned
+// and exposed via LEYLINE_SOCKET so the pipeline under test finds it.
+func requireWriteDaemon(t *testing.T) {
+	t.Helper()
+	sock := lltest.StartPinnedDaemon(t)
+	t.Setenv("LEYLINE_SOCKET", sock)
+}
+
+// realWriteBack replicates the cmd/mount_nfs.go NFS write-back pipeline:
+// validate(+emit_ast) → format (gofumpt) → lint (same parse) → splice →
+// surgical update.
 func realWriteBack(store *graph.MemoryStore) func(string, graph.SourceOrigin, []byte) error {
 	return func(nodeID string, origin graph.SourceOrigin, content []byte) error {
 		node, err := store.GetNode(nodeID)
@@ -94,8 +113,10 @@ func realWriteBack(store *graph.MemoryStore) func(string, graph.SourceOrigin, []
 			return fmt.Errorf("node not found: %w", err)
 		}
 
-		// 1. Validate syntax
-		if err := writeback.Validate(content, origin.FilePath); err != nil {
+		// 1. Validate syntax — ONE leyline parse also yields the AST rows
+		// the linter consumes below.
+		astPayload, err := writeback.ValidateWithAST(content, origin.FilePath)
+		if err != nil {
 			store.WriteStatus.Store(filepath.Dir(nodeID), err.Error())
 			draft := make([]byte, len(content))
 			copy(draft, content)
@@ -106,9 +127,9 @@ func realWriteBack(store *graph.MemoryStore) func(string, graph.SourceOrigin, []
 		// 2. Format (gofumpt for Go, hclwrite for HCL)
 		formatted := writeback.FormatBuffer(content, origin.FilePath)
 
-		// 3. Lint (warning only)
+		// 3. Lint (warning only) — reuses step 1's parse
 		if strings.HasSuffix(origin.FilePath, ".go") {
-			if diags, err := linter.Lint(formatted, "go"); err == nil && len(diags) > 0 {
+			if diags, err := linter.LintAST(astPayload); err == nil && len(diags) > 0 {
 				var sb strings.Builder
 				for _, d := range diags {
 					sb.WriteString(d.String() + "\n")
@@ -165,10 +186,10 @@ func readNode(t *testing.T, gfs *nfsmount.GraphFS, path string) string {
 	return string(buf[:n])
 }
 
-func TestIntegration_InferAndIngest(t *testing.T) {
+func TestIntegration_IngestAndProject(t *testing.T) {
 	fix := setup(t)
 
-	// The inferred schema + ingestion should produce a HelloWorld node
+	// The schema + ingestion should produce a HelloWorld node
 	node, err := fix.store.GetNode("functions/HelloWorld/source")
 	require.NoError(t, err, "functions/HelloWorld/source should exist in graph")
 	assert.Contains(t, string(node.Data), "Original Content Long Long Long")
@@ -183,6 +204,7 @@ func TestIntegration_ContextAwareness(t *testing.T) {
 }
 
 func TestIntegration_Truncation(t *testing.T) {
+	requireWriteDaemon(t)
 	fix := setup(t)
 
 	// Write shorter content — old tail must not remain in source file
@@ -197,6 +219,7 @@ func TestIntegration_Truncation(t *testing.T) {
 }
 
 func TestIntegration_Diagnostics(t *testing.T) {
+	requireWriteDaemon(t)
 	fix := setup(t)
 
 	// Write broken syntax
@@ -219,6 +242,7 @@ func TestIntegration_Diagnostics(t *testing.T) {
 }
 
 func TestIntegration_Recovery(t *testing.T) {
+	requireWriteDaemon(t)
 	fix := setup(t)
 
 	// First: write broken syntax to set diagnostic state
@@ -239,6 +263,7 @@ func TestIntegration_Recovery(t *testing.T) {
 }
 
 func TestIntegration_SequentialWrites(t *testing.T) {
+	requireWriteDaemon(t)
 	fix := setup(t)
 
 	// Two sequential writes to the same node — both should land.
@@ -262,6 +287,7 @@ func TestIntegration_SequentialWrites(t *testing.T) {
 }
 
 func TestIntegration_GofumptFormat(t *testing.T) {
+	requireWriteDaemon(t)
 	fix := setup(t)
 
 	// FormatGoBuffer uses format.Source which requires a complete Go file.
@@ -281,4 +307,33 @@ func TestIntegration_GofumptFormat(t *testing.T) {
 	diag := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/last-write-status")
 	assert.Contains(t, diag, "ok",
 		"write-back pipeline should complete successfully")
+}
+
+func TestIntegration_LintDiagnostic_NilSlice(t *testing.T) {
+	requireWriteDaemon(t)
+	fix := setup(t)
+
+	// A valid write containing an uninitialized slice declaration must
+	// splice AND surface the warning-only lint diagnostic — produced from
+	// the SAME leyline parse that validated the write.
+	snippet := "func HelloWorld() {\n\tvar s []int\n\t_ = s\n}\n"
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source", []byte(snippet))
+
+	src, err := os.ReadFile(fix.srcFile)
+	require.NoError(t, err)
+	assert.Contains(t, string(src), "var s []int",
+		"lint findings are warnings — the write must still splice")
+
+	lint := readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/lint")
+	assert.Contains(t, lint, "Nil slice declaration",
+		"lint diagnostic should surface via _diagnostics/lint")
+	assert.Contains(t, lint, "line 2:",
+		"diagnostic line is 1-based in String() (var s []int is snippet line 2)")
+
+	// A clean follow-up write clears the lint diagnostic.
+	writeToNode(t, fix.gfs, "/functions/HelloWorld/source",
+		[]byte("func HelloWorld() {\n\tfmt.Println(\"clean\")\n}\n"))
+	lint = readNode(t, fix.gfs, "/functions/HelloWorld/_diagnostics/lint")
+	assert.Contains(t, lint, "clean",
+		"lint diagnostic should reset after a clean write")
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -1,7 +1,14 @@
-// Package validate exposes tree-sitter syntax validation for external consumers.
+// Package validate exposes syntax validation for external consumers.
 //
-// This is the public API for mache's AST validation. It supports Go, Python,
-// JavaScript, TypeScript, SQL, HCL, YAML, and Rust via tree-sitter grammars.
+// This is the public API for mache's AST validation. Since mache-73b885 it is
+// backed by the pinned leyline daemon's `validate` op (ley-line-open >=
+// v0.7.8) instead of in-process tree-sitter, and supports Go, Python,
+// JavaScript, TypeScript/TSX, Rust, and Elixir. Extensions the daemon does
+// not validate (including .sql, .tf/.hcl, .yaml, .md, .toml, which the old
+// in-process grammar set covered) pass through with no error. A leyline
+// daemon is acquired lazily on first use (see internal/leyline
+// ValidateContent for the latency profile); daemon-acquisition failures
+// surface as ordinary errors, never as false "valid" results.
 //
 // Usage:
 //
@@ -17,9 +24,9 @@ import (
 // ValidationError contains structured information about a syntax error.
 type ValidationError = writeback.ValidationError
 
-// Content parses content with tree-sitter for the language inferred from
-// filePath's extension. Returns nil if the AST is clean or the language
-// is unknown (pass-through).
+// Content validates content for the language inferred from filePath's
+// extension. Returns nil if the AST is clean or the extension is not
+// validated (pass-through).
 func Content(content []byte, filePath string) error {
 	return writeback.Validate(content, filePath)
 }
@@ -48,8 +55,8 @@ func FileErrors(filePath string) []ValidationError {
 	return ContentErrors(content, filePath)
 }
 
-// SupportedExtension returns true if the file extension is recognized
-// by the tree-sitter grammar set.
+// SupportedExtension returns true if the file extension is validated by the
+// leyline daemon's validate op.
 func SupportedExtension(filePath string) bool {
-	return writeback.LanguageForPath(filePath) != nil
+	return writeback.SupportedPath(filePath)
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -3,9 +3,12 @@
 // This is the public API for mache's AST validation. Since mache-73b885 it is
 // backed by the pinned leyline daemon's `validate` op (ley-line-open >=
 // v0.7.8) instead of in-process tree-sitter, and supports Go, Python,
-// JavaScript, TypeScript/TSX, Rust, and Elixir. Extensions the daemon does
-// not validate (including .sql, .tf/.hcl, .yaml, .md, .toml, which the old
-// in-process grammar set covered) pass through with no error. A leyline
+// JavaScript, TypeScript/TSX, Rust, and Elixir; HCL/Terraform validates
+// in-process via hclsyntax. EVERY other extension passes through with no
+// error — including .sql/.yaml/.md/.toml/.json AND the ~25 further
+// extensions the old in-process grammar set covered (.c/.cpp/.java/.rb/
+// .php/.kt/.lua/.sh/...). Content in those languages splices as written,
+// with no structural check, until leyline grows the grammars. A leyline
 // daemon is acquired lazily on first use (see internal/leyline
 // ValidateContent for the latency profile); daemon-acquisition failures
 // surface as ordinary errors, never as false "valid" results.

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -131,7 +131,7 @@ func TestSupportedExtension(t *testing.T) {
 		{"comp.tsx", true},
 		{"lib.rs", true},
 		{"app.ex", true},
-		{"infra.tf", false},  // was true pre-mache-73b885
+		{"infra.tf", true},   // HCL validates in-process via hclsyntax (mache-73b885)
 		{"README.md", false}, // was true pre-mache-73b885
 		{"data.json", false},
 		{"no_extension", false},

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -3,52 +3,81 @@ package validate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/lltest"
 )
 
-// The validate package is mache's public API surface for AST
-// syntax validation — external consumers (e.g. CI scripts,
-// pre-commit hooks) import it instead of internal/writeback. The
-// tests here pin the API contract: valid input returns nil, invalid
-// input returns a populated error / non-empty error slice, and the
-// File/FileErrors variants reach disk correctly. The underlying
-// tree-sitter parsing is exercised by internal/writeback's own
-// suite; we don't re-test it here.
+// The validate package is mache's public API surface for syntax validation —
+// external consumers (e.g. CI scripts, pre-commit hooks) import it instead of
+// internal/writeback. The tests here pin the API contract: valid input
+// returns nil, invalid input returns a populated error / non-empty error
+// slice, and the File/FileErrors variants reach disk correctly. Validation is
+// served by a leyline daemon; these tests run against a fake daemon whose
+// verdict keys off a content marker, so the suite needs no real binary. The
+// real-parser path is covered by internal/writeback's gated e2e suite.
+
+// brokenMarker makes the fake daemon report a syntax error — the tests only
+// exercise plumbing, not parsing.
+const brokenMarker = "syntax error here"
+
+// useMarkerDaemon wires a fake leyline daemon that flags any content
+// containing brokenMarker and validates everything else.
+func useMarkerDaemon(t *testing.T) {
+	t.Helper()
+	sock := lltest.FakeDaemon(t, func(req map[string]any) any {
+		content, _ := req["content"].(string)
+		if strings.Contains(content, brokenMarker) {
+			return map[string]any{
+				"ok": false,
+				"errors": []any{
+					map[string]any{"row": 2, "col": 14, "byte_start": 28, "byte_end": 45, "message": "syntax error"},
+				},
+				"diagnostics": []any{},
+			}
+		}
+		return map[string]any{"ok": true, "errors": []any{}, "diagnostics": []any{}}
+	})
+	t.Setenv("LEYLINE_SOCKET", sock)
+}
 
 func TestContent_ValidGoReturnsNil(t *testing.T) {
+	useMarkerDaemon(t)
 	src := []byte("package main\n\nfunc main() {}\n")
 	assert.NoError(t, Content(src, "main.go"))
 }
 
 func TestContent_InvalidGoReturnsError(t *testing.T) {
+	useMarkerDaemon(t)
 	src := []byte("package main\n\nfunc main() { syntax error here }\n")
 	assert.Error(t, Content(src, "main.go"),
 		"validate.Content must surface syntax errors so external CI gates can fail loudly")
 }
 
 func TestContent_UnknownExtensionPassesThrough(t *testing.T) {
-	// Pass-through guarantee: callers can hand validate any
-	// extension without wrapping in a language probe. .xyz has no
-	// tree-sitter grammar, so we return nil rather than a "no
-	// grammar" error.
+	// Pass-through guarantee: callers can hand validate any extension
+	// without wrapping in a language probe. .xyz is not in the daemon's
+	// validate set, so we return nil rather than a "no grammar" error —
+	// and the daemon is never contacted (no fake is wired here).
 	src := []byte("anything goes here\n")
 	assert.NoError(t, Content(src, "data.xyz"))
 }
 
 func TestContentErrors_ValidGoReturnsEmpty(t *testing.T) {
+	useMarkerDaemon(t)
 	src := []byte("package main\n\nfunc main() {}\n")
 	errs := ContentErrors(src, "main.go")
 	assert.Empty(t, errs)
 }
 
 func TestContentErrors_InvalidGoPopulatesSlice(t *testing.T) {
-	// The point of ContentErrors over Content is structured
-	// per-error positions for diagnostic UIs — assert we get at
-	// least one entry, not a count, since tree-sitter's recovery
-	// can split one logical error into multiple AST nodes.
+	// The point of ContentErrors over Content is structured per-error
+	// positions for diagnostic UIs — assert we get at least one entry.
+	useMarkerDaemon(t)
 	src := []byte("package main\n\nfunc main() { syntax error here }\n")
 	errs := ContentErrors(src, "main.go")
 	assert.NotEmpty(t, errs,
@@ -56,6 +85,7 @@ func TestContentErrors_InvalidGoPopulatesSlice(t *testing.T) {
 }
 
 func TestFile_ValidGoReturnsNil(t *testing.T) {
+	useMarkerDaemon(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(path, []byte("package main\n"), 0o644))
@@ -63,6 +93,7 @@ func TestFile_ValidGoReturnsNil(t *testing.T) {
 }
 
 func TestFile_InvalidGoReturnsError(t *testing.T) {
+	useMarkerDaemon(t)
 	dir := t.TempDir()
 	path := filepath.Join(dir, "main.go")
 	require.NoError(t, os.WriteFile(path,
@@ -71,23 +102,25 @@ func TestFile_InvalidGoReturnsError(t *testing.T) {
 }
 
 func TestFile_NonexistentReturnsError(t *testing.T) {
-	// Read errors propagate — callers can distinguish "file
-	// missing" from "syntax error" by the error type if they
-	// need to (errors.Is on os.ErrNotExist).
+	// Read errors propagate — callers can distinguish "file missing" from
+	// "syntax error" by the error type if they need to (errors.Is on
+	// os.ErrNotExist).
 	err := File("/nonexistent/path/to/file.go")
 	assert.Error(t, err)
 }
 
 func TestFileErrors_NonexistentReturnsNil(t *testing.T) {
-	// FileErrors swallows read errors and returns nil — the
-	// diagnostic UI flavor doesn't have a way to surface a
-	// non-AST error. Callers that care about read errors should
-	// use File() instead.
+	// FileErrors swallows read errors and returns nil — the diagnostic UI
+	// flavor doesn't have a way to surface a non-AST error. Callers that
+	// care about read errors should use File() instead.
 	errs := FileErrors("/nonexistent/path/to/file.go")
 	assert.Nil(t, errs)
 }
 
 func TestSupportedExtension(t *testing.T) {
+	// Since mache-73b885 the supported set is the leyline daemon's validate
+	// language set — .tf/.hcl, .sql, .yaml, .md, .toml (covered by the old
+	// in-process grammar set) are now pass-through, .ex/.exs are new.
 	tests := []struct {
 		path string
 		want bool
@@ -95,15 +128,18 @@ func TestSupportedExtension(t *testing.T) {
 		{"main.go", true},
 		{"app.py", true},
 		{"index.ts", true},
-		{"infra.tf", true},
-		{"data.json", false}, // JSON has no tree-sitter grammar in mache's set
-		{"README.md", true},  // Markdown is registered
+		{"comp.tsx", true},
+		{"lib.rs", true},
+		{"app.ex", true},
+		{"infra.tf", false},  // was true pre-mache-73b885
+		{"README.md", false}, // was true pre-mache-73b885
+		{"data.json", false},
 		{"no_extension", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.path, func(t *testing.T) {
 			assert.Equal(t, tc.want, SupportedExtension(tc.path),
-				"SupportedExtension must agree with the tree-sitter grammar registry")
+				"SupportedExtension must agree with the leyline validate language set")
 		})
 	}
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -117,6 +117,17 @@ func TestFileErrors_NonexistentReturnsNil(t *testing.T) {
 	assert.Nil(t, errs)
 }
 
+func TestContentErrors_BrokenHCLPopulatesSlice(t *testing.T) {
+	// #527 re-review residual: the diagnostics flavor skipped the in-process
+	// HCL branch, so external diagnostic UIs saw "supported, no errors" for
+	// broken HCL while Content() errored. No daemon is wired — HCL must not
+	// need one.
+	errs := ContentErrors([]byte(`resource "x" { broken {{{`), "main.tf")
+	assert.NotEmpty(t, errs, "broken HCL must produce diagnostics, not silence")
+	assert.NoError(t, Content([]byte("resource \"x\" \"y\" {\n  count = 1\n}\n"), "ok.tf"))
+	assert.Empty(t, ContentErrors([]byte("resource \"x\" \"y\" {\n  count = 1\n}\n"), "ok.tf"))
+}
+
 func TestSupportedExtension(t *testing.T) {
 	// Since mache-73b885 the supported set is the leyline daemon's validate
 	// language set — .tf/.hcl, .sql, .yaml, .md, .toml (covered by the old


### PR DESCRIPTION
## Summary
Completes bead mache-73b885 (items 3+4): the write-back path no longer parses with in-process CGO tree-sitter. `grep smacker internal/writeback/ internal/linter/ tests/` → empty. **PR-B (mache-37ae8b) is now sized at exactly 23 remaining sitter importers**, all parse-side.

### Pin: ley-line-open v0.7.5 → v0.7.8 (SHA-verified)
v0.7.8 ships both mache-blocking adds. Baseline regenerated in the same commit per the standing rule — **dead_code 16 → 3**: the 13 grandfathered identifier-as-VALUE false-positives (cobra `RunE:` handlers, suite factories) collapse now that the extractor emits those refs; the 3 survivors are the true positives the tree-sitter projection also flags.

### Writeback validation → leyline `validate` op
- `internal/leyline/validate.go`: typed client over the existing UDS machinery; codes against the `errors[]` wire (0-based row/col, byte ranges, MISSING zero-width); a response without the `errors` key is a hard "daemon too old, need ≥ v0.7.8" error — never a silent fallback.
- `internal/writeback/validate.go`: same `Validate` signature + `ValidationError` shape (draft-mode diagnostics unchanged); `ValidateWithAST` returns the `emit_ast` payload.
- Non-Go-daemon-set languages (`.tf/.sql/.toml/...`) now pass through unvalidated (documented + test-pinned; hclwrite remains HCL's structural check).

### Linter → SQL over the same parse
`internal/linter` reimplements the nil-slice rule as SQL over the `emit_ast` rows (in-memory modernc sqlite; direct-child structure via the materialized-path node_id). **mount_nfs runs validate+lint from ONE parse per write.** Bonus: fixes the old rule's false positive on `var x []T = v`.

### DiscoverOrStart spawns only the exact-pinned binary
Surfaced during this work: the daemon SPAWN path still did raw LookPath + unchecked cache stat (mache-0acdf6 drift) — a stale PATH leyline would be spawned and every write would draft with daemon-too-old. The spawn now routes through `ResolveBinary` (exact pin at every tier, SHA-verified download, MACHE_NO_LEYLINE respected). An already-running daemon is still honored (user-owned; wire handshake + per-op probes cover it). Spawn-branch tests seed pin-versioned stubs and can no longer hit the network.

### Test infrastructure
`internal/lltest`: FakeDaemon (canned UDS wire) + StartPinnedDaemon (private arena/socket, skip-never-download). Unit tests cover the wire contract, position mapping, daemon-too-old, pass-through; gated e2e covers real broken-Go positions, emit_ast round trip, nil-slice lint, and the full write-back pipeline through GraphFS (all executed locally, none skipped). `tests/integration_test.go` no longer imports sitter.

## Verification
Full `task check` green end-to-end; `task smells` passes with 10 ratchet findings burned down structurally rather than baselined; fresh SHA-verified 0.7.8 download exercised.

## After this merges
mache-73b885 closes. PR-B (mache-37ae8b) deletes the remaining 23 sitter importers + CGO_ENABLED=0 releases, pending the language-coverage decision (leyline parses 11/28 registry languages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)