### PR TITLE
chore(leyline): pin published v0.10.2 release

### DIFF
--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -919,7 +919,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/algebra_flat.rs",
-      "count": 1
+      "count": 2
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1410,6 +1410,16 @@
       "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/ast_walker_calls.go",
       "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/ast_walker_extract.go",
+      "count": 1
+    },
+    {
+      "rule_id": "fan_out_skew",
+      "source_id": "internal/ingest/ast_walker_nodes.go",
+      "count": 2
     },
     {
       "rule_id": "fan_out_skew",

--- a/docs/superpowers/plans/2026-07-23-leyline-v0.10.2-pin.md
+++ b/docs/superpowers/plans/2026-07-23-leyline-v0.10.2-pin.md
@@ -1,0 +1,193 @@
+# Leyline v0.10.2 Pin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Mache download, verify, advertise, and test ley-line-open `v0.10.2`.
+
+**Architecture:** Keep `internal/leyline/socket.go` as the binary-version source of truth and `internal/leyline/binary_pin.go` as the release-asset trust root. Regenerate `server.json` from those constants so registry consumers receive the same dependency version Mache executes. Do not change the Go schema client because the release retains wire major `1` and compatibility floor `0.6.0`.
+
+**Tech Stack:** Go, Taskfile, MCP Registry `server.json`, GitHub release assets, SHA-256.
+
+## Global Constraints
+
+- Pin the exact release tag `v0.10.2`.
+- Pin all four published binary digests: Darwin/Linux × AMD64/ARM64.
+- Keep `github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.7.1`.
+- Require `wire_format_major = 1` and `compat_min_schema_version = 0.6.0`.
+- Preserve the daemon flag `--control`; the published LLO binary supports it.
+
+______________________________________________________________________
+
+### Task 1: Pin the release and its trust metadata
+
+**Files:**
+
+- Modify: `internal/leyline/socket.go`
+- Modify: `internal/leyline/binary_pin.go`
+- Test: `internal/leyline/binary_pin_test.go`
+
+**Interfaces:**
+
+- Consumes: GitHub release `v0.10.2` and its four `sha256:` asset digests.
+
+- Produces: `leylineBinaryVersion = "v0.10.2"` and a complete `leylinePinnedSHA256` map.
+
+- [x] **Step 1: Write the failing release-pin test**
+
+Add an assertion to `internal/leyline/binary_pin_test.go`:
+
+```go
+func TestPinnedBinaryReleaseIsV0102(t *testing.T) {
+	assert.Equal(t, "v0.10.2", leylineBinaryVersion)
+}
+```
+
+- [x] **Step 2: Run the test and verify the old pin fails**
+
+Run:
+
+```bash
+go test ./internal/leyline -run '^TestPinnedBinaryReleaseIsV0102$'
+```
+
+Expected: failure showing actual `v0.8.0`, expected `v0.10.2`.
+
+- [x] **Step 3: Update the binary version and all four digests**
+
+Set:
+
+```go
+const leylineBinaryVersion = "v0.10.2"
+```
+
+Use these exact map values:
+
+```go
+"darwin-amd64": "28bc4de1bb6658a882a3ba06c24a7a92d0b516250eed7a9f44528698489fb0e3",
+"darwin-arm64": "90d865bd30b588165e3434e5c6ccb640b03c839309334fab841f6e08879c640f",
+"linux-amd64":  "d36589b0fdb2efe7a6f6942d363831eb612b38328c86b4bf4c95e42d59d1f9c1",
+"linux-arm64":  "c9690af47ea1bac176c13af3535c6dc3a484aa1542032a7803a37959c07f786a",
+```
+
+Update adjacent version commentary from `v0.8.0` to `v0.10.2` without claiming a schema-client bump.
+
+- [x] **Step 4: Run the focused Leyline tests**
+
+Run:
+
+```bash
+go test -tags boltdb -race -timeout 20m ./internal/leyline
+```
+
+Expected: pass.
+
+### Task 2: Regenerate and verify registry wiring
+
+**Files:**
+
+- Modify: `server.json`
+- Modify: `docs/smell-baseline.json`
+- Test: `cmd/mcp_registry_invariants_test.go`
+- Test: `tools/server-json-gen/main_test.go`
+
+**Interfaces:**
+
+- Consumes: exported `leyline.BinaryVersion`.
+
+- Produces: `server.json` dependency metadata advertising `0.10.2`.
+
+- [x] **Step 1: Run the stale-generation gate**
+
+Run:
+
+```bash
+task gen:server-json:check
+```
+
+Expected: failure because committed `server.json` still advertises `0.8.0`.
+
+- [x] **Step 2: Regenerate the descriptor**
+
+Run:
+
+```bash
+task gen:server-json
+```
+
+Expected: `server.json` changes only where derived Leyline dependency metadata requires `0.10.2`.
+
+- [x] **Step 3: Verify registry and generator invariants**
+
+Run:
+
+```bash
+go test ./cmd ./tools/server-json-gen
+task gen:server-json:check
+```
+
+Expected: all commands pass.
+
+- [x] **Step 4: Rebaseline and audit analyzer-version output**
+
+Run:
+
+```bash
+task smells:baseline
+git diff -- docs/smell-baseline.json
+```
+
+Expected: one existing `duplicate_definitions` count changes from `1` to `2`;
+`fan_out_skew` gains `ast_walker_extract.go` with count `1` and
+`ast_walker_nodes.go` with count `2`; no baseline entry disappears.
+
+### Task 3: Validate, commit, publish, and merge
+
+**Files:**
+
+- Verify: all files changed by Tasks 1–2 and this plan.
+
+**Interfaces:**
+
+- Consumes: the exact committed release wiring.
+
+- Produces: a mergeable branch whose pre-push gate matches CI.
+
+- [x] **Step 1: Commit the complete derived state**
+
+Run:
+
+```bash
+git add docs/superpowers/plans/2026-07-23-leyline-v0.10.2-pin.md \
+  docs/smell-baseline.json internal/leyline/socket.go \
+  internal/leyline/binary_pin.go internal/leyline/binary_pin_test.go server.json
+git commit -m "[mache-b56f07] chore(leyline): pin v0.10.2 release"
+```
+
+This ordering is required because `task smells` analyzes `git archive HEAD`;
+an uncommitted regenerated baseline is intentionally invisible to that gate.
+
+- [x] **Step 2: Run the full repository gate**
+
+Run:
+
+```bash
+task ci
+git diff --check
+git status --short
+```
+
+Expected: CI passes and the worktree is clean.
+
+- [ ] **Step 3: Push through the full pre-push gate**
+
+Run:
+
+```bash
+git push -u origin codex/mache-b56f07-leyline-v0.10.2
+```
+
+Expected: hook passes and the branch is published.
+
+- [ ] **Step 4: Open a ready PR and enable auto-merge**
+
+Create a PR targeting `main` that records the release URL, all four digests, unchanged wire/schema compatibility, and the verification commands. Enable auto-merge so repository CodeQL and code-quality rules remain authoritative.

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -33,10 +33,10 @@ const BinaryVersion = leylineBinaryVersion
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "f5fb211ff35b863273cd1cf2c1ed911a9724d53d444aa4f0f90180e263fb5734",
-	"darwin-arm64": "78e47b7abf70c29e42a31a937ff84f8f0c20af1625727818a133f6cea9418d83",
-	"linux-amd64":  "d5510a540d2ed26bf8d861899f07cac62a78778e4ef0dd00d9da3133d8b5162f",
-	"linux-arm64":  "03ca51e453193ad27020dbc30c811da1ccc2a1f12ef980eb9a7cb6f8b07d876d",
+	"darwin-amd64": "28bc4de1bb6658a882a3ba06c24a7a92d0b516250eed7a9f44528698489fb0e3",
+	"darwin-arm64": "90d865bd30b588165e3434e5c6ccb640b03c839309334fab841f6e08879c640f",
+	"linux-amd64":  "d36589b0fdb2efe7a6f6942d363831eb612b38328c86b4bf4c95e42d59d1f9c1",
+	"linux-arm64":  "c9690af47ea1bac176c13af3535c6dc3a484aa1542032a7803a37959c07f786a",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/binary_pin_test.go
+++ b/internal/leyline/binary_pin_test.go
@@ -71,6 +71,10 @@ func TestExtractSemver(t *testing.T) {
 	}
 }
 
+func TestPinnedBinaryReleaseIsV0102(t *testing.T) {
+	assert.Equal(t, "v0.10.2", leylineBinaryVersion)
+}
+
 func TestLeylineVersionMatchesPin(t *testing.T) {
 	pin := strings.TrimPrefix(leylineBinaryVersion, "v") // e.g. "0.7.0"
 	dir := t.TempDir()

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -780,58 +780,44 @@ func (c *SocketClient) Prioritize(files []string) error {
 // tagged releases have downloadable leyline-<os>-<arch> assets — the go.mod
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
-// As of this pin, the daemon binary is v0.7.5 while go.mod's leyline-schema
-// stays v0.7.1 — deliberately. The 0.7.1→0.7.5 daemon bumps are all
-// WIRE-UNCHANGED (wire_format_major=1, compat_min_schema_version stays 0.6.0):
-// v0.7.2 added the additive, node_hash-keyed _cfg / _cfg_edge tables (the
-// analysis-substrate CFG scaffold — schema only; row population is deferred to
-// LLO ley-line-open-a0fadd, so the tables come up empty on parse) and fixed the
-// ingest walker to honor .gitignore (LLO PR #178); v0.7.3 was a confinement /
-// cloister fix (v1 BLAKE3 digest); v0.7.4 added the additive node_refs
-// container_node_id column (nearest enclosing def), which closes mache's
-// ref-based smell-rule parity (fan_out_skew / untested_function — bead
-// ley-line-open-b9d1d5); v0.7.5 added the arena-owner sentinel (kills the
-// cross-repo cache-pollution class) and the additive node_defs.canonical_kind
-// column (closed κ vocabulary — lets dead_code filter WHERE canonical_kind IN
-// ('function','method','type'), collapsing its leyline over-report). All
-// additive — mache does not consume the new columns / CFG types yet (that is
-// the LLO-only smell-gate consolidation, mache-608a3c), and the v0.7.2–v0.8.0
-// leyline-schema Go submodule tags are unpublished (clients/go/leyline-schema
-// stops at v0.7.1) BECAUSE THE WIRE HASN'T CHANGED — wire_format_major=1 with
-// compat floor 0.6.0 has held from v0.7.0 through v0.8.0, so the v0.7.1 schema
-// client still decodes v0.8.0's wire. The version-parity gate (mache-b8af69)
-// checks the schema pin sits in [leylineSchemaCompatFloor, binary], not that
-// it equals the binary minor (that only held while everything was 0.7.x).
-// Earlier context: v0.7.0 raised compat_min to 0.6.0 and added source_blobs /
-// capnp_blobs / _ast_pointer, the unified daemon.sheaf.invalidate topic, and
-// cross-language def/ref extraction (ley-line-open-caf423); v0.7.1 was a
-// sheaf-correctness patch; v0.8.0 added validate coverage (27/28),
-// node_refs.qualifier, and extraction epochs — all additive, wire unchanged.
+// As of this pin, the daemon binary is v0.10.2 while go.mod's leyline-schema
+// stays v0.7.1 — deliberately. The release's generated compatibility document
+// reports wire_format_major=1 and compat_min_schema_version=0.6.0, so the
+// v0.7.1 client remains inside the daemon's supported [floor, binary] range.
+// The version-parity gate (mache-b8af69) enforces that range rather than
+// requiring the schema tag to equal the binary minor.
+//
+// Earlier context: v0.7.0 raised the compatibility floor to 0.6.0 and added
+// source_blobs / capnp_blobs / _ast_pointer plus the unified
+// daemon.sheaf.invalidate topic. v0.7.4 and v0.7.5 added AST columns without
+// changing the wire major; v0.8.0 added validate coverage, node_refs.qualifier,
+// and extraction epochs. The wire major and compatibility floor remain
+// unchanged in v0.10.2.
 //
 // The version-check (leylineVersionMatchesPin) is EXACT major.minor.patch —
 // LLO patch releases have changed the emitted _ast schema (0.7.4 added
 // container_node_id, 0.7.5 added canonical_kind), so the patch does NOT
-// float (mache-608a3c). v0.7.5 ships all four leyline-<os>-<arch> daemon
+// float (mache-608a3c). v0.10.2 ships all four leyline-<os>-<arch> daemon
 // binaries (darwin/linux × amd64/arm64).
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets.
 // The go.mod leyline-schema pin only needs bumping when the WIRE format
 // changes (a new schema module tag is published) — a binary-version bump with
-// unchanged wire (like v0.8.0) does NOT require a schema bump; the parity gate
+// unchanged wire (like v0.10.2) does NOT require a schema bump; the parity gate
 // enforces the [floor, binary] range that makes this safe.
 //
 // Doubles as this build's leyline schema-client version for the startup
 // wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch.
-const leylineBinaryVersion = "v0.8.0"
+const leylineBinaryVersion = "v0.10.2"
 
 // leylineSchemaCompatFloor is the OLDEST leyline-schema Go client version
 // whose wire format the pinned binary still accepts (ley-line-open's
 // compat_min_schema_version). The schema Go module
 // (clients/go/leyline-schema, go.mod pinned) is tagged SEPARATELY from the
 // binary and only re-cut when the capnp wire types change — so it lags the
-// binary version legitimately (v0.8.0 binary, but the wire has been
+// binary version legitimately (v0.10.2 binary, but the wire has been
 // wire_format_major=1 / floor 0.6.0 since well before, so the newest schema
 // tag is still v0.7.1). The parity gate asserts the go.mod schema pin sits in
 // [floor, binary], NOT that it equals the binary's minor (which only held by

--- a/server.json
+++ b/server.json
@@ -81,7 +81,7 @@
     "io.github.agentic-research.mache/required-deps": {
       "io.github.agentic-research/ley-line-open": {
         "purpose": "Required. `leyline parse` is mache's sole source parser since v0.18.0 (ADR-0012 step 4) — it produces the _ast tables every source projection reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and embeddings (semantic_search).",
-        "minimum-version": "0.8.0"
+        "minimum-version": "0.10.2"
       }
     },
     "io.github.agentic-research.mache/source-acceptance": {


### PR DESCRIPTION
## What changed

- bump Mache's exact ley-line-open binary pin from `v0.8.0` to `v0.10.2`
- pin GitHub-published SHA-256 digests for Darwin/Linux × AMD64/ARM64
- regenerate `server.json` so Cloister/registry consumers see minimum version `0.10.2`
- keep the Go schema client at `v0.7.1`: v0.10.2 still reports wire major `1` and compatibility floor `0.6.0`
- add a release-pin regression test
- rebaseline the analyzer-derived smell graph after auditing the exact v0.10.2 differences
- include the implementation/verification plan

## Analyzer baseline audit

The new parser changes only four findings in unchanged source:

- `duplicate_definitions` count for `algebra_flat.rs`: `1 → 2`
- add `fan_out_skew` for `ast_walker_extract.go`: `1`
- add `fan_out_skew` for `ast_walker_nodes.go`: `2`

No baseline finding disappeared.

## Runtime verification

The real auto-download path installed `~/.mache/bin/leyline`, which reports `leyline 0.10.2 (open)`. Its SHA-256 is `90d865bd30b588165e3434e5c6ccb640b03c839309334fab841f6e08879c640f`, exactly matching the published Darwin ARM64 digest. The daemon still accepts `--control`.

## Checks

- focused release-pin red/green test
- `go test -tags boltdb -race -timeout 20m ./internal/leyline ./cmd ./tools/server-json-gen`
- `task gen:server-json:check`
- `task smells`
- `task ci`
- full pre-push gate

Closes `mache-b56f07`.