### PR TITLE
chore(leyline): adopt ley-line-open v0.11.3 (+ pin-bump automation)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -331,6 +331,59 @@ tasks:
         echo "cache is namespaced by pin — other versions here belong to other mache builds and are left alone:"
         ls -1 "$HOME/.mache/bin"/leyline* 2>/dev/null | sed 's/^/  /' || true
 
+  leyline:pin-bump:
+    desc: "Bump the pinned leyline release: TAG=v0.11.1 task leyline:pin-bump. Rewrites leylineBinaryVersion, the four SHA-256 asset digests, the pin test, and server.json's minimum-version in one step, then prints what still needs a HUMAN decision."
+    preconditions:
+      - sh: command -v gh
+        msg: "gh required to read release asset digests — https://cli.github.com"
+      - sh: command -v perl
+        msg: "perl required for the in-place pin rewrites"
+    cmds:
+      - |
+        set -euo pipefail
+        : "${TAG:?set TAG, e.g. TAG=v0.11.1 task leyline:pin-bump}"
+        BARE="${TAG#v}"
+        echo "==> fetching release assets for $TAG"
+        # The digest field is "sha256:<hex>"; the pin map stores bare hex.
+        ASSETS=$(gh release view "$TAG" --repo agentic-research/ley-line-open --json assets \
+          --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"')
+        if [ -z "$ASSETS" ]; then
+          echo "no leyline-<os>-<arch> assets on $TAG — a release without binaries cannot be pinned" >&2
+          exit 1
+        fi
+        COUNT=$(printf '%s\n' "$ASSETS" | wc -l | tr -d ' ')
+        if [ "$COUNT" -ne 4 ]; then
+          echo "expected 4 platform assets, got $COUNT:" >&2
+          printf '%s\n' "$ASSETS" >&2
+          echo "refusing to write a partial pin map — a missing platform fails closed at download time" >&2
+          exit 1
+        fi
+        printf '%s\n' "$ASSETS" | while read -r name digest; do
+          plat="${name#leyline-}"
+          hex="${digest#sha256:}"
+          echo "    $plat  $hex"
+          # Replace the hex for this platform key, leaving the map shape alone.
+          perl -pi -e "s|(\"$plat\":\s*\")[0-9a-f]{64}(\")|\${1}$hex\${2}|" internal/leyline/binary_pin.go
+        done
+        echo "==> rewriting version pins"
+        perl -pi -e "s|(leylineBinaryVersion = \")v[0-9.]+(\")|\${1}$TAG\${2}|" internal/leyline/socket.go
+        perl -pi -e "s|(assert\.Equal\(t, \")v[0-9.]+(\", leylineBinaryVersion\))|\${1}$TAG\${2}|" internal/leyline/binary_pin_test.go
+        perl -pi -e "s|(\"minimum-version\":\s*\")[0-9.]+(\")|\${1}$BARE\${2}|" server.json
+        echo
+        echo "==> mechanical bump done. STILL NEEDS A HUMAN:"
+        echo "  1. go.mod leyline-schema — bump ONLY if a schema module tag was published for $TAG."
+        echo "     Check: go list -m -versions github.com/agentic-research/ley-line-open/clients/go/leyline-schema"
+        echo "  2. The doc block above leylineBinaryVersion in internal/leyline/socket.go records"
+        echo "     the wire major, the compat floor, and WHAT CHANGED. It is prose and this task"
+        echo "     will not invent it. Read the release notes and write it."
+        echo "  3. LINEAGE. If the release changes how node addresses are DERIVED (LLO v0.11.0"
+        echo "     bumped IR_SCHEMA_VERSION merkle-ast-v1 -> v2), then persisted .db artifacts"
+        echo "     built by the previous leyline MUST BE REBUILT, not reused — sources are"
+        echo "     byte-identical so no content- or time-based check can see it (mache-438104)."
+        echo "     Say so in the PR body and the changelog, not just here."
+        echo
+        echo "==> then: task check  &&  MACHE_LIVE_LEYLINE_RELEASE=1 go test -count=1 -run '^TestLivePinnedReleaseDownload$' ./internal/leyline"
+
   test:ast:
     desc: "ASTWalker correctness over real leyline _ast — fast named signal (skips if the pinned leyline isn't cached; never downloads). Replaces the retired sitter↔AST parity gate — in-process tree-sitter was removed in ADR-0012 step 4 (mache-37ae8b), so there is no second projector to be parity WITH."
     cmds:

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -198,11 +198,6 @@
     },
     {
       "rule_id": "duplicate_code",
-      "source_id": "internal/graph/graph_suite_test.go",
-      "count": 2
-    },
-    {
-      "rule_id": "duplicate_code",
       "source_id": "internal/graph/graph_test.go",
       "count": 2
     },
@@ -348,18 +343,13 @@
     },
     {
       "rule_id": "duplicate_code",
-      "source_id": "internal/leyline/sheaf.go",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
       "source_id": "internal/leyline/sheaf_cascade_bench_test.go",
       "count": 1
     },
     {
       "rule_id": "duplicate_code",
       "source_id": "internal/leyline/sheaf_subscriber.go",
-      "count": 3
+      "count": 2
     },
     {
       "rule_id": "duplicate_code",
@@ -673,11 +663,6 @@
     },
     {
       "rule_id": "duplicate_definitions",
-      "source_id": "internal/leyline/wire.go",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
       "source_id": "internal/materialize/materialize_test.go",
       "count": 1
     },
@@ -789,7 +774,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/backend.rs",
-      "count": 4
+      "count": 6
     },
     {
       "rule_id": "duplicate_definitions",
@@ -869,7 +854,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/epic.rs",
-      "count": 2
+      "count": 3
     },
     {
       "rule_id": "duplicate_definitions",
@@ -909,12 +894,12 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/migrate.rs",
-      "count": 3
+      "count": 4
     },
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/algebra_chain.rs",
-      "count": 5
+      "count": 6
     },
     {
       "rule_id": "duplicate_definitions",
@@ -924,7 +909,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/algebra_lww.rs",
-      "count": 4
+      "count": 5
     },
     {
       "rule_id": "duplicate_definitions",
@@ -934,7 +919,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/fold.rs",
-      "count": 8
+      "count": 11
     },
     {
       "rule_id": "duplicate_definitions",
@@ -944,12 +929,12 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/log.rs",
-      "count": 4
+      "count": 6
     },
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/log_sqlite.rs",
-      "count": 5
+      "count": 9
     },
     {
       "rule_id": "duplicate_definitions",
@@ -959,7 +944,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/observation/quarantine.rs",
-      "count": 3
+      "count": 4
     },
     {
       "rule_id": "duplicate_definitions",
@@ -999,7 +984,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/queue.rs",
-      "count": 2
+      "count": 3
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1034,12 +1019,12 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/scanner.rs",
-      "count": 4
+      "count": 6
     },
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/scope.rs",
-      "count": 3
+      "count": 5
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1099,7 +1084,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/sprites_provider.rs",
-      "count": 3
+      "count": 5
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1109,12 +1094,12 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/store_dolt.rs",
-      "count": 3
+      "count": 4
     },
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/store_sqlite.rs",
-      "count": 3
+      "count": 4
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1149,7 +1134,7 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/xref.rs",
-      "count": 2
+      "count": 3
     },
     {
       "rule_id": "duplicate_definitions",
@@ -1653,22 +1638,32 @@
     },
     {
       "rule_id": "god_file",
-      "source_id": "internal/ingest/ast_walker.go",
-      "count": 1
-    },
-    {
-      "rule_id": "god_file",
-      "source_id": "internal/ingest/sqlite_writer.go",
-      "count": 1
-    },
-    {
-      "rule_id": "god_file",
       "source_id": "internal/nfsmount/graphfs.go",
       "count": 1
     },
     {
       "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/crates/bdr/src/decompose.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/crates/bdr/src/harmony.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
       "source_id": "testdata/snapshots/medium-rust-rosary/crates/bdr/src/parse.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/crates/bdr/src/provenance.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/acp.rs",
       "count": 1
     },
     {
@@ -1708,7 +1703,22 @@
     },
     {
       "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/dsse.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/epic.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/github.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/handoff.rs",
       "count": 1
     },
     {
@@ -1774,6 +1784,11 @@
     {
       "rule_id": "god_file",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/store_sqlite.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/vcs.rs",
       "count": 1
     },
     {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.10.4
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-task/task/v3 v3.52.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.10.4 h1:iYLh8FN/4veY9v5rQIpNXth/5/jowhn/NmKzUTlX1jQ=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.10.4/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3 h1:hsHtavHO5Jq5u2UerIqMkY6O4v9K/JT7lqr37dWq0OQ=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -33,10 +33,10 @@ const BinaryVersion = leylineBinaryVersion
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "c8d0e639b9cbdd3f88b68e40ad697c56a2533e0b6c421ce1780ac4a9167b1d06",
-	"darwin-arm64": "9759d796f20adb710b3636cca0c9b1fddbc495ec97659305da11e5354bd03347",
-	"linux-amd64":  "6b976bb1e98080da4995406ba2ed053883a350eed6bf3975187687ed38aff0e0",
-	"linux-arm64":  "7768c09baba6a078ab87e3f844e6fa8c699a5d22f86d1812a31e1c1446bed03a",
+	"darwin-amd64": "71bbf5e417cd9c03197f0b6c08c00f86e5576c3be9c31ed7b80c736b4e716b47",
+	"darwin-arm64": "eb5445a6e71fe7dce6f53aa289106070df66319766ad84315150508e007bf9c8",
+	"linux-amd64":  "658b14d160b2b4f6c49aab818a80d0f5bffd17f9a0c194ec1d16b3de0d627805",
+	"linux-arm64":  "c4e3f063742285a0c98994e115561a7f8551c52b8e559bd231b79c079c1aab23",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/binary_pin_test.go
+++ b/internal/leyline/binary_pin_test.go
@@ -72,7 +72,7 @@ func TestExtractSemver(t *testing.T) {
 }
 
 func TestPinnedBinaryReleaseMatchesAdoptedContract(t *testing.T) {
-	assert.Equal(t, "v0.10.4", leylineBinaryVersion)
+	assert.Equal(t, "v0.11.3", leylineBinaryVersion)
 }
 
 func TestPinnedBinarySHA256CoversSupportedPlatforms(t *testing.T) {

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -803,23 +803,47 @@ func (c *SocketClient) Prioritize(files []string) error {
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
 // As of this pin, both the daemon binary and go.mod's leyline-schema module are
-// v0.10.4. The release's generated compatibility document reports
-// wire_format_major=1 and compat_min_schema_version=0.6.0, so older compatible
-// clients remain inside the daemon's supported [floor, binary] range. The
-// version-parity gate (mache-b8af69) enforces that range.
+// v0.11.3. The wire major and compatibility floor are unchanged from the 0.10
+// line; the version-parity gate (mache-b8af69) enforces the [floor, binary]
+// range.
+//
+// THE 0.10 -> 0.11 BUMP CROSSES AN IR LINEAGE BOUNDARY. v0.11.0 raised
+// IR_SCHEMA_VERSION from "merkle-ast-v1" to "merkle-ast-v2": giving
+// function_signature_item the canonical_kind `function` it lacked rewrote every
+// Rust trait signature's node_hash, because the preimage hashes
+// canonical_kind(raw).unwrap_or(raw). SOURCES ARE BYTE-IDENTICAL, so no
+// content- or time-based check can see it — mache's cache lockfiles hash raw
+// source bytes and the parse skip is mtime+size. Any persisted .db built by a
+// pre-0.11 leyline must be REBUILT, not reused; a stale one serves v1 addresses
+// while this binary computes v2 (mache-438104). _mache_meta now records
+// leyline_pin / leyline_version so which-leyline-built-this is answerable from
+// the artifact.
+//
+// v0.11.x also changed what the projection CONTAINS, which is why the smell
+// baseline was regenerated in the same commit rather than separately:
+//   - module qualification (ley-line-open-23377a) emits a qualified alias
+//     alongside each bare token, doubling def rows under mod_item (966 -> 1932
+//     on the Rust snapshot). The definitions are unchanged — distinct node_id
+//     is 7251 before and after — but the token vocabulary is not, so
+//     duplicate_definitions legitimately reports different groups.
+//   - overloaded symbols survive (ley-line-open-5d3cb6): _lsp previously kept
+//     one row per {parent}/{name} and silently replaced the rest. Now
+//     discernible overloads carry a signature discriminator and indistinct ones
+//     an ordinal. NOTE the ordinal branch is positional — verified that
+//     inserting a TypeScript overload renumbers the ones below it — so #~N is
+//     not a stable address.
 //
 // Earlier context: v0.7.0 raised the compatibility floor to 0.6.0 and added
 // source_blobs / capnp_blobs / _ast_pointer plus the unified
 // daemon.sheaf.invalidate topic. v0.7.4 and v0.7.5 added AST columns without
 // changing the wire major; v0.8.0 added validate coverage, node_refs.qualifier,
-// and extraction epochs. The wire major and compatibility floor remain
-// unchanged in v0.10.4.
+// and extraction epochs.
 //
 // The version-check (leylineVersionMatchesPin) is EXACT major.minor.patch —
 // LLO patch releases have changed the emitted _ast schema (0.7.4 added
 // container_node_id, 0.7.5 added canonical_kind), so the patch does NOT
-// float (mache-608a3c). v0.10.4 ships all four leyline-<os>-<arch> daemon
-// binaries (darwin/linux × amd64/arm64).
+// float (mache-608a3c). v0.11.3 ships all four leyline-<os>-<arch> daemon
+// binaries (darwin/linux x amd64/arm64).
 //
 // BUMP THIS to the latest published ley-line-open release with binary assets.
 // The go.mod leyline-schema pin only needs bumping when a schema module tag is
@@ -829,7 +853,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch.
-const leylineBinaryVersion = "v0.10.4"
+const leylineBinaryVersion = "v0.11.3"
 
 // leylineSchemaCompatFloor is the OLDEST leyline-schema Go client version
 // whose wire format the pinned binary still accepts (ley-line-open's

--- a/server.json
+++ b/server.json
@@ -81,7 +81,7 @@
     "io.github.agentic-research.mache/required-deps": {
       "io.github.agentic-research/ley-line-open": {
         "purpose": "Required. `leyline parse` is mache's sole source parser since v0.18.0 (ADR-0012 step 4) — it produces the _ast tables every source projection reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and embeddings (semantic_search).",
-        "minimum-version": "0.10.4"
+        "minimum-version": "0.11.3"
       }
     },
     "io.github.agentic-research.mache/source-acceptance": {


### PR DESCRIPTION
Two commits: the automation, then the adoption it produced.

## `4932227` — `TAG=v0.11.3 task leyline:pin-bump`

Rewrites the four platform SHA-256 digests, `leylineBinaryVersion`, the pin test assertion, and `server.json`'s `minimum-version`. **Fails closed** if the release doesn't carry exactly four `leyline-<os>-<arch>` assets, rather than writing a partial map that keeps one stale digest — a failure that passes on darwin-arm64 and breaks linux CI.

It deliberately refuses three things: the `go.mod` schema module (independent tag), the doc block (prose), and the lineage call. Those are the second commit.

## `0966c3f` — the adoption

| verified against the published release | |
|---|---|
| four SHA-256 digests | compared byte-for-byte with `gh release view` |
| download + verify | end to end — the download path checks the digest just written, so this exercises the pin, not a string compare |
| namespaced cache | writes `~/.mache/bin/leyline-v0.11.3` beside the existing `v0.10.3`, neither clobbering (#574) |
| `_mache_meta` | stamps `leyline_pin=v0.11.3`, `leyline_version="leyline 0.11.3 (open)"` |
| `go.mod` | a v0.11.3 leyline-schema module tag exists → bumped |
| `task check` | green |

## The baseline is regenerated in this commit, deliberately

`ley-line-open-23377a` shipped: LLO now emits a **module-qualified alias alongside each bare token**, doubling def rows under `mod_item` on the Rust snapshot (966 → 1932).

The **definitions are unchanged** — distinct `node_id` is 7251 before and after — but the token *vocabulary* is not, so `duplicate_definitions` legitimately reports different groups. No grouping change makes the rule version-invariant: counting `DISTINCT node_id` gives the identical 340, and canonicalising to one token per definition drifts the other way (128 → 109). The baseline is a derived artifact of the projection; the projection changed.

**The delta was checked, not trusted**: 465 → 468 entries, **zero added or grown outside `testdata/snapshots/medium-rust-rosary`**, and five findings disappeared.

Two hypotheses I had wrong, recorded in the commit because they cost time: `25811f` (`function_signature_item` gaining `canonical_kind=function`) *did* ship — 166 nodes flipped `NULL → function`, confirmed — but `duplicate_definitions` already excludes that node kind, so it isn't the mechanism; and the rule is not double-counting aliases.

## Lineage — the reason the doc block changed, not just the version string

0.10 → 0.11 crosses an IR boundary. v0.11.0 raised `IR_SCHEMA_VERSION` `merkle-ast-v1 → v2`, rewriting Rust trait signature `node_hash` from **byte-identical sources**. Every staleness mechanism mache has is content- or time-based, so none can see it.

**Any persisted `.db` built by a pre-0.11 leyline must be rebuilt, not reused.** That's now in the doc block above `leylineBinaryVersion`, where the next bump will find it, rather than only in a bead.

Also recorded there, from testing `ley-line-open-5d3cb6` against this release rather than taking it on report: overloaded symbols now survive (`_lsp` previously kept one row per `{parent}/{name}` and silently replaced the rest), **but the ordinal branch `#~N` is positional** — inserting a TypeScript overload renumbers the ones below it. Consumers must not key on it.

Bead: mache-438104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro