### PR TITLE
[mache-e5e570] docs(adr): ADR-0006 status note mis-dated its own outcome

### DIFF
--- a/docs/adr/0006-pure-go-mcp-first.md
+++ b/docs/adr/0006-pure-go-mcp-first.md
@@ -1,12 +1,19 @@
 ---
-title: "ADR-0006: Pure Go, MCP-First — Remove CGO and FUSE"
+title: 'ADR-0006: Pure Go, MCP-First — Remove CGO and FUSE'
 status: Implemented
 date: 2026-04-12
 tags: [architecture, pure-go, cgo, fuse, mcp, implemented]
 ---
 
-> **Status note:** Implemented — shipped in v0.18.0. CGO tree-sitter and FUSE were removed;
-> see [ADR-0012](0012-cgo-removal-migration.md) for the migration plan.
+> **Status note:** Implemented, but **in two stages** — not the single release this ADR
+> proposed below. FUSE was removed in **v0.7.0**, leaving NFS (`go-nfs` + `billy`) as the
+> only mount backend; for FUSE today, use `leyline serve` from ley-line-open. In-process
+> CGO tree-sitter outlived this ADR by eleven minors and was not removed until **v0.18.0**
+> (`mache-37ae8b`), via the [ADR-0012](0012-cgo-removal-migration.md) migration plan —
+> step 4 of which is what actually made the release binary `CGO_ENABLED=0`.
+>
+> The plan below still reads "a single versioned release (v0.7.0)". That is the proposal
+> as written in 2026-04, kept for provenance; it is not what happened.
 
 ## Context
 


### PR DESCRIPTION
Surfaced while verifying a mache-side claim I'd relayed into `ley-line-open-fe10a6`. LLO's ADR-0029 §2.2 assigns manifest-mode work to **"mache's existing FUSE/NFS mount"** — a component that hasn't existed in that shape since v0.7.0. Checking that, I found mache's own ADR was the unreliable source.

## The defect

The status note read:

> Implemented — shipped in v0.18.0. CGO tree-sitter and FUSE were removed

That collapses two removals **eleven minors apart**:

| Removal | Actually shipped | Evidence |
|---|---|---|
| FUSE backend | **v0.7.0** | `ROADMAP.md:22`; CHANGELOG starts at v0.8.0 with no FUSE entry; no `fusemount` package in git history |
| in-process CGO tree-sitter | **v0.18.0** | `mache-37ae8b`, ADR-0012 step 4 — what actually made the release binary `CGO_ENABLED=0` |

ADR-0006 *proposed* doing both at once ("a single versioned release (v0.7.0)", "Tag v0.7.0"). Only the FUSE half happened then. **The status note asserted the proposal's shape onto history** — the most misleading failure mode for an ADR, since the whole point is recording what was decided versus what occurred.

There's an irony worth preserving: the ADR's own *Alternatives Considered* rejected "gradual removal across multiple releases" as extending the maintenance burden. That is exactly what happened, and the status note is where it got papered over.

## What changed

Only the status note. The plan body still says "a single versioned release (v0.7.0)" — that's the 2026-04 proposal, worth keeping as provenance, now explicitly labelled as the proposal rather than the outcome.

## The pattern

**Third stale-claim site this session in a place no gate walks.** `docs:lint`'s `covers-version` check only spans top-level `docs/*.md`, so `docs/adr/` and `docs/schemas/` both age silently:

1. `melange.yaml` — CGO comment above a `CGO_ENABLED=0` pipeline (#548)
2. `docs/schemas/go.md` — `covers-version: v0.8.0` (#548)
3. this one

All three were wrong about the same event: the CGO/FUSE removal. Extending the lint to subdirectories is worth considering, though ADRs are historical documents where `covers-version` is the wrong check — they need "does this status note match the changelog", which is a different rule. Not attempted here.

`task ci` green.