### PR TITLE
chore(release): v0.20.0 — P0 construct loss, v0.11.3 lineage bump, boundary ratchet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,90 @@ bumps may include breaking changes.
 
 ## [Unreleased]
 
+## [v0.20.0] — 2026-07-28
+
+### ⚠️ Action required before upgrading
+
+- **Rebuild any persisted `.db` built before ley-line-open v0.11.0.** Do not
+  reuse it. mache now pins leyline v0.11.3, and v0.11.0 raised
+  `IR_SCHEMA_VERSION` from `merkle-ast-v1` to `merkle-ast-v2` — giving
+  `function_signature_item` the `canonical_kind` it lacked rewrote every Rust
+  trait signature's `node_hash`, because the preimage hashes
+  `canonical_kind(raw).unwrap_or(raw)`.
+
+  **Sources are byte-identical across that change**, so nothing mache has can
+  detect it: cache lockfiles hash raw source bytes and the parse skip is
+  mtime+size. A `.db` built by a pre-0.11 leyline and served afterwards carries
+  v1 addresses while the binary computes v2, silently. Most paths write a fresh
+  temp `.db` per parse, so the exposed case is specifically
+  `mache build -o x.db` followed later by `mache serve x.db`
+  (`mache-438104`).
+
+  `.db` files now record which leyline produced them — `_mache_meta` carries
+  `leyline_pin`, `leyline_version`, and `leyline_source` — so this is
+  answerable from the artifact rather than by inference.
+
+### Fixed
+
+- **Constructs were silently dropped on name collision** (`mache-c725e9`, P0).
+  Two constructs whose schema name rendered the same string took the same node
+  ID, and the last write won; the earlier ones vanished with no error and no
+  diagnostic. On ley-line-open's Rust workspace **3,597 of 4,137 functions
+  reached the projection — 540 lost**. On mache's own source, 1 of 10
+  `func init()` in `cmd/` survived, and `cmd/mount.go`'s init — the one
+  registering `--schema`/`--data`/`--control` — was absent from mache's own
+  graph entirely.
+
+  The dedup guard existed but was unreachable: it gated on
+  `store.GetNode(id).Children`, and `SQLiteWriter.GetNode` never populates
+  `Children`. It was live on `MemoryStore` and dead on the build path. Claimed
+  IDs are now tracked in the engine rather than read back from a store, so
+  collision detection no longer depends on which backend is written to.
+  Post-fix the projection returns **4,137 — exactly the `_ast` ground truth**.
+
+- **`nodes.record` was declared `JSON`, which gives it NUMERIC affinity**
+  (`mache-4b8a42`). SQLite picks affinity by substring-matching the declared
+  type; `JSON` matches none, so it fell through to NUMERIC and rewrote any
+  text that parses as a number (`'007'` → `7`, `'1.10'` → `1.1`). Ingest was
+  immune by accident — it binds `[]byte`, and BLOBs bypass the conversion —
+  but write-back through the mount binds a string and did not.
+
+- **Rust test code was judged as production API** (`mache-c7d56d`). Go states
+  test-ness in the file name; Rust states it in an attribute and colocates it
+  in the production file, so no path predicate can see it. On ley-line-open/rs,
+  46% of files carry `#[cfg(test)]`. `fan_out_skew` dropped 176 → 86 findings
+  (51% were test helpers, which legitimately call many things to build
+  fixtures) and `duplicate_definitions` 654 → 414.
+
+- **Rust dead-code findings from Cargo layout** (`mache-8ecfd7`). `tests/`,
+  `benches/`, and `examples/` are separate crates whose entry points the
+  harness invokes; every function in them read as dead. 2,524 → 1,986.
+
+- **`mache serve`'s auto-leyline log described a path that no longer exists**
+  (`mache-6dda39`). It claimed the fallback used `SitterWalker`, removed in
+  v0.18.0, and pointed at `MACHE_NO_LEYLINE=1` as "the in-process watcher path"
+  without saying that path now needs `leyline` to pre-parse — while the same
+  flag disables downloading it. The message states the precondition and names
+  the pinned version.
+
 ### Changed
+
+- **`nodes.record` is now TEXT in every writer, and holds TEXT.** Both the
+  declared type and the bound value changed. Ingest previously bound `[]byte`
+  (stored BLOB) while write-back bound a string (stored TEXT), and SQLite never
+  considers a BLOB equal to a TEXT value — so `WHERE record = ?` matched only
+  nodes that had been written back and silently missed every ingested one
+  (`mache-6bed54`). **`typeof(record)` flips `blob` → `text` for existing
+  ingested rows**; content bytes are unchanged, and anything diffing `.db`
+  files bytewise or asserting on `typeof` will see it.
+
+- **The leyline binary cache is namespaced by pinned version**
+  (`mache-0acdf6`). It was one unversioned path, so every mache build on a
+  machine treated that file as its own and they overwrote each other — observed
+  going v0.10.4 → v0.10.2 → v0.10.4 within a single session while different
+  builds ran. Since LLO ships `_ast` schema changes in patch releases, the
+  graph shape silently depended on which mache last touched the cache.
+  `~/.mache/bin/leyline-v0.11.3` and `-v0.10.3` now coexist.
 
 - **Node properties moved to a dedicated `props` column** (`mache-90b89b`).
   `Node.Properties` was `map[string][]byte`, and `encoding/json` renders
@@ -18,23 +101,52 @@ bumps may include breaking changes.
   `imports` out of reach of every SQL consumer and smell rule. They are now
   real nested JSON in their own column: `json_extract(props,'$.lang')` returns
   `go`, and nested fields like `$.imports.fmt` resolve.
+
 - **`record` means two things instead of three.** It held a source data record
   *or* inline rendered content *or* serialized properties; the third is gone.
   The `CASE WHEN kind = NodeKindDir` guard in `NodesTableReader` is deleted —
   it existed only to stop a `GetNode` shipping a file's whole body, and `props`
   never holds content, so the separation is structural now.
+
 - **`Node.Properties` is `map[string]json.RawMessage`.** Access it through
   `PropString`/`PropRaw` and their setters, re-exported from the public `graph`
   package for external consumers.
 
-### Fixed
+- **Node properties moved to a dedicated `props` column** (`mache-90b89b`).
+  `Node.Properties` was `map[string][]byte`, and `encoding/json` renders
+  `[]byte` as base64 — so a projection stored
+  `{"imports":"eyJmbXQiOiJmbXQifQ==","lang":"Z28="}` where it meant
+  `{"imports":{"fmt":"fmt"},"lang":"go"}`, double-encoding `imports` (already
+  JSON) and inflating the record 2.3x. The costly part was not the size but
+  that `json_extract(record,'$.lang')` returned `Z28=`, putting `lang`/`pkg`/
+  `imports` out of reach of every SQL consumer and smell rule. They are now
+  real nested JSON in their own column: `json_extract(props,'$.lang')` returns
+  `go`, and nested fields like `$.imports.fmt` resolve.
 
-- **`mache serve`'s auto-leyline log described a path that no longer exists**
-  (`mache-6dda39`). It claimed the fallback used `SitterWalker`, removed in
-  v0.18.0, and pointed at `MACHE_NO_LEYLINE=1` as "the in-process watcher path"
-  without saying that path now needs `leyline` to pre-parse — while the same
-  flag disables downloading it. The message states the precondition and names
-  the pinned version.
+- **`record` means two things instead of three.** It held a source data record
+  *or* inline rendered content *or* serialized properties; the third is gone.
+  The `CASE WHEN kind = NodeKindDir` guard in `NodesTableReader` is deleted —
+  it existed only to stop a `GetNode` shipping a file's whole body, and `props`
+  never holds content, so the separation is structural now.
+
+- **`Node.Properties` is `map[string]json.RawMessage`.** Access it through
+  `PropString`/`PropRaw` and their setters, re-exported from the public `graph`
+  package for external consumers.
+
+### Added
+
+- **The LLO data-plane boundary is enforced** (`mache-e64f36`). mache is the
+  control plane — smell rules, queries, code intelligence, the MCP surface —
+  and ley-line-open is the data plane. A ratchet test fails when a file outside
+  a written allowlist writes an LLO-owned table, so "mache does not do
+  data-plane work" is checkable rather than folklore. Three files are
+  allowlisted with reasons; the set may only shrink.
+
+- **`TAG=vX.Y.Z task leyline:pin-bump`** rewrites the four platform SHA-256
+  digests, the pinned version, the pin test, and `server.json`'s
+  `minimum-version` in one step, and fails closed if a release does not carry
+  all four platform assets. It deliberately refuses to write the doc block or
+  decide the lineage question.
 
 ### Removed
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.19.0
-last-verified: 2026-07-24
+covers-version: v0.20.0
+last-verified: 2026-07-28
 sources-of-truth:
   - internal/lang/lang.go
   - internal/leyline/socket.go
@@ -176,7 +176,7 @@ source dir → leyline parse (pure-Go daemon, Rust tree-sitter) → .db with
 mache (Engine + ASTWalker, or SQLiteGraph — both pure Go) → MemoryStore/SQLiteGraph → MCP / NFS
 ```
 
-ley-line-open's `leyline parse` produces a `.db` containing the full AST (plus optional LSP enrichment). Every mache entry point — `build`, `serve`, `mount`, `infer`, and the test-fixture registry — invokes `leyline parse` on a source directory and then projects the `_ast` via the pure-Go `ASTWalker` (`SetASTWalker`); `SQLiteGraph` reads a pre-baked `.db` directly via `json_extract()` and lazy content resolution. No CGO, no in-memory tree-sitter AST. leyline is provisioned automatically (`ResolveBinary` — PATH → `~/.mache/bin/leyline` → SHA-verified download of the exact pin); when it is genuinely unavailable, source projection is a hard error rather than a silent degradation.
+ley-line-open's `leyline parse` produces a `.db` containing the full AST (plus optional LSP enrichment). Every mache entry point — `build`, `serve`, `mount`, `infer`, and the test-fixture registry — invokes `leyline parse` on a source directory and then projects the `_ast` via the pure-Go `ASTWalker` (`SetASTWalker`); `SQLiteGraph` reads a pre-baked `.db` directly via `json_extract()` and lazy content resolution. No CGO, no in-memory tree-sitter AST. leyline is provisioned automatically (`ResolveBinary` — PATH → `~/.mache/bin/leyline-<pinned-version>` → SHA-verified download of the exact pin); when it is genuinely unavailable, source projection is a hard error rather than a silent degradation. The cache is namespaced BY PIN: it was one unversioned path, so every mache build on a machine treated that file as its own and they overwrote each other — and because LLO ships `_ast` schema changes in patch releases, the graph shape silently depended on which mache last touched it. Concurrent pins now coexist. Each `.db` also records the leyline that produced it in `_mache_meta` (`leyline_pin`, `leyline_version`, `leyline_source`), so "which producer built this artifact" is answerable from the artifact rather than inferred.
 
 The only registry language leyline can't parse is **cue** (no tree-sitter-0.26 cue grammar exists anywhere — so no path could parse it), which the schema coverage guard reports loudly. This is the [ADR-0006: Pure Go, MCP-First](adr/0006-pure-go-mcp-first.md) end state; ley-line-open is required for source projection. mache consumes leyline purely as a subprocess/daemon over its UDS socket — there is no CGO/FFI linkage into mache (the dev-only `leyline_fs` FFI binding, `internal/leyline/client.go`, was removed; libleyline_fs lives in and is published by ley-line-open).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.19.0
-last-verified: 2026-07-21
+covers-version: v0.20.0
+last-verified: 2026-07-28
 sources-of-truth:
   - CHANGELOG.md
 audience: [contributors, maintainers, users]

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,7 @@
 ---
 status: current
-covers-version: v0.19.0
-last-verified: 2026-07-21
+covers-version: v0.20.0
+last-verified: 2026-07-28
 sources-of-truth:
   - CHANGELOG.md
   - .beads/


### PR DESCRIPTION
Changelog + docs for v0.20.0. **No code changes** — everything here already merged across nine PRs.

## ⚠️ The headline is a migration requirement, not a feature

> **Rebuild any persisted `.db` built before ley-line-open v0.11.0. Do not reuse it.**

mache now pins leyline v0.11.3, and v0.11.0 raised `IR_SCHEMA_VERSION` `merkle-ast-v1 → v2` — giving `function_signature_item` the `canonical_kind` it lacked rewrote every Rust trait signature's `node_hash`.

**Sources are byte-identical across that change**, so nothing mache has can detect it: cache lockfiles hash raw source bytes, the parse skip is mtime+size. A `.db` built pre-0.11 and served afterwards carries v1 addresses while the binary computes v2, silently. The exposed path is specifically `mache build -o x.db` then later `mache serve x.db`.

`.db` files now record their producer (`leyline_pin`, `leyline_version`, `leyline_source` in `_mache_meta`), so this is answerable from the artifact rather than inferred.

## What shipped

**Fixed**
- **P0 — constructs silently dropped on name collision.** 3,597 of 4,137 functions reached the projection on ley-line-open/rs; **540 lost**. On mache's own source, 1 of 10 `func init()` in `cmd/` survived, and `cmd/mount.go`'s — the one registering `--schema`/`--data`/`--control` — was absent from mache's own graph. The dedup guard existed but was unreachable: it gated on `GetNode(id).Children`, which `SQLiteWriter` never populates. Post-fix: **4,137, exactly the `_ast` ground truth**.
- `nodes.record` declared `JSON` gave it NUMERIC affinity (`'007'` → `7`). Ingest was immune by accident (binds `[]byte`); write-back was not.
- Rust test code judged as production API — `fan_out_skew` 176 → 86, `duplicate_definitions` 654 → 414.
- Rust dead-code from Cargo layout — 2,524 → 1,986.

**Changed**
- `nodes.record` is TEXT everywhere and holds TEXT. **`typeof(record)` flips `blob` → `text`** for existing ingested rows — content bytes unchanged, but anything diffing `.db` files bytewise or asserting on `typeof` will see it.
- The leyline binary cache is namespaced by pin. It was one unversioned path that concurrent mache builds overwrote — observed going v0.10.4 → v0.10.2 → v0.10.4 within a single session.
- Node properties moved to a `props` column (previously unreleased; folded in here since it ships in this tag).

**Added**
- The LLO data-plane boundary is enforced as a ratchet.
- `TAG=vX.Y.Z task leyline:pin-bump`.

## The docs commit exists because a gate demanded it

`task docs:lint` failed the release branch: `covers-version` must track the newest changelog heading. Bumping it required re-reading the docs, and one claim was genuinely stale — `ARCHITECTURE.md` still described provisioning as `PATH → ~/.mache/bin/leyline → download`, which stopped being true when the cache was namespaced.

Fixed, **with the reasoning recorded**, because the old shape reads perfectly sensible and someone would restore it.

## Verification

`task check` green on this branch. The release pipeline itself was audited separately and works — v0.19.0 published 3 binaries, checksums, and `ghcr.io/agentic-research/mache:v0.19.0`, with all five jobs green. That audit was entirely manual, which is filed as mache-4d7f2c.

## After merge

`git tag v0.20.0 && git push origin v0.20.0` fires `release.yml`. Left deliberately to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro