### PR TITLE
refactor(ingest): children have one accessor, correct on every backend

### DIFF
--- a/internal/ingest/engine_ingest.go
+++ b/internal/ingest/engine_ingest.go
@@ -121,8 +121,16 @@ func (e *Engine) ingestRawFileUnder(path, prefix string, modTime time.Time) erro
 				parent, err := e.Store.GetNode(parentID)
 				if err == nil {
 					if e.childSeen[parentID] == nil {
-						e.childSeen[parentID] = make(map[string]bool, len(parent.Children))
-						for _, c := range parent.Children {
+						// ListChildren, not parent.Children — the field is nil on
+						// every SQLite-backed store, so seeding from it started
+						// this set empty on the build path (mache-e3d9bb).
+						existing, lerr := listChildrenTolerant(e.Store, parentID)
+						if lerr != nil {
+							e.mu.Unlock()
+							return fmt.Errorf("list children of %s: %w", parentID, lerr)
+						}
+						e.childSeen[parentID] = make(map[string]bool, len(existing))
+						for _, c := range existing {
 							e.childSeen[parentID][c] = true
 						}
 					}

--- a/internal/ingest/engine_refs.go
+++ b/internal/ingest/engine_refs.go
@@ -1,6 +1,10 @@
 package ingest
 
-import "github.com/agentic-research/mache/internal/graph"
+import (
+	"strings"
+
+	"github.com/agentic-research/mache/internal/graph"
+)
 
 // --- Parallel ingestion types ---
 
@@ -33,14 +37,66 @@ type refLink struct {
 type bufferingTarget struct {
 	IngestionTarget
 	bufferedNodes []*graph.Node
+	// bufferedChildren maps a parent ID to the buffered file children not yet
+	// written to the table, so ListChildren can answer completely. Without it
+	// a construct dir reports zero children until ReplaceFileNodes runs, which
+	// is the whole window ingest operates in.
+	bufferedChildren map[string][]string
+}
+
+// ListChildren unions the underlying store's answer with the file nodes this
+// target is still holding.
+//
+// Necessary because AddNode defers file nodes for a later ReplaceFileNodes
+// swap while passing directory nodes straight through. Asking the underlying
+// SQLiteWriter alone would report a construct directory as childless for the
+// entire duration of ingest — technically true of the table, and useless as an
+// answer. Children have one accessor; it has to be right (mache-e3d9bb).
+func (b *bufferingTarget) ListChildren(id string) ([]string, error) {
+	base, err := b.IngestionTarget.ListChildren(id)
+	if err != nil {
+		return nil, err
+	}
+	pending := b.bufferedChildren[id]
+	if len(pending) == 0 {
+		return base, nil
+	}
+	seen := make(map[string]bool, len(base))
+	for _, c := range base {
+		seen[c] = true
+	}
+	out := append([]string(nil), base...)
+	for _, c := range pending {
+		if !seen[c] {
+			seen[c] = true
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+// noteBuffered records a buffered node's parent so ListChildren can find it.
+func (b *bufferingTarget) noteBuffered(parentID, childID string) {
+	if parentID == "" {
+		return
+	}
+	if b.bufferedChildren == nil {
+		b.bufferedChildren = make(map[string][]string)
+	}
+	b.bufferedChildren[parentID] = append(b.bufferedChildren[parentID], childID)
 }
 
 func (b *bufferingTarget) AddNode(n *graph.Node) {
 	if n.Mode.IsDir() {
 		b.IngestionTarget.AddNode(n)
-	} else { // coverage:ignore
-		b.bufferedNodes = append(b.bufferedNodes, n) // coverage:ignore
-	} // coverage:ignore
+		return
+	}
+	b.bufferedNodes = append(b.bufferedNodes, n)
+	// Derive the parent from the ID — a buffered file's parent is its path
+	// prefix — so ListChildren sees it before the swap.
+	if i := strings.LastIndex(n.ID, "/"); i > 0 {
+		b.noteBuffered(n.ID[:i], n.ID)
+	}
 }
 
 func (b *bufferingTarget) AddDef(token, dirID string) error {
@@ -64,6 +120,7 @@ func (b *bufferingTarget) AddFileChildren(parent *graph.Node, files []*graph.Nod
 	b.bufferedNodes = append(b.bufferedNodes, files...)
 	for _, f := range files {
 		parent.Children = append(parent.Children, f.ID)
+		b.noteBuffered(parent.ID, f.ID)
 	}
 	b.IngestionTarget.AddNode(parent)
 }

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -2,6 +2,7 @@ package ingest
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -245,6 +246,27 @@ func collectNodes(result *recordResult, schema api.Node, walker Walker, ctx any,
 	}
 }
 
+// listChildrenTolerant returns a node's children, treating "node not found" as
+// "no children" rather than an error.
+//
+// The call sites replaced GetNode()+read-the-field, which ignored a lookup
+// failure entirely (`if existing, err := store.GetNode(id); err == nil`). A
+// node that has not been created yet legitimately has no children, and the
+// backends disagree about whether asking is an error: MemoryStore returns
+// ErrNotFound, SQLiteWriter returns an empty set. Normalising the accessor
+// means normalising that too, otherwise the fix trades a silent wrong answer
+// for a spurious hard failure (mache-e3d9bb).
+func listChildrenTolerant(store IngestionTarget, id string) ([]string, error) {
+	kids, err := store.ListChildren(id)
+	if err != nil {
+		if errors.Is(err, graph.ErrNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return kids, nil
+}
+
 // processNode is the schema-driven recursion that walks a single Match through
 // the topology, mutating the store as it goes. Counterpart to collectNodes,
 // which is the pure (store-free) variant for parallel SQLite ingest.
@@ -313,9 +335,15 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 
 		// Create/Update Node — preserve existing children when merging
 		// multiple files into the same node (e.g. multiple .go files in one package).
-		var existingChildren []string
-		if existing, err := store.GetNode(id); err == nil {
-			existingChildren = existing.Children
+		//
+		// Via ListChildren, NOT GetNode().Children. Children have one accessor
+		// because the stores disagree on the other: MemoryStore returns the live
+		// node so Children is populated, every SQLite-backed store rebuilds from
+		// one row and leaves it nil. Reading the field made this merge inert on
+		// the build path while working in memory (mache-e3d9bb).
+		existingChildren, err := listChildrenTolerant(store, id)
+		if err != nil {
+			return fmt.Errorf("list children of %s: %w", id, err)
 		}
 
 		node := &graph.Node{
@@ -409,8 +437,16 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 			parent, err := store.GetNode(parentId)
 			if err == nil {
 				if e.childSeen[parentId] == nil {
-					e.childSeen[parentId] = make(map[string]bool, len(parent.Children))
-					for _, c := range parent.Children {
+					// Seed from ListChildren rather than parent.Children: the
+					// field is nil on every SQLite-backed store, so seeding from
+					// it silently started this set empty on the build path.
+					existing, lerr := listChildrenTolerant(store, parentId)
+					if lerr != nil {
+						e.mu.Unlock()
+						return fmt.Errorf("list children of %s: %w", parentId, lerr)
+					}
+					e.childSeen[parentId] = make(map[string]bool, len(existing))
+					for _, c := range existing {
 						e.childSeen[parentId][c] = true
 					}
 				}
@@ -458,11 +494,19 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 			}
 		}
 
-		// Re-fetch current node (updated by recursion) — preserve Children + Properties
-		var currentChildren []string
+		// Re-fetch current node (updated by recursion) — preserve Children +
+		// Properties. Children come from ListChildren, Properties from GetNode:
+		// they have different contracts. Properties round-trips through the
+		// props column on every store; Children does NOT round-trip through
+		// GetNode on any SQLite-backed one, so reading it here silently
+		// discarded the children the recursion had just added on the build path
+		// (mache-e3d9bb).
+		currentChildren, err := listChildrenTolerant(store, id)
+		if err != nil {
+			return fmt.Errorf("list children of %s: %w", id, err)
+		}
 		var currentProps map[string]json.RawMessage
-		if current, err := store.GetNode(id); err == nil {
-			currentChildren = current.Children
+		if current, gerr := store.GetNode(id); gerr == nil {
 			currentProps = current.Properties
 		}
 

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -654,8 +654,47 @@ func (w *SQLiteWriter) GetNode(id string) (*graph.Node, error) {
 	return n, nil
 }
 
+// ListChildren answers from the parent_id column, the same way
+// NodesTableReader does at read time.
+//
+// This returned `nil, nil // Not used during ingest` for a long time, and that
+// stub read like a CONSTRAINT — you cannot ask for children while still
+// writing them. It is not one. Rows INSERTed in an open transaction are
+// readable inside that same transaction (probed: 3 inserted, 2 children
+// visible before commit), and this writer already holds the tx and already
+// writes parent_id on every node.
+//
+// The stub had a cost. Because neither accessor answered, engine code that
+// needed a node's children read GetNode().Children instead — which MemoryStore
+// populates and every SQLite-backed store leaves nil. A dedup guard branched on
+// exactly that, was live on one backend and dead on the other, and silently
+// dropped 540 constructs (mache-c725e9). Making this method honest is what lets
+// children have ONE accessor that is correct everywhere (mache-e3d9bb).
+//
+// Note the tx caveat: file nodes are buffered by bufferingTarget for a later
+// ReplaceFileNodes swap, so they are not in the table yet. bufferingTarget
+// overrides this method to union its buffer in; callers that go through it get
+// the complete answer.
 func (w *SQLiteWriter) ListChildren(id string) ([]string, error) {
-	return nil, nil // Not used during ingest
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.tx == nil {
+		return nil, nil
+	}
+	rows, err := w.tx.Query(`SELECT id FROM nodes WHERE parent_id = ? ORDER BY name`, id)
+	if err != nil {
+		return nil, fmt.Errorf("list children of %s: %w", id, err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []string
+	for rows.Next() {
+		var childID string
+		if err := rows.Scan(&childID); err != nil {
+			return nil, err
+		}
+		out = append(out, childID)
+	}
+	return out, rows.Err()
 }
 
 func (w *SQLiteWriter) ListChildStats(id string) ([]graph.NodeStat, error) {


### PR DESCRIPTION
The two `IngestionTarget` implementations disagreed about a node's children. `MemoryStore` returns the live node so `GetNode().Children` is populated; every SQLite-backed store rebuilds from one row and leaves it nil. Code reading the field got a **backend-dependent answer with no warning** — which is how a dedup guard came to be live on one path and dead on the other, silently dropping 540 constructs (mache-c725e9).

The previous framing had two options, both large: police the divergence with a conformance harness, or wait for arena delegation to delete the second store. **There is a small one — normalize the operation.**

## `ListChildren` is now the single accessor

**`SQLiteWriter.ListChildren`** was `return nil, nil // Not used during ingest`.

That stub *read* like a constraint — you can't ask for children while still writing them — and it isn't one. Rows `INSERT`ed in an open transaction are readable inside that transaction (probed: 3 inserted, **2 children visible before commit**), and this writer already holds the tx and writes `parent_id` on every node. It now runs the same `parent_id` query `NodesTableReader` already uses.

**`bufferingTarget.ListChildren`** unions the file nodes it's still holding for the later `ReplaceFileNodes` swap. Without that, a construct directory reports zero children for the entire ingest window — true of the table, useless as an answer.

Four call sites moved off `GetNode().Children`. **No production code reads that field off a `GetNode` result now.** It remains `MemoryStore`'s internal mechanism but is no longer an accessor.

## Found while doing it — a live bug, not the one I was fixing

`engine_walk.go:479`, *"re-fetch current node — preserve Children + Properties"*.

Those have **different contracts**: `Properties` round-trips through the `props` column on every store; `Children` does not round-trip through `GetNode` on any SQLite-backed one. That line was **discarding children the recursion had just added**, on the build path only.

Same class as the P0, still live, and it surfaced by *replacing the call sites* rather than by auditing for it.

## The error contract diverged too

`MemoryStore.ListChildren` returns `ErrNotFound` for a node that doesn't exist; `SQLiteWriter` returns an empty set. The replaced code ignored lookup failure entirely (`if existing, err := store.GetNode(id); err == nil`), so a direct translation turned a tolerated miss into a hard error and **broke five tests**.

`listChildrenTolerant` treats not-found as no-children — what the old code did implicitly.

Worth stating plainly: **a conformance pin over the field value would never have surfaced this.** The backends disagreed about whether *asking* is an error, not just about the answer. Only replacing the callers found it.

## Verification

- Projections **identical**: 15 nodes on the Go fixture with `gofix/functions` still holding all three `init()`; the Rust collision fixture still resolves three distinct `new` constructs.
- `task check` green.

The `GetNodePopulatesChildren` pin (#575) stays — it catches a backend *changing* its answer. This removes the reason to ask.

## Relationship to delegation

This makes arena delegation (mache-e64f36) **simpler, not redundant**: one accessor to move instead of two disagreeing ones.

Bead: mache-e3d9bb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro