### PR TITLE
[mache-0ca7e6] docs(ci): describe required aggregate gates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,11 @@ consumer smoke without depending on GitHub release uptime.
 1. **Commit your changes**. We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) messages (e.g., `fix: ...`, `feat: ...`, `docs: ...`).
 1. **Open a pull request** with a clear description of the change.
 
+Merges require the stable `CI required` and `Integration required` checks.
+Those aggregate checks wait for every applicable matrix job. Documentation-only
+changes still emit both checks, but skip the expensive Go and integration
+matrices.
+
 ## Scope of Contributions
 
 We welcome bug fixes, documentation improvements, and small feature additions.


### PR DESCRIPTION
Documents the two stable required checks added by #565. This intentionally docs-only PR also proves that both required aggregate contexts terminate successfully while the expensive Go and integration matrices are skipped.\n\nValidation: task docs:lint; git diff --check; pre-push task ci.