### PR TITLE
chore(leyline): adopt ley-line-open v0.12.1

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -345,8 +345,13 @@ tasks:
         BARE="${TAG#v}"
         echo "==> fetching release assets for $TAG"
         # The digest field is "sha256:<hex>"; the pin map stores bare hex.
+        # Match the DAEMON binaries exactly — leyline-<os>-<arch> — not every
+        # asset whose name starts with "leyline-". v0.12.1 began shipping
+        # leyline-mcp-descriptor-<os>-<arch> alongside them, which a prefix
+        # match swept in and turned the 4-asset guard into a spurious failure.
+        # The guard was right to refuse; the filter was wrong.
         ASSETS=$(gh release view "$TAG" --repo agentic-research/ley-line-open --json assets \
-          --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"')
+          --jq '.assets[]|select(.name|test("^leyline-(darwin|linux)-(amd64|arm64)$"))|"\(.name) \(.digest)"')
         if [ -z "$ASSETS" ]; then
           echo "no leyline-<os>-<arch> assets on $TAG — a release without binaries cannot be pinned" >&2
           exit 1

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.12.1
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-task/task/v3 v3.52.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3 h1:hsHtavHO5Jq5u2UerIqMkY6O4v9K/JT7lqr37dWq0OQ=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.11.3/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.12.1 h1:ydW7nQNEQ3ZRRZcvrdO8Jdkes9iLm3YErkzcr2Exli4=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.12.1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -33,10 +33,10 @@ const BinaryVersion = leylineBinaryVersion
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
 //	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "71bbf5e417cd9c03197f0b6c08c00f86e5576c3be9c31ed7b80c736b4e716b47",
-	"darwin-arm64": "eb5445a6e71fe7dce6f53aa289106070df66319766ad84315150508e007bf9c8",
-	"linux-amd64":  "658b14d160b2b4f6c49aab818a80d0f5bffd17f9a0c194ec1d16b3de0d627805",
-	"linux-arm64":  "c4e3f063742285a0c98994e115561a7f8551c52b8e559bd231b79c079c1aab23",
+	"darwin-amd64": "9871ae9dd17b7c685ba12d3ad4d103e719d10834a189c73c94872ad8262289d8",
+	"darwin-arm64": "2018d879056e95058bbb5862eaf696252929a8f88fdf728a1a092db65c1beba8",
+	"linux-amd64":  "d9c900bf81b3ba60a083ce55e0fea4a65f477cda730dcd27a08ce5127a37d414",
+	"linux-arm64":  "2d994da88d938a3ae3c23aa87d427fcbd4f350d6ca8b7d306545abfcc9907dda",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/binary_pin_test.go
+++ b/internal/leyline/binary_pin_test.go
@@ -72,7 +72,7 @@ func TestExtractSemver(t *testing.T) {
 }
 
 func TestPinnedBinaryReleaseMatchesAdoptedContract(t *testing.T) {
-	assert.Equal(t, "v0.11.3", leylineBinaryVersion)
+	assert.Equal(t, "v0.12.1", leylineBinaryVersion)
 }
 
 func TestPinnedBinarySHA256CoversSupportedPlatforms(t *testing.T) {

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -803,9 +803,26 @@ func (c *SocketClient) Prioritize(files []string) error {
 // schema-client pin may sit on a newer pseudo-version that has no release).
 //
 // As of this pin, both the daemon binary and go.mod's leyline-schema module are
-// v0.11.3. The wire major and compatibility floor are unchanged from the 0.10
+// v0.12.1. The wire major and compatibility floor are unchanged from the 0.10
 // line; the version-parity gate (mache-b8af69) enforces the [floor, binary]
 // range.
+//
+// v0.11.3 -> v0.12.1 DOES NOT CROSS AN IR LINEAGE BOUNDARY — checked by
+// measurement, not inferred from release notes: _meta.ir_schema_version reads
+// "merkle-ast-v2" on both, extraction_epoch is unchanged (4 -> 4), and a
+// re-parse of the same fixture produces an identical _ast row count
+// (250369 -> 250369). No .db rebuild is required crossing this bump.
+// ley-line-open-348de6 shipped the ir_schema_version field in v0.11.1 — this is
+// the first mache bump able to answer the lineage question this way instead of
+// reading changelog prose; see mache-43d63d for consuming it as a first-class
+// signal rather than reading it ad hoc as done here.
+//
+// v0.12.x adds leyline-mcp-descriptor, a shared server.json emitter
+// (ley-line-open-4ec276) that mache's own server.json work fed into
+// (mache-e28a9f): multiple packages / per-package transport landed
+// (ley-line-open-44cc45), but there is still no session field on
+// TransportMeta, so cloister cannot yet derive mache's per-transport session
+// requirement (http is stateful, stdio is not) from the generated descriptor.
 //
 // THE 0.10 -> 0.11 BUMP CROSSES AN IR LINEAGE BOUNDARY. v0.11.0 raised
 // IR_SCHEMA_VERSION from "merkle-ast-v1" to "merkle-ast-v2": giving
@@ -853,7 +870,7 @@ func (c *SocketClient) Prioritize(files []string) error {
 // wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
 // queries the daemon's leyline_version op and refuses on a structural
 // mismatch.
-const leylineBinaryVersion = "v0.11.3"
+const leylineBinaryVersion = "v0.12.1"
 
 // leylineSchemaCompatFloor is the OLDEST leyline-schema Go client version
 // whose wire format the pinned binary still accepts (ley-line-open's

--- a/server.json
+++ b/server.json
@@ -81,7 +81,7 @@
     "io.github.agentic-research.mache/required-deps": {
       "io.github.agentic-research/ley-line-open": {
         "purpose": "Required. `leyline parse` is mache's sole source parser since v0.18.0 (ADR-0012 step 4) — it produces the _ast tables every source projection reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and embeddings (semantic_search).",
-        "minimum-version": "0.11.3"
+        "minimum-version": "0.12.1"
       }
     },
     "io.github.agentic-research.mache/source-acceptance": {


### PR DESCRIPTION
## Bug found and fixed in the pin-bump task itself

`TAG=v0.12.1 task leyline:pin-bump` refused to run: v0.12.1 ships 8 assets matching a `leyline-` prefix, not 4. v0.12.x added `leyline-mcp-descriptor-*` binaries alongside the daemon ones, and the asset filter was a loose prefix match that swept both in, tripping the "exactly 4 platform assets" fail-closed guard.

The guard did exactly what it was built for. The filter was wrong. Tightened to match `leyline-(darwin|linux)-(amd64|arm64)` exactly rather than any name starting with `leyline-`.

## Verified against the published release

| | |
|---|---|
| four SHA-256 digests | compared byte-for-byte with `gh release view` |
| download + verify | exercised end to end |
| namespaced cache | `~/.mache/bin/leyline-v0.12.1` beside `-v0.11.3` and `-v0.10.3`, none clobbering |
| `_mache_meta` | `leyline_pin=v0.12.1`, `leyline_version="leyline 0.12.1 (open)"` |
| `go.mod` | a v0.12.1 leyline-schema module tag exists → bumped |
| `task check` | green |

## Lineage — checked by measurement for the first time, not inferred

`ley-line-open-348de6` shipped `_meta.ir_schema_version` in v0.11.1. This is the first mache bump able to ask the lineage question directly instead of reading changelog prose:

```
_meta.ir_schema_version   v0.11.3=merkle-ast-v2   v0.12.1=merkle-ast-v2
_meta.extraction_epoch    v0.11.3=4               v0.12.1=4
_ast row count on a re-parse of the same fixture: 250369 → 250369
```

**v0.11.3 → v0.12.1 does not cross an IR lineage boundary.** No `.db` rebuild required for this bump, unlike v0.10.4 → v0.11.0.

Consuming this field as a first-class signal — rather than reading it ad hoc as done here — is `mache-43d63d`. **Now unblocked**: the field has existed since v0.11.1 and this pin already carries it.

## Also new in this line

v0.12.x ships `leyline-mcp-descriptor`, a shared `server.json` emitter (`ley-line-open-4ec276`) that mache's own `server.json` work fed into (`mache-e28a9f`). `ley-line-open-44cc45` landed multiple packages / per-package transport — half of what mache asked for.

The other half isn't there: `TransportMeta` still has only `typ`/`url`, no session field, so cloister still can't derive mache's per-transport session requirement (http is stateful, stdio isn't) from the generated descriptor. Recorded in the doc block for whoever revisits `e28a9f`.

No smell baseline change — the projection is identical (250369 → 250369 `_ast` rows on the same fixture).

Bead: mache-438104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro