### PR TITLE
[mache-19326d] feat(cli): mache leyline path / exec — reach the pinned leyline without depending on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ bumps may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- **`mache leyline path` and `mache leyline exec` — invoke the pinned leyline
+  without depending on PATH.** mache resolves leyline through one pin-checked
+  chokepoint and caches it version-namespaced under `~/.mache/bin`, which is not
+  on PATH. A human or agent typing bare `leyline` got none of that. Measured on
+  a machine that had run `task install`: `~/.local/bin/leyline` reported 0.10.3
+  while the pin was v0.13.0, so `leyline cdc enable --db x.db` ran a 0.10.3
+  parser against a `.db` mache built with 0.13.0 — invisible, since both
+  binaries are named `leyline` and neither announces the mismatch. `mache leyline path` prints the resolved absolute path and nothing else
+  (`$(mache leyline path) cdc enable --db x.db`); `mache leyline exec -- <args>`
+  proxies straight through, forwarding args, stdio and exit status. Neither
+  mutates PATH, shell rc, or the unversioned `~/.mache/bin/leyline` path, which
+  stays never-written (`mache-0acdf6`). (`mache-19326d`)
+
 ## [v0.20.0] — 2026-07-30
 
 ### ⚠️ Action required before upgrading

--- a/README.md
+++ b/README.md
@@ -115,6 +115,33 @@ See [Architecture](docs/ARCHITECTURE.md) for the full picture.
 
 </details>
 
+## Running the pinned leyline (mache-19326d)
+
+<details>
+<summary><code>mache leyline path</code> / <code>mache leyline exec</code> — reach the exact pinned binary without touching PATH</summary>
+
+mache pins an exact ley-line-open release and caches it version-namespaced under `~/.mache/bin`, which is **not** on PATH. So a bare `leyline` in your shell runs whatever copy PATH happens to hold — often an older one — against `.db` files mache parsed with the pin. Both are named `leyline`; neither warns. Since leyline v0.13.0 shipped `leyline cdc enable` / `leyline cdc gc`, invoking leyline directly is a real workflow, so this is a real skew.
+
+Two subcommands make the version question unaskable instead of answered-by-PATH-convention:
+
+```bash
+# Absolute path of the pinned binary, and nothing else on stdout.
+mache leyline path
+
+# Compose it — version-correct by construction.
+$(mache leyline path) cdc enable --db ./mache.db
+
+# Or proxy straight through: args, stdin/stdout/stderr and exit status forwarded.
+mache leyline exec -- cdc enable --db ./mache.db
+mache leyline exec cdc gc --db ./mache.db
+```
+
+Both resolve through mache's pin-checked chokepoint, so a non-pinned `leyline` earlier on PATH is reported on stderr and ignored rather than silently used. Neither mutates PATH, your shell rc, or the unversioned `~/.mache/bin/leyline` path (which stays never-written — see [`internal/leyline/binary_cache_path.go`](internal/leyline/binary_cache_path.go)).
+
+`MACHE_NO_LEYLINE=1` still disables provisioning; `MACHE_LEYLINE_BINARY` still overrides the pin for LLO development.
+
+</details>
+
 ## Portable cache (mache-aeb262)
 
 <details>

--- a/cmd/leyline_proxy.go
+++ b/cmd/leyline_proxy.go
@@ -1,0 +1,181 @@
+// `mache leyline path` / `mache leyline exec` — invoking the PINNED leyline.
+//
+// mache resolves leyline through one pin-checked chokepoint
+// (leyline.ResolveBinary: MACHE_LEYLINE_BINARY → PATH → version-namespaced
+// ~/.mache/bin cache → SHA-verified download, each tier accepted only on the
+// EXACT pinned version). A human or agent typing bare `leyline` gets none of
+// that — they get whatever PATH happens to hold.
+//
+// Measured on a machine that had run `task install` (bead mache-19326d):
+//
+//	~/.local/bin/leyline           0.10.3   ON PATH      <- what `leyline` meant
+//	~/.mache/bin/leyline-v0.13.0   0.13.0   not on PATH  <- what mache actually used
+//
+// `~/.mache/bin` is not on PATH, so `leyline cdc enable --db x.db` typed at a
+// shell ran a 0.10.3 parser against a db mache built with 0.13.0. Both binaries
+// are named `leyline` and neither announces the mismatch. Since v0.13.0 shipped
+// `leyline cdc enable` / `leyline cdc gc`, invoking leyline directly is a real
+// workflow, so this is a real skew — the same defect class as mache-0acdf6
+// (silently changing _ast shape between runs), relocated from the cache to PATH.
+//
+// These two subcommands make the version question UNASKABLE rather than
+// answered-by-PATH-convention:
+//
+//	$(mache leyline path) cdc enable --db x.db     # shell interpolation
+//	mache leyline exec -- cdc enable --db x.db     # direct invocation
+//
+// Deliberately NOT done here (both re-open shipped bugs):
+//
+//   - No write to ~/.mache/bin/leyline (the unversioned path). mache-0acdf6
+//     made that path read-only-never-written because it was a shared mutable
+//     resource concurrent mache builds overwrote; see binary_cache_path.go.
+//     Nothing in this file writes to the cache at all — ResolveBinary owns
+//     provisioning, and it only ever writes the pin-namespaced path.
+//   - No PATH or shell-rc mutation. A shim dir on PATH just reintroduces
+//     "which version does bare `leyline` mean" the moment the pin moves.
+//
+// Resolution failures are returned verbatim from ResolveBinary so there is one
+// error vocabulary for "no pinned leyline", not two.
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/spf13/cobra"
+)
+
+// leylineExecExit terminates mache with leyline's exit status. Indirected
+// through a var so the exec path can be exercised in-process by tests without
+// killing the test binary; production always points at os.Exit.
+var leylineExecExit = os.Exit
+
+var leylineCmd = &cobra.Command{
+	Use:   "leyline",
+	Short: "Locate or run the exact ley-line-open build mache pins",
+	Long: `Reach the pinned leyline binary without depending on PATH.
+
+mache pins an exact ley-line-open release (` + leyline.BinaryVersion + `) and
+caches it version-namespaced under ~/.mache/bin, which is NOT on PATH. A bare
+` + "`leyline`" + ` in your shell therefore runs whatever copy PATH holds — often an
+older one — against .db files mache parsed with the pin. Both are named
+` + "`leyline`" + `; neither warns.
+
+  mache leyline path                          # absolute path, nothing else
+  $(mache leyline path) cdc enable --db x.db  # version-correct by construction
+  mache leyline exec -- cdc enable --db x.db  # same, without the subshell
+
+Both resolve through mache's pin-checked chokepoint, so a non-pinned leyline
+earlier on PATH is reported and ignored rather than silently used. Neither
+mutates PATH, your shell rc, or the unversioned ~/.mache/bin/leyline path.`,
+}
+
+var leylinePathCmd = &cobra.Command{
+	Use:   "path",
+	Short: "Print the absolute path of the pinned leyline binary (and nothing else)",
+	Long: `Print the absolute path of the pinned leyline binary, with no other
+stdout output, so it composes: $(mache leyline path) cdc enable --db x.db
+
+Diagnostics (e.g. "leyline on PATH is not the pinned <ver> — ignoring it") go to
+stderr, keeping stdout safe for command substitution. Provisions the pinned
+binary if it is absent, unless MACHE_NO_LEYLINE is set.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		p, err := pinnedLeylinePath()
+		if err != nil {
+			return err
+		}
+		_, err = fmt.Fprintln(cmd.OutOrStdout(), p)
+		return err
+	},
+}
+
+var leylineExecCmd = &cobra.Command{
+	Use:   "exec [--] [args...]",
+	Short: "Run the pinned leyline binary, forwarding args, stdio and exit status",
+	Long: `Run the pinned leyline binary as a transparent proxy: every argument is
+forwarded verbatim, stdin/stdout/stderr are inherited, and mache exits with
+leyline's exit status.
+
+Flag parsing is disabled for this subcommand so leyline's own flags reach
+leyline instead of being claimed by mache — including --help. A leading "--" is
+accepted (and stripped) for callers who prefer to be explicit:
+
+  mache leyline exec -- cdc enable --db x.db
+  mache leyline exec cdc gc --db x.db`,
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		code, err := runLeylineExec(args, cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
+		if err != nil {
+			return err
+		}
+		if code != 0 {
+			// Faithful proxying means mache's exit status IS leyline's;
+			// returning an error here would flatten every failure to 1.
+			leylineExecExit(code)
+		}
+		return nil
+	},
+}
+
+func init() {
+	leylineCmd.AddCommand(leylinePathCmd)
+	leylineCmd.AddCommand(leylineExecCmd)
+	rootCmd.AddCommand(leylineCmd)
+}
+
+// pinnedLeylinePath resolves the pinned leyline binary and returns it as an
+// absolute path.
+//
+// ResolveBinary may return a PATH-relative result (exec.LookPath preserves a
+// relative PATH entry), which would break the moment the caller substituted it
+// into a command run from another directory — the exact "wrong binary, no
+// warning" failure this command exists to remove. Absolutising is therefore
+// part of the contract, not a nicety.
+//
+// Errors are returned unwrapped: ResolveBinary already names the pin and the
+// remedy, and a second layer of wording would give the same condition two
+// vocabularies.
+func pinnedLeylinePath() (string, error) {
+	p, err := leyline.ResolveBinary(true)
+	if err != nil {
+		return "", err
+	}
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return "", fmt.Errorf("resolve absolute path of pinned leyline %s: %w", p, err)
+	}
+	return abs, nil
+}
+
+// runLeylineExec runs the pinned leyline with args, wired to the given streams,
+// and reports leyline's exit status. A non-zero status is a RESULT, not an
+// error: only a failure to resolve or launch leyline returns err non-nil, so
+// callers can distinguish "leyline ran and said no" from "there is no leyline".
+func runLeylineExec(args []string, stdin io.Reader, stdout, stderr io.Writer) (int, error) {
+	bin, err := pinnedLeylinePath()
+	if err != nil {
+		return 0, err
+	}
+	// With DisableFlagParsing cobra hands over the raw argv, "--" included.
+	// Strip one leading separator so `exec -- cdc enable` and `exec cdc enable`
+	// are the same invocation; any later "--" belongs to leyline.
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	c := exec.Command(bin, args...) //nolint:gosec // bin is the pin-verified binary; proxying is the point
+	c.Stdin, c.Stdout, c.Stderr = stdin, stdout, stderr
+	if err := c.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return exitErr.ExitCode(), nil
+		}
+		return 0, fmt.Errorf("run pinned leyline %s: %w", bin, err)
+	}
+	return 0, nil
+}

--- a/cmd/leyline_proxy_test.go
+++ b/cmd/leyline_proxy_test.go
@@ -1,0 +1,397 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pinnedLeylineSemver is the pin without its leading "v" — the form a real
+// leyline prints in `leyline <ver> (open)`.
+func pinnedLeylineSemver() string { return strings.TrimPrefix(leyline.BinaryVersion, "v") }
+
+// writeLeylineStub plants an executable fake leyline at path. It answers
+// `--version` with "leyline <version> (open)" (the shape internal/leyline's
+// version gate parses) and runs body for every other argv.
+//
+// body must use only shell BUILTINS: isolateLeylineResolution empties PATH so
+// that resolution is decided solely by planted binaries, which also means the
+// stub inherits a PATH with no /bin on it (an earlier draft used `cat` and got
+// "command not found").
+func writeLeylineStub(t *testing.T, path, version, body string) string {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'leyline " + version + " (open)'; exit 0; fi\n" +
+		body + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return path
+}
+
+// isolateLeylineResolution makes leyline resolution depend ONLY on what the
+// test plants: an empty HOME (so no real ~/.mache cache leaks in), a PATH
+// containing exactly one scratch dir, no MACHE_LEYLINE_BINARY override, and
+// MACHE_NO_LEYLINE set so a resolution miss fails instead of hitting the
+// network. Returns (home, pathDir).
+func isolateLeylineResolution(t *testing.T) (string, string) {
+	t.Helper()
+	home, pathDir := t.TempDir(), t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", pathDir)
+	t.Setenv(leyline.BinaryOverrideEnv, "")
+	t.Setenv("MACHE_NO_LEYLINE", "1")
+	return home, pathDir
+}
+
+// pinnedCacheStubPath is where mache's version-namespaced cache keeps THIS
+// build's pin. Note it is never the unversioned ~/.mache/bin/leyline, which
+// mache-0acdf6 made read-only-never-written.
+func pinnedCacheStubPath(home string) string {
+	return filepath.Join(home, ".mache", "bin", "leyline-"+leyline.BinaryVersion)
+}
+
+// runLeylinePath invokes `mache leyline path` in-process and returns stdout.
+func runLeylinePath(t *testing.T) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	leylinePathCmd.SetOut(&out)
+	t.Cleanup(func() { leylinePathCmd.SetOut(nil) })
+	err := leylinePathCmd.RunE(leylinePathCmd, nil)
+	return strings.TrimSpace(out.String()), err
+}
+
+// ---------------------------------------------------------------------------
+// The bug this exists to fix: a stale leyline on PATH shadowing the pin.
+// ---------------------------------------------------------------------------
+
+// TestLeylinePath_ResolvesPinnedDespiteStalePATHShadow reproduces the exact
+// three-way skew measured in mache-19326d — a 0.10.3 leyline first on PATH
+// while the pinned build sits in a cache dir that is not on PATH — and asserts
+// `mache leyline path` reports the PIN, not the shadow.
+//
+// The LookPath assertion in the middle is the falsifier: it pins down that a
+// shell (i.e. a human or agent typing bare `leyline`) genuinely resolves the
+// stale binary in this fixture. Any implementation that answers this question
+// with PATH — the pre-fix state of the world, where PATH was the only answer a
+// caller had — resolves to that same stale path and fails the assertions below.
+func TestLeylinePath_ResolvesPinnedDespiteStalePATHShadow(t *testing.T) {
+	home, pathDir := isolateLeylineResolution(t)
+
+	shadow := writeLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
+	pinned := writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
+
+	viaPATH, err := exec.LookPath("leyline")
+	require.NoError(t, err)
+	require.Equal(t, shadow, viaPATH,
+		"fixture must actually shadow — PATH has to resolve the stale stub for this test to mean anything")
+
+	got, err := runLeylinePath(t)
+	require.NoError(t, err)
+
+	assert.Equal(t, pinned, got, "must report the pinned binary from the version-namespaced cache")
+	assert.NotEqual(t, viaPATH, got, "reporting the PATH copy is precisely the mache-19326d version skew")
+	assert.True(t, filepath.IsAbs(got), "callers substitute this into a command line from arbitrary cwds")
+}
+
+// TestLeylineExec_RunsPinnedDespiteStalePATHShadow is the same shadowing proof
+// for the exec surface: the process that actually runs must be the pin.
+func TestLeylineExec_RunsPinnedDespiteStalePATHShadow(t *testing.T) {
+	home, pathDir := isolateLeylineResolution(t)
+
+	writeLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
+	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
+
+	var stdout, stderr bytes.Buffer
+	code, err := runLeylineExec([]string{"--", "cdc", "enable"}, strings.NewReader(""), &stdout, &stderr)
+	require.NoError(t, err)
+	assert.Zero(t, code)
+	assert.Contains(t, stdout.String(), "PINNED-RAN")
+	assert.NotContains(t, stdout.String(), "SHADOW-RAN", "exec must not proxy to the stale PATH copy")
+}
+
+// ---------------------------------------------------------------------------
+// Resolution tiers
+// ---------------------------------------------------------------------------
+
+func TestLeylinePath_ResolutionTiers(t *testing.T) {
+	tests := []struct {
+		name        string
+		pathVersion string // planted on PATH; "" = nothing on PATH
+		cached      bool   // plant the pinned binary in the namespaced cache
+		wantTier    string // "path" | "cache"
+		wantErrHas  string
+	}{
+		{
+			name:        "pinned on PATH is accepted",
+			pathVersion: pinnedLeylineSemver(),
+			wantTier:    "path",
+		},
+		{
+			name:        "stale on PATH loses to the cached pin",
+			pathVersion: "0.10.3",
+			cached:      true,
+			wantTier:    "cache",
+		},
+		{
+			name:     "cache alone resolves when PATH is empty",
+			cached:   true,
+			wantTier: "cache",
+		},
+		{
+			// A newer-than-pin PATH build is still a different _ast producer.
+			name:        "newer-than-pin on PATH is rejected, not preferred",
+			pathVersion: "99.0.0",
+			cached:      true,
+			wantTier:    "cache",
+		},
+		{
+			name:        "stale on PATH with no cache errors naming the pin",
+			pathVersion: "0.10.3",
+			wantErrHas:  leyline.BinaryVersion,
+		},
+		{
+			name:        "a binary with no parseable version is not trusted",
+			pathVersion: "not-a-version",
+			wantErrHas:  leyline.BinaryVersion,
+		},
+		{
+			name:       "nothing anywhere errors naming the pin",
+			wantErrHas: leyline.BinaryVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, pathDir := isolateLeylineResolution(t)
+
+			var onPath string
+			if tt.pathVersion != "" {
+				onPath = writeLeylineStub(t, filepath.Join(pathDir, "leyline"), tt.pathVersion, "exit 0")
+			}
+			var inCache string
+			if tt.cached {
+				inCache = writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+			}
+
+			got, err := runLeylinePath(t)
+
+			if tt.wantErrHas != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrHas,
+					"resolution failures must reuse ResolveBinary's wording, which names the pin")
+				assert.Empty(t, got, "no path may be printed when resolution failed")
+				return
+			}
+			require.NoError(t, err)
+			switch tt.wantTier {
+			case "path":
+				assert.Equal(t, onPath, got)
+			case "cache":
+				assert.Equal(t, inCache, got)
+			}
+		})
+	}
+}
+
+// TestLeylinePath_NeverWritesUnversionedCachePath guards mache-0acdf6: the
+// unversioned ~/.mache/bin/leyline is a shared mutable resource concurrent
+// mache builds used to fight over, so it is read-only-never-written. Resolving
+// through this command must not change that.
+func TestLeylinePath_NeverWritesUnversionedCachePath(t *testing.T) {
+	home, _ := isolateLeylineResolution(t)
+	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+
+	got, err := runLeylinePath(t)
+	require.NoError(t, err)
+	assert.Equal(t, pinnedCacheStubPath(home), got)
+
+	unversioned := filepath.Join(home, ".mache", "bin", "leyline")
+	_, statErr := os.Lstat(unversioned)
+	assert.True(t, os.IsNotExist(statErr),
+		"the unversioned path must stay unwritten (mache-0acdf6); got %v", statErr)
+}
+
+// ---------------------------------------------------------------------------
+// exec proxy fidelity
+// ---------------------------------------------------------------------------
+
+func TestLeylineExec_ProxyFidelity(t *testing.T) {
+	// The stub reports what it received so the proxy contract is observable:
+	// argv on stdout, a marker on stderr, stdin echoed back, exit status taken
+	// from the first argument when it is a bare number.
+	const stubBody = `echo "argv:$*"
+echo "stub-stderr" >&2
+IFS= read -r line
+echo "stdin:$line"
+case "$1" in
+  exit-*) exit "${1#exit-}" ;;
+esac
+exit 0`
+
+	tests := []struct {
+		name       string
+		args       []string
+		stdin      string
+		wantArgv   string
+		wantCode   int
+		wantStdout []string
+	}{
+		{
+			name:       "double dash separator is stripped before leyline sees it",
+			args:       []string{"--", "cdc", "enable", "--db", "x.db"},
+			wantArgv:   "argv:cdc enable --db x.db",
+			wantStdout: []string{"argv:cdc enable --db x.db"},
+		},
+		{
+			name:       "args pass through without a separator",
+			args:       []string{"cdc", "gc", "--db", "x.db"},
+			wantArgv:   "argv:cdc gc --db x.db",
+			wantStdout: []string{"argv:cdc gc --db x.db"},
+		},
+		{
+			name:       "leyline flags are not claimed by mache",
+			args:       []string{"--help"},
+			wantArgv:   "argv:--help",
+			wantStdout: []string{"argv:--help"},
+		},
+		{
+			name:       "a later double dash belongs to leyline",
+			args:       []string{"--", "parse", "--", "extra"},
+			wantArgv:   "argv:parse -- extra",
+			wantStdout: []string{"argv:parse -- extra"},
+		},
+		{
+			name:       "no args runs leyline bare",
+			args:       nil,
+			wantArgv:   "argv:",
+			wantStdout: []string{"argv:"},
+		},
+		{
+			name:       "stdin is forwarded",
+			args:       []string{"parse"},
+			stdin:      "from-caller\n",
+			wantStdout: []string{"stdin:from-caller"},
+		},
+		{
+			name:       "non-zero exit status is reported, not flattened",
+			args:       []string{"exit-7"},
+			wantCode:   7,
+			wantStdout: []string{"argv:exit-7"},
+		},
+		{
+			name:       "exit status 1 is still distinguishable from a launch failure",
+			args:       []string{"exit-1"},
+			wantCode:   1,
+			wantStdout: []string{"argv:exit-1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			home, _ := isolateLeylineResolution(t)
+			writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), stubBody)
+
+			var stdout, stderr bytes.Buffer
+			code, err := runLeylineExec(tt.args, strings.NewReader(tt.stdin), &stdout, &stderr)
+
+			require.NoError(t, err, "leyline ran, so err is reserved for resolve/launch failures")
+			assert.Equal(t, tt.wantCode, code)
+			for _, want := range tt.wantStdout {
+				assert.Contains(t, stdout.String(), want)
+			}
+			assert.Contains(t, stderr.String(), "stub-stderr", "leyline's stderr must stay on stderr")
+			assert.NotContains(t, stdout.String(), "stub-stderr", "stderr must not be folded into stdout")
+		})
+	}
+}
+
+// TestLeylineExec_ResolutionFailureIsAnError separates the two failure modes:
+// "leyline ran and said no" (exit code) versus "there is no pinned leyline"
+// (error). Only the latter should surface ResolveBinary's message.
+func TestLeylineExec_ResolutionFailureIsAnError(t *testing.T) {
+	isolateLeylineResolution(t) // nothing planted anywhere
+
+	var stdout, stderr bytes.Buffer
+	code, err := runLeylineExec([]string{"cdc", "gc"}, strings.NewReader(""), &stdout, &stderr)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), leyline.BinaryVersion, "must name the pin, reusing ResolveBinary's wording")
+	assert.Zero(t, code)
+	assert.Empty(t, stdout.String())
+}
+
+// TestLeylineExecCmd_PropagatesExitStatus covers the cobra wiring: a non-zero
+// leyline status must reach os.Exit rather than being returned as an error,
+// which Execute() would flatten to 1.
+func TestLeylineExecCmd_PropagatesExitStatus(t *testing.T) {
+	home, _ := isolateLeylineResolution(t)
+	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 42")
+
+	var gotCode int
+	exited := false
+	orig := leylineExecExit
+	leylineExecExit = func(code int) { gotCode, exited = code, true }
+	t.Cleanup(func() { leylineExecExit = orig })
+
+	leylineExecCmd.SetOut(&bytes.Buffer{})
+	leylineExecCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() { leylineExecCmd.SetOut(nil); leylineExecCmd.SetErr(nil) })
+
+	require.NoError(t, leylineExecCmd.RunE(leylineExecCmd, []string{"--", "cdc", "gc"}))
+	assert.True(t, exited, "a non-zero leyline status must terminate mache with that status")
+	assert.Equal(t, 42, gotCode)
+}
+
+// TestLeylineExecCmd_ZeroStatusDoesNotExit — the success path must fall through
+// normally so deferred cleanup elsewhere in mache still runs.
+func TestLeylineExecCmd_ZeroStatusDoesNotExit(t *testing.T) {
+	home, _ := isolateLeylineResolution(t)
+	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+
+	orig := leylineExecExit
+	called := false
+	leylineExecExit = func(int) { called = true }
+	t.Cleanup(func() { leylineExecExit = orig })
+
+	leylineExecCmd.SetOut(&bytes.Buffer{})
+	leylineExecCmd.SetErr(&bytes.Buffer{})
+	t.Cleanup(func() { leylineExecCmd.SetOut(nil); leylineExecCmd.SetErr(nil) })
+
+	require.NoError(t, leylineExecCmd.RunE(leylineExecCmd, []string{"--", "parse"}))
+	assert.False(t, called, "a zero status must not call os.Exit")
+}
+
+// ---------------------------------------------------------------------------
+// Command surface
+// ---------------------------------------------------------------------------
+
+// TestLeylineCmd_Registered guards the surface itself: these subcommands only
+// help if they are reachable as `mache leyline path` / `mache leyline exec`.
+func TestLeylineCmd_Registered(t *testing.T) {
+	var parent *cobra.Command
+	for _, c := range rootCmd.Commands() {
+		if c.Name() == "leyline" {
+			parent = c
+			break
+		}
+	}
+	require.NotNil(t, parent, "`mache leyline` must be registered on the root command")
+
+	subs := map[string]bool{}
+	for _, c := range parent.Commands() {
+		subs[c.Name()] = true
+	}
+	assert.True(t, subs["path"], "`mache leyline path` must exist")
+	assert.True(t, subs["exec"], "`mache leyline exec` must exist")
+
+	assert.True(t, leylineExecCmd.DisableFlagParsing,
+		"exec must not parse flags, or leyline's own flags never reach leyline")
+}

--- a/cmd/leyline_proxy_test.go
+++ b/cmd/leyline_proxy_test.go
@@ -18,7 +18,7 @@ import (
 // leyline prints in `leyline <ver> (open)`.
 func pinnedLeylineSemver() string { return strings.TrimPrefix(leyline.BinaryVersion, "v") }
 
-// writeLeylineStub plants an executable fake leyline at path. It answers
+// plantLeylineStub plants an executable fake leyline at path. It answers
 // `--version` with "leyline <version> (open)" (the shape internal/leyline's
 // version gate parses) and runs body for every other argv.
 //
@@ -26,7 +26,7 @@ func pinnedLeylineSemver() string { return strings.TrimPrefix(leyline.BinaryVers
 // that resolution is decided solely by planted binaries, which also means the
 // stub inherits a PATH with no /bin on it (an earlier draft used `cat` and got
 // "command not found").
-func writeLeylineStub(t *testing.T, path, version, body string) string {
+func plantLeylineStub(t *testing.T, path, version, body string) string {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	script := "#!/bin/sh\n" +
@@ -85,8 +85,8 @@ func runLeylinePath(t *testing.T) (string, error) {
 func TestLeylinePath_ResolvesPinnedDespiteStalePATHShadow(t *testing.T) {
 	home, pathDir := isolateLeylineResolution(t)
 
-	shadow := writeLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
-	pinned := writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
+	shadow := plantLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
+	pinned := plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
 
 	viaPATH, err := exec.LookPath("leyline")
 	require.NoError(t, err)
@@ -106,8 +106,8 @@ func TestLeylinePath_ResolvesPinnedDespiteStalePATHShadow(t *testing.T) {
 func TestLeylineExec_RunsPinnedDespiteStalePATHShadow(t *testing.T) {
 	home, pathDir := isolateLeylineResolution(t)
 
-	writeLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
-	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
+	plantLeylineStub(t, filepath.Join(pathDir, "leyline"), "0.10.3", "echo SHADOW-RAN")
+	plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "echo PINNED-RAN")
 
 	var stdout, stderr bytes.Buffer
 	code, err := runLeylineExec([]string{"--", "cdc", "enable"}, strings.NewReader(""), &stdout, &stderr)
@@ -174,11 +174,11 @@ func TestLeylinePath_ResolutionTiers(t *testing.T) {
 
 			var onPath string
 			if tt.pathVersion != "" {
-				onPath = writeLeylineStub(t, filepath.Join(pathDir, "leyline"), tt.pathVersion, "exit 0")
+				onPath = plantLeylineStub(t, filepath.Join(pathDir, "leyline"), tt.pathVersion, "exit 0")
 			}
 			var inCache string
 			if tt.cached {
-				inCache = writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+				inCache = plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
 			}
 
 			got, err := runLeylinePath(t)
@@ -207,7 +207,7 @@ func TestLeylinePath_ResolutionTiers(t *testing.T) {
 // through this command must not change that.
 func TestLeylinePath_NeverWritesUnversionedCachePath(t *testing.T) {
 	home, _ := isolateLeylineResolution(t)
-	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+	plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
 
 	got, err := runLeylinePath(t)
 	require.NoError(t, err)
@@ -223,11 +223,10 @@ func TestLeylinePath_NeverWritesUnversionedCachePath(t *testing.T) {
 // exec proxy fidelity
 // ---------------------------------------------------------------------------
 
-func TestLeylineExec_ProxyFidelity(t *testing.T) {
-	// The stub reports what it received so the proxy contract is observable:
-	// argv on stdout, a marker on stderr, stdin echoed back, exit status taken
-	// from the first argument when it is a bare number.
-	const stubBody = `echo "argv:$*"
+// leylineEchoStubBody makes the proxy contract observable: it reports the argv
+// it received on stdout, writes a marker to stderr, echoes one line of stdin
+// back, and exits with the status named by an `exit-N` first argument.
+const leylineEchoStubBody = `echo "argv:$*"
 echo "stub-stderr" >&2
 IFS= read -r line
 echo "stdin:$line"
@@ -236,79 +235,103 @@ case "$1" in
 esac
 exit 0`
 
+// runProxiedStub plants leylineEchoStubBody as the pinned binary and proxies
+// args to it, returning leyline's exit status and captured streams. It fails
+// the test on a resolve/launch error, since every caller here expects the stub
+// to have actually run.
+func runProxiedStub(t *testing.T, args []string, stdin string) (int, string, string) {
+	t.Helper()
+	home, _ := isolateLeylineResolution(t)
+	plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), leylineEchoStubBody)
+
+	var stdout, stderr bytes.Buffer
+	code, err := runLeylineExec(args, strings.NewReader(stdin), &stdout, &stderr)
+	require.NoError(t, err, "leyline ran, so err is reserved for resolve/launch failures")
+
+	assert.Contains(t, stderr.String(), "stub-stderr", "leyline's stderr must stay on stderr")
+	assert.NotContains(t, stdout.String(), "stub-stderr", "stderr must not be folded into stdout")
+	return code, stdout.String(), stderr.String()
+}
+
+// TestLeylineExec_ForwardsArgs — every argument reaches leyline verbatim, and
+// mache claims none of them.
+func TestLeylineExec_ForwardsArgs(t *testing.T) {
 	tests := []struct {
-		name       string
-		args       []string
-		stdin      string
-		wantArgv   string
-		wantCode   int
-		wantStdout []string
+		name     string
+		args     []string
+		wantArgv string
 	}{
 		{
-			name:       "double dash separator is stripped before leyline sees it",
-			args:       []string{"--", "cdc", "enable", "--db", "x.db"},
-			wantArgv:   "argv:cdc enable --db x.db",
-			wantStdout: []string{"argv:cdc enable --db x.db"},
+			name:     "double dash separator is stripped before leyline sees it",
+			args:     []string{"--", "cdc", "enable", "--db", "x.db"},
+			wantArgv: "argv:cdc enable --db x.db",
 		},
 		{
-			name:       "args pass through without a separator",
-			args:       []string{"cdc", "gc", "--db", "x.db"},
-			wantArgv:   "argv:cdc gc --db x.db",
-			wantStdout: []string{"argv:cdc gc --db x.db"},
+			name:     "args pass through without a separator",
+			args:     []string{"cdc", "gc", "--db", "x.db"},
+			wantArgv: "argv:cdc gc --db x.db",
 		},
 		{
-			name:       "leyline flags are not claimed by mache",
-			args:       []string{"--help"},
-			wantArgv:   "argv:--help",
-			wantStdout: []string{"argv:--help"},
+			name:     "leyline flags are not claimed by mache",
+			args:     []string{"--help"},
+			wantArgv: "argv:--help",
 		},
 		{
-			name:       "a later double dash belongs to leyline",
-			args:       []string{"--", "parse", "--", "extra"},
-			wantArgv:   "argv:parse -- extra",
-			wantStdout: []string{"argv:parse -- extra"},
+			name:     "a later double dash belongs to leyline",
+			args:     []string{"--", "parse", "--", "extra"},
+			wantArgv: "argv:parse -- extra",
 		},
 		{
-			name:       "no args runs leyline bare",
-			args:       nil,
-			wantArgv:   "argv:",
-			wantStdout: []string{"argv:"},
-		},
-		{
-			name:       "stdin is forwarded",
-			args:       []string{"parse"},
-			stdin:      "from-caller\n",
-			wantStdout: []string{"stdin:from-caller"},
-		},
-		{
-			name:       "non-zero exit status is reported, not flattened",
-			args:       []string{"exit-7"},
-			wantCode:   7,
-			wantStdout: []string{"argv:exit-7"},
-		},
-		{
-			name:       "exit status 1 is still distinguishable from a launch failure",
-			args:       []string{"exit-1"},
-			wantCode:   1,
-			wantStdout: []string{"argv:exit-1"},
+			name:     "no args runs leyline bare",
+			args:     nil,
+			wantArgv: "argv:",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			home, _ := isolateLeylineResolution(t)
-			writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), stubBody)
+			code, stdout, _ := runProxiedStub(t, tt.args, "")
+			assert.Zero(t, code)
+			assert.Contains(t, stdout, tt.wantArgv)
+		})
+	}
+}
 
-			var stdout, stderr bytes.Buffer
-			code, err := runLeylineExec(tt.args, strings.NewReader(tt.stdin), &stdout, &stderr)
+// TestLeylineExec_ForwardsStdinAndExitStatus — stdin reaches leyline, and
+// leyline's exit status reaches the caller instead of being flattened.
+func TestLeylineExec_ForwardsStdinAndExitStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		stdin      string
+		wantCode   int
+		wantStdout string
+	}{
+		{
+			name:       "stdin is forwarded",
+			args:       []string{"parse"},
+			stdin:      "from-caller\n",
+			wantStdout: "stdin:from-caller",
+		},
+		{
+			name:       "non-zero exit status is reported, not flattened",
+			args:       []string{"exit-7"},
+			wantCode:   7,
+			wantStdout: "argv:exit-7",
+		},
+		{
+			name:       "exit status 1 is still distinguishable from a launch failure",
+			args:       []string{"exit-1"},
+			wantCode:   1,
+			wantStdout: "argv:exit-1",
+		},
+	}
 
-			require.NoError(t, err, "leyline ran, so err is reserved for resolve/launch failures")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, stdout, _ := runProxiedStub(t, tt.args, tt.stdin)
 			assert.Equal(t, tt.wantCode, code)
-			for _, want := range tt.wantStdout {
-				assert.Contains(t, stdout.String(), want)
-			}
-			assert.Contains(t, stderr.String(), "stub-stderr", "leyline's stderr must stay on stderr")
-			assert.NotContains(t, stdout.String(), "stub-stderr", "stderr must not be folded into stdout")
+			assert.Contains(t, stdout, tt.wantStdout)
 		})
 	}
 }
@@ -333,7 +356,7 @@ func TestLeylineExec_ResolutionFailureIsAnError(t *testing.T) {
 // which Execute() would flatten to 1.
 func TestLeylineExecCmd_PropagatesExitStatus(t *testing.T) {
 	home, _ := isolateLeylineResolution(t)
-	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 42")
+	plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 42")
 
 	var gotCode int
 	exited := false
@@ -354,7 +377,7 @@ func TestLeylineExecCmd_PropagatesExitStatus(t *testing.T) {
 // normally so deferred cleanup elsewhere in mache still runs.
 func TestLeylineExecCmd_ZeroStatusDoesNotExit(t *testing.T) {
 	home, _ := isolateLeylineResolution(t)
-	writeLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
+	plantLeylineStub(t, pinnedCacheStubPath(home), pinnedLeylineSemver(), "exit 0")
 
 	orig := leylineExecExit
 	called := false


### PR DESCRIPTION
## The problem, measured

mache resolves leyline through one pin-checked chokepoint (`leyline.ResolveBinary`: `MACHE_LEYLINE_BINARY` → PATH → version-namespaced `~/.mache/bin` cache → SHA-verified download, each tier accepted only on the **exact** pinned version). A human or agent typing bare `leyline` gets none of that — they get whatever PATH holds.

On a machine that had run `task install`:

```
~/.local/bin/leyline           0.10.3   ON PATH       <- what `leyline` meant
~/.mache/bin/leyline-v0.13.0   0.13.0   not on PATH   <- what mache actually used
```

`~/.mache/bin` is not on PATH, so `leyline cdc enable --db x.db` typed at a shell ran a 0.10.3 parser against a `.db` mache built with 0.13.0. Both binaries are named `leyline` and neither announces the mismatch. Since leyline v0.13.0 shipped `leyline cdc enable` / `leyline cdc gc`, invoking leyline directly is a real workflow — so this is the `mache-0acdf6` defect class (silently changing `_ast` shape between runs) relocated from the cache to PATH.

This never broke mache itself; ResolveBinary already logs when it ignores a non-pinned PATH entry. It breaks the human/agent who invokes leyline directly.

## What this adds

Options (a) and (b) from the bead — a few lines apart, different callers:

```bash
mache leyline path                          # absolute path, nothing else on stdout
$(mache leyline path) cdc enable --db x.db  # shell interpolation
mache leyline exec -- cdc enable --db x.db  # direct invocation
mache leyline exec cdc gc --db x.db         # the `--` is optional
```

- `path` writes only the resolved absolute path to stdout, so it composes in `$()`. ResolveBinary's `"… is not the pinned <ver> — ignoring it"` diagnostic already goes to stderr, so the shadow is still reported without polluting the substitution. Absolutising is part of the contract: `exec.LookPath` preserves a relative PATH entry, which would break the moment a caller substituted it into a command run from another directory.
- `exec` sets `DisableFlagParsing` so leyline's own flags (including `--help`) reach leyline rather than being claimed by mache, strips one leading `--`, forwards stdin/stdout/stderr, and exits with **leyline's** status rather than flattening every failure to 1 (`Execute()` hardcodes exit 1 on a returned error).
- Resolution errors are returned unwrapped, so "no pinned leyline" keeps one error vocabulary instead of two.

## Deliberately not done — both re-open shipped bugs

- **No write to `~/.mache/bin/leyline`** (the unversioned path). `mache-0acdf6` made it read-only-never-written because it was a shared mutable resource concurrent mache builds overwrote, silently changing `_ast` shape between runs. Nothing here writes to the cache at all — ResolveBinary owns provisioning and only ever writes the pin-namespaced path. There is a regression test asserting the unversioned path stays absent.
- **No PATH or shell-rc mutation.** A shim dir on PATH reintroduces "which version does bare `leyline` mean" the moment the pin moves.
- **No `mache install` / `mache uninstall`.** The bead scopes those as the larger follow-up; they need the PATH/dotfile design settled first. Taskfile install targets are untouched.

## Tests

The load-bearing one is the shadowing case, on both surfaces: plant a deliberately wrong-version (0.10.3) stub **earlier on PATH** than the pinned stub in the namespaced cache, assert `exec.LookPath("leyline")` genuinely resolves the stale one (so the fixture is proven to shadow), then assert `mache leyline path` reports the pin and `mache leyline exec` runs the pin.

Falsified by mutation: replacing `pinnedLeylinePath`'s `ResolveBinary` call with `exec.LookPath("leyline")` — i.e. the pre-fix state of the world, where PATH was the only answer a caller had — fails both, reporting/running the stale stub.

Also covered: resolution tiers (pinned-on-PATH accepted, stale loses to cache, **newer**-than-pin rejected rather than preferred, unparseable version not trusted, nothing-anywhere errors naming the pin), the unversioned cache path staying unwritten, arg forwarding (`--` stripping, later `--` belonging to leyline, `--help` not claimed, no args), stdin forwarding, stdout/stderr separation, and exit-status propagation through the cobra wiring.

`task ci` (the full pre-push gate: gofumpt, vet, golangci-lint, leyline consumer smoke, `test:ast`, race tests, validate, smell ratchet, preflight, server.json) passes. The second commit is the smell-ratchet fix — the gate archives `HEAD`, so it only sees committed files, which is why `task check` on an uncommitted tree could not have caught it.

Closes `mache-19326d`'s (a)/(b) scope.