### PR TITLE
fix(ingest): stop silently dropping constructs on name collision (P0)

### DIFF
--- a/internal/graph/graph_suite_test.go
+++ b/internal/graph/graph_suite_test.go
@@ -63,16 +63,34 @@ type SuiteOpts struct {
 	// WritableGraph, HotSwapGraph) set this true; MemoryStore does
 	// not — it returns ErrNotFound for the empty key.
 	RootEmptyReturnsDir bool
+
+	// GetNodePopulatesChildren pins whether this backend fills
+	// GetNode().Children for directories, or leaves it empty and expects
+	// callers to use ListChildren.
+	//
+	// The backends genuinely disagree today, and the split is not random:
+	// MemoryStore (and HotSwapGraph, which wraps it) returns the live node so
+	// Children is present, while EVERY SQLite-backed reader — SQLiteGraph,
+	// NodesTableReader/WritableGraph, and SQLiteWriter — rebuilds a node from
+	// a single row and leaves Children nil. Populating it would cost an extra
+	// child query on what is the hottest read path in the system.
+	//
+	// This flag does NOT bless the divergence; it makes it explicit so it
+	// cannot drift further while the contract is decided (mache-e3d9bb). Until
+	// then, engine code must not branch on GetNode().Children — a guard that
+	// did exactly that was live on memory and dead on the build path, dropping
+	// 540 constructs from one Rust corpus (mache-c725e9).
+	GetNodePopulatesChildren bool
 }
 
-// RunGraphSuite runs the full Graph interface contract suite against any
-// implementation. Each test is independent — failures are isolated.
-func RunGraphSuite(t *testing.T, factory GraphFactory) {
-	RunGraphSuiteWithOpts(t, factory, SuiteOpts{})
-}
-
-// RunGraphSuiteWithOpts is the explicit form. Prefer this for new
-// implementations so the contract assertion is precise.
+// RunGraphSuiteWithOpts runs the full Graph interface contract suite against
+// any implementation. Each test is independent — failures are isolated.
+//
+// Every backend passes its opts explicitly: a bare RunGraphSuite convenience
+// wrapper existed and took SuiteOpts{}, which meant a new backend silently
+// accepted the permissive defaults instead of stating its answer. Opts are
+// where the contract's known variation lives, so making them mandatory is the
+// point.
 func RunGraphSuiteWithOpts(t *testing.T, factory GraphFactory, opts SuiteOpts) {
 	t.Helper()
 
@@ -94,6 +112,42 @@ func RunGraphSuiteWithOpts(t *testing.T, factory GraphFactory, opts SuiteOpts) {
 			} else {
 				assert.ErrorIs(t, err, ErrNotFound)
 			}
+		}
+	})
+
+	// The Graph contract exposes a node's children TWICE — as GetNode().Children
+	// and via ListChildren() — and nothing made the two agree. SQLiteWriter's
+	// GetNode never populated Children at all (it selects kind/mtime/record/
+	// context/props and stops), which silently disabled a dedup guard in the
+	// ingest engine that gated on `len(existing.Children) > 0`. That guard was
+	// live on MemoryStore and dead on the build path: one engine, one input,
+	// two backends, two different graphs, and 540 constructs dropped from a
+	// single Rust corpus (mache-c725e9, mache-e3d9bb).
+	//
+	// A wide struct whose fields each backend populates at its own discretion
+	// is not an interface — it is a suggestion. This asserts the two views
+	// agree, so a backend cannot answer "no children" through one accessor and
+	// "three children" through the other.
+	t.Run("GetNode/children_agree_with_ListChildren", func(t *testing.T) {
+		g := factory(t)
+		for _, dir := range []string{"pkg", "pkg/auth", "pkg/main", "pkg/empty"} {
+			listed, err := g.ListChildren(dir)
+			require.NoError(t, err, "ListChildren(%s)", dir)
+
+			n, err := g.GetNode(dir)
+			require.NoError(t, err, "GetNode(%s)", dir)
+
+			if opts.GetNodePopulatesChildren {
+				assert.ElementsMatch(t, listed, n.Children,
+					"this backend populates GetNode().Children, so it MUST agree with "+
+						"ListChildren(%q)", dir)
+				continue
+			}
+			assert.Empty(t, n.Children,
+				"this backend is pinned as NOT populating GetNode().Children — if it "+
+					"started, callers would silently change behaviour depending on "+
+					"backend. Flip GetNodePopulatesChildren deliberately, don't drift "+
+					"into it (mache-e3d9bb)")
 		}
 	})
 
@@ -400,23 +454,52 @@ func writableGraphFactory(t *testing.T) Graph {
 // Suite runners — one per implementation
 // ---------------------------------------------------------------------------
 
-func TestMemoryStore_GraphSuite(t *testing.T) {
-	// MemoryStore returns ErrNotFound for GetNode("") — no synthetic root.
-	RunGraphSuite(t, memoryStoreFactory)
-}
+// TestGraphBackends_Suite runs the contract suite against every Graph
+// implementation. Adding a backend is one table row plus a factory — which is
+// also why the entries live in a table rather than four near-identical
+// functions: the previous shape duplicated the same call line per backend, so
+// each new implementation added another copy.
+//
+// Each row states its answers explicitly. There is no permissive default to
+// fall into: a backend whose behaviour is not yet pinned should be added with
+// the answer it actually gives, and changed deliberately when the contract is.
+func TestGraphBackends_Suite(t *testing.T) {
+	backends := []struct {
+		name    string
+		factory GraphFactory
+		opts    SuiteOpts
+		why     string
+	}{
+		{
+			name:    "MemoryStore",
+			factory: memoryStoreFactory,
+			opts:    SuiteOpts{GetNodePopulatesChildren: true},
+			why:     "returns the live node pointer, so Children is present; ErrNotFound for GetNode(\"\")",
+		},
+		{
+			name:    "HotSwapGraph",
+			factory: hotSwapFactory,
+			opts:    SuiteOpts{GetNodePopulatesChildren: true},
+			why:     "wraps MemoryStore in this fixture and inherits both answers; swapping in an SQLiteGraph flips them, which is the point of HotSwap",
+		},
+		{
+			name:    "SQLiteGraph",
+			factory: sqliteGraphFactory,
+			opts:    SuiteOpts{RootEmptyReturnsDir: true},
+			why:     "rebuilds a node from one row, so Children is left to ListChildren",
+		},
+		{
+			name:    "WritableGraph",
+			factory: writableGraphFactory,
+			opts:    SuiteOpts{RootEmptyReturnsDir: true},
+			why:     "backed by NodesTableReader — same single-row rebuild, same answers",
+		},
+	}
 
-func TestHotSwapGraph_GraphSuite(t *testing.T) {
-	// HotSwapGraph wraps MemoryStore in this fixture, so it inherits
-	// MemoryStore's ErrNotFound behaviour for empty id. If a future
-	// caller swaps in an SQLiteGraph the contract flips — that's
-	// the point of HotSwap.
-	RunGraphSuite(t, hotSwapFactory)
-}
-
-func TestSQLiteGraph_GraphSuite(t *testing.T) {
-	RunGraphSuiteWithOpts(t, sqliteGraphFactory, SuiteOpts{RootEmptyReturnsDir: true})
-}
-
-func TestWritableGraph_GraphSuite(t *testing.T) {
-	RunGraphSuiteWithOpts(t, writableGraphFactory, SuiteOpts{RootEmptyReturnsDir: true})
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			t.Logf("%s: %s", b.name, b.why)
+			RunGraphSuiteWithOpts(t, b.factory, b.opts)
+		})
+	}
 }

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -35,6 +35,7 @@ type Engine struct {
 	RespectGitignore bool   // when true, skip files matching .gitignore patterns (default: true)
 	routedFiles      map[string]int
 	childSeen        map[string]map[string]bool // parentID → set of child IDs (O(1) dedup)
+	claimedIDs       map[string]int             // construct node ID → times claimed (collision dedup, mache-c725e9)
 	gitignore        *gitignoreMatcher          // loaded from .gitignore when RespectGitignore is true
 	astWalker        *ASTWalker                 // SQL-backed walker for ley-line pre-parsed .db files (sole walker post-CGO-removal)
 	fileIndex        map[string]FileIndexEntry  // cached file metadata for incremental re-ingestion
@@ -80,6 +81,7 @@ func NewEngine(schema *api.Topology, store IngestionTarget) *Engine {
 		RespectGitignore: true,
 		routedFiles:      make(map[string]int),
 		childSeen:        make(map[string]map[string]bool),
+		claimedIDs:       make(map[string]int),
 	}
 }
 
@@ -120,6 +122,7 @@ func (e *Engine) SetFileIndex(index map[string]FileIndexEntry) { // coverage:ign
 func (e *Engine) Ingest(path string) error {
 	// Reset dedup state so stale entries from a prior Ingest don't persist.
 	e.childSeen = make(map[string]map[string]bool)
+	e.claimedIDs = make(map[string]int)
 
 	absPath, err := filepath.Abs(path)
 	if err != nil { // coverage:ignore

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -29,6 +29,78 @@ func dedupSuffix(sourceFile string) string {
 	return ".from_" + sanitized
 }
 
+// idToPath is the inverse of toNodeID for rebuilding a filesystem path from a
+// claimed node ID.
+func idToPath(id string) string {
+	return filepath.FromSlash(id)
+}
+
+// claimConstructID reserves a node ID for a content-bearing construct and
+// returns the ID to actually use, disambiguating when the name is taken.
+//
+// Guarantee: this never returns an ID already handed out during this Ingest, so
+// a construct can never be overwritten by a later one. That is the invariant —
+// the specific suffix is not.
+//
+// Disambiguation prefers the existing ".from_<file>" shape, which is meaningful
+// when two files contribute the same name (multiple Go init()s in one package).
+// It falls back to a numeric suffix only when that is ALSO taken, which is the
+// same-file case the old code could not express at all: dedupSuffix is a
+// function of the source file alone, so N>2 constructs sharing a name within one
+// file all rendered the identical suffixed ID and collided again.
+//
+// PROVISIONAL. A numeric suffix is not a good identity — it is positional, so
+// inserting a construct above renumbers the ones below. It exists to stop data
+// loss now, not to settle addressing. The real fix is for the name to be unique
+// in the first place: receiver- and module-qualified construct names
+// (mache-c777ef), sourced from ley-line's node_defs rather than re-derived per
+// language, moving toward the (semantic address, node_hash) identity in
+// mache-e64f36. Collisions are logged at WARN precisely so that work stays
+// visible rather than being papered over here.
+//
+// Only content-bearing nodes are claimed. A schema node with a static name and
+// no files — a package or category directory matched once per record — is
+// SUPPOSED to collapse so its children merge under one parent; suffixing those
+// would shatter every directory in the projection.
+func (e *Engine) claimConstructID(id, parentPath, name, sourceFile string) string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.claimedIDs == nil {
+		e.claimedIDs = make(map[string]int)
+	}
+	if _, taken := e.claimedIDs[id]; !taken {
+		e.claimedIDs[id] = 1
+		return id
+	}
+
+	candidate := id
+	if sourceFile != "" {
+		suffixed := toNodeID(filepath.Join(parentPath, name+dedupSuffix(sourceFile)))
+		if _, taken := e.claimedIDs[suffixed]; !taken {
+			e.claimedIDs[suffixed] = 1
+			log.Printf("[WARN] duplicate construct name %q under %q — emitting %q; "+
+				"the schema's name template is not unique for this language (mache-c777ef)",
+				name, parentPath, suffixed)
+			return suffixed
+		}
+		candidate = suffixed
+	}
+
+	// Same name, same file: neither the bare name nor the file-suffixed form is
+	// free. Walk a counter until one is.
+	for n := 2; ; n++ {
+		numbered := fmt.Sprintf("%s.%d", candidate, n)
+		if _, taken := e.claimedIDs[numbered]; !taken {
+			e.claimedIDs[numbered] = 1
+			log.Printf("[WARN] duplicate construct name %q under %q in %s — emitting %q; "+
+				"same-file collision, so the name carries no distinguishing information "+
+				"(mache-c777ef)", name, parentPath, sourceFile, numbered)
+			return numbered
+		}
+	}
+}
+
 // processRecord is a pure function — parses one SQLite record through the schema
 // and returns all nodes to create, without touching the store.
 //
@@ -215,16 +287,27 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 		currentPath := filepath.Join(parentPath, name)
 		id := toNodeID(currentPath)
 
-		// Dedup: when this node has files and a node with the same ID
-		// already exists with file children (i.e., from a different source file),
-		// append a source-file suffix to disambiguate.
-		// This handles cases like multiple init() functions across Go files.
-		if len(schema.Files) > 0 && sourceFile != "" {
-			if existing, err := store.GetNode(id); err == nil && len(existing.Children) > 0 {
-				suffix := dedupSuffix(sourceFile)
-				name = name + suffix
-				currentPath = filepath.Join(parentPath, name)
-				id = toNodeID(currentPath)
+		// Dedup: two constructs whose schema name template renders the same
+		// string want the same node ID, and whoever writes last wins — the
+		// earlier ones vanish with no error and no diagnostic.
+		//
+		// This used to gate on `store.GetNode(id).Children`, which is
+		// unreachable on the build path: SQLiteWriter.GetNode never populates
+		// Children (it selects kind/mtime/record/context/props and nothing
+		// else), so the condition was always false and the branch was dead.
+		// MemoryStore returns the live node, so it DID fire there — one engine,
+		// two backends, two different graphs (mache-e3d9bb). Measured cost of
+		// the dead branch: 733 unaddressable Rust constructs (16.9%), and 9 of
+		// mache's own cmd/ init() functions absent from its own graph
+		// (mache-c725e9).
+		//
+		// Claimed IDs are tracked in the engine, not read back from the store,
+		// following the e.childSeen precedent below — collision detection must
+		// not depend on which backend is being written to.
+		if len(schema.Files) > 0 {
+			if claimed := e.claimConstructID(id, parentPath, name, sourceFile); claimed != id {
+				id = claimed
+				currentPath = idToPath(claimed)
 			}
 		}
 


### PR DESCRIPTION
Two constructs whose schema name template renders the same string wanted the same node ID, and whoever wrote last won. The earlier ones vanished — no error, no warning, no diagnostic.

## Scale, measured against ground truth

ley-line-open's Rust workspace, 245 files:

| | |
|---|---|
| `_ast` `function_item` nodes (ground truth) | 4,137 |
| reaching the projection **before** | 3,597 |
| **after** | **4,137** ✅ |

The 540 missing were exactly the bare-name collisions: projection count equalled the count of **distinct bare names** to *zero residual*, confirmed against ley-line's own `node_defs` index rather than inferred from a regex.

On mache's own source: **10 `func init()` in `cmd/`, 1 captured.** `cmd/mount.go`'s init() — the one registering `--schema`/`--data`/`--control` — was absent from mache's graph entirely, with no coarser node to recover it from. Rust at least kept the bytes inside the enclosing `impl` blob; Go had nowhere.

## Why the existing guard never fired

It gated on `store.GetNode(id).Children`, and `SQLiteWriter.GetNode` **never populates `Children`** — it selects `kind/mtime/record/context/props` and nothing else, and its `ListChildren` is `return nil, nil // Not used during ingest`. The condition was always false on the build path; the branch was dead code.

`MemoryStore` returns the live node pointer, so the same guard *did* fire there. One engine, one schema, one input, two backends, **two different graphs** — filed separately as mache-e3d9bb, and **not fixed here** (see below).

A second, independent defect: even when it fired, `dedupSuffix()` is a function of the source file alone, so N>2 constructs sharing a name within one file all rendered the identical suffixed ID and collided again.

## Fix

Claimed IDs are tracked in the engine, not read back from the store, following the existing `e.childSeen` precedent — **collision detection must not depend on which backend is being written to.**

Disambiguation prefers the meaningful `.from_<file>` shape and falls back to a counter only for same-file collisions, which the old code could not express at all. Every collision logs at WARN naming the construct and its parent; 832 fire on the Rust corpus.

`cmd/mount.go`'s init() now lands at `cmd/functions/init.from_mount_go`.

## Provisional by design

A numeric suffix is not an identity — it's positional, so inserting a construct above renumbers those below. This stops the data loss; it does **not** settle addressing. The real fix is for the name to be unique in the first place: receiver- and module-qualified names sourced from ley-line's `node_defs` instead of re-derived per language (mache-c777ef), moving toward the `(semantic address, node_hash)` model in mache-e64f36. The WARN exists so that work stays visible rather than being deferred silently.

## Scope note

**mache-e3d9bb is not fixed by this PR.** This routes *around* the store-contract divergence; it doesn't repair it. `MemoryStore` still returns `Children`, `SQLiteWriter` still doesn't, and the next code to read `Children` hits the same trap. That needs a conformance test across every `IngestionTarget` implementation.

## Verification

- full suite green
- smell gate passes against the **existing baseline** — 540 new nodes introduced no new gated smells, no regeneration needed
- ground-truth match verified by rebuilding the Rust corpus and comparing to `_ast`

Beads: mache-c725e9 (P0). Related: mache-e3d9bb, mache-c777ef, mache-e64f36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro