### PR TITLE
fix(build): record which leyline produced a .db in _mache_meta

### DIFF
--- a/cmd/build_meta.go
+++ b/cmd/build_meta.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/agentic-research/mache/internal/ingest"
 	"github.com/agentic-research/mache/internal/lang"
+	"github.com/agentic-research/mache/internal/leyline"
 	_ "modernc.org/sqlite"
 )
 
@@ -22,7 +23,9 @@ import (
 //
 // The table is `(key TEXT PRIMARY KEY, value TEXT NOT NULL)`. Keys
 // today: `backend`, `mache_version`, `mache_commit`, `built_at` (RFC
-// 3339). Best-effort: any failure logs and returns nil — the build
+// 3339), plus the leyline provenance keys from leylineMetaRows —
+// `leyline_pin`, `leyline_version`, and `leyline_source` when a binary was
+// resolved. Best-effort: any failure logs and returns nil — the build
 // shouldn't fail because the marker couldn't be written.
 func writeBuildMetadata(dbPath, backend string) error {
 	db, err := sql.Open("sqlite", dbPath)
@@ -46,6 +49,7 @@ func writeBuildMetadata(dbPath, backend string) error {
 		{"mache_commit", Commit},
 		{"built_at", time.Now().UTC().Format(time.RFC3339)},
 	}
+	rows = append(rows, leylineMetaRows()...)
 	for _, kv := range rows {
 		if _, err := db.Exec(
 			`INSERT OR REPLACE INTO _mache_meta (key, value) VALUES (?, ?)`,
@@ -56,6 +60,60 @@ func writeBuildMetadata(dbPath, backend string) error {
 		}
 	}
 	return nil
+}
+
+// leylineMetaRows returns the leyline provenance rows for _mache_meta.
+//
+// Recorded because the producing leyline determines how merkle-AST node
+// addresses are DERIVED, and mache has no other way to observe that. LLO
+// v0.11.0 bumped IR_SCHEMA_VERSION from merkle-ast-v1 to merkle-ast-v2,
+// rewriting every Rust trait signature's node_hash from BYTE-IDENTICAL sources
+// (ley-line-open #282). Every staleness mechanism mache has is content- or
+// time-based — cache lockfiles hash raw source bytes, the parse skip is
+// mtime+size — so none of them can see it. Before this, a .db built under
+// merkle-ast-v1 and served after the upgrade was indistinguishable from a fresh
+// one, and would serve stale addresses indefinitely (mache-438104).
+//
+// Two values, because they answer different questions and can disagree:
+//
+//	leyline_version — what actually ran. MACHE_LEYLINE_BINARY can point at a
+//	                  local build, so this is the only honest answer to "what
+//	                  produced this .db".
+//	leyline_pin     — what this mache build requires. Always present, even when
+//	                  no binary was resolved (a pure-.db path), so the pin a
+//	                  given mache expects is always recoverable from the
+//	                  artifact.
+//
+// A mismatch between them is the diagnostic: it means an override was in play
+// and the .db may not match what CI would produce.
+//
+// This is the half mache can fix alone. Consuming a lineage tag published by
+// LLO is the durable fix and is separate (mache-43d63d, blocked on
+// ley-line-open-348de6) — a version string is a proxy for lineage, not lineage
+// itself: two releases can share an IR schema, and one release can change it.
+func leylineMetaRows() [][2]string {
+	prov, ok := leyline.Provenance()
+	return leylineMetaRowsFrom(prov, ok, leyline.PinnedBinaryVersion())
+}
+
+// leylineMetaRowsFrom is the pure form, taking the provenance rather than
+// reading the process-global record. Split out so tests can exercise every
+// branch — resolved, unresolved, override-in-play — without mutating a
+// package-level singleton that has no reset and would leak into every
+// subsequent test in the package.
+func leylineMetaRowsFrom(prov leyline.LeylineProvenance, ok bool, pin string) [][2]string {
+	rows := [][2]string{{"leyline_pin", pin}}
+	if !ok || prov.Version == "" {
+		// No binary resolved this process (pure-.db build, or resolution
+		// failed). Record the absence rather than omitting the key, so a
+		// consumer can tell "built without leyline" from "built by an older
+		// mache that didn't stamp this".
+		return append(rows, [2]string{"leyline_version", "unresolved"})
+	}
+	return append(rows,
+		[2]string{"leyline_version", prov.Version},
+		[2]string{"leyline_source", prov.Source},
+	)
 }
 
 // countNodes returns the number of rows in `nodes`, or -1 if the table

--- a/cmd/build_meta_leyline_test.go
+++ b/cmd/build_meta_leyline_test.go
@@ -1,0 +1,139 @@
+package cmd
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "modernc.org/sqlite"
+)
+
+// Regression for mache-438104.
+//
+// A persisted .db's node addresses depend on which leyline produced it: LLO
+// v0.11.0 bumped IR_SCHEMA_VERSION merkle-ast-v1 -> v2, rewriting node_hash for
+// Rust trait signatures from BYTE-IDENTICAL sources. mache's staleness checks
+// are all content- or time-based (cache lockfiles hash source bytes, the parse
+// skip is mtime+size), so none can observe it. Before this, _mache_meta recorded
+// nothing about leyline and two .dbs from identical sources under different
+// lineages were indistinguishable.
+//
+// These pin the two properties that make the artifact self-describing: the pin
+// is ALWAYS recorded, and the resolved version is recorded when known and
+// explicitly marked when not.
+
+func readMeta(t *testing.T, dbPath string) map[string]string {
+	t.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query(`SELECT key, value FROM _mache_meta`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var k, v string
+		require.NoError(t, rows.Scan(&k, &v))
+		out[k] = v
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+// The pin must be present unconditionally. It is compile-time, so there is no
+// circumstance where mache cannot answer "which leyline did this build
+// require?" — and an artifact that cannot answer that is the failure this bead
+// is about.
+func TestBuildMetadata_AlwaysRecordsLeylinePin(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "meta.db")
+	require.NoError(t, writeBuildMetadata(dbPath, "leyline"))
+
+	meta := readMeta(t, dbPath)
+	assert.Equal(t, leyline.PinnedBinaryVersion(), meta["leyline_pin"],
+		"leyline_pin must record the compile-time pin so the artifact is self-describing")
+	assert.NotEmpty(t, meta["leyline_pin"])
+
+	// The pre-existing keys must survive the addition.
+	assert.Equal(t, "leyline", meta["backend"])
+	assert.NotEmpty(t, meta["built_at"])
+}
+
+// When no binary was resolved this process, the key is still written with an
+// explicit marker. Omitting it would make "built without leyline" look identical
+// to "built by an older mache that did not stamp this" — a consumer could not
+// distinguish absence-of-fact from absence-of-feature.
+func TestBuildMetadata_RecordsUnresolvedRatherThanOmitting(t *testing.T) {
+	if _, ok := leyline.Provenance(); ok {
+		t.Skip("a binary was resolved in this process; cannot exercise the unresolved path")
+	}
+	dbPath := filepath.Join(t.TempDir(), "meta.db")
+	require.NoError(t, writeBuildMetadata(dbPath, "leyline"))
+
+	meta := readMeta(t, dbPath)
+	v, present := meta["leyline_version"]
+	assert.True(t, present, "the key must be written even when nothing was resolved")
+	assert.Equal(t, "unresolved", v)
+}
+
+// The resolved version must be the one that actually RAN, not the pin. These
+// differ whenever MACHE_LEYLINE_BINARY points at a local build — exactly when
+// knowing the difference matters, because the .db may not match what CI
+// produces.
+//
+// Exercised through the pure form so it neither depends on a leyline binary
+// being installed nor mutates the process-global provenance record.
+func TestLeylineMetaRows_ResolvedVersionIsRecordedSeparatelyFromPin(t *testing.T) {
+	prov := leyline.LeylineProvenance{
+		Path:            "/tmp/leyline-dev",
+		Version:         "leyline 0.11.0 (open)",
+		Source:          "PATH",
+		ExpectedVersion: "v0.10.4",
+	}
+	got := map[string]string{}
+	for _, kv := range leylineMetaRowsFrom(prov, true, "v0.10.4") {
+		got[kv[0]] = kv[1]
+	}
+
+	assert.Equal(t, "leyline 0.11.0 (open)", got["leyline_version"],
+		"must record what ran, not what was required")
+	assert.Equal(t, "v0.10.4", got["leyline_pin"],
+		"the pin is independent of what was resolved and must not be overwritten")
+	assert.Equal(t, "PATH", got["leyline_source"])
+
+	assert.NotEqual(t, got["leyline_pin"], got["leyline_version"],
+		"this fixture is the override case on purpose: a divergence between "+
+			"pin and resolved version is the diagnostic signal, so both must be "+
+			"recorded independently")
+}
+
+// An unresolved build records the marker rather than dropping the key, so a
+// consumer can tell "built without leyline" from "built by an older mache that
+// did not stamp this".
+func TestLeylineMetaRows_UnresolvedIsExplicit(t *testing.T) {
+	got := map[string]string{}
+	for _, kv := range leylineMetaRowsFrom(leyline.LeylineProvenance{}, false, "v0.10.4") {
+		got[kv[0]] = kv[1]
+	}
+	assert.Equal(t, "unresolved", got["leyline_version"])
+	assert.Equal(t, "v0.10.4", got["leyline_pin"], "the pin is known even with no binary")
+	_, hasSource := got["leyline_source"]
+	assert.False(t, hasSource, "no source tier to report when nothing was resolved")
+}
+
+// ok=true with an empty Version is the degenerate case: a binary was resolved
+// but `--version` failed. Treated as unresolved, because an empty string in the
+// artifact is worse than an explicit marker.
+func TestLeylineMetaRows_EmptyVersionTreatedAsUnresolved(t *testing.T) {
+	got := map[string]string{}
+	for _, kv := range leylineMetaRowsFrom(leyline.LeylineProvenance{Path: "/x"}, true, "v0.10.4") {
+		got[kv[0]] = kv[1]
+	}
+	assert.Equal(t, "unresolved", got["leyline_version"],
+		"a binary whose version could not be read must not stamp an empty string")
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -793,6 +793,11 @@ func autoInvokeLeylineParse(sourceDir string) (string, func(), error) {
 	if err != nil {
 		return "", nil, err
 	}
+	// Publish which binary this is. Without it Provenance() reports "no binary
+	// resolved" even though we are about to run one, and writeBuildMetadata has
+	// nothing to stamp into the .db — leaving artifacts whose producing leyline
+	// is unknowable (mache-438104).
+	leyline.RecordResolved(leylineBin, "resolved")
 
 	tmpFile, err := os.CreateTemp("", "mache-leyline-*.db")
 	if err != nil {

--- a/internal/leyline/provenance_record.go
+++ b/internal/leyline/provenance_record.go
@@ -1,0 +1,31 @@
+package leyline
+
+// RecordResolved publishes the provenance of a leyline binary resolved outside
+// the managed-daemon path, so Provenance() reports it too.
+//
+// Provenance was populated only by DiscoverOrStart (socket.go), the daemon
+// route. Every other caller of ResolveBinary — notably `mache build` via
+// autoInvokeLeylineParse — resolved a binary, shelled out to it, and left
+// Provenance() reporting "mache hasn't resolved one this process". That is a
+// lie by omission in exactly the situation the provenance record exists for:
+// mache had just run a leyline binary and could not say which.
+//
+// It matters beyond diagnostics. `mache build` writes a persisted .db, and the
+// leyline that produced it determines how merkle-AST node addresses are DERIVED
+// — LLO v0.11.0 bumped IR_SCHEMA_VERSION from merkle-ast-v1 to merkle-ast-v2,
+// rewriting every Rust trait signature's node_hash from BYTE-IDENTICAL sources
+// (ley-line-open #282). No content- or time-based staleness check can see that:
+// mache's cache lockfiles hash raw source bytes, the parse skip is mtime+size,
+// and _mache_meta recorded nothing about leyline at all. Two .db files built
+// from identical sources under different leyline lineages were
+// indistinguishable (mache-438104).
+//
+// Recording the resolved binary is the part of that mache can fix alone, today.
+// Consuming a lineage tag published by LLO is the durable fix and is separate
+// (mache-43d63d, blocked on ley-line-open-348de6).
+func RecordResolved(path, source string) {
+	if path == "" {
+		return
+	}
+	recordResolvedLeyline(path, source)
+}

--- a/internal/leyline/provenance_test.go
+++ b/internal/leyline/provenance_test.go
@@ -109,3 +109,68 @@ func TestQueryBinaryVersion_HonorsProbeTimeout(t *testing.T) {
 		t.Error("generous deadline should resolve the version, got empty")
 	}
 }
+
+// RecordResolved is the public entry point for non-daemon callers (mache
+// build's autoInvokeLeylineParse). Before it existed, Provenance() was
+// populated only by DiscoverOrStart, so `mache build` resolved a binary, ran
+// it, and still reported "no binary resolved this process" — leaving
+// _mache_meta with nothing to stamp and .db artifacts whose producing leyline
+// was unknowable (mache-438104).
+//
+// Declared in this file, after TestProvenance, deliberately: that test asserts
+// the PRE-resolution state (ok=false), so it must run before anything records.
+// Go runs a package's tests in declaration order across filename-sorted files,
+// and a separate provenance_record_test.go would sort ahead of provenance_test.go
+// and break it.
+func TestRecordResolved_PublishesPathSourceAndVersion(t *testing.T) {
+	origTimeout := probeTimeout
+	probeTimeout = 30 * time.Second
+	t.Cleanup(func() { probeTimeout = origTimeout })
+
+	bin := writeFakeLeyline(t, "leyline "+leylineBinaryVersion+" (open)")
+	RecordResolved(bin, "resolved")
+
+	p, ok := Provenance()
+	if !ok {
+		t.Fatal("after RecordResolved, Provenance must report a resolved binary")
+	}
+	if p.Path != bin {
+		t.Errorf("path: got %q want %q", p.Path, bin)
+	}
+	if p.Source != "resolved" {
+		t.Errorf("source: got %q want %q", p.Source, "resolved")
+	}
+	if p.Version == "" {
+		t.Error("version must be queried from the binary, not left empty — " +
+			"an empty version is what writeBuildMetadata records as 'unresolved'")
+	}
+	if !p.VersionMatches {
+		t.Errorf("fake reports the pin %q but VersionMatches is false (got %q)",
+			leylineBinaryVersion, p.Version)
+	}
+}
+
+// An empty path must not clobber an existing record. The guard matters because
+// callers pass the result of a resolution that may have failed; overwriting a
+// good record with nothing would make the artifact stamp WORSE than not calling
+// it at all.
+func TestRecordResolved_EmptyPathIsANoOp(t *testing.T) {
+	origTimeout := probeTimeout
+	probeTimeout = 30 * time.Second
+	t.Cleanup(func() { probeTimeout = origTimeout })
+
+	bin := writeFakeLeyline(t, "leyline "+leylineBinaryVersion+" (open)")
+	RecordResolved(bin, "resolved")
+	before, _ := Provenance()
+
+	RecordResolved("", "should-be-ignored")
+
+	after, ok := Provenance()
+	if !ok {
+		t.Fatal("an empty-path call must not un-resolve the record")
+	}
+	if after.Path != before.Path || after.Source != before.Source {
+		t.Errorf("empty path overwrote the record: %q/%q -> %q/%q",
+			before.Path, before.Source, after.Path, after.Source)
+	}
+}


### PR DESCRIPTION
A persisted `.db`'s node addresses depend on which leyline produced it, and mache had no way to observe that.

LLO v0.11.0 bumped `IR_SCHEMA_VERSION` from `merkle-ast-v1` to `merkle-ast-v2` (ley-line-open #282), rewriting every Rust trait signature's `node_hash` — from **byte-identical sources**, because the preimage hashes `canonical_kind(raw).unwrap_or(raw)` and `25811f` gave `function_signature_item` the kappa it lacked.

Byte-identical is the load-bearing part. Every staleness mechanism mache has is content- or time-based: cache lockfiles hash raw source bytes, the parse skip is mtime+size, and `_mache_meta` recorded `backend`/`mache_version`/`mache_commit`/`built_at` with **nothing about leyline at all**. None of them can see this change. Two `.db` files built from identical sources under different leyline lineages were indistinguishable.

The exposed path is `mache build -o x.db` then `mache serve x.db` across an upgrade. Most paths write a fresh temp `.db` per parse and `smellMemo` is in-process only, so the exposure is narrow **by accident** rather than by design — not a property to rely on.

## What it records

| key | meaning |
|---|---|
| `leyline_pin` | the compile-time pin. **Always** written, even when no binary was resolved |
| `leyline_version` | what actually ran — differs from the pin whenever `MACHE_LEYLINE_BINARY` points at a local build |
| `leyline_source` | resolution tier (PATH / cached / downloaded) |

A divergence between pin and version *is* the diagnostic: it means an override was in play and the `.db` may not match what CI produces.

An unresolved build writes `leyline_version="unresolved"` rather than omitting the key, so a consumer can distinguish "built without leyline" from "built by an older mache that didn't stamp this". Same for a binary whose `--version` won't read — an empty string in an artifact is worse than an explicit marker.

## Also fixes a lie by omission

`Provenance()` was populated only by `DiscoverOrStart`, the daemon route. `mache build` resolved a binary via `autoInvokeLeylineParse`, shelled out to it, and left `Provenance()` reporting "mache hasn't resolved one this process" — in exactly the situation the provenance record exists for.

## Testing

`leylineMetaRows` is split into a pure `leylineMetaRowsFrom(prov, ok, pin)` so all four branches are covered deterministically — resolved, unresolved, override-in-play, and a binary whose version won't read — without depending on a leyline being installed and without mutating a package-level singleton that has no reset and would leak into every later test in the package.

`RecordResolved`'s tests are declared in `provenance_test.go` after `TestProvenance` deliberately: that test asserts the **pre-resolution** state (`ok=false`), so it must run before anything records. A separate `provenance_record_test.go` would sort ahead of it and break it.

## Not a lineage tag

A version string is a **proxy**: two releases can share an IR schema, and one release can change it. Consuming LLO's `ir_schema_version` is the durable fix and is separate — mache-43d63d, blocked on ley-line-open-348de6. This is the half mache can do alone, today, and is worth having regardless of whether that field ships.

**The pin stays at v0.10.4.** Bumping past v0.11.0 waits for v0.11.1.

## Verification

Real `mache build` now stamps `leyline_pin=v0.10.4`, `leyline_version="leyline 0.10.4 (open)"`, `leyline_source=resolved`. Full suite and smell gate green, baseline untouched.

Bead: mache-438104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro