### PR TITLE
[mache-e34aec] fix(docs): retire the LLO-optional model in published claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ That's the 30-second path for the flagship application — code intelligence on 
 Two things new users hit:
 
 - **HTTP is the canonical transport.** One shared daemon serves every project, routing per session via the MCP roots protocol. `--stdio` exists only as an escape hatch for CI / sandboxes / headless agents and is never registered for editor use (see [ADR-0022](docs/adr/0022-mcp-transport-canonical.md)).
-- For **Rust / Python / TypeScript**, point mache at a [ley-line-open](https://github.com/agentic-research/ley-line-open)-built `.db` instead of a directory (`mache serve ./code.db`) to get accurate `find_callers` + `get_type_info` + `get_diagnostics`. A bare directory uses the built-in tree-sitter tier, which is tuned for Go.
+- **[ley-line-open](https://github.com/agentic-research/ley-line-open) is a hard requirement, not an add-on.** Since v0.18.0 mache has no in-process parser: `leyline parse` produces the `_ast` database that every source projection reads. `task install` provisions the pinned binary. Point mache at a directory *or* a pre-built `.db` — both route through leyline; a pre-built `.db` just skips the parse step and can carry LSP/embedding enrichment.
 
 To project non-code data instead, hand `mache serve` (or `mache mount`) a schema with `--schema` and point it at your JSON or SQLite source — the [example schemas](examples/README.md) cover NVD, KEV, Notion, Trivy, Terraform, and more.
 
@@ -29,13 +29,41 @@ For the full first-run flow — source choice (directory vs `.db` vs live hot-sw
 
 ## Code intelligence: what it gives an agent
 
-The code projection is where the engine is deepest. Eighteen MCP tools wrap the projected graph (seventeen read-surface plus `write_file`). Fourteen work standalone; four (`semantic_search`, `get_type_info`, `get_diagnostics`, `get_sheaf_status`) draw on [ley-line-open](https://github.com/agentic-research/ley-line-open) enrichment. `find_smells` covers fourteen structural code-smell rules (`dead_code`, `cyclomatic_complexity`, `god_file`, `fan_out_skew`, `untested_function`, …); five of those require a `.db` built by ley-line-open.
+The code projection is where the engine is deepest. **18 MCP tools** wrap the projected graph — 17 read-surface plus `write_file`.
 
-**Live LSP enrichment.** `get_type_info` / `get_diagnostics` no longer need a pre-baked `.db` — pass a `file=` and mache auto-spawns the ley-line daemon, which drives the language server (rust-analyzer, gopls, …) on demand and projects real hover / type / diagnostic data into the graph. Verified end-to-end on **Rust and Go** (e.g. `get_type_info(symbol, file)` returns rust-analyzer's signature + doc comment). This is the same primitive [Serena](https://github.com/oraios/serena) is built on, but as one enrichment *tier* over a tree-sitter base that still works without a language server — see [`prior-art/`](prior-art/) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
+| What you get                                | Tools                                                                     | Tier         | Status                                                |
+| ------------------------------------------- | ------------------------------------------------------------------------- | ------------ | ----------------------------------------------------- |
+| **Parse** source into a graph               | —                                                                         | required     | Stable — 27 of 28 languages (all but cue: no grammar) |
+| **Orient** in an unfamiliar repo            | `get_overview`, `get_architecture`, `get_diagram`                         | base         | Stable                                                |
+| **Cluster** related code                    | `get_communities`                                                         | base         | *Beta* — Louvain                                      |
+| **Navigate** by structure, not string match | `find_definition`, `list_directory`, `read_file`, `resolve_ref`, `search` | base         | Stable                                                |
+| **Trace** the call graph, both directions   | `find_callers`, `find_callees`, `get_impact`                              | base         | Stable — `find_callees` on serve fixed in v0.18.0     |
+| **Judge** structural quality                | `find_smells` — 14 rules                                                  | base¹        | Stable — `fan_out_skew` is qualifier-aware            |
+| **Edit** without breaking the file          | `write_file` — validate → format → splice, draft mode on reject           | base         | Stable                                                |
+| **Types + diagnostics** from a real LSP     | `get_type_info`, `get_diagnostics`                                        | + LSP pass   | Stable, optional tier                                 |
+| **Search by meaning**, not tokens           | `semantic_search`                                                         | + embeddings | Stable, optional tier                                 |
+| **Check enrichment freshness**              | `get_sheaf_status`                                                        | any²         | Stable                                                |
+| **Serve across repos**                      | *(`--mount NAME=PATH`)*                                                   | base         | Stable — `find_callers` federates; callees per-mount  |
+| **Mount as a filesystem** + write back      | *(NFS)*                                                                   | base         | Stable                                                |
+| **Move a built graph** between machines/CI  | *(`mache cache` push/pull/verify)*                                        | —            | Stable — content-addressed, local dir or OCI          |
+| **Infer a schema** from data                | *(`--infer`)*                                                             | —            | *Beta* — FCA + greedy entropy                         |
 
-For the full tool inventory and capability matrix (which tools need which tables), see [ARCHITECTURE.md § MCP Server](docs/ARCHITECTURE.md#core-abstractions) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
+**Tiers.** There is no "works without ley-line-open" tier — `leyline parse` *is* the parser.
+
+- **base** — any source projection. `leyline parse` → `_ast` → pure-Go `ASTWalker`, from a directory or a pre-built `.db`.
+- **+ LSP pass** — leyline's LSP tier, auto-spawned on demand (pass a `file=`) or pre-baked into a `.db`. Drives the real language server (rust-analyzer, gopls, …); verified end-to-end on **Rust and Go**. Same primitive [Serena](https://github.com/oraios/serena) is built on, but as an enrichment *tier* over the `_ast` base rather than the foundation.
+- **+ embeddings** — a ley-line-open-built `.db` carrying embedding vectors.
+
+¹ 5 of the 14 rules need an enriched `.db`.  ² Reports daemon cache state; returns `{available: false}` when unreachable, so it's safe to call anywhere.
+
+Internal machinery — canonical `v_refs`/`v_defs` views (ADR-0013), the capnp event-log readthrough, snapshot memoization, the e2e tool/flamegraph harness — lives in [ARCHITECTURE.md](docs/ARCHITECTURE.md) and [CHANGELOG.md](CHANGELOG.md).
+
+For which tools read which tables, see [ARCHITECTURE.md § MCP Server](docs/ARCHITECTURE.md#core-abstractions) and [§ Interplay with ley-line-open](docs/ARCHITECTURE.md#interplay-with-ley-line-open).
 
 ## How it works
+
+<details>
+<summary>Schema → walkers → graph → MCP / filesystem (with diagram)</summary>
 
 Every projection follows the same shape: a schema declares the topology, walkers extract nodes and edges from the source (JSONPath for JSON, direct SQL for SQLite, AST queries for code), and the resulting graph is served over MCP or mounted as a filesystem. The source-code path — the most developed — looks like this:
 
@@ -50,38 +78,21 @@ flowchart LR
     FS -.- Agent
 ```
 
-1. **Parse** — `leyline parse` (from ley-line-open) turns source into an `_ast` database (27 of 28 languages — all but cue, which has no tree-sitter grammar anywhere). mache reads it pure-Go via the `ASTWalker`; in-process CGO tree-sitter was removed in [ADR-0012](docs/adr/0012-cgo-removal-migration.md) step 4.
+1. **Parse** — `leyline parse` (from ley-line-open) turns source into an `_ast` database. mache reads it pure-Go via the `ASTWalker`; in-process CGO tree-sitter was removed in [ADR-0012](docs/adr/0012-cgo-removal-migration.md) step 4.
 1. **Infer** — schema inference (FCA + greedy entropy) discovers the natural groupings (`functions/`, `types/`, `classes/`)
 1. **Link** — cross-reference extraction builds a call graph from identifiers and imports. When the LSP pass from ley-line-open has run, refs flow through a sibling `.bindings.capnp` typed event log (per [ADR-0013](docs/adr/0013-refs-defs-canonical-schema.md)) rather than SQL columns — the wire format is the cross-runtime contract.
 1. **Project** — the graph is exposed as MCP tools (primary) or a mounted filesystem (optional)
 
 The graph is the same on either path; MCP and the filesystem are two ways to talk to it.
 
-## Status
-
-| Capability                              | Status                                                                                           |
-| --------------------------------------- | ------------------------------------------------------------------------------------------------ |
-| Tree-sitter parsing (28 langs)          | Stable                                                                                           |
-| MCP server (17 tools, HTTP canonical)   | Stable                                                                                           |
-| Cross-repo serve (`--mount NAME=PATH`)  | Stable (find_callers federates; find_callees stays per-mount for now)                            |
-| Cross-references (callers/callees)      | Stable                                                                                           |
-| `find_smells` (14 structural rules)     | Stable. `fan_out_skew` is qualifier-aware via ley-line-open `BindingRecord.qualifier`            |
-| Canonical views (ADR-0013)              | Stable. `v_refs`/`v_defs` with fidelity poset (`mention` ⊑ `binding`)                            |
-| Capnp event-log readthrough             | Stable. `${db}.bindings.capnp` is the cross-runtime contract for binding refs                    |
-| E2E tool harness + flamegraphs          | Stable. `task profile-tools-pprof` + `task flamegraphs` produce per-tool pprof + SVG flamegraphs |
-| `MemoryStore.{Defs,Refs}Map` cache      | Stable. Memoized snapshots; invalidated on AddDef / AddRef / DeleteFileNodes                     |
-| NFS mount + write-back                  | Stable                                                                                           |
-| Schema inference (FCA)                  | Beta                                                                                             |
-| Community detection (Louvain)           | Beta                                                                                             |
-| LSP enrichment (type info, diagnostics) | Optional — [ley-line-open](https://github.com/agentic-research/ley-line-open)                    |
-| Semantic search (embeddings)            | Optional — [ley-line-open](https://github.com/agentic-research/ley-line-open)                    |
+</details>
 
 <details>
 <summary>Why this exists</summary>
 
 Agents operate without topology. They see flat files, grep for strings, build a mental model, forget it next turn, rebuild it. The structure is *in* the data — functions call other functions, types reference types, configs depend on configs — but nothing exposes it.
 
-Mache does. Point it at data, it figures out the shape. Source code gets parsed by tree-sitter. JSON and YAML get walked. Schema inference discovers the natural groupings without config. The agent can then explore the topology directly: follow call chains, find definitions, read context, write back.
+Mache does. Point it at data, it figures out the shape. Source code gets parsed by `leyline parse`. JSON and YAML get walked. Schema inference discovers the natural groupings without config. The agent can then explore the topology directly: follow call chains, find definitions, read context, write back.
 
 Built for agents first. The design choices — stable node paths across edits, identity-preserving write-back — exist because agents need to reference things reliably across turns. The outputs are human-discernible because the representations are filesystems and SQL, but the topology is the point.
 
@@ -105,6 +116,9 @@ See [Architecture](docs/ARCHITECTURE.md) for the full picture.
 </details>
 
 ## Portable cache (mache-aeb262)
+
+<details>
+<summary>Content-addressed <code>.db</code> bundles — push/pull/verify, OCI transport</summary>
 
 `mache cache` push/pulls the projected `.db` as a content-addressed bundle so CI / new dev machines / agents don't re-parse a million lines on every cold start.
 
@@ -132,22 +146,27 @@ When the source db has an `_ast` table, chunks carry the AST node rows too — p
 
 See [`docs/cache/phase-4-chunk-shape.md`](docs/cache/phase-4-chunk-shape.md) for the wire format and [`cloister-spec/build-cache/v1/`](https://github.com/agentic-research/cloister/tree/main/cloister-spec/build-cache/v1) for the OCI transport spec.
 
+</details>
+
 ## Deployment modes
+
+<details>
+<summary>Bundle / OCI image (production) vs local dev</summary>
 
 Mache has two supported deployment shapes:
 
 **Bundle / image (canonical production path).** Mache ships its own
 [apko](https://github.com/chainguard-dev/apko) +
 [melange](https://github.com/chainguard-dev/melange) configs to produce a
-distroless OCI image (`mache:0.11.0`, ~33MB, x86_64 + aarch64). This is the
+distroless OCI image (`mache:0.18.0`, ~33MB, x86_64 + aarch64). This is the
 unit that a cluster orchestrator (e.g. cloister) deploys; inside the
 bundle, mache speaks to a co-located ley-line daemon over a UDS socket
 and is unreachable except via the orchestrator-mediated wire.
 
 ```bash
-task image                          # → mache.tar (mache:0.11.0)
+task image                          # → mache.tar (mache:0.18.0)
 docker load -i mache.tar
-docker run --rm -i mache:0.11.0 serve --stdio /path/to/source
+docker run --rm -i mache:0.18.0 serve --stdio /path/to/source
 ```
 
 Given a fixed `melange.rsa` signing key and pinned toolchain, the build is
@@ -178,6 +197,8 @@ in CI or when leyline-open hasn't published a release for your platform.
 Exposing this mode externally requires a reverse proxy in front for auth;
 mache itself does not implement perimeter auth (the bundle gets it from
 the orchestrator).
+
+</details>
 
 ## Docs
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -153,7 +153,7 @@ tasks:
       - rm -f melange.rsa melange.rsa.pub
 
   image:
-    desc: Build OCI image (melange + apko) → mache.tar (mache:0.8.0)
+    desc: Build OCI image (melange + apko) → mache.tar, tagged from internal/buildinfo/version.txt
     preconditions:
       - sh: command -v melange
         msg: "melange required — install: https://github.com/chainguard-dev/melange"
@@ -167,7 +167,7 @@ tasks:
       # secret for byte-stable artifacts.
       - test -f melange.rsa -a -f melange.rsa.pub || melange keygen melange.rsa
       - melange build melange.yaml --arch x86_64,aarch64 --signing-key melange.rsa --out-dir ./packages
-      - apko build apko.yaml mache:0.8.0 mache.tar --keyring-append melange.rsa.pub
+      - apko build apko.yaml "mache:$(tr -d '[:space:]' < internal/buildinfo/version.txt)" mache.tar --keyring-append melange.rsa.pub
       - 'echo "Built mache.tar — load with: docker load -i mache.tar"'
 
   image:verify:

--- a/cmd/readme_tool_matrix_test.go
+++ b/cmd/readme_tool_matrix_test.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestREADMEToolMatrixMatchesRegistry pins the README's "what it gives an
+// agent" matrix to the live MCP registry.
+//
+// This exists because the claim drifted in exactly the way you'd expect a
+// hand-copied number to: the README prose said "Eighteen MCP tools" while
+// the Status table two sections down still said "17 tools", and both were
+// maintained by hand against a registry that had moved. The repo already
+// has a `drift_doc_outdated_count` smell rule whose own description names
+// "'17 MCP tools' should match a SQL ground-truth query" as its motivating
+// example — but that rule is a v1 placeholder that returns zero rows, so
+// nothing actually caught it.
+//
+// Ground truth here is the registry itself (via `tools/list` on a real
+// server), not a grep over source, so a tool that is renamed or added
+// fails this test until the README's matrix is updated to match.
+func TestREADMEToolMatrixMatchesRegistry(t *testing.T) {
+	readme, err := os.ReadFile(filepath.Join(macheRepoRoot(t), "README.md"))
+	require.NoError(t, err, "read README.md")
+	doc := string(readme)
+
+	tools := inspectRegisteredToolsForInvariants(t).Result.Tools
+
+	// Every registered tool must be documented in the README, as inline
+	// code (`get_overview`) so it lands in the matrix rather than in
+	// incidental prose.
+	var undocumented []string
+	for _, tool := range tools {
+		if !strings.Contains(doc, "`"+tool.Name+"`") {
+			undocumented = append(undocumented, tool.Name)
+		}
+	}
+	assert.Empty(t, undocumented,
+		"MCP tools registered but absent from README.md — add them to the "+
+			"'Code intelligence: what it gives an agent' matrix")
+
+	// The headline count must match the registry. Exact-string containment
+	// rather than a regex over prose: the README states the number in one
+	// canonical place and this asserts that place is right.
+	claim := fmt.Sprintf("**%d MCP tools**", len(tools))
+	assert.Contains(t, doc, claim,
+		"README.md must state the tool count as %q (registry currently "+
+			"registers %d tools); update the matrix intro when tools are "+
+			"added or removed", claim, len(tools))
+}

--- a/cmd/version_singlesource_test.go
+++ b/cmd/version_singlesource_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agentic-research/mache/internal/buildinfo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // These guard the version single-sourcing (PR: version-single-source).
@@ -24,4 +29,47 @@ func TestMacheProducerVersionIsRealNotPlaceholder(t *testing.T) {
 	if MacheProducerVersion != buildinfo.Version {
 		t.Errorf("MacheProducerVersion %q != buildinfo.Version %q", MacheProducerVersion, buildinfo.Version)
 	}
+}
+
+// TestREADMEImageTagsMatchBuildinfo catches copy-pasteable version rot in
+// the README's deployment instructions.
+//
+// This is not hypothetical: the README advertised `mache:0.11.0` and the
+// Taskfile's apko invocation hardcoded `mache:0.8.0` while buildinfo said
+// 0.18.0 — three different versions, so `task image` produced a
+// ten-release-stale tag and the documented `docker run` line referenced an
+// image that was never published. Nothing gated either one.
+func TestREADMEImageTagsMatchBuildinfo(t *testing.T) {
+	version := buildinfo.Version
+
+	raw, err := os.ReadFile(filepath.Join(macheRepoRoot(t), "README.md"))
+	require.NoError(t, err, "read README.md")
+	doc := string(raw)
+
+	// Scan for `mache:<semver>` occurrences without a regex: take the run of
+	// version characters following each "mache:" and require it to be the
+	// current version. Non-version suffixes (e.g. `mache:latest`, or prose
+	// that happens to contain "mache:") are ignored.
+	const marker = "mache:"
+	var stale []string
+	for idx := 0; ; {
+		hit := strings.Index(doc[idx:], marker)
+		if hit < 0 {
+			break
+		}
+		start := idx + hit + len(marker)
+		end := start
+		for end < len(doc) && (doc[end] == '.' || (doc[end] >= '0' && doc[end] <= '9')) {
+			end++
+		}
+		if tag := doc[start:end]; tag != "" && tag != version {
+			stale = append(stale, marker+tag)
+		}
+		idx = start
+	}
+
+	assert.Empty(t, stale,
+		"README.md references image tags that disagree with "+
+			"internal/buildinfo/version.txt (%s); these are copy-pasteable, so "+
+			"a stale tag sends users to an image that does not exist", version)
 }

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -11,6 +11,13 @@ import (
 	"strings"
 )
 
+// BinaryVersion is the exact ley-line-open release mache pins, downloads and
+// verifies. Exported so artifact generators (tools/server-json-gen) can derive
+// the dependency version mache publishes rather than restating it — server.json
+// previously carried an independently-maintained "0.4.5" that had fallen four
+// minors behind this pin.
+const BinaryVersion = leylineBinaryVersion
+
 // leylinePinnedSHA256 pins the SHA-256 of each ley-line-open release asset for
 // leylineBinaryVersion, keyed "<GOOS>-<GOARCH>". mache verifies every
 // DOWNLOADED leyline against this: the binary it runs must be byte-identical to

--- a/internal/mcpregistry/registry.go
+++ b/internal/mcpregistry/registry.go
@@ -33,12 +33,49 @@ type Tool struct {
 	// cloister/cloister-spec/mcp-tool/v1 contract.
 	Name string
 
-	// RequiresLeyLineOpen marks tools whose backend reads tables only
-	// produced by ley-line-open's enrichment passes (_ast, _lsp_*,
-	// _embeddings). Surfaced in server.json's
-	// `io.github.agentic-research.mache/tools` block; informational
-	// only — the cloister wire ignores it.
-	RequiresLeyLineOpen bool
+	// Tier records which ley-line-open artifacts a tool's backend needs
+	// beyond the base `_ast` projection. Surfaced in server.json's
+	// `io.github.agentic-research.mache/tools` block; informational only —
+	// the cloister wire ignores it.
+	//
+	// The empty value means TierBase, so entries that need nothing beyond
+	// the parse output stay declaration-free.
+	Tier Tier
+}
+
+// Tier names the ley-line-open artifact a tool depends on.
+//
+// Before v0.18.0 this was a bool named RequiresLeyLineOpen, splitting the
+// surface into "standalone" and "requires-ley-line-open". ADR-0012 step 4
+// removed the in-process parser and made `leyline parse` the sole source
+// parser, at which point *every* source projection requires ley-line-open
+// and "standalone" described nothing. The meaningful question became which
+// additional artifact a tool needs, which is what these tiers record.
+type Tier string
+
+const (
+	// TierBase needs only the `_ast` tables that `leyline parse` produces
+	// for any source projection. This is the zero value.
+	TierBase Tier = "base"
+
+	// TierLSP needs the `_lsp_*` tables from leyline's LSP pass, either
+	// pre-baked into a .db or produced on demand by the daemon.
+	TierLSP Tier = "lsp"
+
+	// TierEmbeddings needs embedding vectors in a ley-line-open-built .db.
+	TierEmbeddings Tier = "embeddings"
+
+	// TierAny is for tools that read no projected tables at all and are
+	// therefore safe to call against any source (e.g. daemon status).
+	TierAny Tier = "any"
+)
+
+// Resolved returns the tier, mapping the zero value to TierBase.
+func (t Tier) Resolved() Tier {
+	if t == "" {
+		return TierBase
+	}
+	return t
 }
 
 // ToolRegistry returns the canonical, ordered list of MCP tools mache
@@ -58,13 +95,13 @@ func ToolRegistry() []Tool {
 		{Name: "find_callers"},
 		{Name: "find_callees"},
 		{Name: "search"},
-		{Name: "semantic_search", RequiresLeyLineOpen: true},
+		{Name: "semantic_search", Tier: TierEmbeddings},
 		{Name: "get_communities"},
 		{Name: "find_definition"},
-		{Name: "get_type_info", RequiresLeyLineOpen: true},
-		{Name: "get_diagnostics", RequiresLeyLineOpen: true},
+		{Name: "get_type_info", Tier: TierLSP},
+		{Name: "get_diagnostics", Tier: TierLSP},
 		{Name: "get_overview"},
-		{Name: "get_sheaf_status"},
+		{Name: "get_sheaf_status", Tier: TierAny},
 		{Name: "get_impact"},
 		{Name: "get_architecture"},
 		{Name: "get_diagram"},

--- a/internal/mcpregistry/registry_test.go
+++ b/internal/mcpregistry/registry_test.go
@@ -80,3 +80,30 @@ func TestCloisterGroupAdvertisedPrefixIsMachePrefix(t *testing.T) {
 			g.Name, g.AdvertisedPrefix)
 	}
 }
+
+// TestToolTiersAreValid guards the tier vocabulary.
+//
+// Tier is a string type, so a typo ("lsp " / "standalone") would compile and
+// then be emitted straight into the published server.json. "standalone" in
+// particular must never come back: it described the pre-v0.18.0 world where
+// mache had an in-process parser, and ADR-0012 step 4 removed that — every
+// source projection now requires ley-line-open.
+func TestToolTiersAreValid(t *testing.T) {
+	valid := map[Tier]bool{
+		TierBase:       true,
+		TierLSP:        true,
+		TierEmbeddings: true,
+		TierAny:        true,
+	}
+	for _, tool := range ToolRegistry() {
+		resolved := tool.Tier.Resolved()
+		if !valid[resolved] {
+			t.Errorf("tool %q has unknown tier %q — valid tiers are base, lsp, embeddings, any",
+				tool.Name, resolved)
+		}
+		if string(resolved) == "standalone" {
+			t.Errorf("tool %q uses the retired %q tier: ley-line-open is required for "+
+				"every source projection since v0.18.0", tool.Name, "standalone")
+		}
+	}
+}

--- a/server.json
+++ b/server.json
@@ -51,7 +51,7 @@
       }
     },
     "io.github.agentic-research.mache/tools": {
-      "standalone": [
+      "base": [
         "list_directory",
         "read_file",
         "find_callers",
@@ -60,7 +60,6 @@
         "get_communities",
         "find_definition",
         "get_overview",
-        "get_sheaf_status",
         "get_impact",
         "get_architecture",
         "get_diagram",
@@ -68,16 +67,21 @@
         "resolve_ref",
         "find_smells"
       ],
-      "requires-ley-line-open": [
-        "semantic_search",
+      "lsp": [
         "get_type_info",
         "get_diagnostics"
+      ],
+      "embeddings": [
+        "semantic_search"
+      ],
+      "any": [
+        "get_sheaf_status"
       ]
     },
-    "io.github.agentic-research.mache/optional-deps": {
+    "io.github.agentic-research.mache/required-deps": {
       "io.github.agentic-research/ley-line-open": {
-        "purpose": "Provides _ast / _lsp_* / _embeddings tables consumed by semantic_search, get_type_info, get_diagnostics, and the AST-backed find_smells rules.",
-        "minimum-version": "0.4.5"
+        "purpose": "Required. `leyline parse` is mache's sole source parser since v0.18.0 (ADR-0012 step 4) — it produces the _ast tables every source projection reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and embeddings (semantic_search).",
+        "minimum-version": "0.8.0"
       }
     },
     "io.github.agentic-research.mache/source-acceptance": {

--- a/tools/server-json-gen/main.go
+++ b/tools/server-json-gen/main.go
@@ -30,8 +30,10 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 
 	"github.com/agentic-research/mache/internal/buildinfo"
+	"github.com/agentic-research/mache/internal/leyline"
 	"github.com/agentic-research/mache/internal/mcpregistry"
 )
 
@@ -85,10 +87,10 @@ const websiteURL = "https://github.com/agentic-research/mache/blob/main/GETTING-
 // drop-in copy.
 const defaultHTTPPort = "7532"
 
-// minLeyLineOpenVersion declares the minimum LLO release whose
-// enrichment tables mache reads. Bumped in lock-step with LLO's
-// substrate / wire-format changes that touch _ast / _lsp_* schemas.
-const minLeyLineOpenVersion = "0.4.5"
+// minLeyLineOpenVersion is the LLO version mache publishes as its dependency
+// floor, derived from the binary pin mache actually verifies at runtime so the
+// two cannot drift.
+var minLeyLineOpenVersion = strings.TrimPrefix(leyline.BinaryVersion, "v")
 
 // serverDoc is the top-level server.json envelope. Field order is
 // load-bearing — encoding/json's struct-field ordering is the contract
@@ -135,12 +137,17 @@ type transportEntry struct {
 	Note    string   `json:"note"`
 }
 
-type toolSplit struct {
-	Standalone          []string `json:"standalone"`
-	RequiresLeyLineOpen []string `json:"requires-ley-line-open"`
+// toolTiers is the `_meta…/tools` block: tool names bucketed by the
+// ley-line-open artifact they need. Emitted in a fixed tier order so the
+// generated file is stable.
+type toolTiers struct {
+	Base       []string `json:"base"`
+	LSP        []string `json:"lsp"`
+	Embeddings []string `json:"embeddings"`
+	Any        []string `json:"any"`
 }
 
-type optionalDep struct {
+type requiredDep struct {
 	Purpose        string `json:"purpose"`
 	MinimumVersion string `json:"minimum-version"`
 }
@@ -262,25 +269,27 @@ func buildDoc() (*serverDoc, error) {
 		})
 	}
 
-	// Standalone vs requires-ley-line-open split mirrors the existing
-	// hand-maintained block. Drive it from the registry's
-	// RequiresLeyLineOpen field so it can't drift from the truth.
-	var standalone, llo []string
+	// Bucket by tier, driven off the registry so it cannot drift. There is
+	// deliberately no "standalone" bucket: since ADR-0012 step 4, leyline
+	// parses every source projection, so no tool runs without ley-line-open.
+	var tiers toolTiers
 	for _, tool := range registry {
-		if tool.RequiresLeyLineOpen {
-			llo = append(llo, tool.Name)
-		} else {
-			standalone = append(standalone, tool.Name)
+		switch tool.Tier.Resolved() {
+		case mcpregistry.TierLSP:
+			tiers.LSP = append(tiers.LSP, tool.Name)
+		case mcpregistry.TierEmbeddings:
+			tiers.Embeddings = append(tiers.Embeddings, tool.Name)
+		case mcpregistry.TierAny:
+			tiers.Any = append(tiers.Any, tool.Name)
+		default:
+			tiers.Base = append(tiers.Base, tool.Name)
 		}
 	}
 
 	meta := newOrderedObject()
 	meta.set("io.github.agentic-research.mache/transports", buildTransports())
-	meta.set("io.github.agentic-research.mache/tools", toolSplit{
-		Standalone:          standalone,
-		RequiresLeyLineOpen: llo,
-	})
-	meta.set("io.github.agentic-research.mache/optional-deps", buildOptionalDeps())
+	meta.set("io.github.agentic-research.mache/tools", tiers)
+	meta.set("io.github.agentic-research.mache/required-deps", buildRequiredDeps())
 	meta.set("io.github.agentic-research.mache/source-acceptance", sourceAcceptance{
 		Directories: "any tree containing source files — auto-detects language preset (Go, Rust, Python, TypeScript, ...)",
 		DBFiles:     ".db files produced by `mache build` or `leyline parse` open instantly via SQLiteGraph (pure-Go path)",
@@ -343,10 +352,13 @@ func buildTransports() *orderedObject {
 	return transports
 }
 
-func buildOptionalDeps() *orderedObject {
+func buildRequiredDeps() *orderedObject {
 	deps := newOrderedObject()
-	deps.set("io.github.agentic-research/ley-line-open", optionalDep{
-		Purpose:        "Provides _ast / _lsp_* / _embeddings tables consumed by semantic_search, get_type_info, get_diagnostics, and the AST-backed find_smells rules.",
+	deps.set("io.github.agentic-research/ley-line-open", requiredDep{
+		Purpose: "Required. `leyline parse` is mache's sole source parser since v0.18.0 " +
+			"(ADR-0012 step 4) — it produces the _ast tables every source projection " +
+			"reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and " +
+			"embeddings (semantic_search).",
 		MinimumVersion: minLeyLineOpenVersion,
 	})
 	return deps


### PR DESCRIPTION
Post-v0.18.0 audit: ADR-0012 step 4 made `leyline parse` the sole source parser, but three published artifacts still described the world where mache had an in-process parser. None of them were gated, so all three were shipping wrong.

## What was false

| Claim | Reality |
|---|---|
| `server.json`: 15 tools listed as `standalone` | nothing is standalone — leyline parses every source projection |
| `server.json`: ley-line-open is an **optional** dep, min `0.4.5` | required, and the real pin is `v0.8.0` (4 minors ahead) |
| README `docker run mache:0.11.0` | that image was never published — copy-paste fails |
| Taskfile `apko build … mache:0.8.0` | `task image` built a **ten-release-stale** tag |
| README prose "Eighteen MCP tools" vs Status table "17 tools" | registry has 18 |

`task version:check` only ever covered `version.txt` ↔ `melange.yaml` ↔ git tag, so both version bugs were invisible to CI. Three different versions were live simultaneously.

## Fixes

**At the generator, not the artifact.** `server.json` is generated from `internal/mcpregistry` with a `gen:server-json:check` drift gate — a hand-edit would have been reverted by the next regen.

- `Tool.RequiresLeyLineOpen bool` → typed `Tier` (`base` / `lsp` / `embeddings` / `any`). A bool cannot express a world where ley-line-open is universally required; the meaningful question became *which* artifact a tool needs.
- `optional-deps` → `required-deps`, with the version floor **derived** from a newly-exported `leyline.BinaryVersion` so the two cannot drift again.
- Taskfile's apko tag now derives from `version.txt`.
- README's tool matrix and Status table both enumerated capabilities → merged into one "what you get" table (capability, tools, tier, status). Non-tool rows (parsing, mount, cache, inference) carry `—` in the Tools column. The language count went from stated 3× to 1×.

## Tests

Each verified to fail on the drift it targets, then restored:

- `TestREADMEToolMatrixMatchesRegistry` — pins the matrix to a live `tools/list` response, not a grep over source
- `TestREADMEImageTagsMatchBuildinfo` — catches copy-pasteable tag rot
- `TestToolTiersAreValid` — guards the tier vocabulary, blocks `standalone` returning

**Deliberately not added:** assertions that `server.json`'s tool inventory, cloister groups, or version match the registry. `cmd/serve_handlers_test.go` already anchors `ToolRegistry()` to the live server in both directions, `registry_test.go` covers group coverage, and `serverVersion` derives from `buildinfo` — that chain was already complete. Three such tests were written and then deleted once I found it.

## Follow-up

The merged table is still hand-maintained (tool names/tiers are test-pinned; the maturity column has no ground truth). Generating it from `mcpregistry` — the precondition for an in-repo wiki — is tracked as `mache-d07b38`.

Closes `mache-e34aec`.

## Verification

`task ci` green, log-verified rather than by exit code (it reported exit 0 while failing four times during this work). Includes `smells:run` against the pinned leyline and `gen:server-json:check`.
