### PR TITLE
[mache-37ae8b] docs(release): add v0.18.0 CHANGELOG entry, bump covers-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,63 @@ All notable changes to mache are documented here. This project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html); pre-1.0 minor
 bumps may include breaking changes.
 
+## [v0.18.0] — 2026-07-21
+
+The CGO-removal wave, part two — and the end of it: the in-process tree-sitter
+backend is gone, ley-line is the sole source parser, and the released binaries
+are built `CGO_ENABLED=0`. Removing the in-process projector exposed an
+O(nodes²) blowup in the pure-Go `ASTWalker` and a silently-dead `find_callees`
+on the serve path; both are fixed and verified here.
+
+### Changed
+
+- **Pure Go — in-process CGO tree-sitter removed** (ADR-0012 step 4). Every
+  source path (`build` / `serve` / `mount` / `infer` / testfixtures) routes
+  through `leyline parse` → `_ast` → the pure-Go `ASTWalker`. `SitterWalker`,
+  `sitter_flatten`, the 28 vendored grammar bindings and the `go-tree-sitter`
+  dependency are deleted (−428K lines of generated `parser.c` alone), and the
+  release builds `CGO_ENABLED=0`. The pinned leyline parses 27 of 28 registry
+  languages (all but cue, which has no compatible grammar crate); a schema
+  coverage guard reports the gap loudly. The `leyline_fs` FFI stays behind its
+  separate `//go:build leyline` tag. (`mache-37ae8b`, #533)
+
+### Fixed
+
+- **O(nodes²) projection blowup → O(nodes)** — porting SitterWalker's in-memory
+  tree walk to per-node SQL made every child lookup re-scan all same-kind nodes
+  in the file, so a whole-repo projection took >3 min (and hung ~20 min in
+  testfixtures). Fixed with a per-file in-memory node index, once-per-file
+  call/ref extraction, and build-only read tuning (mmap). **cmd/ 4m22s → 3.1s
+  (~78×); whole repo >3 min → ~10s**, with output proven byte-identical to the
+  pre-fix baseline (0 differing rows across `nodes`/`node_refs`/`node_defs`).
+  (`mache-4f3840`)
+- **`find_callees` silently returned nothing on serve/mount** — the call
+  extractor fed the *graph node id* into `_ast` as `source_id`, matching zero
+  rows every time; test coverage hid it behind a regex stand-in. Restored via a
+  scoped+qualified `_ast` query, with the construct's `_ast` scope persisted at
+  projection time, plus a `node_refs` fallback so it also works on a
+  schema-built `.db` served without an `_ast` table. (`mache-fd9982`,
+  `mache-6fbaf1`)
+- **Read-connection tuning no longer mutates served databases** — the
+  single-connection + `locking_mode=EXCLUSIVE` tuning is scoped to the one-shot
+  build that owns its temp db; it previously clobbered the served graph's pool
+  and held a process-lifetime file lock. (`mache-010123`)
+- **Whole-file extraction surfaces DB errors instead of caching partials** — a
+  transient failure could permanently empty a file's callees/refs with no
+  signal. (`mache-015f5c`, `mache-6ff371`)
+- **ASTWalker caches invalidated on re-ingest**, and the unsynchronized
+  `childSeen` map is now mutex-guarded against concurrent `ReIngestFile`.
+  (`mache-018eee`, `mache-024e9c`, `mache-706757`)
+
+### Internal
+
+- CI provisions the pinned leyline before tests, so the sole-parser projection
+  tests run instead of silently skipping. (`mache-01c467`)
+- Whole-repo E2E fixtures retiered out of the `-race` unit run (they blew the
+  20-minute budget under the race detector) and run non-race in the integration
+  workflow. (`mache-4f3840`)
+- `modernc.org/sqlite` 1.53.0 → 1.54.0. (#532)
+
 ## [v0.17.0] — 2026-07-14
 
 The CGO-removal wave, part one: the structural smell gate runs entirely on the

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.17.0
-last-verified: 2026-07-08
+covers-version: v0.18.0
+last-verified: 2026-07-21
 sources-of-truth:
   - internal/lang/lang.go
   - cmd/serve_handlers.go

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 ---
 status: current
-covers-version: v0.17.0
+covers-version: v0.18.0
 last-verified: 2026-07-21
 sources-of-truth:
   - CHANGELOG.md

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.17.0
-last-verified: 2026-07-14
+covers-version: v0.18.0
+last-verified: 2026-07-21
 sources-of-truth:
   - CHANGELOG.md
   - .beads/
@@ -11,7 +11,7 @@ supersedes: []
 
 # Roadmap
 
-## Current state (as of 2026-07, through v0.17.0)
+## Current state (as of 2026-07, through v0.18.0)
 
 v0.8.0 — the "constellation wave" — ships paired with **ley-line-open v0.2.0**. The wire format between them is now content-addressable: substrate identity is the BLAKE3 `current_root` of the arena payload, not a monotonic generation counter. Old mache reading new arenas (or vice versa) fails loudly with a clear version-mismatch error rather than corrupting reads. See [CHANGELOG.md § v0.8.0](../CHANGELOG.md) for the full break, [ADR-0014](adr/0014-mache-in-constellation.md) for the architectural framing.
 

--- a/docs/reference/arena.md
+++ b/docs/reference/arena.md
@@ -1,6 +1,6 @@
 ---
 status: current
-covers-version: v0.17.0
+covers-version: v0.18.0
 last-verified: 2026-07-08
 sources-of-truth:
   - scripts/arena.sh
@@ -9,6 +9,11 @@ supersedes: []
 ---
 
 # Mache Arena: 6-Level Agent Benchmark
+
+> **Note:** the recorded results below were last measured on v0.17.0
+> (`last-verified: 2026-07-08`), i.e. **before** the v0.18.0 pure-Go cutover and
+> the O(nodes²)→O(nodes) projection fix. The methodology is current; the numbers
+> are not. A re-run against v0.18.0 is tracked in `mache-b7ec42`.
 
 The Arena is a custom benchmark that tests whether an LLM-driven agent can operate on real code **only through mache's filesystem abstraction** — no direct file access. The target code is intentionally bespoke so memorized patterns don't help.
 


### PR DESCRIPTION
v0.18.0 was tagged and released **without a CHANGELOG entry** — `CHANGELOG.md` and the shipped `v0.18.0` tag both topped out at `## [v0.17.0]`.

The **docs-lint invariant caught it**: `scripts/docs-lint.sh` enforces `covers-version == newest CHANGELOG heading`, so ROADMAP couldn't legitimately claim v0.18.0 while the CHANGELOG didn't have it. Good gate — it turned a silent release-hygiene gap into a hard failure.

## What this adds

- **`## [v0.18.0]` CHANGELOG entry** — pure-Go CGO-tree-sitter removal (ADR-0012 step 4); the O(nodes²)→O(nodes) projection fix (**cmd/ 4m22s → 3.1s ≈ 78×**, whole-repo >3min → ~10s, output byte-identical to baseline); `find_callees` restored on serve/mount; plus the read-tuning, error-surfacing, cache-invalidation and `childSeen` race fixes, and the CI/E2E changes.
- **`covers-version` → v0.18.0** in the four docs that carry it (ARCHITECTURE, ROADMAP, README, reference/arena) + ROADMAP's "through v0.18.0" marker.

## Honesty notes

- `last-verified` bumped **only** where content was actually re-verified today.
- **`docs/reference/arena.md` keeps `last-verified: 2026-07-08`** and gains an explicit note: its benchmark numbers predate the v0.18.0 work, methodology is current, numbers are not. The re-run is tracked in `mache-b7ec42`.

## Verification

`task docs:lint — latest version: v0.18.0 | 0 fail, 0 warn` · `task smells — PASS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)