### PR TITLE
fix(leyline): resolve pinned binary in live tests

### DIFF
--- a/cmd/agent.go
+++ b/cmd/agent.go
@@ -7,12 +7,12 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
 
+	"github.com/agentic-research/mache/internal/gitutil"
 	"github.com/spf13/cobra"
 )
 
@@ -191,7 +191,7 @@ func generateMountName(sourcePath, gitRepo string) string {
 // Returns (org/repo, branch, remoteURL, error).
 func detectGitInfo(path string) (string, string, string, error) {
 	// Check if path is in a git repo
-	cmd := exec.Command("git", "-C", path, "rev-parse", "--show-toplevel")
+	cmd := gitutil.HermeticGitCommand("-C", path, "rev-parse", "--show-toplevel")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", "", "", nil // Not a git repo, not an error
@@ -200,7 +200,7 @@ func detectGitInfo(path string) (string, string, string, error) {
 	repoRoot := strings.TrimSpace(string(output))
 
 	// Get current branch
-	cmd = exec.Command("git", "-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
+	cmd = gitutil.HermeticGitCommand("-C", repoRoot, "rev-parse", "--abbrev-ref", "HEAD")
 	branchOutput, err := cmd.Output()
 	branch := "unknown"
 	if err == nil {
@@ -208,7 +208,7 @@ func detectGitInfo(path string) (string, string, string, error) {
 	}
 
 	// Get remote URL
-	cmd = exec.Command("git", "-C", repoRoot, "remote", "get-url", "origin")
+	cmd = gitutil.HermeticGitCommand("-C", repoRoot, "remote", "get-url", "origin")
 	remoteOutput, err := cmd.Output()
 	remoteURL := ""
 	if err == nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/internal/gitutil"
 	"github.com/agentic-research/mache/internal/graph"
 	"github.com/agentic-research/mache/internal/ingest"
 	"github.com/agentic-research/mache/internal/leyline"
@@ -102,7 +103,7 @@ func runServe(cmd *cobra.Command, args []string) error {
 			}()
 			baseDir := filepath.Join(parentDir, "base")
 			log.Printf("cloning %s for HTTP mode...", serveRepo)
-			cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", serveRepo, baseDir)
+			cmd := gitutil.HermeticGitCommand("clone", "--depth=1", "--single-branch", serveRepo, baseDir)
 			cmd.Stdout = os.Stderr
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {
@@ -393,7 +394,7 @@ func cloneRepo(repoURL string) (string, func(), error) {
 	}
 
 	log.Printf("cloning %s (shallow)...", repoURL)
-	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", repoURL, tmpDir)
+	cmd := gitutil.HermeticGitCommand("clone", "--depth=1", "--single-branch", repoURL, tmpDir)
 	cmd.Stdout = os.Stderr // show progress on stderr (not MCP stdout)
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/serve_hosted.go
+++ b/cmd/serve_hosted.go
@@ -7,12 +7,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/agentic-research/mache/internal/gitutil"
 )
 
 // repoClone tracks a shared base clone for a repo URL in hosted mode.
@@ -124,7 +125,7 @@ func (r *graphRegistry) getOrCreateRepoClone(repoURL string) (string, error) {
 	baseDir := filepath.Join(parentDir, "base")
 
 	log.Printf("cloning %s for hosted mode...", redactURL(repoURL))
-	cmd := exec.Command("git", "clone", "--depth=1", "--single-branch", repoURL, baseDir)
+	cmd := gitutil.HermeticGitCommand("clone", "--depth=1", "--single-branch", repoURL, baseDir)
 	cmd.Dir = parentDir
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr

--- a/cmd/serve_repo.go
+++ b/cmd/serve_repo.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/agentic-research/mache/internal/gitutil"
 )
 
 // sanitizeSessionID ensures a session ID is safe for use as a filesystem path.
@@ -42,7 +43,7 @@ func createWorktree(cloneDir, sessionID string) (string, error) {
 	}
 
 	wtDir := filepath.Join(sessionsDir, safe)
-	cmd := exec.Command("git", "worktree", "add", wtDir, "HEAD")
+	cmd := gitutil.HermeticGitCommand("worktree", "add", wtDir, "HEAD")
 	cmd.Dir = cloneDir
 	if out, err := cmd.CombinedOutput(); err != nil {
 		return "", fmt.Errorf("git worktree add: %s: %w", string(out), err)
@@ -53,7 +54,7 @@ func createWorktree(cloneDir, sessionID string) (string, error) {
 // removeWorktree removes a git worktree and its directory.
 // Falls back to rm -rf if git worktree remove fails.
 func removeWorktree(cloneDir, worktreeDir string) error {
-	cmd := exec.Command("git", "worktree", "remove", "--force", worktreeDir)
+	cmd := gitutil.HermeticGitCommand("worktree", "remove", "--force", worktreeDir)
 	cmd.Dir = cloneDir
 	if err := cmd.Run(); err != nil {
 		log.Printf("git worktree remove failed, falling back to rm: %v", err)

--- a/cmd/serve_repo_test.go
+++ b/cmd/serve_repo_test.go
@@ -2,12 +2,13 @@ package cmd
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/gitutil"
 )
 
 // initTestGitRepo creates a temp git repo with one commit for worktree tests.
@@ -19,7 +20,7 @@ func initTestGitRepo(t *testing.T) string {
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test"},
 	} {
-		c := exec.Command(cmd[0], cmd[1:]...)
+		c := gitutil.HermeticGitCommand(cmd[1:]...)
 		c.Dir = dir
 		require.NoError(t, c.Run(), "git init failed")
 	}
@@ -28,7 +29,7 @@ func initTestGitRepo(t *testing.T) string {
 		{"git", "add", "."},
 		{"git", "commit", "-m", "init"},
 	} {
-		c := exec.Command(cmd[0], cmd[1:]...)
+		c := gitutil.HermeticGitCommand(cmd[1:]...)
 		c.Dir = dir
 		require.NoError(t, c.Run())
 	}

--- a/internal/gitutil/command.go
+++ b/internal/gitutil/command.go
@@ -1,0 +1,50 @@
+// Package gitutil provides hermetic Git subprocess construction.
+package gitutil
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// HermeticGitCommand constructs a Git command without repository-local environment
+// variables inherited from a parent Git hook. Those variables take precedence
+// over cmd.Dir and `git -C`, which can make a nested command operate on the
+// repository whose hook is running instead of its explicit target.
+func HermeticGitCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("git", args...)
+	cmd.Env = WithoutLocalEnv(os.Environ())
+	return cmd
+}
+
+// WithoutLocalEnv removes the variables listed by
+// `git rev-parse --local-env-vars`.
+func WithoutLocalEnv(env []string) []string {
+	clean := make([]string, 0, len(env))
+	for _, entry := range env {
+		name, _, _ := strings.Cut(entry, "=")
+		if localEnv[name] {
+			continue
+		}
+		clean = append(clean, entry)
+	}
+	return clean
+}
+
+var localEnv = map[string]bool{
+	"GIT_ALTERNATE_OBJECT_DIRECTORIES": true,
+	"GIT_COMMON_DIR":                   true,
+	"GIT_CONFIG":                       true,
+	"GIT_CONFIG_COUNT":                 true,
+	"GIT_CONFIG_PARAMETERS":            true,
+	"GIT_DIR":                          true,
+	"GIT_GRAFT_FILE":                   true,
+	"GIT_IMPLICIT_WORK_TREE":           true,
+	"GIT_INDEX_FILE":                   true,
+	"GIT_NO_REPLACE_OBJECTS":           true,
+	"GIT_OBJECT_DIRECTORY":             true,
+	"GIT_PREFIX":                       true,
+	"GIT_REPLACE_REF_BASE":             true,
+	"GIT_SHALLOW_FILE":                 true,
+	"GIT_WORK_TREE":                    true,
+}

--- a/internal/gitutil/command_test.go
+++ b/internal/gitutil/command_test.go
@@ -1,0 +1,28 @@
+package gitutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHermeticGitCommand(t *testing.T) {
+	t.Setenv("GIT_DIR", "/tmp/poison.git")
+
+	cmd := HermeticGitCommand("--version")
+	assert.NotContains(t, cmd.Env, "GIT_DIR=/tmp/poison.git")
+	require.NoError(t, cmd.Run())
+}
+
+func TestWithoutLocalEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"GIT_DIR=/repo/.git",
+		"GIT_INDEX_FILE=/repo/.git/index",
+		"GIT_CONFIG_COUNT=2",
+		"HOME=/tmp/home",
+	}
+
+	assert.Equal(t, []string{"PATH=/usr/bin", "HOME=/tmp/home"}, WithoutLocalEnv(env))
+}

--- a/internal/ingest/git.go
+++ b/internal/ingest/git.go
@@ -4,9 +4,10 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/agentic-research/mache/internal/gitutil"
 )
 
 // GetGitHints returns the default inference hints for Git repositories.
@@ -33,7 +34,7 @@ func LoadGitCommits(repoPath string) ([]any, error) {
 	// %B: Raw body (subject + body)
 	format := "%H%n%T%n%P%n%an%n%aI%n%B" + sep
 
-	cmd := exec.Command("git", "log", "--all", "--date=iso", fmt.Sprintf("--pretty=format:%s", format))
+	cmd := gitutil.HermeticGitCommand("log", "--all", "--date=iso", fmt.Sprintf("--pretty=format:%s", format))
 	cmd.Dir = repoPath
 
 	// Increase buffer size for large logs

--- a/internal/ingest/git_test.go
+++ b/internal/ingest/git_test.go
@@ -1,11 +1,12 @@
 package ingest
 
 import (
-	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/gitutil"
 )
 
 func TestLoadGitCommits(t *testing.T) {
@@ -43,7 +44,7 @@ With body`)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {
-	cmd := exec.Command("git", args...)
+	cmd := gitutil.HermeticGitCommand(args...)
 	cmd.Dir = dir
 	err := cmd.Run()
 	require.NoError(t, err, "git %v failed", args)

--- a/internal/leyline/sheaf_cascade_bench_test.go
+++ b/internal/leyline/sheaf_cascade_bench_test.go
@@ -30,12 +30,12 @@ import (
 // marshal/unmarshal + UDS write/read, neither of which scales with
 // CPU count.
 //
-// Skipped automatically when `leyline` is not on PATH (same gate as
-// TestE2E_SheafCascade_AgainstLiveDaemon).
+// Skipped automatically when the pinned `leyline` cannot be resolved (same
+// gate as TestE2E_SheafCascade_AgainstLiveDaemon).
 func BenchmarkCascade_InvalidateWithStalk(b *testing.B) {
-	leylineBin, err := exec.LookPath("leyline")
+	leylineBin, err := ResolveBinary(false)
 	if err != nil {
-		b.Skip("leyline binary not on PATH — skipping live-daemon bench")
+		b.Skipf("pinned leyline unavailable — skipping live-daemon bench: %v", err)
 	}
 
 	sock, cleanup := startDaemonForBench(b, leylineBin)
@@ -90,9 +90,9 @@ func BenchmarkCascade_InvalidateWithStalk(b *testing.B) {
 // Worth measuring so any future regression that bloats the wire format
 // is caught.
 func BenchmarkCascade_InvalidateHeuristicMode(b *testing.B) {
-	leylineBin, err := exec.LookPath("leyline")
+	leylineBin, err := ResolveBinary(false)
 	if err != nil {
-		b.Skip("leyline binary not on PATH — skipping live-daemon bench")
+		b.Skipf("pinned leyline unavailable — skipping live-daemon bench: %v", err)
 	}
 
 	sock, cleanup := startDaemonForBench(b, leylineBin)

--- a/internal/leyline/sheaf_e2e_test.go
+++ b/internal/leyline/sheaf_e2e_test.go
@@ -33,17 +33,20 @@ import (
 // continuity contract: mache pushes topology + post-change stalks,
 // daemon returns reachable regions via the agreement-plane δ⁰ check.
 //
-// Skipped automatically when `leyline` is not on PATH so CI without
-// the daemon binary (and developer machines without it) stays green.
+// Skipped automatically when the pinned `leyline` cannot be resolved so CI
+// without the daemon binary (and developer machines without it) stays green.
 // Test files are sized so the daemon's auto-spawn-and-bind path
 // completes inside the timeout — extend the deadline if the bench
 // repo grows beyond a few KB of fixtures.
 func TestE2E_SheafCascade_AgainstLiveDaemon(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // isolate ~/.mache/ from sibling tests
-	leylineBin, err := exec.LookPath("leyline")
+	// Resolve before HOME isolation so the resolver can find the pinned binary
+	// under the developer's ~/.mache/bin. A raw LookPath here would bypass the
+	// production version gate and may launch an incompatible local CLI.
+	leylineBin, err := ResolveBinary(false)
 	if err != nil {
-		t.Skip("leyline binary not on PATH — skipping cross-runtime e2e")
+		t.Skipf("pinned leyline unavailable — skipping cross-runtime e2e: %v", err)
 	}
+	t.Setenv("HOME", t.TempDir()) // isolate ~/.mache/ from sibling tests
 
 	// Each subtest gets its own isolated daemon. The daemon derives the
 	// UDS socket path from --control (replaces .ctrl with .sock), and

--- a/internal/leyline/sheaf_subscriber_e2e_test.go
+++ b/internal/leyline/sheaf_subscriber_e2e_test.go
@@ -44,7 +44,7 @@ import (
 // side of its conn after activation, so sharing with SheafClient
 // would race per SocketClient.Subscribe's docstring.
 //
-// Skipped when `leyline` is not on PATH (same gate as
+// Skipped when the pinned `leyline` cannot be resolved (same gate as
 // TestE2E_SheafCascade_AgainstLiveDaemon + the cascade benches).
 //
 // REGRESSION GUARD for ley-line-open-5caa59: pre-LLO-v0.4.3 daemons
@@ -55,11 +55,13 @@ import (
 // refactor regresses this path, this test catches it before the bug
 // reaches live runtime.
 func TestE2E_SheafSubscriber_AgainstLiveDaemon(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // isolate ~/.mache/ from sibling tests
-	leylineBin, err := exec.LookPath("leyline")
+	// Resolve before HOME isolation so ~/.mache/bin remains a valid fallback.
+	// ResolveBinary rejects incompatible PATH binaries just like production.
+	leylineBin, err := ResolveBinary(false)
 	if err != nil {
-		t.Skip("leyline binary not on PATH — skipping cross-runtime subscriber e2e")
+		t.Skipf("pinned leyline unavailable — skipping cross-runtime subscriber e2e: %v", err)
 	}
+	t.Setenv("HOME", t.TempDir()) // isolate ~/.mache/ from sibling tests
 
 	// Mache pins to LLO v0.6+ (PR #147 unified emit under
 	// `daemon.sheaf.invalidate`; the pre-v0.6 `sheaf.invalidate` topic


### PR DESCRIPTION
## What changed

- route live Leyline E2E tests and benchmarks through Mache's exact-version resolver
- resolve the pinned binary before test HOME isolation
- add hermetic Git subprocess construction that strips repository-local `GIT_*` hook variables
- route clone, worktree, repository metadata, and Git-ingest subprocesses through that helper

## Why

A different `leyline` executable earlier on PATH accepted `--control-path`, while Mache's pinned LLO release correctly accepts `--control`. Raw `exec.LookPath` in live tests bypassed Mache's version gate. Separately, Git's pre-push hook environment caused nested temp-repository tests to mutate Mache's own index because inherited `GIT_DIR`/`GIT_INDEX_FILE` overrode `cmd.Dir`.

## Verification

- poisoned-Git-environment clone/worktree/ingest regression tests
- `go test -tags boltdb -race -timeout 20m ./internal/leyline ./internal/lltest ./internal/gitutil ./internal/ingest ./cmd`
- `task ci`
- actual pre-push hook passed and branch pushed

Closes `mache-88715f`.