### PR TITLE
[mache-19326d] test(ci): verify a real mache installation, not the source tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,10 +169,54 @@ jobs:
       - name: server.json drift check
         run: task gen:server-json:check
 
+  install-verify:
+    needs: changes
+    if: needs.changes.outputs.heavy == 'true'
+    # The INSTALL gate (bead mache-19326d). Every other CI job exercises the
+    # source tree; this one exercises an artifact a user could actually have.
+    # It installs mache the way `task install` does and then verifies the
+    # INSTALLED binary: the leyline it resolves is the pin (with a deliberately
+    # stale leyline planted first on PATH), the version it reports is one this
+    # tree could have produced, and the core MCP tools return the expected
+    # values for a fixture it projects itself.
+    #
+    # CI invokes the Taskfile target, never the commands — a developer running
+    # `task install:verify` runs byte-identical checks.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          lfs: true
+          # merge-base --is-ancestor needs real history to answer "was this
+          # binary built from this tree"; a depth-1 checkout has none.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install Task
+        env:
+          GOTOOLCHAIN: auto
+        run: go install github.com/go-task/task/v3/cmd/task@v3.50.0
+
+      - name: Install mache
+        run: task install
+
+      - name: Verify the installed binary
+        run: task install:verify BIN="$HOME/.local/bin/mache"
+
+      - name: Verify the published image (clean HOME)
+        # Deliberately NOT MACHE_VERIFY_REQUIRE_DOCKER: on a commit that has
+        # bumped version.txt ahead of the last release, the image for that
+        # version does not exist yet and the leg skips, which is honest. The
+        # release workflow is where that skip should become a failure.
+        run: task install:verify:docker
+
   required:
     name: CI required
     if: always()
-    needs: [changes, test, lint, server-json-drift]
+    needs: [changes, test, lint, server-json-drift, install-verify]
     runs-on: ubuntu-latest
     steps:
       - name: Require every applicable CI job
@@ -182,6 +226,7 @@ jobs:
           TEST_RESULT: ${{ needs.test.result }}
           LINT_RESULT: ${{ needs.lint.result }}
           SERVER_JSON_RESULT: ${{ needs.server-json-drift.result }}
+          INSTALL_VERIFY_RESULT: ${{ needs.install-verify.result }}
         run: |
           test "$CHANGES_RESULT" = "success"
           case "$HEAVY" in
@@ -192,3 +237,4 @@ jobs:
           test "$TEST_RESULT" = "success"
           test "$LINT_RESULT" = "success"
           test "$SERVER_JSON_RESULT" = "success"
+          test "$INSTALL_VERIFY_RESULT" = "success"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ bumps may include breaking changes.
 
 ### Added
 
+- **`task install:verify` — an install gate that verifies a real installation
+  instead of assuming one.** Every other gate in this repo exercises the source
+  tree; nothing checked an artifact a user could actually have (`mache-4d7f2c`).
+  The new target drives an *installed binary* by fork/exec and MCP-over-the-wire
+  and asserts on content, not exit codes: the leyline the binary resolves is the
+  pin — proven against a deliberately stale leyline planted first on PATH, the
+  measured `mache-19326d` skew; the version it reports is one this tree could
+  have produced, down to the built commit being an ancestor of HEAD; and
+  `find_definition` / `get_overview` / `list_directory` / `find_smells` return
+  the *expected values* for a fixture the binary projects itself. Runnable
+  locally, wired into `task check`, `task ci` and a CI job that invokes the same
+  target. `task install:verify:docker` adds the clean-HOME leg — no `~/.mache`,
+  no checkout, no Taskfile — against the published image, which is
+  `mache-19326d`'s acceptance criterion and the one condition a dev box cannot
+  honestly simulate; it also pins the image's `serve`-baked `ENTRYPOINT`, so
+  `docker run IMAGE version` silently booting a server (`mache-504adc`) is a
+  stated expectation rather than a surprise. The docker leg skips when no daemon
+  or image is reachable, so it never reddens CI on a box without docker; set
+  `MACHE_VERIFY_REQUIRE_DOCKER=1` to make those skips failures.
+  (`mache-19326d`, `mache-4d7f2c`, `mache-504adc`)
+
 - **`mache leyline path` and `mache leyline exec` — invoke the pinned leyline
   without depending on PATH.** mache resolves leyline through one pin-checked
   chokepoint and caches it version-namespaced under `~/.mache/bin`, which is not

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,6 +21,57 @@ tasks:
       - cmd: codesign -s - --force --deep --entitlements entitlements.plist ~/.local/bin/mache
         platforms: [darwin]
 
+  install:verify:
+    desc: |
+      Install gate — verify a REAL mache installation instead of assuming one.
+      Asserts, with content assertions rather than exit codes: the leyline the
+      binary RESOLVES is the pin (proven against a deliberately stale leyline
+      planted first on PATH — bead mache-19326d); the binary's reported version
+      is what this tree says it should be; and the core MCP tools return the
+      EXPECTED VALUES for a fixture the binary itself projects.
+
+      Verifies the freshly-built bin/mache by default. Point it at any other
+      installed artifact with BIN, and at a published release with
+      MACHE_VERIFY_EXPECT_VERSION / MACHE_VERIFY_EXPECT_LEYLINE:
+
+        task install:verify
+        task install:verify BIN=~/.local/bin/mache
+        MACHE_VERIFY_EXPECT_VERSION=0.20.0 task install:verify BIN=/tmp/mache-v0.20.0
+
+      The clean-HOME (no ~/.mache, no checkout, no Taskfile) leg lives in
+      `task install:verify:docker`; a dev box cannot honestly simulate it.
+    deps: [build, leyline:ensure]
+    vars:
+      BIN: '{{.BIN | default .BINARY_NAME}}'
+    cmds:
+      # `go` needs no preflight guard (toolchain-safe), and the binary under
+      # test is asserted to exist by the suite itself rather than by a
+      # precondition — a MISSING install is the failure this gate reports, not
+      # a reason to decline to run.
+      - |
+        set -euo pipefail
+        BIN_ABS="$(cd "$(dirname "{{.BIN}}")" && pwd)/$(basename "{{.BIN}}")"
+        MACHE_VERIFY_BINARY="$BIN_ABS" go test -count=1 -v \
+          -skip 'TestPublishedImage|TestDockerCleanHome' ./tests/installverify/
+
+  install:verify:docker:
+    desc: |
+      Clean-HOME half of the install gate — bead mache-19326d's acceptance
+      criterion, run against the PUBLISHED image in a container with no
+      ~/.mache, no repo checkout and no Taskfile. Also verifies the image
+      reports its own tag's version (bead mache-4d7f2c) and pins the
+      `serve`-baked ENTRYPOINT that makes `docker run IMAGE version` silently
+      boot a server (bead mache-504adc).
+
+      Skips when no docker daemon is reachable or the image is not fetchable,
+      so it never reddens CI on a box without docker. Set
+      MACHE_VERIFY_REQUIRE_DOCKER=1 to turn those skips into failures, and
+      MACHE_VERIFY_IMAGE=<ref> to check an image other than this tree's.
+    cmds:
+      # No `command -v docker` guard here on purpose: the suite probes for the
+      # daemon itself so it can SKIP, where a precondition would fail the task.
+      - go test -count=1 -v -run 'TestPublishedImage|TestDockerCleanHome' ./tests/installverify/
+
   build:
     desc: Build and codesign mache
     vars:
@@ -744,6 +795,7 @@ tasks:
       - task: test:ast
       - task: test
       - task: validate
+      - task: install:verify
       - task: gates:preflight
       - task: gen:server-json:check
 
@@ -767,6 +819,7 @@ tasks:
       - task: test:ast
       - task: test
       - task: validate
+      - task: install:verify
       - task: gates:preflight
       - task: gen:server-json:check
 

--- a/tests/installverify/docker_test.go
+++ b/tests/installverify/docker_test.go
@@ -157,14 +157,14 @@ func TestPublishedImageReportsItsTagVersion(t *testing.T) {
 	require.NoError(t, res.err)
 	require.Zerof(t, res.code, "`mache version` in %s exited %d: %s", d.image, res.code, res.combined())
 
-	m := versionLineRe.FindStringSubmatch(res.stdout)
-	require.Lenf(t, m, 2, "image mache printed no version line:\n%s", res.combined())
+	token, ok := parseVersionLine(res.stdout)
+	require.Truef(t, ok, "image mache printed no version line:\n%s", res.combined())
 
-	_, tag, ok := strings.Cut(d.image, ":")
-	if !ok {
+	_, tag, hasTag := strings.Cut(d.image, ":")
+	if !hasTag {
 		t.Skipf("image reference %q carries no tag to compare against", d.image)
 	}
-	assert.Equal(t, strings.TrimPrefix(tag, "v"), m[1],
+	assert.Equal(t, strings.TrimPrefix(tag, "v"), token,
 		"the mache inside %s reports a version its tag does not claim", d.image)
 }
 
@@ -182,16 +182,16 @@ func TestPublishedImageBundlesThePinnedLeyline(t *testing.T) {
 	res := d.runIn(imageLeylinePath, nil, "--version")
 	require.NoError(t, res.err)
 	require.Zerof(t, res.code, "bundled leyline --version exited %d: %s", res.code, res.combined())
-	m := semverRe.FindStringSubmatch(res.combined())
-	require.Lenf(t, m, 2, "bundled leyline printed no version:\n%s", res.combined())
+	got := firstSemver(res.combined())
+	require.NotEmptyf(t, got, "bundled leyline printed no version:\n%s", res.combined())
 
 	want := expectedLeylinePin(t)
 	if img, expected := d.image, "ghcr.io/agentic-research/mache:v"+versionTxt(t, macheTreeRoot(t)); img != expected {
 		t.Logf("image %s is not this tree's release image (%s); bundled leyline is %s, this tree pins %s",
-			img, expected, m[1], want)
+			img, expected, got, want)
 		return
 	}
-	assert.Equal(t, want, m[1], "the image bundles a leyline that is not this tree's pin")
+	assert.Equal(t, want, got, "the image bundles a leyline that is not this tree's pin")
 }
 
 // TestDockerCleanHomeProjectsAndQueries is the acceptance criterion itself:

--- a/tests/installverify/docker_test.go
+++ b/tests/installverify/docker_test.go
@@ -1,0 +1,268 @@
+package installverify
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The clean-HOME leg — bead mache-19326d's acceptance criterion in the one
+// place it can be honestly met.
+//
+// "A user with only the released mache binary (no repo, no Taskfile) can
+// provision the pinned leyline and invoke it version-correctly" is not
+// testable on a dev box: the box has ~/.mache, a checkout, a Taskfile, and a
+// leyline on PATH, and no amount of env scrubbing removes the possibility that
+// one of them is why something worked. A container has none of them.
+//
+// This leg SKIPS when docker is absent or the image cannot be fetched, so it
+// never reddens CI on an agent box without a daemon. Set
+// MACHE_VERIFY_REQUIRE_DOCKER=1 (CI, release verification) to turn those skips
+// into failures — otherwise a permanently-skipping gate is indistinguishable
+// from a passing one.
+
+const (
+	imageEnv       = "MACHE_VERIFY_IMAGE"
+	requireDockerE = "MACHE_VERIFY_REQUIRE_DOCKER"
+
+	// Paths inside the published image (Dockerfile.release).
+	imageMachePath   = "/usr/local/bin/mache"
+	imageLeylinePath = "/usr/local/bin/leyline"
+
+	// jsonSentinel marks where a container script's log output stops and the
+	// JSON document to be parsed begins.
+	jsonSentinel = "---INSTALL-VERIFY-JSON---"
+)
+
+// dockerRequired reports whether a docker skip should be a failure instead.
+func dockerRequired() bool { return os.Getenv(requireDockerE) != "" }
+
+// skipOrFail skips the test, or fails it when docker was declared required.
+func skipOrFail(t *testing.T, format string, args ...any) {
+	t.Helper()
+	msg := fmt.Sprintf(format, args...)
+	if dockerRequired() {
+		t.Fatalf("%s (%s is set, so this is a failure rather than a skip)", msg, requireDockerE)
+	}
+	t.Skipf("%s — set %s=1 to make this a failure instead", msg, requireDockerE)
+}
+
+// verifyImage is the published image under test. Defaults to the image for
+// THIS tree's release version, so `task install:verify:docker` on a release
+// commit checks the artifact that commit publishes.
+func verifyImage(t *testing.T) string {
+	t.Helper()
+	if v := strings.TrimSpace(os.Getenv(imageEnv)); v != "" {
+		return v
+	}
+	return "ghcr.io/agentic-research/mache:v" + versionTxt(t, macheTreeRoot(t))
+}
+
+// dockerAvailable reports whether a docker CLI and a live daemon are both
+// present. `docker version --format {{.Server.Version}}` fails when the CLI is
+// installed but the daemon is not running, which is the common agent-box case.
+func dockerAvailable(t *testing.T) bool {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		return false
+	}
+	res := runner{}.run(t, "docker", "version", "--format", "{{.Server.Version}}")
+	return res.err == nil && res.code == 0
+}
+
+// ensureImage makes the image locally available, pulling once if needed.
+func ensureImage(t *testing.T, image string) bool {
+	t.Helper()
+	inspect := runner{}.run(t, "docker", "image", "inspect", image)
+	if inspect.err == nil && inspect.code == 0 {
+		return true
+	}
+	res := runner{}.run(t, "docker", "pull", "--quiet", image)
+	if res.err != nil || res.code != 0 {
+		t.Logf("docker pull %s failed: %s", image, res.combined())
+		return false
+	}
+	return true
+}
+
+// dockerImage is a fetched image plus the assertions' shared context.
+type dockerImage struct {
+	t     *testing.T
+	image string
+}
+
+// setupDockerImage performs the skip dance once and returns a handle.
+func setupDockerImage(t *testing.T) dockerImage {
+	t.Helper()
+	if !dockerAvailable(t) {
+		skipOrFail(t, "no docker daemon available")
+	}
+	image := verifyImage(t)
+	if !ensureImage(t, image) {
+		skipOrFail(t, "image %s is not fetchable", image)
+	}
+	return dockerImage{t: t, image: image}
+}
+
+// runIn executes argv inside the image with an explicit entrypoint. Every
+// invocation here passes --entrypoint on purpose: see
+// TestPublishedImageEntrypointIsSerize below for why a bare `docker run IMAGE
+// <cmd>` does not do what it looks like it does.
+func (d dockerImage) runIn(entrypoint string, extraDockerArgs []string, argv ...string) result {
+	d.t.Helper()
+	args := []string{"run", "--rm", "--entrypoint", entrypoint}
+	args = append(args, extraDockerArgs...)
+	args = append(args, d.image)
+	args = append(args, argv...)
+	return runner{}.run(d.t, "docker", args...)
+}
+
+// TestPublishedImageEntrypointBakesInServe pins bead mache-504adc: the image's
+// ENTRYPOINT already carries `serve`, so `docker run IMAGE version` is
+// `mache serve version` — it does NOT print a version, it silently boots a
+// default server on 7532 and blocks. Anything driving this image (README
+// snippets, CI, this file) must pass --entrypoint.
+//
+// Asserting the entrypoint structurally, rather than describing the hazard in
+// a comment, means a future change to how the image is driven either updates
+// this expectation deliberately or fails here.
+func TestPublishedImageEntrypointBakesInServe(t *testing.T) {
+	d := setupDockerImage(t)
+
+	res := runner{}.run(t, "docker", "image", "inspect", d.image,
+		"--format", "{{json .Config.Entrypoint}}")
+	require.NoError(t, res.err)
+	require.Zerof(t, res.code, "docker image inspect: %s", res.combined())
+
+	var entrypoint []string
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(res.stdout)), &entrypoint))
+	assert.Equal(t, []string{imageMachePath, "serve"}, entrypoint,
+		"the image bakes `serve` into ENTRYPOINT (mache-504adc) — every `docker run` of it "+
+			"appends to `mache serve`, so callers must pass --entrypoint to run any other subcommand")
+}
+
+// TestPublishedImageReportsItsTagVersion is gate (b) for the OCI artifact:
+// the mache inside the image must report the version its tag claims.
+// Nothing verified this before (bead mache-4d7f2c).
+func TestPublishedImageReportsItsTagVersion(t *testing.T) {
+	d := setupDockerImage(t)
+
+	res := d.runIn(imageMachePath, nil, "version")
+	require.NoError(t, res.err)
+	require.Zerof(t, res.code, "`mache version` in %s exited %d: %s", d.image, res.code, res.combined())
+
+	m := versionLineRe.FindStringSubmatch(res.stdout)
+	require.Lenf(t, m, 2, "image mache printed no version line:\n%s", res.combined())
+
+	_, tag, ok := strings.Cut(d.image, ":")
+	if !ok {
+		t.Skipf("image reference %q carries no tag to compare against", d.image)
+	}
+	assert.Equal(t, strings.TrimPrefix(tag, "v"), m[1],
+		"the mache inside %s reports a version its tag does not claim", d.image)
+}
+
+// TestPublishedImageBundlesThePinnedLeyline asserts the leyline shipped
+// alongside mache in the image is the one that mache pins. A mismatch here is
+// the containerised form of the mache-19326d skew: the .db an image builds
+// would be parsed by a different leyline than the one its mache expects.
+//
+// The comparison is only meaningful when the image is the one THIS tree
+// publishes — an older tag legitimately pins an older leyline — so a
+// non-matching tag logs rather than asserts.
+func TestPublishedImageBundlesThePinnedLeyline(t *testing.T) {
+	d := setupDockerImage(t)
+
+	res := d.runIn(imageLeylinePath, nil, "--version")
+	require.NoError(t, res.err)
+	require.Zerof(t, res.code, "bundled leyline --version exited %d: %s", res.code, res.combined())
+	m := semverRe.FindStringSubmatch(res.combined())
+	require.Lenf(t, m, 2, "bundled leyline printed no version:\n%s", res.combined())
+
+	want := expectedLeylinePin(t)
+	if img, expected := d.image, "ghcr.io/agentic-research/mache:v"+versionTxt(t, macheTreeRoot(t)); img != expected {
+		t.Logf("image %s is not this tree's release image (%s); bundled leyline is %s, this tree pins %s",
+			img, expected, m[1], want)
+		return
+	}
+	assert.Equal(t, want, m[1], "the image bundles a leyline that is not this tree's pin")
+}
+
+// TestDockerCleanHomeProjectsAndQueries is the acceptance criterion itself:
+// from a HOME with nothing in it, no repo checkout and no Taskfile, the
+// published binary must project a source tree and answer a real query about it.
+//
+// HOME is redirected to an empty in-container path (the image's default /data
+// is a declared VOLUME and could be populated by a caller), and the fixture is
+// mounted read-only, so the only thing that can make this pass is the shipped
+// artifact.
+func TestDockerCleanHomeProjectsAndQueries(t *testing.T) {
+	d := setupDockerImage(t)
+
+	// One shell so the .db survives between commands — `--rm` discards the
+	// container filesystem, so a second `docker run` would start from nothing.
+	// jsonSentinel separates mache's own chatter from the JSON to be parsed:
+	// splitting on a marker the script emits is deterministic, where guessing
+	// where the log stops and the document starts is not.
+	script := strings.Join([]string{
+		"set -e",
+		`test ! -e "$HOME/.mache"`, // genuinely clean to begin with
+		imageMachePath + " build /source /tmp/fixture.db",
+		"test -s /tmp/fixture.db", // exit 0 is not evidence
+		"echo " + jsonSentinel,
+		// One named rule, not `--rule '*'`: the glob form streams one JSON
+		// document PER RULE, which is not a value an assertion can decode.
+		imageMachePath + " find-smells --db /tmp/fixture.db --rule untested_function --format=json --fail-on=none",
+	}, "\n")
+
+	res := d.runIn("/bin/sh", []string{
+		"-e", "HOME=/tmp/clean-home",
+		"-v", fixtureDir(t) + ":/source:ro",
+	}, "-c", script)
+
+	require.NoError(t, res.err)
+	require.Zerof(t, res.code,
+		"a clean-HOME projection failed inside %s — this is exactly the state a release-asset "+
+			"or Homebrew user is in\n%s", d.image, res.combined())
+
+	// The build log names the leyline it resolved; inside the image that must
+	// be the bundled one, reached with no download and no ~/.mache.
+	assert.Contains(t, res.combined(), imageLeylinePath,
+		"the containerised mache must resolve the bundled leyline, not go looking elsewhere")
+
+	// And the query must return the RIGHT answer, not merely a well-formed
+	// one. The fixture holds exactly two top-level functions and no tests, so
+	// untested_function must name both, by their projection addresses.
+	_, after, ok := strings.Cut(res.stdout, jsonSentinel)
+	require.Truef(t, ok, "the script's JSON marker never appeared:\n%s", res.combined())
+	body := strings.TrimSpace(after)
+	require.NotEmpty(t, body, "find-smells produced no JSON:\n%s", res.combined())
+
+	var scan struct {
+		Rule     string `json:"rule"`
+		Total    int    `json:"total"`
+		Findings []struct {
+			SourceID string `json:"source_id"`
+			NodeID   string `json:"node_id"`
+		} `json:"findings"`
+	}
+	require.NoErrorf(t, json.Unmarshal([]byte(body), &scan),
+		"find-smells output is not the expected JSON shape:\n%s", body)
+
+	assert.Equal(t, "untested_function", scan.Rule)
+	nodeIDs := make([]string, 0, len(scan.Findings))
+	for _, f := range scan.Findings {
+		assert.Equal(t, "pkg/checksum.go", f.SourceID)
+		nodeIDs = append(nodeIDs, f.NodeID)
+	}
+	assert.ElementsMatch(t,
+		[]string{fixtureChecksumDef, "pkg/checksum.go/function_declaration_1"}, nodeIDs,
+		"the containerised projection must address the fixture's two functions exactly")
+	assert.Equal(t, len(scan.Findings), scan.Total, "reported total must match the findings returned")
+}

--- a/tests/installverify/installverify_test.go
+++ b/tests/installverify/installverify_test.go
@@ -1,0 +1,161 @@
+// Package installverify is the INSTALL gate: it verifies a real mache
+// installation instead of assuming one.
+//
+// # Why this exists separately from the rest of the suite
+//
+// mache already has an all-tools harness (cmd/all_tools_e2e_test.go,
+// TestArena_AllTools). It exercises the tool surface by constructing graphs
+// IN PROCESS, which answers "does this source tree behave" — a different
+// question from "does the artifact a user actually installed behave". Three
+// things are invisible to an in-process test and are exactly what shipped
+// broken:
+//
+//   - the version the installed binary REPORTS (bead mache-4d7f2c: nothing
+//     verified a published artifact after the fact);
+//   - which leyline that binary REACHES. A stale ~/.local/bin/leyline 0.10.3
+//     shadowed the v0.13.0 pin on the reporter's machine, so `leyline cdc
+//     enable` at a shell ran a parser three minors off from the one that built
+//     the .db (bead mache-19326d). An in-process test resolves leyline through
+//     the same package it is testing, so it cannot see the skew;
+//   - whether the binary works from a CLEAN HOME with no repo checkout and no
+//     Taskfile — the condition every release-asset and Homebrew user is in,
+//     and the one a dev box cannot honestly simulate (docker_test.go).
+//
+// So this package drives an EXTERNAL binary: fork/exec only, MCP over the
+// wire, no imports from cmd/. It deliberately does not use
+// github.com/mark3labs/mcp-go's client either — the server speaks that
+// library, and a gate that verifies a library against itself proves less than
+// one that speaks the raw protocol a third-party consumer speaks.
+//
+// # Running it
+//
+//	task install:verify                        # the just-built bin/mache
+//	task install:verify BIN=~/.local/bin/mache # what `task install` installed
+//	task install:verify:docker                 # clean-HOME leg, published image
+//
+// The binary under test comes from MACHE_VERIFY_BINARY. With it unset every
+// test here skips, so `go test ./...` stays green without a build step; the
+// Taskfile targets above are the supported entry points and CI invokes those.
+package installverify
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// binaryEnv names the mache binary under test. Absent -> skip, so this package
+// is inert under a plain `go test ./...` and load-bearing under `task
+// install:verify`.
+const binaryEnv = "MACHE_VERIFY_BINARY"
+
+// cmdTimeout bounds every subprocess this package runs. Generous: `mache
+// build` shells out to leyline, which parses a whole tree.
+const cmdTimeout = 5 * time.Minute
+
+// macheBinary returns the absolute path of the binary under test, skipping the
+// test when none is configured.
+func macheBinary(t *testing.T) string {
+	t.Helper()
+	p := strings.TrimSpace(os.Getenv(binaryEnv))
+	if p == "" {
+		t.Skipf("%s unset — run `task install:verify` (or set %s=/path/to/mache)", binaryEnv, binaryEnv)
+	}
+	abs, err := filepath.Abs(p)
+	require.NoError(t, err, "resolve %s=%q", binaryEnv, p)
+	info, err := os.Stat(abs)
+	require.NoErrorf(t, err, "%s=%s does not exist — the gate verifies an INSTALLED binary, so a missing one is a failure, not a skip", binaryEnv, abs)
+	require.False(t, info.IsDir(), "%s=%s is a directory", binaryEnv, abs)
+	require.NotZero(t, info.Mode()&0o111, "%s=%s is not executable", binaryEnv, abs)
+	return abs
+}
+
+// result is the outcome of one subprocess run.
+type result struct {
+	stdout string
+	stderr string
+	code   int
+	err    error // non-nil only when the process could not be run/awaited
+}
+
+// combined is stdout+stderr, for assertions that don't care which stream a
+// diagnostic landed on.
+func (r result) combined() string { return r.stdout + r.stderr }
+
+// runner runs a command with a bounded timeout and an explicit environment.
+type runner struct {
+	env []string // when nil, the parent environment is inherited
+	dir string
+}
+
+// run executes name with args and captures both streams. A non-zero exit is a
+// RESULT, not an error — callers assert on the code — so err is reserved for
+// "could not run it at all".
+func (rn runner) run(t *testing.T, name string, args ...string) result {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), cmdTimeout)
+	defer cancel()
+
+	c := exec.CommandContext(ctx, name, args...)
+	c.Dir = rn.dir
+	if rn.env != nil {
+		c.Env = rn.env
+	}
+	var stdout, stderr strings.Builder
+	c.Stdout, c.Stderr = &stdout, &stderr
+
+	err := c.Run()
+	res := result{stdout: stdout.String(), stderr: stderr.String()}
+	if err == nil {
+		return res
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		res.code = exitErr.ExitCode()
+		return res
+	}
+	res.err = err
+	return res
+}
+
+// mustRun runs a command and fails the test unless it exits 0, quoting both
+// streams — a gate whose failure message omits the tool's own diagnostic wastes
+// the run that produced it.
+func (rn runner) mustRun(t *testing.T, name string, args ...string) result {
+	t.Helper()
+	res := rn.run(t, name, args...)
+	require.NoError(t, res.err, "run %s %v", name, args)
+	require.Zerof(t, res.code, "%s %v exited %d\n--- stdout ---\n%s\n--- stderr ---\n%s",
+		name, args, res.code, res.stdout, res.stderr)
+	return res
+}
+
+// macheTreeRoot is the mache checkout this test file lives in. Used to read
+// version.txt and to reach the fixture; the gate reads the SOURCE OF TRUTH
+// from the tree and compares the INSTALLED binary against it, which is the
+// whole point.
+func macheTreeRoot(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd() // tests/installverify
+	require.NoError(t, err)
+	root := filepath.Dir(filepath.Dir(wd))
+	_, err = os.Stat(filepath.Join(root, "go.mod"))
+	require.NoErrorf(t, err, "expected the repo root at %s (no go.mod there)", root)
+	return root
+}
+
+// fixtureDir is the tiny, deliberately stable source tree the MCP assertions
+// project. See its package doc for why its shape is load-bearing.
+func fixtureDir(t *testing.T) string {
+	t.Helper()
+	d, err := filepath.Abs(filepath.Join("testdata", "fixture"))
+	require.NoError(t, err)
+	return d
+}

--- a/tests/installverify/leyline_pin_test.go
+++ b/tests/installverify/leyline_pin_test.go
@@ -1,0 +1,270 @@
+package installverify
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expectLeylineEnv pins the leyline version the installed mache must reach,
+// for release-verification mode (a downloaded v0.19.0 asset pins a different
+// leyline than this tree does). Unset, the expectation is this tree's pin.
+const expectLeylineEnv = "MACHE_VERIFY_EXPECT_LEYLINE"
+
+// shadowVersion is the version the deliberately-stale stub reports. It is the
+// version measured in bead mache-19326d: ~/.local/bin/leyline was 0.10.3 while
+// the pin was v0.13.0, so `leyline cdc enable` at a shell ran a parser three
+// minors off from the one that built the .db. Both binaries are named
+// `leyline`; neither warns.
+const shadowVersion = "0.10.3"
+
+// semverRe pulls the first MAJOR.MINOR[.PATCH] token out of a version line
+// such as "leyline 0.13.0 (open)".
+var semverRe = regexp.MustCompile(`\bv?(\d+\.\d+(?:\.\d+)?)\b`)
+
+// expectedLeylinePin is the leyline version the installed mache must resolve.
+func expectedLeylinePin(t *testing.T) string {
+	t.Helper()
+	if v := strings.TrimSpace(os.Getenv(expectLeylineEnv)); v != "" {
+		return strings.TrimPrefix(v, "v")
+	}
+	return strings.TrimPrefix(leyline.BinaryVersion, "v")
+}
+
+// leylineSemver runs `<path> --version` and returns the semver it reports.
+// A binary that will not run, or whose output carries no version, yields "" —
+// unverifiable is NOT a pass, matching internal/leyline's own posture.
+func leylineSemver(t *testing.T, env []string, path string) string {
+	t.Helper()
+	res := runner{env: env}.run(t, path, "--version")
+	if res.err != nil || res.code != 0 {
+		return ""
+	}
+	m := semverRe.FindStringSubmatch(res.combined())
+	if len(m) != 2 {
+		return ""
+	}
+	return m[1]
+}
+
+// checkLeylinePin is the gate's actual comparator, factored out so its ability
+// to REJECT can be exercised directly (see
+// TestLeylinePinComparatorRejectsAStaleBinary). Returns nil only when path
+// reports exactly want.
+func checkLeylinePin(t *testing.T, env []string, path, want string) error {
+	t.Helper()
+	got := leylineSemver(t, env, path)
+	if got == "" {
+		return fmt.Errorf("%s reports no parseable version — refusing to treat an unverifiable leyline as the pin %s", path, want)
+	}
+	if got != want {
+		return fmt.Errorf("leyline at %s reports %s, but mache pins %s", path, got, want)
+	}
+	return nil
+}
+
+// plantStaleLeyline writes an executable stub that answers --version with
+// shadowVersion and shouts on stdout for any other argv, and returns its
+// directory and path.
+func plantStaleLeyline(t *testing.T) (dir, path string) {
+	t.Helper()
+	dir = t.TempDir()
+	path = filepath.Join(dir, "leyline")
+	script := "#!/bin/sh\n" +
+		"if [ \"$1\" = \"--version\" ]; then echo 'leyline " + shadowVersion + " (open)'; exit 0; fi\n" +
+		"echo SHADOW-RAN\n"
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+	return dir, path
+}
+
+// envWithPathPrefix returns the ambient environment with dir PREPENDED to PATH
+// and MACHE_LEYLINE_BINARY cleared, so resolution is decided by PATH order and
+// the pinned cache alone — no override short-circuits the question.
+func envWithPathPrefix(t *testing.T, dir string) []string {
+	t.Helper()
+	out := make([]string, 0, len(os.Environ())+1)
+	for _, kv := range os.Environ() {
+		switch {
+		case strings.HasPrefix(kv, "PATH="):
+			out = append(out, "PATH="+dir+string(os.PathListSeparator)+strings.TrimPrefix(kv, "PATH="))
+		case strings.HasPrefix(kv, leyline.BinaryOverrideEnv+"="):
+			// dropped
+		default:
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// resolvedLeyline asks the INSTALLED mache which leyline it would use.
+// `mache leyline path` prints the absolute path on stdout and nothing else
+// (diagnostics go to stderr), which is the only reason this question is
+// answerable from outside the process at all.
+func resolvedLeyline(t *testing.T, bin string, env []string) string {
+	t.Helper()
+	res := runner{env: env}.run(t, bin, "leyline", "path")
+	require.NoError(t, res.err, "run %s leyline path", bin)
+	require.Zerof(t, res.code,
+		"`%s leyline path` exited %d — an installed mache must be able to name the leyline it uses "+
+			"(this subcommand is how the version question is asked; a binary without it predates PR #584)\n"+
+			"--- stdout ---\n%s\n--- stderr ---\n%s", bin, res.code, res.stdout, res.stderr)
+	p := strings.TrimSpace(res.stdout)
+	require.NotEmpty(t, p, "`leyline path` printed nothing on stdout")
+	require.True(t, filepath.IsAbs(p), "`leyline path` must print an absolute path, got %q", p)
+	return p
+}
+
+// TestLeylineInUseIsThePin is gate (a) in its ambient form: whatever leyline
+// the installed mache resolves in the environment you actually have must be
+// the pinned one.
+func TestLeylineInUseIsThePin(t *testing.T) {
+	bin := macheBinary(t)
+	want := expectedLeylinePin(t)
+
+	got := resolvedLeyline(t, bin, nil)
+	require.NoError(t, checkLeylinePin(t, nil, got, want),
+		"the installed mache resolves a leyline that is not the pin — every _ast-derived "+
+			"number it produces (projections, smell counts, node hashes) inherits that skew")
+	t.Logf("resolved leyline: %s (%s), pin %s", got, leylineSemver(t, nil, got), want)
+}
+
+// TestStaleLeylineOnPathDoesNotShadowThePin is the scenario this gate exists
+// for: bead mache-19326d, reproduced against the INSTALLED binary.
+//
+// A stale leyline is planted FIRST on PATH — proven live by asserting that a
+// shell resolves it — and mache must still reach the pin. Before `mache
+// leyline path` existed, PATH was the only answer a caller had, so this
+// fixture is exactly the world the reporter was in; any regression that hands
+// resolution back to PATH resolves the stub and turns this red.
+func TestStaleLeylineOnPathDoesNotShadowThePin(t *testing.T) {
+	bin := macheBinary(t)
+	want := expectedLeylinePin(t)
+
+	shadowDir, shadow := plantStaleLeyline(t)
+	env := envWithPathPrefix(t, shadowDir)
+
+	// Fixture liveness. Without this the test could pass because the shadow
+	// was never reachable, which proves nothing.
+	viaShell := runner{env: env}.mustRun(t, "/bin/sh", "-c", "command -v leyline")
+	require.Equal(t, shadow, strings.TrimSpace(viaShell.stdout),
+		"the fixture must actually shadow — a shell has to resolve the stale stub for this test to mean anything")
+	require.NotEqual(t, want, shadowVersion, "the shadow must differ from the pin, or it shadows nothing")
+
+	got := resolvedLeyline(t, bin, env)
+	assert.NotEqual(t, shadow, got, "resolving the PATH copy is precisely the mache-19326d skew")
+	assert.NoError(t, checkLeylinePin(t, env, got, want))
+
+	// The exec surface must agree with the path surface — a caller who runs
+	// `mache leyline exec` rather than interpolating `$(mache leyline path)`
+	// must get the same binary.
+	execd := runner{env: env}.mustRun(t, bin, "leyline", "exec", "--", "--version")
+	assert.NotContains(t, execd.combined(), "SHADOW-RAN",
+		"`mache leyline exec` must not proxy to the stale PATH copy")
+	m := semverRe.FindStringSubmatch(execd.stdout)
+	require.Len(t, m, 2, "`mache leyline exec -- --version` printed no version:\n%s", execd.combined())
+	assert.Equal(t, want, m[1], "the leyline mache RUNS must report the pin")
+}
+
+// TestLeylinePinComparatorRejectsAStaleBinary proves the comparator above can
+// fail. A gate that cannot go red is worse than no gate: it reads as evidence
+// while asserting nothing. Here the stale stub is fed to checkLeylinePin
+// directly, and the rejection must name both versions so the failure is
+// actionable rather than merely loud.
+func TestLeylinePinComparatorRejectsAStaleBinary(t *testing.T) {
+	want := expectedLeylinePin(t)
+	_, shadow := plantStaleLeyline(t)
+
+	err := checkLeylinePin(t, nil, shadow, want)
+	require.Error(t, err, "a %s binary must not satisfy a %s pin", shadowVersion, want)
+	assert.Contains(t, err.Error(), shadowVersion)
+	assert.Contains(t, err.Error(), want)
+
+	// An unverifiable binary is also a rejection, not a pass.
+	unrunnable := filepath.Join(t.TempDir(), "leyline")
+	require.NoError(t, os.WriteFile(unrunnable, []byte("not a program"), 0o644))
+	assert.Error(t, checkLeylinePin(t, nil, unrunnable, want),
+		"a leyline whose version cannot be read must be refused, not assumed to match")
+}
+
+// verifyHome is a HOME the gate owns. It is deliberately NOT t.TempDir():
+// provisioning downloads a ~30MB release asset, and a per-run temp HOME would
+// re-download on every `task check`. A stable location is genuinely clean the
+// first time (and on every CI runner) and cheap afterwards, while the
+// post-condition asserted below stays meaningful either way — see its caller.
+func verifyHome(t *testing.T) string {
+	t.Helper()
+	home := filepath.Join(os.TempDir(), "mache-installverify-home")
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".mache", "bin"), 0o755))
+	// Remove the UNVERSIONED path if a previous run (or anything else) left
+	// one, so "absent afterwards" means mache did not write it rather than
+	// "it was never there and nothing tried".
+	require.NoError(t, os.RemoveAll(filepath.Join(home, ".mache", "bin", "leyline")))
+	return home
+}
+
+// TestCleanHomeProvisionsOnlyTheVersionedPath is bead mache-19326d's
+// acceptance criterion minus the container: from a HOME with no ~/.mache and a
+// PATH with no leyline on it, the installed binary must provision the pin by
+// itself — no repo, no Taskfile, no `task leyline:ensure`.
+//
+// It simultaneously guards mache-0acdf6 from the OUTSIDE: the unversioned
+// ~/.mache/bin/leyline was a shared mutable resource concurrent mache builds
+// overwrote, silently changing _ast shape between runs, so provisioning must
+// write ONLY the version-namespaced path. cmd/leyline_proxy_test.go pins that
+// in-process; this pins that the SHIPPED binary behaves the same way.
+func TestCleanHomeProvisionsOnlyTheVersionedPath(t *testing.T) {
+	bin := macheBinary(t)
+	if os.Getenv("MACHE_NO_LEYLINE") != "" {
+		t.Skip("MACHE_NO_LEYLINE set — provisioning is the subject of this test, so there is nothing to assert")
+	}
+	want := expectedLeylinePin(t)
+	home := verifyHome(t)
+
+	// PATH without any leyline, so the pinned cache is the only way to
+	// succeed. /usr/bin:/bin keeps the download path's own shell-outs working.
+	env := append(scrubbedEnv(t), "HOME="+home, "PATH=/usr/bin:/bin")
+
+	got := resolvedLeyline(t, bin, env)
+	assert.Equal(t, filepath.Join(home, ".mache", "bin", "leyline-"+leylinePinTag(t)), got,
+		"provisioning must land in the VERSION-NAMESPACED cache path")
+	assert.NoError(t, checkLeylinePin(t, env, got, want))
+
+	_, err := os.Lstat(filepath.Join(home, ".mache", "bin", "leyline"))
+	assert.Truef(t, os.IsNotExist(err),
+		"the unversioned ~/.mache/bin/leyline must stay unwritten (mache-0acdf6); got %v", err)
+}
+
+// leylinePinTag is the pin in its v-prefixed tag form, which is how the cache
+// namespaces filenames.
+func leylinePinTag(t *testing.T) string {
+	t.Helper()
+	return "v" + expectedLeylinePin(t)
+}
+
+// scrubbedEnv is the ambient environment minus every variable that could
+// pre-decide leyline resolution or relocate HOME.
+func scrubbedEnv(t *testing.T) []string {
+	t.Helper()
+	drop := []string{"HOME=", "PATH=", leyline.BinaryOverrideEnv + "="}
+	out := make([]string, 0, len(os.Environ()))
+	for _, kv := range os.Environ() {
+		skip := false
+		for _, p := range drop {
+			if strings.HasPrefix(kv, p) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, kv)
+		}
+	}
+	return out
+}

--- a/tests/installverify/leyline_pin_test.go
+++ b/tests/installverify/leyline_pin_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -25,9 +24,22 @@ const expectLeylineEnv = "MACHE_VERIFY_EXPECT_LEYLINE"
 // `leyline`; neither warns.
 const shadowVersion = "0.10.3"
 
-// semverRe pulls the first MAJOR.MINOR[.PATCH] token out of a version line
-// such as "leyline 0.13.0 (open)".
-var semverRe = regexp.MustCompile(`\bv?(\d+\.\d+(?:\.\d+)?)\b`)
+// firstSemver returns the first MAJOR.MINOR.PATCH field of a version line such
+// as "leyline 0.13.0 (open)", or "" when there is none.
+//
+// A field scan with a shape check, not a pattern: this mirrors
+// internal/leyline's own extractSemver, which is unexported, and keeps the gate
+// on the repo's structural-over-regex side (bead-documented preference, and the
+// regexp ratchet in internal/lint enforces it).
+func firstSemver(s string) string {
+	for _, field := range strings.Fields(s) {
+		candidate := strings.TrimPrefix(strings.Trim(field, "(),"), "v")
+		if isSemverBase(candidate) {
+			return candidate
+		}
+	}
+	return ""
+}
 
 // expectedLeylinePin is the leyline version the installed mache must resolve.
 func expectedLeylinePin(t *testing.T) string {
@@ -47,11 +59,7 @@ func leylineSemver(t *testing.T, env []string, path string) string {
 	if res.err != nil || res.code != 0 {
 		return ""
 	}
-	m := semverRe.FindStringSubmatch(res.combined())
-	if len(m) != 2 {
-		return ""
-	}
-	return m[1]
+	return firstSemver(res.combined())
 }
 
 // checkLeylinePin is the gate's actual comparator, factored out so its ability
@@ -167,9 +175,9 @@ func TestStaleLeylineOnPathDoesNotShadowThePin(t *testing.T) {
 	execd := runner{env: env}.mustRun(t, bin, "leyline", "exec", "--", "--version")
 	assert.NotContains(t, execd.combined(), "SHADOW-RAN",
 		"`mache leyline exec` must not proxy to the stale PATH copy")
-	m := semverRe.FindStringSubmatch(execd.stdout)
-	require.Len(t, m, 2, "`mache leyline exec -- --version` printed no version:\n%s", execd.combined())
-	assert.Equal(t, want, m[1], "the leyline mache RUNS must report the pin")
+	ran := firstSemver(execd.stdout)
+	require.NotEmpty(t, ran, "`mache leyline exec -- --version` printed no version:\n%s", execd.combined())
+	assert.Equal(t, want, ran, "the leyline mache RUNS must report the pin")
 }
 
 // TestLeylinePinComparatorRejectsAStaleBinary proves the comparator above can

--- a/tests/installverify/mcp_client_test.go
+++ b/tests/installverify/mcp_client_test.go
@@ -1,0 +1,301 @@
+package installverify
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A minimal MCP Streamable-HTTP client — deliberately hand-rolled.
+//
+// The server speaks github.com/mark3labs/mcp-go. Using that library's client
+// here would verify the library against itself; the question this gate asks is
+// whether an INSTALLED mache answers a third-party consumer on the wire, so it
+// speaks the raw protocol instead. It is ~100 lines because Streamable HTTP is
+// small: POST JSON-RPC, read the session id out of the Mcp-Session-Id response
+// header, echo it on every subsequent call.
+//
+// One behaviour worth writing down, because it costs an unexplained 5s stall
+// and then a confusing error otherwise: a client that does not implement the
+// MCP ROOTS protocol cannot answer the server's roots/list request, so
+// root-dependent tools time out and return "workspace root unavailable". This
+// client does not implement roots — it does not need to, because the harness
+// starts mache with an explicit `--path`, which makes the server resolve the
+// session against that directory instead of asking.
+
+const (
+	// mcpProtocolVersion is the revision this client negotiates. Pinned, not
+	// floating: a gate that silently renegotiates is a gate that can stop
+	// testing the thing it was written for.
+	mcpProtocolVersion = "2025-06-18"
+
+	sessionHeader = "Mcp-Session-Id"
+)
+
+type mcpClient struct {
+	url     string
+	session string
+	http    *http.Client
+	nextID  int
+}
+
+// rpcResponse is the subset of a JSON-RPC response this gate reads.
+type rpcResponse struct {
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error"`
+	Result json.RawMessage `json:"result"`
+}
+
+// toolResult is the subset of an MCP CallToolResult this gate reads. Every
+// mache tool answers with a single text content block whose body is JSON.
+type toolResult struct {
+	IsError bool `json:"isError"`
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+}
+
+func newMCPClient(url string) *mcpClient {
+	return &mcpClient{url: url, http: &http.Client{Timeout: 60 * time.Second}}
+}
+
+// post sends one JSON-RPC message and returns the decoded response. A nil
+// response means the server accepted a notification with no body.
+func (c *mcpClient) post(ctx context.Context, method string, params any) (*rpcResponse, http.Header, error) {
+	c.nextID++
+	msg := map[string]any{"jsonrpc": "2.0", "method": method}
+	if params != nil {
+		msg["params"] = params
+	}
+	if !strings.HasPrefix(method, "notifications/") {
+		msg["id"] = c.nextID
+	}
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	if c.session != "" {
+		req.Header.Set(sessionHeader, c.session)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+	if resp.StatusCode >= 400 {
+		return nil, resp.Header, fmt.Errorf("%s: HTTP %d: %s", method, resp.StatusCode, strings.TrimSpace(string(raw)))
+	}
+	payload := unwrapSSE(resp.Header.Get("Content-Type"), raw)
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return nil, resp.Header, nil // accepted notification
+	}
+	var out rpcResponse
+	if err := json.Unmarshal(payload, &out); err != nil {
+		return nil, resp.Header, fmt.Errorf("%s: decode response %q: %w", method, string(payload), err)
+	}
+	if out.Error != nil {
+		return nil, resp.Header, fmt.Errorf("%s: JSON-RPC error %d: %s", method, out.Error.Code, out.Error.Message)
+	}
+	return &out, resp.Header, nil
+}
+
+// unwrapSSE extracts the JSON payload from an event-stream body. Streamable
+// HTTP may answer either as application/json or as a one-event SSE frame; both
+// carry the same JSON-RPC message.
+func unwrapSSE(contentType string, raw []byte) []byte {
+	if !strings.Contains(contentType, "text/event-stream") {
+		return raw
+	}
+	var buf bytes.Buffer
+	sc := bufio.NewScanner(bytes.NewReader(raw))
+	sc.Buffer(make([]byte, 0, 64*1024), 16*1024*1024)
+	for sc.Scan() {
+		if line, ok := strings.CutPrefix(sc.Text(), "data:"); ok {
+			buf.WriteString(strings.TrimSpace(line))
+		}
+	}
+	return buf.Bytes()
+}
+
+// initialize performs the MCP handshake and captures the session id, which
+// every later call must echo — without it the server answers 404 "Invalid
+// session ID".
+func (c *mcpClient) initialize(ctx context.Context) error {
+	_, hdr, err := c.post(ctx, "initialize", map[string]any{
+		"protocolVersion": mcpProtocolVersion,
+		"capabilities":    map[string]any{},
+		"clientInfo":      map[string]any{"name": "mache-install-verify", "version": "1"},
+	})
+	if err != nil {
+		return err
+	}
+	c.session = hdr.Get(sessionHeader)
+	if c.session == "" {
+		return fmt.Errorf("server returned no %s header; stateful sessions require one", sessionHeader)
+	}
+	_, _, err = c.post(ctx, "notifications/initialized", map[string]any{})
+	return err
+}
+
+// callTool invokes an MCP tool and returns the text body of its single content
+// block. A tool that answered with isError returns an error carrying that text,
+// so "the tool ran" and "the tool worked" stay distinguishable.
+func (c *mcpClient) callTool(ctx context.Context, name string, args map[string]any) (string, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	resp, _, err := c.post(ctx, "tools/call", map[string]any{"name": name, "arguments": args})
+	if err != nil {
+		return "", err
+	}
+	var tr toolResult
+	if err := json.Unmarshal(resp.Result, &tr); err != nil {
+		return "", fmt.Errorf("%s: decode tool result: %w", name, err)
+	}
+	if len(tr.Content) == 0 {
+		return "", fmt.Errorf("%s: tool returned no content blocks", name)
+	}
+	text := tr.Content[0].Text
+	if tr.IsError {
+		return text, fmt.Errorf("%s: tool reported an error: %s", name, text)
+	}
+	return text, nil
+}
+
+// freePort reserves a port by binding and immediately releasing it. `mache
+// serve` rejects a bare ":0" and never reports the port it actually bound, so
+// the caller has to choose one. The window between release and bind is a
+// theoretical race, not a practical one on a test host.
+func freePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	port := l.Addr().(*net.TCPAddr).Port
+	require.NoError(t, l.Close())
+	return port
+}
+
+// startServe launches `mache serve <db> --http localhost:<port> --path <dir>`
+// and blocks until the endpoint answers an initialize, returning a ready
+// client. The process is killed and its output dumped on failure.
+//
+// --path is not optional here: without it the server asks the client for MCP
+// roots, which this client does not implement, and every tool call fails with
+// "workspace root unavailable" after a 5s stall.
+func startServe(t *testing.T, bin, dbPath, basePath string) *mcpClient {
+	t.Helper()
+	port := freePort(t)
+	url := fmt.Sprintf("http://localhost:%d/mcp", port)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	c := exec.CommandContext(ctx, bin, "serve", dbPath,
+		"--http", fmt.Sprintf("localhost:%d", port), "--path", basePath)
+
+	// Child output goes to a FILE, not an in-process buffer. The readiness
+	// loop reads it while the child is still writing, and a shared
+	// bytes.Buffer would need its own lock; the kernel already provides one.
+	logPath := filepath.Join(t.TempDir(), "serve.log")
+	logFile, err := os.Create(logPath)
+	require.NoError(t, err)
+	c.Stdout, c.Stderr = logFile, logFile
+	serveOutput := func() string {
+		b, readErr := os.ReadFile(logPath)
+		if readErr != nil {
+			return fmt.Sprintf("(could not read %s: %v)", logPath, readErr)
+		}
+		return string(b)
+	}
+	require.NoError(t, c.Start(), "start mache serve")
+	require.NoError(t, logFile.Close(), "the child holds its own descriptor")
+
+	done := make(chan struct{})
+	go func() { _ = c.Wait(); close(done) }()
+	t.Cleanup(func() {
+		// CommandContext kills the child on cancel, so Wait always returns and
+		// this needs no timeout of its own.
+		cancel()
+		<-done
+		if t.Failed() {
+			t.Logf("mache serve output:\n%s", serveOutput())
+		}
+	})
+
+	// The "listening on …" log line is printed BEFORE ListenAndServe, so it is
+	// not proof the socket bound. Poll the endpoint instead — via
+	// require.Eventually rather than a hand-rolled sleep loop, which is both
+	// the repo's stated preference and what its sleep_in_test gate enforces.
+	var (
+		client  *mcpClient
+		lastErr error
+		exited  bool
+	)
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			exited = true
+			return true // stop polling; the assertions below explain why
+		default:
+		}
+		candidate := newMCPClient(url)
+		pingCtx, pingCancel := context.WithTimeout(ctx, 10*time.Second)
+		defer pingCancel()
+		if err := candidate.initialize(pingCtx); err != nil {
+			lastErr = err
+			return false
+		}
+		client = candidate
+		return true
+	}, 60*time.Second, 150*time.Millisecond,
+		"mache serve never answered on %s (last error: %v)\n%s", url, lastErr, serveOutput())
+
+	require.Falsef(t, exited, "mache serve exited before becoming ready:\n%s", serveOutput())
+	require.NotNilf(t, client, "mache serve never completed an MCP handshake on %s: %v\n%s",
+		url, lastErr, serveOutput())
+	return client
+}
+
+// decodeJSON unmarshals a tool's text body, failing the test with the body
+// quoted when it is not the JSON the assertion expects.
+func decodeJSON[T any](t *testing.T, tool, body string) T {
+	t.Helper()
+	var v T
+	require.NoErrorf(t, json.Unmarshal([]byte(body), &v),
+		"%s returned a body that is not the expected JSON shape:\n%s", tool, body)
+	return v
+}
+
+// requireFileExists fails when path is missing, quoting what was expected.
+func requireFileExists(t *testing.T, path, what string) os.FileInfo {
+	t.Helper()
+	info, err := os.Stat(path)
+	require.NoErrorf(t, err, "%s missing at %s", what, path)
+	return info
+}

--- a/tests/installverify/mcp_test.go
+++ b/tests/installverify/mcp_test.go
@@ -1,0 +1,177 @@
+package installverify
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Gate (c): the installed binary's commands RUN AND RETURN CORRECT RESULTS.
+//
+// Exit codes are not evidence. `mache serve` exits 0 while serving an empty
+// graph; a projection that lost every symbol answers find_definition with a
+// well-formed "no definition found". Both are green to a smoke test that only
+// checks status. So every assertion below names a specific expected VALUE
+// derived from the fixture — a node id, a symbol count, a rule id — and the
+// fixture is small enough that those values are stated, not computed.
+
+// fixtureChecksumDef is the projection address of ComputeChecksum, the
+// fixture's first top-level declaration. Stating the exact id (rather than
+// asserting non-emptiness) is what makes this an assertion about CORRECTNESS:
+// a backend that returns the right count of wrong addresses fails here.
+const fixtureChecksumDef = "pkg/checksum.go/function_declaration_0"
+
+// buildFixtureDB projects the fixture with the INSTALLED binary and returns
+// the .db path. This is the `mache build` half of the install: a binary that
+// cannot reach a working leyline fails here rather than at serve time.
+func buildFixtureDB(t *testing.T, bin string) string {
+	t.Helper()
+	db := filepath.Join(t.TempDir(), "fixture.db")
+	res := runner{}.mustRun(t, bin, "build", fixtureDir(t), db)
+	t.Logf("mache build: %s", strings.TrimSpace(res.combined()))
+
+	info := requireFileExists(t, db, "projection built by `mache build`")
+	require.NotZero(t, info.Size(), "`mache build` produced an EMPTY .db — exit 0 is not evidence")
+	return db
+}
+
+// TestInstalledMacheServesCorrectResults drives the core MCP tools against a
+// projection the installed binary itself produced, and asserts on their
+// content. One server for all of them: the first tool call of a session pays a
+// one-off root-resolution timeout, and paying it per assertion would buy
+// nothing.
+func TestInstalledMacheServesCorrectResults(t *testing.T) {
+	bin := macheBinary(t)
+	db := buildFixtureDB(t, bin)
+	client := startServe(t, bin, db, fixtureDir(t))
+	ctx := t.Context()
+
+	t.Run("find_definition returns the expected node id", func(t *testing.T) {
+		assertFindDefinition(t, ctx, client)
+	})
+	t.Run("find_definition discriminates — an absent symbol is not found", func(t *testing.T) {
+		assertFindDefinitionMiss(t, ctx, client)
+	})
+	t.Run("get_overview returns non-empty structure", func(t *testing.T) {
+		assertOverview(t, ctx, client)
+	})
+	t.Run("list_directory returns the projected tree", func(t *testing.T) {
+		assertListDirectory(t, ctx, client)
+	})
+	t.Run("find_smells returns the rule registry", func(t *testing.T) {
+		assertSmellRegistry(t, ctx, client)
+	})
+	t.Run("an unknown tool is rejected rather than silently accepted", func(t *testing.T) {
+		_, err := client.callTool(ctx, "no_such_tool", nil)
+		assert.Error(t, err, "the server must reject a tool it does not implement")
+	})
+}
+
+func assertFindDefinition(t *testing.T, ctx context.Context, client *mcpClient) {
+	t.Helper()
+	body, err := client.callTool(ctx, "find_definition", map[string]any{"symbol": "ComputeChecksum"})
+	require.NoError(t, err)
+
+	got := decodeJSON[struct {
+		Symbol      string   `json:"symbol"`
+		Definitions []string `json:"definitions"`
+	}](t, "find_definition", body)
+
+	assert.Equal(t, "ComputeChecksum", got.Symbol)
+	assert.Equal(t, []string{fixtureChecksumDef}, got.Definitions,
+		"the projection must address the fixture's first declaration exactly")
+}
+
+// assertFindDefinitionMiss is the falsifier for assertFindDefinition: if
+// find_definition answered every query with the same non-empty list, that
+// assertion would pass for the wrong reason.
+func assertFindDefinitionMiss(t *testing.T, ctx context.Context, client *mcpClient) {
+	t.Helper()
+	body, err := client.callTool(ctx, "find_definition",
+		map[string]any{"symbol": "NoSuchSymbolInTheFixture"})
+	require.NoError(t, err, "a miss is a result, not a transport failure")
+	assert.NotContains(t, body, fixtureChecksumDef,
+		"a symbol that does not exist must not resolve to one that does")
+}
+
+func assertOverview(t *testing.T, ctx context.Context, client *mcpClient) {
+	t.Helper()
+	body, err := client.callTool(ctx, "get_overview", nil)
+	require.NoError(t, err)
+
+	got := decodeJSON[struct {
+		TopLevel []struct {
+			Name     string `json:"name"`
+			Path     string `json:"path"`
+			Children int    `json:"children"`
+		} `json:"top_level"`
+		TotalDirs  int `json:"total_dirs"`
+		TotalFiles int `json:"total_files"`
+		DefTokens  int `json:"def_tokens"`
+	}](t, "get_overview", body)
+
+	assert.NotEmpty(t, got.TopLevel, "overview must describe the projected tree")
+	assert.Positive(t, got.TotalFiles, "a projection with no files is a silent ingestion failure")
+	assert.GreaterOrEqual(t, got.DefTokens, 2,
+		"the fixture defines ComputeChecksum and VerifyChecksum; fewer means definitions were lost")
+
+	names := make([]string, 0, len(got.TopLevel))
+	for _, d := range got.TopLevel {
+		names = append(names, d.Name)
+	}
+	assert.Contains(t, names, "pkg", "the fixture's only package directory must appear at top level")
+}
+
+func assertListDirectory(t *testing.T, ctx context.Context, client *mcpClient) {
+	t.Helper()
+	body, err := client.callTool(ctx, "list_directory", map[string]any{"path": ""})
+	require.NoError(t, err)
+
+	entries := decodeJSON[[]struct {
+		Name string `json:"name"`
+		Path string `json:"path"`
+		Type string `json:"type"`
+	}](t, "list_directory", body)
+	require.NotEmpty(t, entries, "the root of a built projection is never empty")
+
+	var sawPkgDir bool
+	for _, e := range entries {
+		if e.Name == "pkg" && e.Type == "dir" {
+			sawPkgDir = true
+		}
+	}
+	assert.True(t, sawPkgDir, "expected a `pkg` directory entry, got %s", body)
+}
+
+// assertSmellRegistry calls find_smells with no `rule`, which answers with the
+// rule registry — a known-shape result that does not depend on how much debt
+// the tiny fixture happens to contain, so the assertion is about the tool
+// working rather than about the fixture's contents.
+func assertSmellRegistry(t *testing.T, ctx context.Context, client *mcpClient) {
+	t.Helper()
+	body, err := client.callTool(ctx, "find_smells", nil)
+	require.NoError(t, err)
+
+	got := decodeJSON[struct {
+		Help  string `json:"help"`
+		Rules []struct {
+			ID       string `json:"id"`
+			Severity string `json:"severity"`
+		} `json:"rules"`
+	}](t, "find_smells", body)
+
+	assert.NotEmpty(t, got.Help)
+	require.NotEmpty(t, got.Rules, "the built-in rule set is never empty")
+	ids := make([]string, 0, len(got.Rules))
+	for _, r := range got.Rules {
+		assert.NotEmpty(t, r.ID, "every rule must carry an id")
+		assert.NotEmpty(t, r.Severity, "severity is always emitted, defaulting to warn")
+		ids = append(ids, r.ID)
+	}
+	assert.Contains(t, ids, "duplicate_definitions",
+		"a built-in rule went missing from the shipped binary's registry")
+}

--- a/tests/installverify/testdata/fixture/go.mod
+++ b/tests/installverify/testdata/fixture/go.mod
@@ -1,0 +1,3 @@
+module example.com/machefixture
+
+go 1.24

--- a/tests/installverify/testdata/fixture/pkg/checksum.go
+++ b/tests/installverify/testdata/fixture/pkg/checksum.go
@@ -1,0 +1,24 @@
+// Package pkg is the install-verification fixture's only package.
+//
+// It is deliberately tiny and deliberately BORING: the install gate asserts on
+// exact projection addresses (e.g. pkg/checksum.go/function_declaration_0),
+// which are ordinal within the file. Reordering, inserting, or removing a
+// top-level declaration here changes those addresses and will fail the gate —
+// that is intended. Edit the expectations in mcp_test.go in the same commit.
+package pkg
+
+// ComputeChecksum sums the bytes of b. First top-level declaration in this
+// file, hence function_declaration_0.
+func ComputeChecksum(b []byte) int {
+	total := 0
+	for _, x := range b {
+		total += int(x)
+	}
+	return total
+}
+
+// VerifyChecksum reports whether b sums to want. Second top-level declaration,
+// hence function_declaration_1, and the only caller of ComputeChecksum.
+func VerifyChecksum(b []byte, want int) bool {
+	return ComputeChecksum(b) == want
+}

--- a/tests/installverify/version_test.go
+++ b/tests/installverify/version_test.go
@@ -1,0 +1,173 @@
+package installverify
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// expectEnv pins the version the installed binary must report, for the
+// release-verification mode of this gate: `task install:verify
+// BIN=/tmp/mache-v0.20.0 MACHE_VERIFY_EXPECT_VERSION=0.20.0` checks a
+// downloaded release asset against its own tag (bead mache-4d7f2c) rather than
+// against the working tree.
+const expectEnv = "MACHE_VERIFY_EXPECT_VERSION"
+
+// versionLineRe parses `mache version 0.20.0-2-g56c54b3 (commit …, built …)`.
+// Anchored on the "mache version " prefix so a binary that prints something
+// else entirely fails loudly instead of matching a stray semver elsewhere in
+// its output.
+var versionLineRe = regexp.MustCompile(`(?m)^mache version ([^\s]+) `)
+
+// describeRe decomposes a `git describe`-shaped version into its parts:
+// <base>[-<distance>-g<sha>][-dirty]. `task build` stamps exactly this, and
+// cmd.Version strips only the leading "v".
+var describeRe = regexp.MustCompile(`^(\d+\.\d+\.\d+)(?:-(\d+)-g([0-9a-f]+))?(-dirty)?$`)
+
+// reportedVersion runs `<mache> version` and returns the version token.
+func reportedVersion(t *testing.T, bin string) string {
+	t.Helper()
+	res := runner{}.mustRun(t, bin, "version")
+	m := versionLineRe.FindStringSubmatch(res.stdout)
+	require.Lenf(t, m, 2,
+		"`%s version` must print `mache version <ver> (commit …, built …)`; got:\n%s", bin, res.combined())
+	return m[1]
+}
+
+// git runs a git command in root, returning trimmed stdout and whether it
+// succeeded. Every git fact this gate uses is optional — a released tarball
+// verified outside a checkout has no git at all.
+func git(t *testing.T, root string, args ...string) (string, bool) {
+	t.Helper()
+	res := runner{dir: root}.run(t, "git", args...)
+	if res.err != nil || res.code != 0 {
+		return "", false
+	}
+	return strings.TrimSpace(res.stdout), true
+}
+
+// tagAtHEAD returns the v-prefixed release tag pointing at HEAD, or "".
+// Mirrors `task version:check`'s `git tag --points-at HEAD | grep '^v'`.
+func tagAtHEAD(t *testing.T, root string) string {
+	t.Helper()
+	out, ok := git(t, root, "tag", "--points-at", "HEAD")
+	if !ok {
+		return ""
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if tag := strings.TrimSpace(line); strings.HasPrefix(tag, "v") {
+			return tag
+		}
+	}
+	return ""
+}
+
+// versionTxt is the canonical clean release base, read from the TREE rather
+// than imported from internal/buildinfo on purpose: importing it would compile
+// the expectation from the same source that produced the binary under test,
+// which cannot detect a stale installed artifact. The file is the contract.
+func versionTxt(t *testing.T, root string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(root, "internal", "buildinfo", "version.txt"))
+	require.NoError(t, err, "read internal/buildinfo/version.txt")
+	v := strings.TrimSpace(string(b))
+	require.NotEmpty(t, v, "internal/buildinfo/version.txt is empty")
+	return v
+}
+
+// TestInstalledMacheReportsExpectedVersion is gate (b): the installed binary's
+// reported version must be one this tree could have produced.
+//
+// The failure it catches, stated plainly: `mache` is not the mache you think
+// it is. That has cost an afternoon in this repo already — a Homebrew-tap
+// mache reporting v0.6.6 shadowed a v0.19.0 install, and because both answer
+// to the same name the skew was only findable by auditing PATH by hand (see
+// the mache-6ec106 triage).
+//
+// How strict the comparison is depends on how exact an answer exists:
+//
+//   - MACHE_VERIFY_EXPECT_VERSION set (release-asset mode) -> exact equality;
+//   - a tag at HEAD -> exact equality with the tag, mirroring `task
+//     version:check`, which checks version.txt against melange.yaml and the tag
+//     but never against a binary;
+//   - otherwise -> the RELEASE BASE must be one this tree carries, and the
+//     embedded commit must be an ancestor of HEAD.
+//
+// That last case is deliberately not exact-describe equality. A binary built
+// three commits ago reports a smaller distance than `git describe` says today,
+// and `task build`'s up-to-date check legitimately skips a rebuild when only
+// non-Go files changed — neither is an installation defect, and a gate that
+// cried wolf on both would be turned off. The ancestry check keeps the
+// load-bearing half: a FOREIGN binary's commit is not in this history.
+func TestInstalledMacheReportsExpectedVersion(t *testing.T) {
+	bin := macheBinary(t)
+	root := macheTreeRoot(t)
+	got := reportedVersion(t, bin)
+
+	if want := strings.TrimPrefix(strings.TrimSpace(os.Getenv(expectEnv)), "v"); want != "" {
+		assert.Equalf(t, want, got,
+			"installed mache at %s reports %q but %s says %q", bin, got, expectEnv, want)
+		return
+	}
+
+	clean := versionTxt(t, root)
+	if tag := tagAtHEAD(t, root); tag != "" {
+		assert.Equal(t, "v"+clean, tag,
+			"tag at HEAD must equal v<version.txt> — the same invariant `task version:check` enforces")
+		assert.Equalf(t, clean, got,
+			"HEAD is tagged %s, so the installed binary must report %q exactly (no git-distance suffix); got %q from %s",
+			tag, clean, got, bin)
+		return
+	}
+
+	parts := describeRe.FindStringSubmatch(got)
+	require.Lenf(t, parts, 5,
+		"installed mache at %s reports %q, which is not a version this tree's build could produce "+
+			"(expected <base>[-<distance>-g<sha>][-dirty])", bin, got)
+	base, sha := parts[1], parts[3]
+
+	// The base tracks the most recent REACHABLE tag, which legitimately trails
+	// version.txt inside the release window (version.txt is bumped in the
+	// release commit and tagged afterwards). Accept either, and name both.
+	lastTag := strings.TrimPrefix(firstOK(git(t, root, "describe", "--tags", "--abbrev=0")), "v")
+	candidates := dedupe([]string{clean, lastTag})
+	assert.Containsf(t, candidates, base,
+		"installed mache at %s has release base %q, which matches neither version.txt (%q) nor the "+
+			"last reachable tag (%q). If this is a published asset, state its version: %s=<version>.",
+		bin, base, clean, lastTag, expectEnv)
+
+	if sha == "" {
+		return // a bare `go build` stamps no commit; nothing further to check
+	}
+	_, ok := git(t, root, "merge-base", "--is-ancestor", sha, "HEAD")
+	assert.Truef(t, ok,
+		"installed mache at %s was built from commit %s, which is not an ancestor of HEAD — "+
+			"that binary did not come from this tree", bin, sha)
+}
+
+// firstOK collapses git's (value, ok) to just the value; callers that treat ""
+// as "unknown" do not need to branch.
+func firstOK(v string, _ bool) string { return v }
+
+// dedupe drops empties and duplicates, so an assertion message lists only real
+// candidates.
+func dedupe(in []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s == "" {
+			continue
+		}
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/tests/installverify/version_test.go
+++ b/tests/installverify/version_test.go
@@ -3,7 +3,6 @@ package installverify
 import (
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 
@@ -18,25 +17,116 @@ import (
 // against the working tree.
 const expectEnv = "MACHE_VERIFY_EXPECT_VERSION"
 
-// versionLineRe parses `mache version 0.20.0-2-g56c54b3 (commit …, built …)`.
-// Anchored on the "mache version " prefix so a binary that prints something
-// else entirely fails loudly instead of matching a stray semver elsewhere in
-// its output.
-var versionLineRe = regexp.MustCompile(`(?m)^mache version ([^\s]+) `)
+// versionLinePrefix is what `mache version` prints before the version token.
+// Matching on the prefix and then taking the next FIELD is a structural read of
+// a known output shape — no pattern language involved, and a binary that prints
+// something else entirely fails loudly instead of matching a stray semver
+// elsewhere in its output.
+const versionLinePrefix = "mache version "
 
-// describeRe decomposes a `git describe`-shaped version into its parts:
-// <base>[-<distance>-g<sha>][-dirty]. `task build` stamps exactly this, and
-// cmd.Version strips only the leading "v".
-var describeRe = regexp.MustCompile(`^(\d+\.\d+\.\d+)(?:-(\d+)-g([0-9a-f]+))?(-dirty)?$`)
+// parseVersionLine returns the version token from `mache version <ver> (…)`.
+func parseVersionLine(stdout string) (string, bool) {
+	for _, line := range strings.Split(stdout, "\n") {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), versionLinePrefix)
+		if !ok {
+			continue
+		}
+		token, _, _ := strings.Cut(rest, " ")
+		if token != "" {
+			return token, true
+		}
+	}
+	return "", false
+}
+
+// describedVersion is a `git describe`-shaped version decomposed into its
+// parts: <base>[-<distance>-g<sha>][-dirty]. `task build` stamps exactly this,
+// and cmd.Version strips only the leading "v".
+type describedVersion struct {
+	base  string // MAJOR.MINOR.PATCH
+	sha   string // the g-prefixed commit, "" on a clean tag or a bare build
+	dirty bool
+}
+
+// parseDescribed decomposes a stamped version by splitting on its separators
+// and checking each field's shape, rather than by pattern-matching the whole
+// string. Reports false when the input is not a shape this tree's build could
+// have produced.
+func parseDescribed(v string) (describedVersion, bool) {
+	out := describedVersion{}
+	if trimmed, ok := strings.CutSuffix(v, "-dirty"); ok {
+		out.dirty, v = true, trimmed
+	}
+	parts := strings.Split(v, "-")
+	switch len(parts) {
+	case 1: // a clean tag, or a bare `go build` fallback
+	case 3: // <base>-<distance>-g<sha>
+		if !allDigits(parts[1]) {
+			return describedVersion{}, false
+		}
+		sha, ok := strings.CutPrefix(parts[2], "g")
+		if !ok || !allHex(sha) {
+			return describedVersion{}, false
+		}
+		out.sha = sha
+	default:
+		return describedVersion{}, false
+	}
+	if !isSemverBase(parts[0]) {
+		return describedVersion{}, false
+	}
+	out.base = parts[0]
+	return out, true
+}
+
+// isSemverBase reports whether s is exactly MAJOR.MINOR.PATCH, all numeric.
+func isSemverBase(s string) bool {
+	seg := strings.Split(s, ".")
+	if len(seg) != 3 {
+		return false
+	}
+	for _, part := range seg {
+		if !allDigits(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func allDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func allHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // reportedVersion runs `<mache> version` and returns the version token.
 func reportedVersion(t *testing.T, bin string) string {
 	t.Helper()
 	res := runner{}.mustRun(t, bin, "version")
-	m := versionLineRe.FindStringSubmatch(res.stdout)
-	require.Lenf(t, m, 2,
-		"`%s version` must print `mache version <ver> (commit …, built …)`; got:\n%s", bin, res.combined())
-	return m[1]
+	token, ok := parseVersionLine(res.stdout)
+	require.Truef(t, ok,
+		"`%s version` must print `%s<ver> (commit …, built …)`; got:\n%s", bin, versionLinePrefix, res.combined())
+	return token
 }
 
 // git runs a git command in root, returning trimmed stdout and whether it
@@ -125,11 +215,11 @@ func TestInstalledMacheReportsExpectedVersion(t *testing.T) {
 		return
 	}
 
-	parts := describeRe.FindStringSubmatch(got)
-	require.Lenf(t, parts, 5,
+	parsed, ok := parseDescribed(got)
+	require.Truef(t, ok,
 		"installed mache at %s reports %q, which is not a version this tree's build could produce "+
 			"(expected <base>[-<distance>-g<sha>][-dirty])", bin, got)
-	base, sha := parts[1], parts[3]
+	base, sha := parsed.base, parsed.sha
 
 	// The base tracks the most recent REACHABLE tag, which legitimately trails
 	// version.txt inside the release window (version.txt is bumped in the
@@ -144,8 +234,8 @@ func TestInstalledMacheReportsExpectedVersion(t *testing.T) {
 	if sha == "" {
 		return // a bare `go build` stamps no commit; nothing further to check
 	}
-	_, ok := git(t, root, "merge-base", "--is-ancestor", sha, "HEAD")
-	assert.Truef(t, ok,
+	_, isAncestor := git(t, root, "merge-base", "--is-ancestor", sha, "HEAD")
+	assert.Truef(t, isAncestor,
 		"installed mache at %s was built from commit %s, which is not an ancestor of HEAD — "+
 			"that binary did not come from this tree", bin, sha)
 }


### PR DESCRIPTION
Closes the half of `mache-19326d` that is a *gate*, plus `mache-4d7f2c` and the image half of `mache-504adc`. The `mache install` / `mache uninstall` subcommands are a follow-up PR stacked on this one.

## Why

Every gate in this repo exercises the source tree. Nothing exercised an artifact a user could actually have — so three failures were invisible to CI and were found by hand:

| Found by hand | Bead |
|---|---|
| A stale `~/.local/bin/leyline` 0.10.3 shadowed the v0.13.0 pin, so `leyline cdc enable` at a shell ran a parser three minors off from the one that built the `.db`. Both binaries are named `leyline`; neither warns. | `mache-19326d` |
| Nothing verified a published release artifact after the fact. | `mache-4d7f2c` |
| The published image bakes `serve` into `ENTRYPOINT`, so `docker run IMAGE version` prints no version — it silently boots a default server. | `mache-504adc` |

`cmd/all_tools_e2e_test.go` already covers the tool surface, but **in process**, which answers "does this source tree behave" — a different question from "does the artifact a user installed behave". An in-process test resolves leyline through the same package it is testing, so it structurally cannot see the skew above.

## What `task install:verify` asserts

Drives an **installed binary** by fork/exec and MCP over the wire — no imports from `cmd/`, and deliberately not mcp-go's client (verifying a library against itself proves less than speaking the wire a third-party consumer speaks). Content assertions, not exit codes:

- **(a) the leyline it RESOLVES is the pin** — proven against a deliberately stale leyline planted first on PATH, with the fixture's shadowing asserted live (a shell must actually resolve the stub) so the scenario cannot pass vacuously. A clean-HOME subtest additionally asserts provisioning writes **only** the version-namespaced cache path, guarding `mache-0acdf6` from outside the process.
- **(b) the version it REPORTS** is one this tree could have produced, down to the built commit being an ancestor of HEAD. Exact equality when an explicit expectation is given or a tag is at HEAD, mirroring `task version:check`. Deliberately *not* exact `git describe` equality otherwise — a binary built three commits ago is not an installation defect, and a gate that cried wolf on that would get turned off.
- **(c) the tools return the RIGHT VALUES** — `find_definition` is pinned to an exact projection address (`pkg/checksum.go/function_declaration_0`) for a fixture the binary projects itself, with an absent-symbol subtest as its falsifier; `get_overview` / `list_directory` / `find_smells` assert on structure and known ids.

`task install:verify:docker` adds the clean-HOME leg (no `~/.mache`, no checkout, no Taskfile) against the published image — `mache-19326d`'s acceptance criterion and the one condition a dev box cannot honestly simulate. It also pins the `serve`-baked `ENTRYPOINT` structurally, so `mache-504adc` is a stated expectation rather than a surprise. It **skips** when no daemon or image is reachable so it never reddens CI on a box without docker; `MACHE_VERIFY_REQUIRE_DOCKER=1` turns those skips into failures.

## Proof each gate can fail

Every gate was mutated and observed red, then reverted:

| Gate | Mutation | Observed |
|---|---|---|
| (a) leyline pin | made `ResolveBinary` trust PATH again | `leyline … reports 0.10.3, but mache pins 0.13.0` |
| (a) comparator | fed the stale stub / an unrunnable file directly | both rejected, naming both versions |
| (b) version | stamped `buildVersion=v0.19.0` | `release base "0.19.0" … matches neither version.txt ("0.20.0") nor the last reachable tag` |
| (b) version | stamped `v0.20.0-1-gdeadbee` | `built from commit deadbee, which is not an ancestor of HEAD` |
| (b) version | `MACHE_VERIFY_EXPECT_VERSION=9.9.9` | reported-vs-expected mismatch |
| (c) MCP results | inserted a declaration ahead of the fixture's first function | `expected function_declaration_0, actual function_declaration_1` |
| docker | `MACHE_VERIFY_IMAGE=ubuntu:24.04` | all four image assertions red |
| docker skip | unfetchable tag + `REQUIRE_DOCKER=1` | failure; without the flag, skip |

## CI wiring

New `install-verify` job (added to the `required` gate) runs `task install` then `task install:verify BIN=$HOME/.local/bin/mache`, then `task install:verify:docker`. CI invokes the Taskfile targets and never re-implements the commands. `gate-preflight` passes with no `docker` precondition on purpose — the suite probes for the daemon itself so it can *skip*, where a precondition would *fail*.

`task ci` green locally, including the smell ratchet and the `regexp` import ratchet (both version parsers are structural: `CutPrefix` + field/shape checks, no pattern language).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro