### PR TITLE
[mache-ceb776] refactor: replace 2 production regexes with structural matching

### DIFF
--- a/internal/graph/memstore_imports_test.go
+++ b/internal/graph/memstore_imports_test.go
@@ -1,0 +1,108 @@
+package graph
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+// TestParseGoImports pins the behavior of the deprecated regex import parser.
+//
+// It is NOT dead code: Properties["imports"] is only set when the ingest engine
+// has structured imports (`if fileImports != nil`), and nodes hydrated from a
+// .db via nodes_table_reader carry Context but no imports property — so this is
+// the live path for .db-backed graphs. It parses a possibly-PARTIAL context
+// blob, which is why it stays lenient text matching rather than go/parser
+// (a strict parse of a fragment without a package clause fails outright).
+//
+// These cases exist so the eventual removal — persisting structured imports on
+// the nodes-table path — can prove equivalence before deleting.
+func TestParseGoImports(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ctx  string
+		want map[string]string
+	}{
+		{
+			"single unaliased import — alias is last path segment",
+			`import "fmt"`,
+			map[string]string{"fmt": "fmt"},
+		},
+		{
+			"single aliased import",
+			`import f "fmt"`,
+			map[string]string{"f": "fmt"},
+		},
+		{
+			"unaliased nested path uses last segment",
+			`import "net/http"`,
+			map[string]string{"http": "net/http"},
+		},
+		{
+			"grouped imports",
+			"import (\n\t\"fmt\"\n\t\"os\"\n)",
+			map[string]string{"fmt": "fmt", "os": "os"},
+		},
+		{
+			"grouped with alias",
+			"import (\n\tf \"fmt\"\n\t\"net/http\"\n)",
+			map[string]string{"f": "fmt", "http": "net/http"},
+		},
+		{
+			// KNOWN QUIRK (characterized, not endorsed): blank imports are
+			// skipped correctly, but a DOT import is not. addGoImport skips
+			// alias "." — however memberImportRe's `(\w+)?` cannot capture
+			// ".", so the alias arrives empty and the import degrades into a
+			// regular one keyed by its last path segment ("os"). A real parser
+			// would classify it. Fixing this is part of removing the regex
+			// entirely (persist structured imports on the .db path).
+			"blank imports skipped; dot import degrades to a normal import",
+			"import (\n\t_ \"embed\"\n\t. \"os\"\n\t\"fmt\"\n)",
+			map[string]string{"fmt": "fmt", "os": "os"},
+		},
+		{"no imports", "package foo\n\nvar x = 1", map[string]string{}},
+		{"empty context", "", map[string]string{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseGoImports([]byte(tc.ctx))
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("parseGoImports(%q) = %v, want %v", tc.ctx, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLoadImports_PrefersStructuredOverRegex verifies the structured path wins:
+// when Properties["imports"] is present it is used verbatim and the Context
+// text is never consulted. This is the invariant that makes the regex fallback
+// removable once the .db path persists imports.
+func TestLoadImports_PrefersStructuredOverRegex(t *testing.T) {
+	structured, err := json.Marshal(map[string]string{"alias": "real/path"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := &Node{
+		Properties: map[string][]byte{"imports": structured},
+		// Deliberately conflicting context — must be ignored.
+		Context: []byte(`import "should/not/be/used"`),
+	}
+	got := loadImports(node)
+	want := map[string]string{"alias": "real/path"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadImports = %v, want %v (structured Properties must win over Context)", got, want)
+	}
+}
+
+// TestLoadImports_FallsBackToContext covers the live .db-hydration path:
+// no Properties["imports"], so Context is parsed.
+func TestLoadImports_FallsBackToContext(t *testing.T) {
+	node := &Node{Context: []byte(`import "net/http"`)}
+	got := loadImports(node)
+	want := map[string]string{"http": "net/http"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadImports = %v, want %v", got, want)
+	}
+}

--- a/internal/graph/sqlite_graph_scan.go
+++ b/internal/graph/sqlite_graph_scan.go
@@ -5,10 +5,13 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
+	"text/template"
+	"text/template/parse"
+
+	machetemplate "github.com/agentic-research/mache/internal/template"
 )
 
 // ---------------------------------------------------------------------------
@@ -37,8 +40,59 @@ type leafMapping struct {
 
 // --- Field extraction from name templates ---
 
-// fieldRefRe matches Go template field references like .item.cve.id
-var fieldRefRe = regexp.MustCompile(`\.(\w+(?:\.\w+)*)`)
+// collectTemplateFields walks a parsed template and records every field
+// reference (e.g. `.item.cve.id` → "item.cve.id") into seen.
+//
+// This replaces a `\.(\w+(?:\.\w+)*)` regex over the raw template text. The
+// regex scanned the WHOLE string, so a dot in literal text ("report.txt")
+// became a phantom field path and an always-NULL json_extract column. Parsing
+// sees only genuine field references.
+func collectTemplateFields(n parse.Node, seen map[string]bool) {
+	switch node := n.(type) {
+	case nil:
+		return
+	case *parse.ListNode:
+		if node == nil {
+			return
+		}
+		for _, c := range node.Nodes {
+			collectTemplateFields(c, seen)
+		}
+	case *parse.ActionNode:
+		collectTemplateFields(node.Pipe, seen)
+	case *parse.PipeNode:
+		if node == nil {
+			return
+		}
+		for _, c := range node.Cmds {
+			collectTemplateFields(c, seen)
+		}
+	case *parse.CommandNode:
+		for _, a := range node.Args {
+			collectTemplateFields(a, seen)
+		}
+	case *parse.FieldNode:
+		if len(node.Ident) > 0 {
+			seen[strings.Join(node.Ident, ".")] = true
+		}
+	case *parse.ChainNode:
+		collectTemplateFields(node.Node, seen)
+	case *parse.IfNode:
+		collectBranchFields(node.Pipe, node.List, node.ElseList, seen)
+	case *parse.RangeNode:
+		collectBranchFields(node.Pipe, node.List, node.ElseList, seen)
+	case *parse.WithNode:
+		collectBranchFields(node.Pipe, node.List, node.ElseList, seen)
+	case *parse.TemplateNode:
+		collectTemplateFields(node.Pipe, seen)
+	}
+}
+
+func collectBranchFields(pipe *parse.PipeNode, list, elseList *parse.ListNode, seen map[string]bool) {
+	collectTemplateFields(pipe, seen)
+	collectTemplateFields(list, seen)
+	collectTemplateFields(elseList, seen)
+}
 
 // collectNameTemplates gathers all dynamic name template strings from the schema tree.
 func collectNameTemplates(level *schemaLevel) []string {
@@ -61,9 +115,15 @@ func collectNameTemplates(level *schemaLevel) []string {
 func extractFieldPaths(templates []string) []string {
 	seen := make(map[string]bool)
 	for _, tmpl := range templates {
-		for _, m := range fieldRefRe.FindAllStringSubmatch(tmpl, -1) {
-			seen[m[1]] = true
+		// Parse with mache's func map so schema templates using slice/dig/
+		// lookup/... parse cleanly; text/template supplies the builtins.
+		// An unparseable template contributes nothing — it would fail at
+		// render time anyway, so guessing at its fields is not useful.
+		t, err := template.New("scan").Funcs(machetemplate.Funcs).Parse(tmpl)
+		if err != nil || t.Tree == nil {
+			continue
 		}
+		collectTemplateFields(t.Root, seen)
 	}
 	paths := make([]string, 0, len(seen))
 	for p := range seen {

--- a/internal/graph/sqlite_graph_scan_fields_test.go
+++ b/internal/graph/sqlite_graph_scan_fields_test.go
@@ -1,0 +1,76 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestExtractFieldPaths pins the behavior of the name-template field extractor,
+// which decides which `json_extract($.path)` columns the scan query selects.
+//
+// It replaced a `\.(\w+(?:\.\w+)*)` regex over the raw template string with a
+// real text/template parse + FieldNode walk. The real-template cases below must
+// be identical under both; the "literal dot" case is where they intentionally
+// DIVERGE — see TestExtractFieldPaths_LiteralDotsAreNotFields.
+func TestExtractFieldPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"simple field", []string{"{{.pkg}}"}, []string{"pkg"}},
+		{"nested path", []string{"{{.item.cve.id}}"}, []string{"item.cve.id"}},
+		{
+			"func arg (real nvd-schema shape)",
+			[]string{"{{slice .item.cve.published 0 4}}"},
+			[]string{"item.cve.published"},
+		},
+		{
+			"dedup + sort across templates",
+			[]string{"{{.item.cve.id}}", "{{slice .item.cve.published 5 7}}", "{{.item.cve.id}}"},
+			[]string{"item.cve.id", "item.cve.published"},
+		},
+		{"static template — no fields", []string{"functions"}, []string{}},
+		{"empty input", nil, []string{}},
+		{
+			"multiple fields in one action",
+			[]string{`{{if .a.b}}{{.c.d}}{{end}}`},
+			[]string{"a.b", "c.d"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractFieldPaths(tc.in)
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("extractFieldPaths(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractFieldPaths_LiteralDotsAreNotFields documents the bug the
+// structural parse fixes. The old regex scanned the WHOLE template string, so a
+// dot in literal text (outside any {{action}}) was captured as a field path —
+// yielding a phantom `json_extract(record, '$.txt')` column that always
+// resolves NULL. A template parser only sees real field references.
+func TestExtractFieldPaths_LiteralDotsAreNotFields(t *testing.T) {
+	got := extractFieldPaths([]string{"report.txt {{.id}}"})
+	want := []string{"id"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractFieldPaths = %v, want %v — literal 'report.txt' must NOT "+
+			"become a field path (the old regex captured 'txt')", got, want)
+	}
+}
+
+// TestExtractFieldPaths_UnparseableTemplateIsSkipped ensures a malformed
+// template can't panic or poison the column list. Such a template would fail at
+// render time anyway, so contributing no field paths is the safe behavior.
+func TestExtractFieldPaths_UnparseableTemplateIsSkipped(t *testing.T) {
+	got := extractFieldPaths([]string{"{{.unclosed", "{{.good}}"})
+	want := []string{"good"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("extractFieldPaths = %v, want %v", got, want)
+	}
+}

--- a/internal/lattice/context.go
+++ b/internal/lattice/context.go
@@ -1,7 +1,6 @@
 package lattice
 
 import (
-	"regexp"
 	"sort"
 	"strings"
 
@@ -44,7 +43,25 @@ type FormalContext struct {
 	Stats       map[string]*FieldStats
 }
 
-var dateRe = regexp.MustCompile(`^\d{4}-\d{2}`)
+// looksLikeDatePrefix reports whether s begins with an ISO year-month prefix
+// (YYYY-MM): four digits, '-', two digits. Trailing content is allowed, so full
+// dates and RFC3339 timestamps match.
+//
+// This is a structural digit check rather than a `^\d{4}-\d{2}` regex — same
+// semantics (prefix match, no month-range validation), no regex engine, and it
+// keeps heuristical text-matching out of the projection path. See
+// date_prefix_test.go for the equivalence cases.
+func looksLikeDatePrefix(s string) bool {
+	if len(s) < 7 || s[4] != '-' {
+		return false
+	}
+	for _, i := range [...]int{0, 1, 2, 3, 5, 6} {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
 
 const (
 	enumMaxDistinct      = 20
@@ -93,7 +110,7 @@ func AnalyzeFields(records []any) map[string]*FieldStats {
 			if val, ok := getFieldValue(rec, path); ok {
 				if s, ok := val.(string); ok {
 					fs.Values[s]++
-					if dateRe.MatchString(s) {
+					if looksLikeDatePrefix(s) {
 						fs.IsDate = true
 					}
 				}

--- a/internal/lattice/date_prefix_test.go
+++ b/internal/lattice/date_prefix_test.go
@@ -1,0 +1,39 @@
+package lattice
+
+import "testing"
+
+// TestLooksLikeDatePrefix characterizes the ISO-date detection used to set
+// FieldStats.IsDate (which drives temporal sharding in greedy.go). It replaced
+// a `^\d{4}-\d{2}` regex with a structural digit check; these cases pin the
+// exact semantics so the two are provably equivalent — a PREFIX match (trailing
+// content allowed), no month-range validation (13 is "a date" to this
+// heuristic, exactly as the regex treated it).
+func TestLooksLikeDatePrefix(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want bool
+		why  string
+	}{
+		{"2024-01", true, "bare YYYY-MM"},
+		{"2024-01-15", true, "full ISO date — prefix match"},
+		{"2024-01-15T10:30:00Z", true, "RFC3339 timestamp — prefix match"},
+		{"1999-12 something", true, "trailing text allowed (prefix, not anchored at end)"},
+		{"2024-13", true, "no month-range validation — matches the old regex exactly"},
+		{"2024-00", true, "same: digits only, no range check"},
+
+		{"2024", false, "too short"},
+		{"2024-0", false, "too short (6 chars)"},
+		{"202-01", false, "only 3 leading digits"},
+		{"20244-01", false, "5th char must be '-'"},
+		{"2024/01", false, "separator must be '-'"},
+		{"2024-ab", false, "month chars must be digits"},
+		{"abcd-01", false, "year chars must be digits"},
+		{" 2024-01", false, "not anchored at start — leading space fails"},
+		{"", false, "empty"},
+		{"v2024-01", false, "prefixed, not anchored"},
+	} {
+		if got := looksLikeDatePrefix(tc.in); got != tc.want {
+			t.Errorf("looksLikeDatePrefix(%q) = %v, want %v (%s)", tc.in, got, tc.want, tc.why)
+		}
+	}
+}

--- a/internal/leyline/socket_test.go
+++ b/internal/leyline/socket_test.go
@@ -1047,7 +1047,14 @@ func TestDiscoverOrStart_DaemonExitsDuringStartup(t *testing.T) {
 	require.Error(t, err, "a daemon that exits during startup must error")
 	assert.Contains(t, err.Error(), "exited during startup",
 		"crash path must surface the 'exited during startup' error, not a timeout")
-	assert.Less(t, elapsed, 5*time.Second,
+	// The error-content assertion above is the real proof that exit-detection
+	// fired: waiting out the timeout would surface a TIMEOUT error, not
+	// "exited during startup". This elapsed check is a secondary guard, so its
+	// budget is set for the 30s timeout it's guarding against — not a tight
+	// wall-clock target. A 5s budget flaked reproducibly under `-race` in the
+	// full suite (observed 7.4-7.6s) while passing standalone, blocking
+	// unrelated pushes (mache-474214).
+	assert.Less(t, elapsed, 15*time.Second,
 		"must return on exit-detection, not wait out the 30s timeout")
 
 	managed.mu.Lock()

--- a/internal/lint/regexp_ratchet_test.go
+++ b/internal/lint/regexp_ratchet_test.go
@@ -37,11 +37,20 @@ var regexpAllowlist = map[string]string{
 	"cmd/find_smells_action_test.go":          "asserts on action output text",
 	"cmd/call_extractor_test_helper_test.go":  "test fixture text matching",
 
-	// production code — candidates for structural replacement (follow-up)
-	"internal/ingest/ast_walker_selector.go": "TODO: prefer structural match",
-	"internal/graph/memstore_callees.go":     "TODO: prefer structural match",
-	"internal/graph/sqlite_graph_scan.go":    "TODO: prefer structural match",
-	"internal/lattice/context.go":            "TODO: prefer structural match",
+	// production code — each justified, NOT deferred work (mache-ceb776):
+	//
+	//   ast_walker_selector.go compiles a regex supplied BY THE SCHEMA AUTHOR in
+	//   a tree-sitter `#match?` / `#not-match?` query predicate. The regex is
+	//   the feature contract, not a heuristic — there is nothing to replace.
+	//
+	//   memstore_callees.go leniently extracts Go imports from a possibly-PARTIAL
+	//   context blob on the .db-hydration path (nodes_table_reader sets Context
+	//   but not Properties["imports"], so this is live, not dead). A strict
+	//   go/parser would fail on a fragment with no package clause. Removing it
+	//   means persisting structured imports on the nodes-table path — tracked
+	//   separately. Behavior is pinned by memstore_imports_test.go.
+	"internal/ingest/ast_walker_selector.go": "tree-sitter #match? predicate — user-supplied regex IS the contract",
+	"internal/graph/memstore_callees.go":     "lenient import extraction from partial context text (.db path); structured path preferred",
 }
 
 // dirsToSkip are trees that are not mache's own source (vendored fixtures,


### PR DESCRIPTION
Follow-through on the regex work. The allowlist's four production entries were all labeled `TODO: prefer structural match` — but they're **not the same situation**. Two were genuinely heuristical text matching (replaced); two are legitimate (properly justified). Allowlist **14 → 12**.

## Replaced

**`lattice/context.go`** — `^\d{4}-\d{2}` date detection → `looksLikeDatePrefix`, a structural digit check with *identical* semantics (prefix match, no month-range validation — `2024-13` still counts, exactly as the regex treated it). 16 equivalence cases.

**`graph/sqlite_graph_scan.go`** — `\.(\w+(?:\.\w+)*)` over raw template text → `text/template` parse + `FieldNode` walk. This also **fixes a latent bug**: the regex scanned the *whole* string, so a literal dot (`"report.txt {{.id}}"`) became a phantom field path and an always-NULL `json_extract('$.txt')` column. Only genuine field references are collected now.

## Kept — with real justifications, not TODOs

**`ast_walker_selector.go`** compiles a regex supplied **by the schema author** in a tree-sitter `#match?`/`#not-match?` query predicate. The regex *is* the feature contract — there's nothing to replace.

**`memstore_callees.go`** leniently extracts Go imports from a possibly-**partial** context blob. It is **not dead**: `Properties["imports"]` is set only when the ingest engine has structured imports (`if fileImports != nil`), and `nodes_table_reader.go:121` sets `Context` *without* it — so this is the live path for `.db`-backed graphs. A strict `go/parser` fails on a fragment with no package clause. Removing it means persisting structured imports on the nodes-table path (`mache-f930b6`).

## Tests

All four had **zero** coverage. Added characterization tests for the replaced and kept behaviors — which immediately caught a real quirk: a dot import (`. "os"`) degrades into a normal `os` import because `memberImportRe`'s `(\w+)?` can't capture `.`. Pinned, documented, and fixed for free by `mache-f930b6`.

## Also included

`mache-474214` — `TestDiscoverOrStart_DaemonExitsDuringStartup` asserted `elapsed < 5s`, which flaked **reproducibly** under `-race` in the full suite (7.4–7.6s) while passing standalone, blocking this push twice. Its intent is already proven by the assertion above it (a timeout surfaces a *timeout* error, not `"exited during startup"`), so the secondary elapsed guard is now sized against the 30s timeout it guards.

`task ci` green.