### PR TITLE
[mache-f930b6] fix(graph): restore node Properties at serve time; drop the regex import fallback

### DIFF
--- a/internal/graph/memstore_callees.go
+++ b/internal/graph/memstore_callees.go
@@ -4,64 +4,37 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
-	"regexp"
-	"strings"
 )
 
-// --- Import parsing for qualified callees resolution ---
+// --- Import resolution for qualified callees ---
 
-var (
-	singleImportRe = regexp.MustCompile(`import\s+(\w+\s+)?"([^"]+)"`)
-	groupImportRe  = regexp.MustCompile(`(?s)import\s*\(([^)]*)\)`)
-	memberImportRe = regexp.MustCompile(`(\w+)?\s*"([^"]+)"`)
-)
-
-// loadImports returns structured import mappings from a node.
-// Prefers Properties["imports"] (JSON, set by tree-sitter during ingestion).
-// Falls back to regex parsing of Context text for backward compatibility.
+// loadImports returns alias → import-path mappings for a node.
+//
+// Imports are structured data produced at ingest (engine_walk.go marshals them
+// into Properties["imports"]) and persisted into the nodes-table `record`
+// column, which both SQLiteWriter.GetNode and NodesTableReader.GetNode restore.
+// There is deliberately NO text-scraping fallback: a regex import parser used
+// to sit here for "backward compatibility", but it was heuristical matching of
+// Go source text that mis-classified dot-imports, and the paths that reached it
+// are now covered structurally (mache-f930b6):
+//
+//   - MemoryStore (fresh ingest) — the engine sets Properties directly.
+//   - .db built by SQLiteWriter — Properties round-trip via `record`.
+//   - .db built by leyline — carries no `context` column at all, so the old
+//     fallback could never have fired there anyway.
 func loadImports(node *Node) map[string]string {
-	if node.Properties != nil {
-		if raw, ok := node.Properties["imports"]; ok && len(raw) > 0 {
-			var imports map[string]string
-			if err := json.Unmarshal(raw, &imports); err == nil && len(imports) > 0 {
-				return imports
-			}
-		}
+	if node.Properties == nil {
+		return nil
 	}
-	if node.Context != nil {
-		return parseGoImports(node.Context)
+	raw, ok := node.Properties["imports"]
+	if !ok || len(raw) == 0 {
+		return nil
 	}
-	return nil
-}
-
-// parseGoImports extracts alias → import path mappings from Go context text.
-// For unaliased imports, the alias is the last path segment.
-// Deprecated: prefer structured imports from Properties["imports"].
-func parseGoImports(ctx []byte) map[string]string {
-	imports := make(map[string]string)
-	text := string(ctx)
-
-	for _, m := range singleImportRe.FindAllStringSubmatch(text, -1) {
-		addGoImport(imports, strings.TrimSpace(m[1]), m[2])
+	var imports map[string]string
+	if err := json.Unmarshal(raw, &imports); err != nil || len(imports) == 0 {
+		return nil
 	}
-
-	for _, m := range groupImportRe.FindAllStringSubmatch(text, -1) {
-		for _, im := range memberImportRe.FindAllStringSubmatch(m[1], -1) {
-			addGoImport(imports, strings.TrimSpace(im[1]), im[2])
-		}
-	}
-
 	return imports
-}
-
-func addGoImport(imports map[string]string, alias, path string) {
-	if alias == "_" || alias == "." {
-		return
-	}
-	if alias == "" {
-		alias = filepath.Base(path)
-	}
-	imports[alias] = path
 }
 
 // GetCallees implements Graph. It extracts calls made by the construct, then

--- a/internal/graph/memstore_imports_test.go
+++ b/internal/graph/memstore_imports_test.go
@@ -6,103 +6,68 @@ import (
 	"testing"
 )
 
-// TestParseGoImports pins the behavior of the deprecated regex import parser.
+// TestLoadImports_UsesStructuredProperties covers the only supported import
+// source: structured data set at ingest and round-tripped through the
+// nodes-table `record` column.
+func TestLoadImports_UsesStructuredProperties(t *testing.T) {
+	structured, err := json.Marshal(map[string]string{"alias": "real/path", "http": "net/http"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	node := &Node{Properties: map[string][]byte{"imports": structured}}
+
+	got := loadImports(node)
+	want := map[string]string{"alias": "real/path", "http": "net/http"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadImports = %v, want %v", got, want)
+	}
+}
+
+// TestLoadImports_ContextIsNotParsed pins the deliberate behavior change from
+// mache-f930b6: there is no text-scraping fallback any more.
 //
-// It is NOT dead code: Properties["imports"] is only set when the ingest engine
-// has structured imports (`if fileImports != nil`), and nodes hydrated from a
-// .db via nodes_table_reader carry Context but no imports property — so this is
-// the live path for .db-backed graphs. It parses a possibly-PARTIAL context
-// blob, which is why it stays lenient text matching rather than go/parser
-// (a strict parse of a fragment without a package clause fails outright).
+// A regex import parser used to run over node.Context here "for backward
+// compatibility". It was heuristical matching of Go source text and it
+// mis-classified dot imports — `. "os"` degraded into a normal `os` import,
+// because the alias group `(\w+)?` cannot match ".". Every path that reached it
+// is now covered structurally:
 //
-// These cases exist so the eventual removal — persisting structured imports on
-// the nodes-table path — can prove equivalence before deleting.
-func TestParseGoImports(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		ctx  string
-		want map[string]string
-	}{
-		{
-			"single unaliased import — alias is last path segment",
-			`import "fmt"`,
-			map[string]string{"fmt": "fmt"},
-		},
-		{
-			"single aliased import",
-			`import f "fmt"`,
-			map[string]string{"f": "fmt"},
-		},
-		{
-			"unaliased nested path uses last segment",
-			`import "net/http"`,
-			map[string]string{"http": "net/http"},
-		},
-		{
-			"grouped imports",
-			"import (\n\t\"fmt\"\n\t\"os\"\n)",
-			map[string]string{"fmt": "fmt", "os": "os"},
-		},
-		{
-			"grouped with alias",
-			"import (\n\tf \"fmt\"\n\t\"net/http\"\n)",
-			map[string]string{"f": "fmt", "http": "net/http"},
-		},
-		{
-			// KNOWN QUIRK (characterized, not endorsed): blank imports are
-			// skipped correctly, but a DOT import is not. addGoImport skips
-			// alias "." — however memberImportRe's `(\w+)?` cannot capture
-			// ".", so the alias arrives empty and the import degrades into a
-			// regular one keyed by its last path segment ("os"). A real parser
-			// would classify it. Fixing this is part of removing the regex
-			// entirely (persist structured imports on the .db path).
-			"blank imports skipped; dot import degrades to a normal import",
-			"import (\n\t_ \"embed\"\n\t. \"os\"\n\t\"fmt\"\n)",
-			map[string]string{"fmt": "fmt", "os": "os"},
-		},
-		{"no imports", "package foo\n\nvar x = 1", map[string]string{}},
-		{"empty context", "", map[string]string{}},
+//   - MemoryStore (fresh ingest): the engine sets Properties directly.
+//   - .db built by SQLiteWriter: Properties round-trip via `record`
+//     (NodesTableReader restores them — nodes_table_properties_test.go).
+//   - .db built by leyline: has no `context` column at all, so the fallback
+//     could never have fired there.
+//
+// Context alone must therefore yield no imports rather than a guess.
+func TestLoadImports_ContextIsNotParsed(t *testing.T) {
+	node := &Node{Context: []byte("import (\n\t. \"os\"\n\t\"net/http\"\n)")}
+	if got := loadImports(node); got != nil {
+		t.Errorf("loadImports = %v, want nil — context text must not be scraped for imports", got)
+	}
+}
+
+// TestLoadImports_MalformedPropertiesYieldNil ensures a corrupt or
+// wrong-shaped imports blob degrades to "no imports" instead of panicking or
+// returning half-parsed data.
+func TestLoadImports_MalformedPropertiesYieldNil(t *testing.T) {
+	for name, raw := range map[string][]byte{
+		"not json":     []byte("{not json"),
+		"wrong shape":  []byte(`["a","b"]`),
+		"empty object": []byte(`{}`),
+		"empty bytes":  {},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := parseGoImports([]byte(tc.ctx))
-			if len(got) == 0 && len(tc.want) == 0 {
-				return
-			}
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("parseGoImports(%q) = %v, want %v", tc.ctx, got, tc.want)
+		t.Run(name, func(t *testing.T) {
+			node := &Node{Properties: map[string][]byte{"imports": raw}}
+			if got := loadImports(node); got != nil {
+				t.Errorf("loadImports = %v, want nil", got)
 			}
 		})
 	}
 }
 
-// TestLoadImports_PrefersStructuredOverRegex verifies the structured path wins:
-// when Properties["imports"] is present it is used verbatim and the Context
-// text is never consulted. This is the invariant that makes the regex fallback
-// removable once the .db path persists imports.
-func TestLoadImports_PrefersStructuredOverRegex(t *testing.T) {
-	structured, err := json.Marshal(map[string]string{"alias": "real/path"})
-	if err != nil {
-		t.Fatal(err)
-	}
-	node := &Node{
-		Properties: map[string][]byte{"imports": structured},
-		// Deliberately conflicting context — must be ignored.
-		Context: []byte(`import "should/not/be/used"`),
-	}
-	got := loadImports(node)
-	want := map[string]string{"alias": "real/path"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("loadImports = %v, want %v (structured Properties must win over Context)", got, want)
-	}
-}
-
-// TestLoadImports_FallsBackToContext covers the live .db-hydration path:
-// no Properties["imports"], so Context is parsed.
-func TestLoadImports_FallsBackToContext(t *testing.T) {
-	node := &Node{Context: []byte(`import "net/http"`)}
-	got := loadImports(node)
-	want := map[string]string{"http": "net/http"}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("loadImports = %v, want %v", got, want)
+// TestLoadImports_NoPropertiesYieldsNil covers the bare node case.
+func TestLoadImports_NoPropertiesYieldsNil(t *testing.T) {
+	if got := loadImports(&Node{}); got != nil {
+		t.Errorf("loadImports = %v, want nil", got)
 	}
 }

--- a/internal/graph/nodes_table_properties_test.go
+++ b/internal/graph/nodes_table_properties_test.go
@@ -1,0 +1,106 @@
+package graph
+
+import (
+	"database/sql"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// TestNodesTableReader_RestoresProperties covers the serve-time half of the
+// Properties round-trip. SQLiteWriter marshals a dir node's Properties into the
+// `record` column, and the build-time SQLiteWriter.GetNode restores them — but
+// the serve-time reader used to ignore `record` entirely, so every construct
+// read from a .db silently lost lang/pkg/imports. That loss is why qualified
+// callee resolution had to fall back to regex-scraping context text
+// (mache-f930b6).
+func TestNodesTableReader_RestoresProperties(t *testing.T) {
+	db := newPropsTestDB(t)
+
+	imports, err := json.Marshal(map[string]string{"http": "net/http"})
+	require.NoError(t, err)
+	props, err := json.Marshal(map[string][]byte{
+		"lang":    []byte("go"),
+		"imports": imports,
+	})
+	require.NoError(t, err)
+
+	_, err = db.Exec(
+		`INSERT INTO nodes (id, parent_id, name, kind, size, mtime, record) VALUES (?,?,?,?,?,?,?)`,
+		"pkg/Hello", "pkg", "Hello", NodeKindDir, 0, 0, string(props))
+	require.NoError(t, err)
+
+	r := NewNodesTableReader(db, "nodes", nil, nil, 0o444, 0o555, 8)
+	node, err := r.GetNode("pkg/Hello")
+	require.NoError(t, err)
+	require.NotNil(t, node.Properties, "dir node Properties must survive the .db round-trip")
+	require.Equal(t, []byte("go"), node.Properties["lang"])
+
+	// The structured import path loadImports() prefers must be reachable now.
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(node.Properties["imports"], &got))
+	require.Equal(t, map[string]string{"http": "net/http"}, got)
+}
+
+// TestNodesTableReader_FileRecordIsNotLoadedAsProperties pins the performance
+// guard. For FILE nodes `record` holds rendered content, and this reader is
+// deliberately lazy about content (ContentRef). The SQL-side CASE must keep
+// SQLite from shipping a file's body just to answer GetNode — and that content
+// must never be mistaken for Properties.
+func TestNodesTableReader_FileRecordIsNotLoadedAsProperties(t *testing.T) {
+	db := newPropsTestDB(t)
+
+	body := `{"looks":"like json but is file content"}`
+	_, err := db.Exec(
+		`INSERT INTO nodes (id, parent_id, name, kind, size, mtime, record) VALUES (?,?,?,?,?,?,?)`,
+		"pkg/file.go", "pkg", "file.go", NodeKindFile, len(body), 0, body)
+	require.NoError(t, err)
+
+	r := NewNodesTableReader(db, "nodes", nil, nil, 0o444, 0o555, 8)
+	node, err := r.GetNode("pkg/file.go")
+	require.NoError(t, err)
+	require.Nil(t, node.Properties,
+		"file-node record is content, not Properties — it must not be loaded here")
+	require.NotNil(t, node.Ref, "file nodes stay lazy via ContentRef")
+}
+
+// TestNodesTableReader_NoPropertiesWhenRecordAbsent covers leyline-produced
+// tables, which carry no mache Properties in `record` — GetNode must simply
+// leave Properties nil rather than erroring.
+func TestNodesTableReader_NoPropertiesWhenRecordAbsent(t *testing.T) {
+	db := newPropsTestDB(t)
+	_, err := db.Exec(
+		`INSERT INTO nodes (id, parent_id, name, kind, size, mtime) VALUES (?,?,?,?,?,?)`,
+		"pkg/Bare", "pkg", "Bare", NodeKindDir, 0, 0)
+	require.NoError(t, err)
+
+	r := NewNodesTableReader(db, "nodes", nil, nil, 0o444, 0o555, 8)
+	node, err := r.GetNode("pkg/Bare")
+	require.NoError(t, err)
+	require.Nil(t, node.Properties)
+}
+
+// newPropsTestDB builds a nodes table WITHOUT the optional `context` column —
+// matching what a real `mache build` (leyline backend) emits.
+func newPropsTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "props*.db")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	db, err := sql.Open("sqlite", f.Name())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(`CREATE TABLE nodes (
+		id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
+		kind INTEGER NOT NULL, size INTEGER DEFAULT 0, mtime INTEGER NOT NULL,
+		record_id TEXT, record JSON, source_file TEXT
+	)`)
+	require.NoError(t, err)
+	return db
+}

--- a/internal/graph/nodes_table_reader.go
+++ b/internal/graph/nodes_table_reader.go
@@ -95,10 +95,23 @@ func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 	// Older / leyline-produced nodes tables predate the context column;
 	// only select it when present so GetNode stays backward-compatible
 	// (mache-b8fe72). node.Context feeds the `context` virtual file.
-	query := "SELECT kind, size, mtime, record_id FROM nodes WHERE id = ?"
-	dest := []any{&kind, &size, &mtimeNano, &recordID}
+	// Directory nodes carry their Properties (lang / pkg / imports) serialized
+	// into `record` by SQLiteWriter. Restore them here so a served .db behaves
+	// like a freshly-ingested MemoryStore — without this, every construct node
+	// read at serve time lost lang/pkg/imports, which is why qualified-callee
+	// resolution had to fall back to regex-scraping the context text
+	// (mache-f930b6).
+	//
+	// The CASE guard is load-bearing for performance: for FILE nodes `record`
+	// holds the rendered content, and this reader is deliberately lazy about
+	// content (see ContentRef below). Filtering server-side means SQLite never
+	// ships a file's body just to answer a GetNode.
+	var props []byte
+	recordExpr := fmt.Sprintf("CASE WHEN kind = %d THEN record ELSE NULL END", NodeKindDir)
+	query := "SELECT kind, size, mtime, record_id, " + recordExpr + " FROM nodes WHERE id = ?"
+	dest := []any{&kind, &size, &mtimeNano, &recordID, &props}
 	if r.hasContext {
-		query = "SELECT kind, size, mtime, record_id, context FROM nodes WHERE id = ?"
+		query = "SELECT kind, size, mtime, record_id, " + recordExpr + ", context FROM nodes WHERE id = ?"
 		dest = append(dest, &context)
 	}
 	err := r.db.QueryRow(query, id).Scan(dest...)
@@ -119,6 +132,16 @@ func (r *NodesTableReader) GetNode(id string) (*Node, error) {
 		Mode:    mode,
 		ModTime: time.Unix(0, mtimeNano),
 		Context: context,
+	}
+
+	// Mirrors SQLiteWriter.GetNode: a dir node's `record` is its marshaled
+	// Properties. A dir node with inline Data instead won't unmarshal into the
+	// map shape — that's expected, and leaves Properties nil.
+	if kind == NodeKindDir && len(props) > 0 {
+		var p map[string][]byte
+		if json.Unmarshal(props, &p) == nil && len(p) > 0 {
+			node.Properties = p
+		}
 	}
 
 	if kind == NodeKindFile {

--- a/internal/lint/regexp_ratchet_test.go
+++ b/internal/lint/regexp_ratchet_test.go
@@ -43,14 +43,7 @@ var regexpAllowlist = map[string]string{
 	//   a tree-sitter `#match?` / `#not-match?` query predicate. The regex is
 	//   the feature contract, not a heuristic — there is nothing to replace.
 	//
-	//   memstore_callees.go leniently extracts Go imports from a possibly-PARTIAL
-	//   context blob on the .db-hydration path (nodes_table_reader sets Context
-	//   but not Properties["imports"], so this is live, not dead). A strict
-	//   go/parser would fail on a fragment with no package clause. Removing it
-	//   means persisting structured imports on the nodes-table path — tracked
-	//   separately. Behavior is pinned by memstore_imports_test.go.
 	"internal/ingest/ast_walker_selector.go": "tree-sitter #match? predicate — user-supplied regex IS the contract",
-	"internal/graph/memstore_callees.go":     "lenient import extraction from partial context text (.db path); structured path preferred",
 }
 
 // dirsToSkip are trees that are not mache's own source (vendored fixtures,


### PR DESCRIPTION
Removes the **last** production regex flagged by the ratchet — but the interesting part is *why* it was still there.

## The actual bug

`SQLiteWriter` marshals a dir node's Properties (`lang` / `pkg` / `imports`) into the nodes-table `record` column, and the build-time `SQLiteWriter.GetNode` restores them. But the **serve-time** `NodesTableReader.GetNode` never selected `record` at all — so **every construct read from a `.db` silently lost its Properties.**

That loss is the *only* reason qualified-callee resolution kept a regex fallback scraping Go `import` statements out of context text.

## Fix

`NodesTableReader.GetNode` now restores Properties for dir nodes, with the `record` fetch guarded **SQL-side**:

```sql
CASE WHEN kind = 1 THEN record ELSE NULL END
```

That guard is load-bearing: for **file** nodes `record` holds rendered content, and this reader is deliberately lazy about content (`ContentRef`). Filtering server-side means SQLite never ships a file's body just to answer a `GetNode`. Covered by a test.

## Why deleting the fallback is safe

Verified each path rather than assuming:

| Path | Before | After |
|---|---|---|
| MemoryStore (fresh ingest) | engine sets Properties → structured | unchanged |
| `.db` via SQLiteWriter (legacy source builds) | **fallback did real work** | Properties round-trip via `record` |
| `.db` via leyline (post-ADR-0012 default) | a real `mache build` emits **no `context` column at all** → fallback could never fire | unchanged |

Also removes a latent defect the deleted parser carried: `. "os"` degraded into a normal `os` import, because its alias group `(\w+)?` can't match `.`. (Found by the characterization tests added in #543 — they did their job, then retired with the code they pinned.)

## Notes

- regexp allowlist **12 → 11**.
- The Properties *encoding* is still double-marshaled + base64'd into `record` (**2.3× bloat**, and `json_extract(record,'$.imports')` returns a base64 blob so no SQL/smell rule can reach it). That's a pre-existing on-disk-format wart needing a compat plan — tracked as `mache-90b89b`, not fixed here.

`task ci` green (full `-race` suite — relevant since `GetNode` is hot).