### PR TITLE
[mache-19326d] feat(cli): mache install / uninstall — provisioning without a checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ bumps may include breaking changes.
 
 ### Added
 
+- **`mache install` / `mache uninstall` — provisioning that ships inside the
+  binary.** Until now provisioning lived only in the Taskfile, so it required a
+  repo checkout: a user who installed from a release asset or a package manager
+  had a binary that could not provision its own REQUIRED backend. leyline has
+  been mache's sole parser since ADR-0012 step 4, so that gap is the difference
+  between an installed mache and a working one. `mache install` copies the
+  running binary into a bin directory (default `~/.local/bin`, the same place
+  `task install` uses) and provisions the exact pinned ley-line-open release
+  through `leyline.EnsureCachedBinary`, which SHA-verifies the download and
+  writes only the version-namespaced cache path — the unversioned
+  `~/.mache/bin/leyline` stays never-written (`mache-0acdf6`), and leyline is
+  never placed on PATH by copy, symlink or shim, since that recreates the
+  "which version does bare `leyline` mean" question the pin exists to answer.
+  Your shell rc is not touched: the `export PATH=…` line is printed, and
+  `--update-rc` is an explicit opt-in that writes one idempotent marked block
+  `uninstall --update-rc` can remove again. Both commands refuse a
+  Homebrew-managed mache rather than fighting brew's manifest — the exact
+  shadowing that cost an afternoon in `mache-6ec106`. `--dry-run` reports every
+  change without making one. (`mache-19326d`)
+
 - **`task install:verify` — an install gate that verifies a real installation
   instead of assuming one.** Every other gate in this repo exercises the source
   tree; nothing checked an artifact a user could actually have (`mache-4d7f2c`).

--- a/GETTING-STARTED.md
+++ b/GETTING-STARTED.md
@@ -26,6 +26,32 @@ To check the install:
 mache version
 ```
 
+### Installing without a checkout
+
+`task install` needs this repository. If you got mache from a release asset or a
+package manager, you have a binary and no Taskfile — so the binary provisions
+itself:
+
+```bash
+mache install              # copy this binary to ~/.local/bin and fetch the pinned leyline
+mache install --update-rc  # ...and add the PATH line to your shell rc (opt-in)
+mache uninstall            # remove both again, reporting each path
+```
+
+`mache install` prints the `export PATH=...` line rather than editing your shell
+rc unless you pass `--update-rc`, and it refuses to install over — or uninstall —
+a Homebrew-managed mache, since brew's manifest would still claim the file.
+
+The pinned leyline is cached **version-namespaced** under `~/.mache/bin`, which is
+deliberately not put on PATH: a bare `leyline` in your shell would then mean
+whatever PATH order decided, which is the exact skew this pin exists to prevent.
+Reach the right one explicitly:
+
+```bash
+mache leyline path                          # absolute path, nothing else
+mache leyline exec -- cdc enable --db x.db  # run it, version-correct by construction
+```
+
 ## First run — MCP server
 
 Running mache as an MCP server is **two decisions**: *what to point it at* (the source) and *how the client connects* (the transport). Get these right once and it just works.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ That's the 30-second path for the flagship application — code intelligence on 
 Two things new users hit:
 
 - **HTTP is the canonical transport.** One shared daemon serves every project, routing per session via the MCP roots protocol. `--stdio` exists only as an escape hatch for CI / sandboxes / headless agents and is never registered for editor use (see [ADR-0022](docs/adr/0022-mcp-transport-canonical.md)).
-- **[ley-line-open](https://github.com/agentic-research/ley-line-open) is a hard requirement, not an add-on.** Since v0.18.0 mache has no in-process parser: `leyline parse` produces the `_ast` database that every source projection reads. `task install` provisions the pinned binary. Point mache at a directory *or* a pre-built `.db` — both route through leyline; a pre-built `.db` just skips the parse step and can carry LSP/embedding enrichment.
+- **[ley-line-open](https://github.com/agentic-research/ley-line-open) is a hard requirement, not an add-on.** Since v0.18.0 mache has no in-process parser: `leyline parse` produces the `_ast` database that every source projection reads. `task install` provisions the pinned binary from a checkout; `mache install` does the same from a release asset or package-manager install, where there is no Taskfile. Point mache at a directory *or* a pre-built `.db` — both route through leyline; a pre-built `.db` just skips the parse step and can carry LSP/embedding enrichment.
 
 To project non-code data instead, hand `mache serve` (or the root mount form, `mache <mountpoint>`) a schema with `--schema` and point it at your JSON or SQLite source — the [example schemas](examples/README.md) cover NVD, KEV, Notion, Trivy, Terraform, and more.
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,501 @@
+// `mache install` / `mache uninstall` — provisioning that ships INSIDE the
+// binary.
+//
+// Until now provisioning lived only in the Taskfile: `task install` copies
+// bin/mache to ~/.local/bin and `task leyline:ensure` fetches the pinned
+// ley-line-open release. Both require a repo checkout. A user who installed
+// from a GitHub release asset or a Homebrew tap has neither, so the shipped
+// binary could not provision its own REQUIRED backend — leyline is mache's
+// sole parser since ADR-0012 step 4, and without it `mache build` has nothing
+// to project from.
+//
+// That gap is not theoretical. On the reporter's machine a stale leyline
+// 0.10.3 sat on PATH at ~/.local/bin/leyline while the pin was v0.13.0, so
+// `leyline cdc enable --db x.db` typed at a shell ran a parser three minors
+// off from the one that built the .db. Both binaries are named `leyline`;
+// neither warns (bead mache-19326d).
+//
+// # What this deliberately does NOT do
+//
+//   - It never writes ~/.mache/bin/leyline, the UNVERSIONED path. That was a
+//     shared mutable resource concurrent mache builds overwrote, silently
+//     changing _ast shape between runs, and mache-0acdf6 made it
+//     read-only-never-written. Provisioning goes through
+//     leyline.EnsureCachedBinary, which only ever writes the pin-namespaced
+//     path; nothing here touches the cache directly.
+//   - It never puts leyline on PATH, by symlink, shim or otherwise. A shim
+//     reintroduces "which version does bare `leyline` mean" the moment the pin
+//     moves. `mache leyline path` / `mache leyline exec` answer that question
+//     without the ambiguity.
+//   - It never edits your shell rc behind your back. rustup's posture: print
+//     the line, let the human run it. --update-rc is an explicit opt-in and
+//     writes one idempotent, marked block it can also remove.
+//   - `uninstall` refuses to delete a Homebrew-managed mache. Removing a file
+//     brew believes it owns leaves brew's manifest lying, and the next `brew
+//     upgrade` silently restores it.
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/spf13/cobra"
+)
+
+// executablePath is indirected so tests can name the file being installed
+// instead of copying the test binary. Production always points at
+// os.Executable.
+var executablePath = os.Executable
+
+// rcBlockStart / rcBlockEnd delimit the single region of a shell rc file this
+// command owns. Marked rather than appended blindly so --update-rc is
+// idempotent and `uninstall --update-rc` can remove exactly what it added,
+// leaving anything a human wrote alone.
+const (
+	rcBlockStart = "# >>> mache install >>>"
+	rcBlockEnd   = "# <<< mache install <<<"
+)
+
+type installOpts struct {
+	binDir      string
+	updateRC    bool
+	dryRun      bool
+	skipLeyline bool
+	keepLeyline bool
+}
+
+var installFlags installOpts
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install this mache binary and provision the exact ley-line-open release it pins",
+	Long: `Install this mache binary into a bin directory and provision the exact
+ley-line-open release it pins (` + leyline.BinaryVersion + `).
+
+leyline is mache's sole parser, and mache accepts only the pinned version —
+LLO ships _ast schema changes in PATCH releases, so a near-miss silently
+produces a different projection. Provisioning caches it version-namespaced
+under ~/.mache/bin, which is NOT put on PATH: reach it with
+` + "`mache leyline path`" + ` or ` + "`mache leyline exec`" + `, which resolve
+through mache's pin-checked chokepoint rather than through PATH order.
+
+Your shell rc is not modified unless you pass --update-rc; otherwise the line
+to add is printed for you to run.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runInstall(cmd.OutOrStdout(), installFlags)
+	},
+}
+
+var uninstallCmd = &cobra.Command{
+	Use:   "uninstall",
+	Short: "Remove what `mache install` created, and report what was removed",
+	Long: `Remove the mache binary from the bin directory and the pinned leyline from
+mache's cache, reporting each path.
+
+Only THIS build's pinned leyline is removed: the cache is namespaced by version
+so other mache builds' binaries live in their own files, and deleting them
+would force those builds to re-download. Pass --keep-leyline to leave the cache
+untouched entirely.
+
+A Homebrew-managed mache is refused rather than deleted — brew's manifest would
+still claim the file, and the next upgrade would silently restore it. Pass
+--update-rc to also remove the PATH block ` + "`install --update-rc`" + ` added.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		return runUninstall(cmd.OutOrStdout(), installFlags)
+	},
+}
+
+func init() {
+	for _, c := range []*cobra.Command{installCmd, uninstallCmd} {
+		c.Flags().StringVar(&installFlags.binDir, "bin-dir", "",
+			"Directory to install into (default ~/.local/bin)")
+		c.Flags().BoolVar(&installFlags.dryRun, "dry-run", false,
+			"Report what would change without changing anything")
+		c.Flags().BoolVar(&installFlags.updateRC, "update-rc", false,
+			"Also add (or, on uninstall, remove) the PATH line in your shell rc")
+	}
+	installCmd.Flags().BoolVar(&installFlags.skipLeyline, "no-leyline", false,
+		"Skip provisioning the pinned ley-line-open release")
+	uninstallCmd.Flags().BoolVar(&installFlags.keepLeyline, "keep-leyline", false,
+		"Leave the cached pinned leyline in place")
+
+	rootCmd.AddCommand(installCmd)
+	rootCmd.AddCommand(uninstallCmd)
+}
+
+// resolveBinDir returns the directory to install into, defaulting to
+// ~/.local/bin — the same location `task install` uses, so the two agree
+// rather than each owning a different copy.
+func resolveBinDir(opts installOpts) (string, error) {
+	if opts.binDir != "" {
+		return filepath.Abs(opts.binDir)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "bin"), nil
+}
+
+// homebrewCellar reports the Cellar path backing target, and whether target is
+// Homebrew-managed at all.
+//
+// Detection is structural, not a `brew --prefix` shell-out: every
+// brew-installed binary in a prefix bin/ is a symlink into
+// <prefix>/Cellar/<formula>/<version>/…, so a resolved path containing a
+// "Cellar" element IS the marker, and it works with no brew on PATH and no
+// assumption about where the prefix lives (/usr/local, /opt/homebrew, or a
+// custom HOMEBREW_PREFIX).
+func homebrewCellar(target string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		return "", false
+	}
+	for _, part := range strings.Split(resolved, string(os.PathSeparator)) {
+		if part == "Cellar" {
+			return resolved, true
+		}
+	}
+	return "", false
+}
+
+// sameFile reports whether a and b are the same file on disk, so installing
+// over yourself is recognised rather than truncating the running binary's
+// source.
+func sameFile(a, b string) bool {
+	ai, err := os.Stat(a)
+	if err != nil {
+		return false
+	}
+	bi, err := os.Stat(b)
+	if err != nil {
+		return false
+	}
+	return os.SameFile(ai, bi)
+}
+
+// copyExecutable writes src to dst via a temp file in dst's directory and one
+// rename. The rename is what makes it safe to overwrite a mache that is
+// currently running: the old inode survives for anyone holding it open, where
+// writing in place would corrupt a live process.
+func copyExecutable(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", src, err)
+	}
+	defer func() { _ = in.Close() }()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(dst), err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(dst), ".mache-install-*")
+	if err != nil {
+		return fmt.Errorf("create temp file next to %s: %w", dst, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }() // no-op once the rename succeeds
+
+	if _, err := io.Copy(tmp, in); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("copy to %s: %w", tmpName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", tmpName, err)
+	}
+	if err := os.Chmod(tmpName, 0o755); err != nil {
+		return fmt.Errorf("chmod %s: %w", tmpName, err)
+	}
+	if err := os.Rename(tmpName, dst); err != nil {
+		return fmt.Errorf("install to %s: %w", dst, err)
+	}
+	return nil
+}
+
+func runInstall(out io.Writer, opts installOpts) error {
+	self, err := executablePath()
+	if err != nil {
+		return fmt.Errorf("cannot determine the running mache binary: %w", err)
+	}
+	if resolved, err := filepath.EvalSymlinks(self); err == nil {
+		self = resolved
+	}
+	binDir, err := resolveBinDir(opts)
+	if err != nil {
+		return err
+	}
+	dst := filepath.Join(binDir, "mache")
+
+	if cellar, brewed := homebrewCellar(dst); brewed {
+		return fmt.Errorf(
+			"%s is Homebrew-managed (resolves to %s) — installing over it would leave brew's "+
+				"manifest claiming a file it no longer wrote, and the next `brew upgrade` would "+
+				"silently restore brew's copy. Run `brew uninstall mache` first, or install "+
+				"elsewhere with --bin-dir", dst, cellar)
+	}
+
+	switch {
+	case sameFile(self, dst):
+		logf(out, "mache is already installed at %s (this is the running binary)\n", dst)
+	case opts.dryRun:
+		logf(out, "would install %s -> %s\n", self, dst)
+	default:
+		if err := copyExecutable(self, dst); err != nil {
+			return err
+		}
+		logf(out, "installed %s -> %s\n", self, dst)
+	}
+
+	if err := provisionLeyline(out, opts); err != nil {
+		return err
+	}
+	return reportPATH(out, binDir, opts)
+}
+
+// provisionLeyline fetches the pinned release into the version-namespaced
+// cache. EnsureCachedBinary is the chokepoint that owns this: it verifies the
+// download's SHA-256 against the pinned digest and writes ONLY
+// ~/.mache/bin/leyline-<pin>. Nothing here writes the cache itself, which is
+// how the unversioned path stays never-written (mache-0acdf6).
+func provisionLeyline(out io.Writer, opts installOpts) error {
+	if opts.skipLeyline {
+		logf(out, "skipping leyline provisioning (--no-leyline); mache pins %s\n", leyline.BinaryVersion)
+		return nil
+	}
+	if opts.dryRun {
+		logf(out, "would provision the pinned leyline %s into the version-namespaced cache\n",
+			leyline.BinaryVersion)
+		return nil
+	}
+	path, err := leyline.EnsureCachedBinary()
+	if err != nil {
+		return fmt.Errorf("provision leyline %s: %w", leyline.BinaryVersion, err)
+	}
+	logf(out, "leyline %s ready at %s\n", leyline.BinaryVersion, path)
+	logf(out, "  run it version-correctly with: mache leyline exec -- <args>\n")
+	return nil
+}
+
+// onPATH reports whether dir is already an entry of PATH. Compared as resolved
+// paths so ~/.local/bin and /Users/x/.local/bin are the same answer.
+func onPATH(dir string) bool {
+	want := resolveOrSelf(dir)
+	for _, entry := range filepath.SplitList(os.Getenv("PATH")) {
+		if entry == "" {
+			continue
+		}
+		if resolveOrSelf(entry) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func resolveOrSelf(p string) string {
+	if r, err := filepath.EvalSymlinks(p); err == nil {
+		return r
+	}
+	return filepath.Clean(p)
+}
+
+// exportLine is the shell line that puts dir on PATH. Kept in one place so
+// what is printed and what --update-rc writes cannot drift.
+func exportLine(dir string) string {
+	return fmt.Sprintf("export PATH=%q:$PATH", dir)
+}
+
+// reportPATH prints the export line when the bin dir is not on PATH, and
+// writes it only under --update-rc. Printing rather than writing is the
+// default on purpose: a tool that edits a shell rc unasked is a tool people
+// stop trusting with their home directory.
+func reportPATH(out io.Writer, binDir string, opts installOpts) error {
+	if onPATH(binDir) {
+		logf(out, "%s is already on PATH\n", binDir)
+		return nil
+	}
+	line := exportLine(binDir)
+	if !opts.updateRC {
+		logf(out, "\n%s is not on PATH. Add it:\n\n    %s\n\n"+
+			"Put that in your shell rc, or re-run with --update-rc to have mache add it.\n",
+			binDir, line)
+		return nil
+	}
+	rc, err := shellRCPath()
+	if err != nil {
+		return err
+	}
+	if opts.dryRun {
+		logf(out, "would add the PATH block to %s\n", rc)
+		return nil
+	}
+	if err := writeRCBlock(rc, line); err != nil {
+		return err
+	}
+	logf(out, "added the PATH block to %s — open a new shell or `source %s`\n", rc, rc)
+	return nil
+}
+
+// shellRCPath picks the rc file for the current $SHELL. Only the shells whose
+// rc syntax is actually known are supported; guessing at an unknown shell's
+// syntax would write a line that silently does nothing.
+func shellRCPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	switch shell := filepath.Base(os.Getenv("SHELL")); shell {
+	case "zsh":
+		return filepath.Join(home, ".zshrc"), nil
+	case "bash":
+		return filepath.Join(home, ".bashrc"), nil
+	case "sh", "ksh", "dash":
+		return filepath.Join(home, ".profile"), nil
+	default:
+		return "", fmt.Errorf(
+			"--update-rc does not know where %q keeps its rc file (SHELL=%q); add this line yourself:\n    %s",
+			shell, os.Getenv("SHELL"), exportLine("<bin-dir>"))
+	}
+}
+
+// writeRCBlock replaces (or appends) the single marked block this command
+// owns. Replacing rather than appending is what makes repeated installs
+// idempotent instead of growing the rc file one stanza per run.
+func writeRCBlock(rc, line string) error {
+	existing, err := os.ReadFile(rc)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read %s: %w", rc, err)
+	}
+	block := rcBlockStart + "\n" + line + "\n" + rcBlockEnd + "\n"
+	body := stripRCBlock(string(existing))
+	if body != "" && !strings.HasSuffix(body, "\n") {
+		body += "\n"
+	}
+	return os.WriteFile(rc, []byte(body+block), 0o600)
+}
+
+// stripRCBlock removes the marked block from s, leaving everything else
+// byte-identical. An unterminated start marker removes to end of file — the
+// alternative, leaving it, would make the next write nest a block inside a
+// block.
+func stripRCBlock(s string) string {
+	start := strings.Index(s, rcBlockStart)
+	if start < 0 {
+		return s
+	}
+	rest := s[start:]
+	end := strings.Index(rest, rcBlockEnd)
+	if end < 0 {
+		return s[:start]
+	}
+	tail := rest[end+len(rcBlockEnd):]
+	return s[:start] + strings.TrimPrefix(tail, "\n")
+}
+
+func runUninstall(out io.Writer, opts installOpts) error {
+	binDir, err := resolveBinDir(opts)
+	if err != nil {
+		return err
+	}
+	dst := filepath.Join(binDir, "mache")
+
+	if cellar, brewed := homebrewCellar(dst); brewed {
+		return fmt.Errorf(
+			"%s is Homebrew-managed (resolves to %s) — refusing to delete it out from under brew. "+
+				"Run `brew uninstall mache` instead", dst, cellar)
+	}
+
+	removed := 0
+	switch _, statErr := os.Lstat(dst); {
+	case errors.Is(statErr, os.ErrNotExist):
+		logf(out, "nothing to remove at %s\n", dst)
+	case opts.dryRun:
+		logf(out, "would remove %s\n", dst)
+	default:
+		if err := os.Remove(dst); err != nil {
+			return fmt.Errorf("remove %s: %w", dst, err)
+		}
+		logf(out, "removed %s\n", dst)
+		removed++
+	}
+
+	if err := removePinnedLeyline(out, opts); err != nil {
+		return err
+	}
+	if err := removeRCBlock(out, opts); err != nil {
+		return err
+	}
+	if removed == 0 && !opts.dryRun {
+		logf(out, "note: `mache install` installs to ~/.local/bin by default; "+
+			"use --bin-dir if you installed elsewhere\n")
+	}
+	return nil
+}
+
+// removePinnedLeyline deletes only THIS build's namespaced cache entry. Other
+// versions in ~/.mache/bin belong to other mache builds — the whole point of
+// namespacing (mache-0acdf6) — so removing them would force those builds to
+// re-download, which is not this command's business.
+func removePinnedLeyline(out io.Writer, opts installOpts) error {
+	if opts.keepLeyline {
+		logf(out, "leaving the cached leyline in place (--keep-leyline)\n")
+		return nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	pinned := filepath.Join(home, ".mache", "bin", "leyline-"+leyline.BinaryVersion)
+	switch _, statErr := os.Lstat(pinned); {
+	case errors.Is(statErr, os.ErrNotExist):
+		logf(out, "no cached leyline %s to remove\n", leyline.BinaryVersion)
+	case opts.dryRun:
+		logf(out, "would remove %s\n", pinned)
+	default:
+		if err := os.Remove(pinned); err != nil {
+			return fmt.Errorf("remove %s: %w", pinned, err)
+		}
+		logf(out, "removed %s\n", pinned)
+	}
+	return nil
+}
+
+// removeRCBlock takes back exactly what `install --update-rc` wrote, and only
+// when asked. An uninstall that edited a shell rc unprompted would be the same
+// overreach as an install that did.
+func removeRCBlock(out io.Writer, opts installOpts) error {
+	if !opts.updateRC {
+		return nil
+	}
+	rc, err := shellRCPath()
+	if err != nil {
+		return err
+	}
+	existing, err := os.ReadFile(rc)
+	if errors.Is(err, os.ErrNotExist) {
+		logf(out, "no %s to edit\n", rc)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read %s: %w", rc, err)
+	}
+	stripped := stripRCBlock(string(existing))
+	if stripped == string(existing) {
+		logf(out, "no mache PATH block found in %s\n", rc)
+		return nil
+	}
+	if opts.dryRun {
+		logf(out, "would remove the PATH block from %s\n", rc)
+		return nil
+	}
+	if err := os.WriteFile(rc, []byte(stripped), 0o600); err != nil {
+		return fmt.Errorf("write %s: %w", rc, err)
+	}
+	logf(out, "removed the PATH block from %s\n", rc)
+	return nil
+}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,559 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// isolateInstall gives a test its own HOME, its own PATH, and a fake mache to
+// install, so nothing it does can touch the developer's real ~/.local/bin or
+// ~/.mache. Returns (home, sourceBinary).
+//
+// MACHE_NO_LEYLINE is deliberately NOT set here: several tests plant the pinned
+// binary in the cache and assert the install path finds it there, which is the
+// behaviour that matters. Tests that must not provision pass --no-leyline.
+func isolateInstall(t *testing.T) (home, src string) {
+	t.Helper()
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv(leyline.BinaryOverrideEnv, "")
+	t.Setenv("SHELL", "/bin/zsh")
+
+	src = filepath.Join(t.TempDir(), "mache")
+	require.NoError(t, os.WriteFile(src, []byte("#!/bin/sh\necho fake-mache\n"), 0o755))
+	orig := executablePath
+	executablePath = func() (string, error) { return src, nil }
+	t.Cleanup(func() { executablePath = orig })
+	return home, src
+}
+
+// plantPinnedLeyline puts a binary reporting the pinned version at the
+// version-namespaced cache path, so provisioning is a cache hit and no test
+// reaches the network.
+func plantPinnedLeyline(t *testing.T, home string) string {
+	t.Helper()
+	p := filepath.Join(home, ".mache", "bin", "leyline-"+leyline.BinaryVersion)
+	require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+	body := "#!/bin/sh\necho 'leyline " + strings.TrimPrefix(leyline.BinaryVersion, "v") + " (open)'\n"
+	require.NoError(t, os.WriteFile(p, []byte(body), 0o755))
+	return p
+}
+
+// runCommandBody runs one of the two command bodies and returns its stdout, so
+// every assertion below reads the report the user would see rather than
+// reaching into internals.
+func runCommandBody(t *testing.T, run func(io.Writer, installOpts) error, opts installOpts) (string, error) {
+	t.Helper()
+	var out bytes.Buffer
+	err := run(&out, opts)
+	return out.String(), err
+}
+
+// ---------------------------------------------------------------------------
+// The hard constraint: the unversioned cache path stays unwritten.
+// ---------------------------------------------------------------------------
+
+// TestInstall_NeverWritesUnversionedLeylinePath guards mache-0acdf6, which is
+// the reason this command provisions through leyline.EnsureCachedBinary rather
+// than managing the cache itself. ~/.mache/bin/leyline (no version suffix) was
+// a shared mutable resource that concurrent mache builds overwrote, silently
+// changing _ast shape between runs; it is read-only-never-written.
+//
+// This is the assertion most likely to be broken by a well-meaning later
+// change — "install should make leyline easy to run, let's symlink it" — which
+// is exactly why it is stated here rather than left to the doc comment.
+func TestInstall_NeverWritesUnversionedLeylinePath(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: filepath.Join(home, "bin")})
+	require.NoError(t, err)
+
+	unversioned := filepath.Join(home, ".mache", "bin", "leyline")
+	_, statErr := os.Lstat(unversioned)
+	assert.Truef(t, os.IsNotExist(statErr),
+		"the unversioned ~/.mache/bin/leyline must stay unwritten (mache-0acdf6); got %v", statErr)
+}
+
+// TestInstall_DoesNotPutLeylineOnPATH is the other half of the same
+// constraint. Putting leyline on PATH — by copy, symlink or shim — recreates
+// "which version does bare `leyline` mean" the moment the pin moves, which is
+// the mache-19326d skew rather than a fix for it.
+func TestInstall_DoesNotPutLeylineOnPATH(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	entries, err := os.ReadDir(binDir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.Equal(t, []string{"mache"}, names,
+		"the bin dir must receive mache and nothing else — a leyline here is a PATH shim by another name")
+}
+
+// ---------------------------------------------------------------------------
+// Installing
+// ---------------------------------------------------------------------------
+
+func TestInstall_CopiesTheBinaryExecutable(t *testing.T) {
+	home, src := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	dst := filepath.Join(binDir, "mache")
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err, "install must create %s", dst)
+	want, err := os.ReadFile(src)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "the installed bytes must be the running binary's")
+
+	info, err := os.Stat(dst)
+	require.NoError(t, err)
+	assert.NotZero(t, info.Mode()&0o111, "an installed mache that is not executable is not installed")
+	assert.Contains(t, out, dst)
+}
+
+func TestInstall_OverwritesAnEarlierInstall(t *testing.T) {
+	home, src := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	dst := filepath.Join(binDir, "mache")
+
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(dst, []byte("#!/bin/sh\necho stale\n"), 0o755))
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	want, err := os.ReadFile(src)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "a re-install must replace the older copy, not leave it")
+}
+
+func TestInstall_ReportsWhenItIsAlreadyTheInstalledBinary(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	dst := filepath.Join(binDir, "mache")
+
+	// Run "from" the destination: the same file is both source and target.
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	require.NoError(t, os.WriteFile(dst, []byte("#!/bin/sh\necho installed\n"), 0o755))
+	executablePath = func() (string, error) { return dst, nil }
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err, "installing over yourself must be a no-op, not a truncated binary")
+	assert.Contains(t, out, "already installed")
+
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\necho installed\n", string(got), "the running binary must be left intact")
+}
+
+func TestInstall_DryRunChangesNothing(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: binDir, dryRun: true, updateRC: true})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, "would install")
+	_, statErr := os.Stat(filepath.Join(binDir, "mache"))
+	assert.True(t, os.IsNotExist(statErr), "--dry-run must not write the binary")
+	_, statErr = os.Stat(filepath.Join(home, ".zshrc"))
+	assert.True(t, os.IsNotExist(statErr), "--dry-run must not write the shell rc")
+}
+
+func TestInstall_ProvisionsThePinnedLeyline(t *testing.T) {
+	home, _ := isolateInstall(t)
+	pinned := plantPinnedLeyline(t, home)
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: filepath.Join(home, "bin")})
+	require.NoError(t, err)
+	assert.Contains(t, out, pinned, "install must report the leyline it provisioned")
+	assert.Contains(t, out, leyline.BinaryVersion, "and name the pin, since every _ast number inherits it")
+}
+
+func TestInstall_NoLeylineSkipsProvisioningAndSaysSo(t *testing.T) {
+	home, _ := isolateInstall(t)
+	t.Setenv("MACHE_NO_LEYLINE", "1") // provisioning would fail if it ran at all
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: filepath.Join(home, "bin"), skipLeyline: true})
+	require.NoError(t, err)
+	assert.Contains(t, out, "skipping leyline provisioning")
+	_, statErr := os.Stat(filepath.Join(home, ".mache", "bin"))
+	assert.True(t, os.IsNotExist(statErr), "--no-leyline must not create the cache dir")
+}
+
+// TestInstall_FailsWhenLeylineCannotBeProvisioned — leyline is mache's sole
+// parser, so an install that could not provision it has not installed a
+// working mache. Reporting success would be the silent-degradation failure
+// this whole area exists to prevent.
+func TestInstall_FailsWhenLeylineCannotBeProvisioned(t *testing.T) {
+	home, _ := isolateInstall(t)
+	t.Setenv("MACHE_NO_LEYLINE", "1") // no cache planted, no download allowed
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: filepath.Join(home, "bin")})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), leyline.BinaryVersion, "the failure must name the pin it could not get")
+}
+
+// ---------------------------------------------------------------------------
+// Homebrew
+// ---------------------------------------------------------------------------
+
+// plantBrewMache builds the shape a Homebrew install has — a bin/ symlink into
+// a Cellar tree — and returns the bin dir holding it.
+func plantBrewMache(t *testing.T, prefix string) string {
+	t.Helper()
+	cellar := filepath.Join(prefix, "Cellar", "mache", "0.1.31", "bin")
+	binDir := filepath.Join(prefix, "bin")
+	require.NoError(t, os.MkdirAll(cellar, 0o755))
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	real := filepath.Join(cellar, "mache")
+	require.NoError(t, os.WriteFile(real, []byte("#!/bin/sh\necho brew\n"), 0o755))
+	require.NoError(t, os.Symlink(real, filepath.Join(binDir, "mache")))
+	return binDir
+}
+
+// TestUninstall_RefusesAHomebrewManagedMache is the case that has actually
+// bitten: agentic-research/homebrew-tap ships a Formula/mache.rb that installed
+// kiln's bundled binary under the name `mache`, and it shadowed a ~/.local/bin
+// install for weeks (see the mache-6ec106 triage). Deleting the file would
+// leave brew's manifest claiming it and the next upgrade would restore it, so
+// the answer is `brew uninstall mache`, not `rm`.
+func TestUninstall_RefusesAHomebrewManagedMache(t *testing.T) {
+	home, _ := isolateInstall(t)
+	binDir := plantBrewMache(t, filepath.Join(home, "opt", "homebrew"))
+	link := filepath.Join(binDir, "mache")
+
+	_, err := runCommandBody(t, runUninstall, installOpts{binDir: binDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Homebrew")
+	assert.Contains(t, err.Error(), "brew uninstall mache", "the error must name the correct action")
+
+	_, statErr := os.Lstat(link)
+	assert.NoError(t, statErr, "brew's symlink must survive the refusal")
+}
+
+// TestInstall_RefusesToOverwriteAHomebrewManagedMache — same reasoning in the
+// other direction: overwriting brew's symlink target leaves brew believing it
+// owns bytes it did not write.
+func TestInstall_RefusesToOverwriteAHomebrewManagedMache(t *testing.T) {
+	home, _ := isolateInstall(t)
+	binDir := plantBrewMache(t, filepath.Join(home, "usr", "local"))
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Homebrew")
+
+	got, err := os.ReadFile(filepath.Join(binDir, "mache"))
+	require.NoError(t, err)
+	assert.Equal(t, "#!/bin/sh\necho brew\n", string(got), "brew's binary must be untouched")
+}
+
+// TestHomebrewCellar_DoesNotFalsePositive — the detector must not treat an
+// ordinary path as brew-managed, or `mache uninstall` would refuse to do its
+// job on a normal install.
+func TestHomebrewCellar_DoesNotFalsePositive(t *testing.T) {
+	dir := t.TempDir()
+	plain := filepath.Join(dir, "mache")
+	require.NoError(t, os.WriteFile(plain, []byte("x"), 0o755))
+
+	_, brewed := homebrewCellar(plain)
+	assert.False(t, brewed, "a plain file is not Homebrew-managed")
+
+	// A directory merely NAMED like a cellar component is still not one; the
+	// marker is the path element "Cellar", exactly.
+	near := filepath.Join(dir, "CellarDoor")
+	require.NoError(t, os.MkdirAll(near, 0o755))
+	notBrew := filepath.Join(near, "mache")
+	require.NoError(t, os.WriteFile(notBrew, []byte("x"), 0o755))
+	_, brewed = homebrewCellar(notBrew)
+	assert.False(t, brewed, "'CellarDoor' is not the 'Cellar' path element")
+}
+
+// ---------------------------------------------------------------------------
+// PATH advice and the shell rc
+// ---------------------------------------------------------------------------
+
+// TestInstall_PrintsTheExportLineAndLeavesTheRCAlone is the rustup posture:
+// tell the user what to add, do not reach into their dotfiles uninvited.
+func TestInstall_PrintsTheExportLineAndLeavesTheRCAlone(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	rc := filepath.Join(home, ".zshrc")
+	require.NoError(t, os.WriteFile(rc, []byte("# my own config\n"), 0o600))
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	assert.Contains(t, out, exportLine(binDir), "the line to add must be printed verbatim, ready to paste")
+	assert.Contains(t, out, "--update-rc", "and the opt-in must be discoverable")
+
+	after, err := os.ReadFile(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "# my own config\n", string(after),
+		"the shell rc must be byte-identical without --update-rc")
+}
+
+func TestInstall_SaysNothingToDoWhenTheBinDirIsAlreadyOnPATH(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+	assert.Contains(t, out, "already on PATH")
+	assert.NotContains(t, out, exportLine(binDir), "no advice is needed when the dir is already reachable")
+}
+
+// TestInstall_UpdateRCIsIdempotent — running install twice must leave ONE
+// managed block, not two. An rc file that grows a stanza per install is how
+// tools earn a reputation for vandalising dotfiles.
+func TestInstall_UpdateRCIsIdempotent(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	rc := filepath.Join(home, ".zshrc")
+	require.NoError(t, os.WriteFile(rc, []byte("# mine\nalias k=kubectl\n"), 0o600))
+
+	for range 2 {
+		_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir, updateRC: true})
+		require.NoError(t, err)
+	}
+
+	body, err := os.ReadFile(rc)
+	require.NoError(t, err)
+	got := string(body)
+	assert.Equal(t, 1, strings.Count(got, rcBlockStart), "exactly one managed block")
+	assert.Equal(t, 1, strings.Count(got, rcBlockEnd))
+	assert.Contains(t, got, exportLine(binDir))
+	assert.Contains(t, got, "alias k=kubectl", "the user's own lines must survive")
+}
+
+func TestInstall_UpdateRCCreatesTheFileWhenAbsent(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir, updateRC: true})
+	require.NoError(t, err)
+
+	body, err := os.ReadFile(filepath.Join(home, ".zshrc"))
+	require.NoError(t, err)
+	assert.Contains(t, string(body), exportLine(binDir))
+}
+
+func TestInstall_UpdateRCRefusesAnUnknownShell(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	t.Setenv("SHELL", "/usr/bin/fish")
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: filepath.Join(home, "bin"), updateRC: true})
+	require.Error(t, err, "guessing at an unknown shell's syntax would write a line that silently does nothing")
+	assert.Contains(t, err.Error(), "fish")
+}
+
+func TestShellRCPath_PerShell(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	for shell, want := range map[string]string{
+		"/bin/zsh":  ".zshrc",
+		"/bin/bash": ".bashrc",
+		"/bin/sh":   ".profile",
+	} {
+		t.Setenv("SHELL", shell)
+		got, err := shellRCPath()
+		require.NoError(t, err, shell)
+		assert.Equal(t, filepath.Join(home, want), got, shell)
+	}
+}
+
+// TestStripRCBlock covers the shapes writeRCBlock has to survive re-reading.
+func TestStripRCBlock(t *testing.T) {
+	block := rcBlockStart + "\nexport PATH=\"/x\":$PATH\n" + rcBlockEnd + "\n"
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no block is untouched", in: "# mine\n", want: "# mine\n"},
+		{name: "block alone leaves nothing", in: block, want: ""},
+		{name: "block after user lines", in: "# mine\n" + block, want: "# mine\n"},
+		{name: "block before user lines", in: block + "# after\n", want: "# after\n"},
+		{
+			name: "an unterminated start marker is removed to EOF",
+			in:   "# mine\n" + rcBlockStart + "\nexport PATH=oops\n",
+			want: "# mine\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripRCBlock(tt.in))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Uninstalling
+// ---------------------------------------------------------------------------
+
+func TestUninstall_RemovesTheBinaryAndThePinnedLeyline(t *testing.T) {
+	home, _ := isolateInstall(t)
+	pinned := plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	out, err := runCommandBody(t, runUninstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	dst := filepath.Join(binDir, "mache")
+	_, statErr := os.Lstat(dst)
+	assert.True(t, os.IsNotExist(statErr), "the installed binary must be gone")
+	_, statErr = os.Lstat(pinned)
+	assert.True(t, os.IsNotExist(statErr), "the pinned leyline must be gone")
+
+	assert.Contains(t, out, dst, "uninstall must report what it removed")
+	assert.Contains(t, out, pinned)
+}
+
+// TestUninstall_LeavesOtherBuildsCachedLeylinesAlone — the cache is namespaced
+// by version precisely so concurrent mache builds cannot fight over it
+// (mache-0acdf6). Deleting another build's file would force it to re-download
+// and is not this command's business.
+func TestUninstall_LeavesOtherBuildsCachedLeylinesAlone(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	other := filepath.Join(home, ".mache", "bin", "leyline-v0.0.1-someone-elses-pin")
+	require.NoError(t, os.WriteFile(other, []byte("other build's binary"), 0o755))
+
+	_, err := runCommandBody(t, runUninstall, installOpts{binDir: filepath.Join(home, "bin")})
+	require.NoError(t, err)
+
+	body, err := os.ReadFile(other)
+	require.NoError(t, err, "another build's cached leyline must survive")
+	assert.Equal(t, "other build's binary", string(body))
+}
+
+func TestUninstall_KeepLeylineLeavesTheCache(t *testing.T) {
+	home, _ := isolateInstall(t)
+	pinned := plantPinnedLeyline(t, home)
+
+	out, err := runCommandBody(t, runUninstall, installOpts{binDir: filepath.Join(home, "bin"), keepLeyline: true})
+	require.NoError(t, err)
+	assert.Contains(t, out, "--keep-leyline")
+	_, statErr := os.Lstat(pinned)
+	assert.NoError(t, statErr)
+}
+
+func TestUninstall_DryRunChangesNothing(t *testing.T) {
+	home, _ := isolateInstall(t)
+	pinned := plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	out, err := runCommandBody(t, runUninstall, installOpts{binDir: binDir, dryRun: true})
+	require.NoError(t, err)
+	assert.Contains(t, out, "would remove")
+
+	_, statErr := os.Stat(filepath.Join(binDir, "mache"))
+	assert.NoError(t, statErr, "--dry-run must not remove the binary")
+	_, statErr = os.Stat(pinned)
+	assert.NoError(t, statErr, "--dry-run must not remove the cached leyline")
+}
+
+func TestUninstall_ReportsWhenThereIsNothingToRemove(t *testing.T) {
+	home, _ := isolateInstall(t)
+
+	out, err := runCommandBody(t, runUninstall, installOpts{binDir: filepath.Join(home, "bin")})
+	require.NoError(t, err, "an absent install is not an error")
+	assert.Contains(t, out, "nothing to remove")
+	assert.Contains(t, out, "--bin-dir", "and the likely reason must be named")
+}
+
+func TestUninstall_UpdateRCRemovesExactlyTheManagedBlock(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	rc := filepath.Join(home, ".zshrc")
+	require.NoError(t, os.WriteFile(rc, []byte("# mine\n"), 0o600))
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir, updateRC: true})
+	require.NoError(t, err)
+	_, err = runCommandBody(t, runUninstall, installOpts{binDir: binDir, updateRC: true})
+	require.NoError(t, err)
+
+	body, err := os.ReadFile(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "# mine\n", string(body), "the rc must return to exactly its pre-install content")
+}
+
+func TestUninstall_LeavesTheRCAloneWithoutUpdateRC(t *testing.T) {
+	home, _ := isolateInstall(t)
+	plantPinnedLeyline(t, home)
+	binDir := filepath.Join(home, "bin")
+	rc := filepath.Join(home, ".zshrc")
+
+	_, err := runCommandBody(t, runInstall, installOpts{binDir: binDir, updateRC: true})
+	require.NoError(t, err)
+	before, err := os.ReadFile(rc)
+	require.NoError(t, err)
+
+	_, err = runCommandBody(t, runUninstall, installOpts{binDir: binDir})
+	require.NoError(t, err)
+
+	after, err := os.ReadFile(rc)
+	require.NoError(t, err)
+	assert.Equal(t, string(before), string(after),
+		"uninstall must not edit dotfiles it was not asked to edit")
+}
+
+// ---------------------------------------------------------------------------
+// Command surface
+// ---------------------------------------------------------------------------
+
+// TestInstallCommands_Registered — these only help if they are reachable as
+// `mache install` / `mache uninstall`.
+func TestInstallCommands_Registered(t *testing.T) {
+	byName := map[string]*cobra.Command{}
+	for _, c := range rootCmd.Commands() {
+		byName[c.Name()] = c
+	}
+	for _, name := range []string{"install", "uninstall"} {
+		c, ok := byName[name]
+		require.Truef(t, ok, "`mache %s` must be registered on the root command", name)
+		assert.NotNil(t, c.Flags().Lookup("bin-dir"), "%s needs --bin-dir", name)
+		assert.NotNil(t, c.Flags().Lookup("dry-run"), "%s needs --dry-run", name)
+		assert.NotNil(t, c.Flags().Lookup("update-rc"), "%s needs --update-rc", name)
+	}
+	assert.NotNil(t, byName["install"].Flags().Lookup("no-leyline"))
+	assert.NotNil(t, byName["uninstall"].Flags().Lookup("keep-leyline"))
+}

--- a/tests/installverify/install_cmd_test.go
+++ b/tests/installverify/install_cmd_test.go
@@ -1,0 +1,78 @@
+package installverify
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The install gate's view of `mache install`.
+//
+// cmd/install_test.go covers the command's behaviour in process. What it
+// cannot answer is the question this package exists for: does the SHIPPED
+// binary carry a working provisioning path? A release-asset user has no
+// checkout and no Taskfile, so `mache install` is the only provisioning they
+// have — and a binary that lost the subcommand, or that shipped it broken,
+// looks identical from inside the source tree.
+//
+// leyline provisioning is skipped here (--no-leyline): reaching the pin is
+// already asserted, from the outside and against a stale PATH shadow, in
+// leyline_pin_test.go. What is unproven without this file is the BINARY-COPY
+// half — that the thing landing in the bin dir is a working mache.
+
+// TestInstalledMacheCanInstallItself installs the binary under test into a
+// scratch bin dir with its own install subcommand, then runs the RESULT. A
+// copy that lands non-executable, truncated, or unable to report its version
+// is not an install, however cleanly the command exited.
+func TestInstalledMacheCanInstallItself(t *testing.T) {
+	bin := macheBinary(t)
+	binDir := filepath.Join(t.TempDir(), "bin")
+
+	out := runner{}.mustRun(t, bin, "install", "--bin-dir", binDir, "--no-leyline")
+	assert.Contains(t, out.combined(), binDir, "install must report where it put the binary")
+
+	installed := filepath.Join(binDir, "mache")
+	info := requireFileExists(t, installed, "the binary `mache install` copied")
+	require.NotZerof(t, info.Mode()&0o111, "%s is not executable", installed)
+
+	assert.Equal(t, reportedVersion(t, bin), reportedVersion(t, installed),
+		"the installed copy must be the same mache, not a truncated or stale one")
+}
+
+// TestInstalledMacheInstallDryRunChangesNothing — --dry-run has to be
+// trustworthy on the shipped artifact specifically, because it is what a
+// cautious user runs FIRST against a binary they just downloaded.
+func TestInstalledMacheInstallDryRunChangesNothing(t *testing.T) {
+	bin := macheBinary(t)
+	binDir := filepath.Join(t.TempDir(), "bin")
+
+	out := runner{}.mustRun(t, bin, "install", "--bin-dir", binDir, "--no-leyline", "--dry-run")
+	assert.Contains(t, out.combined(), "would install")
+
+	_, err := os.Stat(filepath.Join(binDir, "mache"))
+	assert.True(t, os.IsNotExist(err), "--dry-run wrote a binary it said it would only plan")
+}
+
+// TestInstalledMacheUninstallRemovesWhatInstallCreated closes the loop: a user
+// who can install from a release asset must be able to undo it with the same
+// binary.
+func TestInstalledMacheUninstallRemovesWhatInstallCreated(t *testing.T) {
+	bin := macheBinary(t)
+	binDir := filepath.Join(t.TempDir(), "bin")
+
+	runner{}.mustRun(t, bin, "install", "--bin-dir", binDir, "--no-leyline")
+	installed := filepath.Join(binDir, "mache")
+	requireFileExists(t, installed, "the binary to be removed")
+
+	// --keep-leyline so the developer's real cache is untouched; the cached
+	// pin is shared with everything else on this machine, and removing it is
+	// not this test's business.
+	out := runner{}.mustRun(t, bin, "uninstall", "--bin-dir", binDir, "--keep-leyline")
+	assert.Contains(t, out.combined(), installed, "uninstall must report what it removed")
+
+	_, err := os.Lstat(installed)
+	assert.True(t, os.IsNotExist(err), "uninstall reported success but left %s", installed)
+}

--- a/tests/installverify/version_test.go
+++ b/tests/installverify/version_test.go
@@ -234,10 +234,25 @@ func TestInstalledMacheReportsExpectedVersion(t *testing.T) {
 	if sha == "" {
 		return // a bare `go build` stamps no commit; nothing further to check
 	}
-	_, isAncestor := git(t, root, "merge-base", "--is-ancestor", sha, "HEAD")
-	assert.Truef(t, isAncestor,
-		"installed mache at %s was built from commit %s, which is not an ancestor of HEAD — "+
-			"that binary did not come from this tree", bin, sha)
+	if _, isAncestor := git(t, root, "merge-base", "--is-ancestor", sha, "HEAD"); isAncestor {
+		return
+	}
+	// Not an ancestor. Two very different causes, and the remedy differs, so
+	// say which: a commit git has never heard of means a FOREIGN binary (the
+	// Homebrew-tap mache in mache-6ec106 is the live example), while a commit
+	// this repo knows but cannot reach means your own binary predates an
+	// amend or rebase. The second is routine — `task build` skips a rebuild
+	// when no .go file changed, so rewriting history alone leaves bin/mache
+	// stamped with a commit that is no longer on any branch — and a gate that
+	// reported it as "foreign" would be disbelieved and then ignored.
+	_, known := git(t, root, "cat-file", "-e", sha+"^{commit}")
+	remedy := "that binary did not come from this tree"
+	if known {
+		remedy = "this tree knows that commit but cannot reach it — you amended or rebased after " +
+			"building, and `task build` skips a rebuild when no .go file changed. Run `task build`."
+	}
+	assert.Failf(t, "installed mache does not match this tree",
+		"%s was built from commit %s, which is not an ancestor of HEAD — %s", bin, sha, remedy)
 }
 
 // firstOK collapses git's (value, ok) to just the value; callers that treat ""


### PR DESCRIPTION
Follow-up to #586 (the install-verification gate, now merged). Closes the *provisioning* half of `mache-19326d`.

## Why

Provisioning existed only in the Taskfile — `task install` copies `bin/mache` to `~/.local/bin`, `task leyline:ensure` fetches the pinned ley-line-open release — and both need this repository. A user who installed from a GitHub release asset or a package manager has a binary and no Taskfile, so the shipped mache could not provision its own **required** backend. Since ADR-0012 step 4 leyline is the sole parser, that is the difference between an installed mache and a working one.

```
mache install              # copy this binary to ~/.local/bin + fetch the pinned leyline
mache install --update-rc  # ...and add the PATH line to your shell rc (opt-in)
mache uninstall            # remove both again, reporting each path
```

## What it deliberately does NOT do

Each of these is a constraint with a test, not a doc comment:

- **Never writes `~/.mache/bin/leyline`, the UNVERSIONED path.** That was a shared mutable resource concurrent mache builds overwrote, silently changing `_ast` shape between runs (`mache-0acdf6`). Provisioning goes through `leyline.EnsureCachedBinary`, which SHA-verifies the download and only ever writes the pin-namespaced path; nothing here touches the cache directly.
- **Never puts leyline on PATH** by copy, symlink or shim. A shim recreates "which version does bare `leyline` mean" the moment the pin moves — that *is* `mache-19326d`, not a fix for it. `mache leyline path` / `exec` (#584) answer the question without the ambiguity. Asserted by requiring the bin dir to contain `mache` and nothing else.
- **Never edits a shell rc uninvited.** rustup's posture: the `export PATH=…` line is printed; `--update-rc` is an explicit opt-in that writes one *idempotent marked block* which `uninstall --update-rc` removes exactly, leaving the user's own lines byte-identical.
- **Refuses a Homebrew-managed mache**, on install *and* uninstall. Deleting or overwriting a file brew's manifest claims leaves it lying and the next `brew upgrade` silently restores it — which is how a v0.6.6 tap binary shadowed a v0.19.0 install for weeks (`mache-6ec106`). Detection is structural: a resolved path containing a `Cellar` element, so it needs no `brew` on PATH and no assumption about the prefix.

`uninstall` removes only **this** build's namespaced leyline; other versions in the cache belong to other mache builds, and deleting them would force those builds to re-download.

## Proof the constraints are load-bearing

Each was mutated and observed red, then reverted:

| Mutation | Test that went red |
|---|---|
| symlink the unversioned `~/.mache/bin/leyline` after provisioning | `TestInstall_NeverWritesUnversionedLeylinePath` |
| weaken the `Cellar` path-element check | both Homebrew refusal tests |
| append the rc block instead of replacing it | `TestInstall_UpdateRCIsIdempotent` |
| skip `copyExecutable` while still reporting success | `TestInstalledMacheCanInstallItself`, `TestInstalledMacheUninstallRemovesWhatInstallCreated` |

## Also extends the gate from #586

`tests/installverify/install_cmd_test.go` asserts the **shipped** binary can install itself: it installs into a scratch bin dir with its own subcommand and then *runs the result*, requiring the same reported version. A copy that lands non-executable or truncated is not an install, however cleanly the command exited — and that is invisible from inside the source tree.

It also sharpens one assertion #586 shipped. The commit-ancestry check reported a *foreign* binary and a *rebased* one with the same words, and I hit the benign case within the hour: `task build` skips a rebuild when no `.go` file changed, so amending or rebasing leaves `bin/mache` stamped with a commit no longer on any branch, and `task ci` then claimed a binary that plainly came from this tree did not. It now distinguishes "git has never heard of this commit" (foreign — the Homebrew-tap mache in `mache-6ec106`) from "known but unreachable" (run `task build`). Both still fail; only the remedy differs. Verified by exercising both branches.

`task ci` green, including the smell ratchet — which earned its keep here: the first draft added a private `say()` printf wrapper that duplicated the existing `logf()` in `cmd/daemon_agent.go`, and two near-identical test helpers. Both were the gate's findings, and both are now deduplicated rather than baselined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro
