### PR TITLE
[rosary-aa8c6d] chore(beads): bead store dolt->sqlite

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,5 +1,10 @@
 # Dolt database (managed by Dolt, not git)
 dolt/
+# Migration backup — `rsry bead migrate --commit` renames dolt/ to dolt.bak/
+# and never deletes it. It is a binary Dolt store; committing it is the
+# rosary-05fbe0 footgun.
+dolt.bak/
+dolt.bak.*/
 dolt-access.lock
 
 # Runtime files

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,7 +1,5 @@
 {
-  "database": "dolt",
-  "backend": "dolt",
-  "dolt_mode": "server",
-  "dolt_database": "mache",
+  "database": "sqlite",
+  "backend": "sqlite",
   "project_id": "44a73290-dad2-4569-86e2-4b889bf8283c"
 }


### PR DESCRIPTION
Migrated this repo's bead store from Dolt to SQLite with `rsry bead migrate
--to sqlite --commit` (rosary v0.10.0, ADR-0021). The dry run verified
field-level fidelity against the Dolt source before the swap, and the counts
were re-checked against the Dolt tables directly.

- .beads/metadata.json now reports backend=sqlite, matching the actual store.
- .beads/.gitignore ignores dolt.bak/ — `--commit` renames dolt/ to dolt.bak/
  rather than deleting it, and that is a binary Dolt store that must never be
  committed (the rosary-05fbe0 footgun).

The pre-migration .beads/ directory is backed up outside the repo.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TzQGRJiJEZr3C4MbSySDkZ