### PR TITLE
[mache-f55ee9] chore(task): fold changed-markdown mdformat into task fmt

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -119,9 +119,32 @@ tasks:
       - golangci-lint run ./...
 
   fmt:
-    desc: Format code with gofumpt
+    desc: Format code (gofumpt) + changed markdown (mdformat, matching the pre-commit hook)
     cmds:
       - gofumpt -w -extra .
+      - task: fmt:md
+
+  fmt:md:
+    desc: |
+      mdformat the markdown you've changed (modified + new), using the same
+      mdformat + plugins the pre-commit hook pins. Run this (or `task fmt`)
+      before `git add` and the commit-time hook is a no-op instead of
+      reformatting your files out from under you and aborting the commit.
+      Scoped to CHANGED files — not all tracked markdown — so it never
+      rewrites test fixtures (cmd/testdata/**) or vendored docs. Excludes
+      .beads/ and testdata/snapshots/, matching the hook's exclusion.
+    preconditions:
+      - sh: command -v mdformat
+        msg: "mdformat required — pip install mdformat mdformat-gfm mdformat-frontmatter"
+    cmds:
+      - |
+        # Union of working-tree-modified, untracked, and staged markdown —
+        # so it works whether you run it before or after `git add`.
+        { git ls-files -mo --exclude-standard '*.md'; \
+          git diff --cached --name-only -- '*.md'; } \
+          | sort -u \
+          | grep -vE '^(\.beads/|testdata/snapshots/)' \
+          | while IFS= read -r f; do [ -f "$f" ] && mdformat "$f"; done
 
   fmt:check:
     desc: |


### PR DESCRIPTION
The pre-commit mdformat hook only formats **staged** files at commit time, so it reformats hand-written markdown out from under a commit and aborts it — hit repeatedly on #537 and #538. The root cause isn't the hook; it's that `task fmt` (the "format before commit" step) only ran gofumpt, never markdown.

## Fix

`task fmt` now also runs `task fmt:md` — mdformat (same pinned plugins as the hook) over **changed** markdown: the union of `git ls-files -mo` (modified + untracked) and `git diff --cached` (staged), minus `.beads/` and `testdata/snapshots/`.

**Scoped to changed files, not all tracked md, on purpose.** A blanket format-all would rewrite `cmd/testdata/preset_fixtures/markdown/README.md` (a test fixture) and vendored `benchmarks/serena/` docs. It also surfaced that 31/86 tracked md files are non-canonical (the hook never touched them) — normalizing those is left as optional hygiene, not bundled here.

## Verified

- clean tree → no-op
- staged misformatted file → canonicalized, **byte-identical to hook output**
- untracked (pre-`git add`) file → formatted

So `task fmt` before `git add` makes the commit-time hook a no-op instead of an abort.

Closes `mache-f55ee9`.