### PR TITLE
fix(install): restart the supervised daemon; .mcp.json registered the wrong transport

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "mache": {
-      "type": "stdio",
-      "command": "mache",
-      "args": ["serve", "--stdio", "."],
-      "env": {}
+      "type": "http",
+      "url": "http://localhost:7532/mcp"
     }
   }
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -20,6 +20,16 @@ tasks:
       - cp {{.BINARY_NAME}} ~/.local/bin/mache
       - cmd: codesign -s - --force --deep --entitlements entitlements.plist ~/.local/bin/mache
         platforms: [darwin]
+      # Replacing the file does NOT re-exec a supervisor that is already
+      # running — it holds the old process. Observed: installed binary at
+      # v0.20.0 while the daemon on :7532 still answered as 0.19.0-10, so
+      # every MCP session got pre-release code silently. `mache daemon
+      # restart` is restart-if-running (launchctl kickstart -k / systemctl
+      # try-restart), so this never starts a daemon on a machine whose owner
+      # did not run `mache init --global`. Uses the binary we just installed,
+      # so the restart logic is the installed version's, not the source
+      # tree's.
+      - ~/.local/bin/mache daemon restart
 
   install:verify:
     desc: |

--- a/cmd/daemon_agent.go
+++ b/cmd/daemon_agent.go
@@ -25,6 +25,17 @@ const (
 // false to exercise plist/unit writing without a real supervisor side effect.
 var daemonAgentAutoload = true
 
+// runSupervisorCmd is the single seam through which restartDaemonAgent reaches
+// launchctl/systemctl. It is a var so tests can assert WHICH command would run
+// without running it — the load-bearing property is that the command is a
+// restart-if-running form (`kickstart -k`, `try-restart`) and never a start
+// form (`bootstrap`, `enable --now`), and that claim is only checkable by
+// inspecting the argv. Executing the real command in a test would also restart
+// the developer's own daemon as a side effect, which a test must never do.
+var runSupervisorCmd = func(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
 // logf writes a progress line, discarding the write error (best-effort output).
 func logf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
 
@@ -188,4 +199,62 @@ func installSystemdUnit(w io.Writer, binPath string) {
 		return
 	}
 	logf(w, "  [daemon] unit installed; systemctl not found — enable it manually.\n")
+}
+
+// restartDaemonAgent restarts an ALREADY-RUNNING supervised mache daemon so it
+// re-execs the binary just installed.
+//
+// WHY THIS EXISTS. `mache install` (and `task install`) replace the file at
+// ~/.local/bin/mache, but a supervisor that is already running holds the OLD
+// process — the inode it exec'd does not change under it. Observed on a real
+// machine: the installed binary reported 0.20.0 while the daemon on
+// localhost:7532 answered `initialize` as 0.19.0-10-g1c3d812, so every MCP
+// session got pre-v0.20.0 code (including the P0 construct-loss bug that
+// release fixed) with nothing anywhere reporting a mismatch. Same shape as the
+// stale-leyline-on-PATH defect (mache-0acdf6): the install succeeded and the
+// thing actually serving you was older.
+//
+// RESTART ONLY, NEVER START. Both commands below are deliberately the
+// restart-if-running variants, not `bootstrap`/`enable --now`:
+//
+//   - launchctl kickstart -k  — the -k kills the running job first; the call
+//     FAILS when the label is not loaded, which is exactly the signal we want.
+//   - systemctl --user try-restart — documented as "restart if running, else do
+//     nothing"; `restart` would START a service the user had stopped.
+//
+// Installing a binary must not conjure a background daemon on a machine whose
+// owner never ran `mache init --global`. Deciding to run one is that command's
+// job; this only keeps an existing decision honest.
+//
+// Best-effort by construction: it reports and returns rather than erroring. A
+// failure here leaves a correctly installed binary and a stale daemon, which is
+// strictly better than failing the install — but it is reported rather than
+// swallowed, because a silent stale daemon is the defect this closes.
+func restartDaemonAgent(w io.Writer) {
+	if !daemonAgentAutoload {
+		return
+	}
+	switch runtime.GOOS {
+	case "darwin":
+		launchctl, err := exec.LookPath("launchctl")
+		if err != nil {
+			return // no supervisor tooling; nothing was running under it
+		}
+		target := fmt.Sprintf("gui/%d/%s", os.Getuid(), launchAgentLabel)
+		if err := runSupervisorCmd(launchctl, "kickstart", "-k", target); err != nil {
+			// Not loaded is the common, benign case: the user never ran
+			// `mache init --global`. Do not present that as a problem.
+			return
+		}
+		logf(w, "restarted the supervised daemon (%s) so it serves the new binary\n", launchAgentLabel)
+	case "linux":
+		systemctl, err := exec.LookPath("systemctl")
+		if err != nil {
+			return
+		}
+		if err := runSupervisorCmd(systemctl, "--user", "try-restart", "mache.service"); err != nil {
+			return
+		}
+		logf(w, "restarted the supervised daemon (mache.service) so it serves the new binary\n")
+	}
 }

--- a/cmd/daemon_cmd.go
+++ b/cmd/daemon_cmd.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// daemonCmd groups operations on the supervised mache HTTP daemon — the
+// keepalive process `mache init --global` installs (launchd on macOS, systemd
+// --user on Linux).
+var daemonCmd = &cobra.Command{
+	Use:   "daemon",
+	Short: "Operate the supervised mache HTTP daemon",
+}
+
+// daemonRestartCmd re-execs an already-running supervised daemon.
+//
+// Exists because replacing the binary does not restart the process holding it:
+// a supervisor keeps serving the inode it exec'd. Observed on a real machine
+// after `task install` — the installed binary reported v0.20.0 while the
+// daemon on localhost:7532 answered `initialize` as 0.19.0-10-g1c3d812, so
+// every MCP session silently got pre-release code.
+//
+// Restart-if-running, never start: see restartDaemonAgent. Running this on a
+// machine with no supervised daemon is a successful no-op, not an error —
+// there is nothing stale to fix, which is the outcome the caller wanted.
+var daemonRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the supervised daemon so it serves the current binary",
+	Long: "Restart the supervised mache HTTP daemon so it re-execs the binary currently " +
+		"installed.\n\nReplacing the binary on disk does not restart a running supervisor — it " +
+		"keeps serving the old process. Run this after installing a new build.\n\nIf no " +
+		"supervised daemon is running this does nothing and succeeds: it never starts a daemon " +
+		"you did not ask for (that is `mache init --global`).",
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, _ []string) error {
+		restartDaemonAgent(cmd.OutOrStdout())
+		return nil
+	},
+}
+
+func init() {
+	daemonCmd.AddCommand(daemonRestartCmd)
+	rootCmd.AddCommand(daemonCmd)
+}

--- a/cmd/daemon_restart_test.go
+++ b/cmd/daemon_restart_test.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The defect these pin (mache install / task install leaving a stale daemon):
+// replacing the binary on disk does not re-exec a supervisor that is already
+// running. Measured on a real machine — installed binary v0.20.0, daemon on
+// :7532 still answering as 0.19.0-10-g1c3d812, every MCP session served
+// pre-release code with nothing reporting the mismatch.
+
+// TestRestartDaemonAgent_RespectsAutoloadGate pins that the autoload gate
+// suppresses the restart entirely. Tests and any non-interactive path set it
+// false; without this check a `go test` run would kickstart the developer's
+// real daemon as a side effect.
+func TestRestartDaemonAgent_RespectsAutoloadGate(t *testing.T) {
+	prev := daemonAgentAutoload
+	daemonAgentAutoload = false
+	t.Cleanup(func() { daemonAgentAutoload = prev })
+
+	var buf bytes.Buffer
+	restartDaemonAgent(&buf)
+	assert.Empty(t, buf.String(),
+		"with autoload gated off the restart must be a total no-op — no supervisor call, no output")
+}
+
+// TestRestartDaemonAgent_UsesRestartNotStart is the load-bearing assertion.
+// The command MUST be a restart-if-running form. `launchctl bootstrap` /
+// `systemctl --user enable --now` would START a daemon on a machine whose
+// owner never ran `mache init --global` — installing a binary must not conjure
+// a background process. Asserting the argv is the only way to check this;
+// running it would both hide the distinction and restart the developer's own
+// daemon.
+func TestRestartDaemonAgent_UsesRestartNotStart(t *testing.T) {
+	prev, prevAuto := runSupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() { runSupervisorCmd, daemonAgentAutoload = prev, prevAuto })
+	daemonAgentAutoload = true
+
+	var got []string
+	runSupervisorCmd = func(name string, args ...string) error {
+		got = append([]string{filepath.Base(name)}, args...)
+		return nil
+	}
+
+	var buf bytes.Buffer
+	restartDaemonAgent(&buf)
+
+	switch runtime.GOOS {
+	case "darwin":
+		require.NotEmpty(t, got, "darwin must attempt a supervisor call")
+		assert.Equal(t, "launchctl", got[0])
+		assert.Contains(t, got, "kickstart", "must kickstart an existing job")
+		assert.Contains(t, got, "-k", "-k kills the running job first; without it the old process survives")
+		assert.NotContains(t, got, "bootstrap", "bootstrap would START a daemon the user did not ask for")
+	case "linux":
+		require.NotEmpty(t, got, "linux must attempt a supervisor call")
+		assert.Equal(t, "systemctl", got[0])
+		assert.Contains(t, got, "try-restart", "try-restart is restart-if-running")
+		assert.NotContains(t, got, "enable", "enable --now would START a stopped service")
+		assert.NotContains(t, got, "start")
+	default:
+		assert.Empty(t, got, "unsupported platforms must not shell out")
+	}
+	if len(got) > 0 {
+		assert.Contains(t, buf.String(), "restarted the supervised daemon")
+	}
+}
+
+// TestRestartDaemonAgent_SupervisorFailureIsSilent pins that a supervisor
+// error (overwhelmingly: the label is not loaded, because the user never ran
+// `mache init --global`) is NOT announced. Reporting it would tell a user
+// something is wrong when nothing is — and claiming a restart that did not
+// happen is worse, since it implies the daemon is current.
+func TestRestartDaemonAgent_SupervisorFailureIsSilent(t *testing.T) {
+	prev, prevAuto := runSupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() { runSupervisorCmd, daemonAgentAutoload = prev, prevAuto })
+	daemonAgentAutoload = true
+	runSupervisorCmd = func(string, ...string) error { return errors.New("Could not find service") }
+
+	var buf bytes.Buffer
+	require.NotPanics(t, func() { restartDaemonAgent(&buf) })
+	assert.Empty(t, buf.String(),
+		"a not-loaded supervisor is the benign common case; it must not claim a restart nor report an error")
+}
+
+// TestDaemonRestartCmd_Wired pins that `mache daemon restart` exists, takes no
+// args, and is reachable from the root command. The Taskfile's install target
+// invokes exactly this string, so a rename here silently breaks `task install`
+// — the docs/CLI gate (mache-e7c825) covers documented invocations, and this
+// covers the Taskfile's.
+func TestDaemonRestartCmd_Wired(t *testing.T) {
+	c, _, err := rootCmd.Find([]string{"daemon", "restart"})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "restart", c.Name())
+	assert.NotNil(t, c.Args, "must reject stray args rather than ignoring them")
+	require.NoError(t, c.Args(c, nil), "zero args is the supported form")
+	assert.Error(t, c.Args(c, []string{"unexpected"}),
+		"an unknown arg must fail loudly, not be silently ignored")
+}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -240,6 +240,7 @@ func runInstall(out io.Writer, opts installOpts) error {
 				"elsewhere with --bin-dir", dst, cellar)
 	}
 
+	replaced := false
 	switch {
 	case sameFile(self, dst):
 		logf(out, "mache is already installed at %s (this is the running binary)\n", dst)
@@ -250,10 +251,19 @@ func runInstall(out io.Writer, opts installOpts) error {
 			return err
 		}
 		logf(out, "installed %s -> %s\n", self, dst)
+		replaced = true
 	}
 
 	if err := provisionLeyline(out, opts); err != nil {
 		return err
+	}
+
+	// A supervisor already running holds the OLD process — replacing the file
+	// does not re-exec it. Without this, `mache install` succeeds and every MCP
+	// session keeps getting the previous build. Only when the binary actually
+	// changed: sameFile and --dry-run must not disturb a running daemon.
+	if replaced {
+		restartDaemonAgent(out)
 	}
 	return reportPATH(out, binDir, opts)
 }


### PR DESCRIPTION
Two defects found by checking what an MCP client actually connects to, rather than assuming the install took. Both are silent — nothing reported either.

## 1. A new binary was installed; the old one kept serving

Measured right after the v0.20.0 release:

```
installed  ~/.local/bin/mache      0.20.0-5-g9c0e374
daemon on  localhost:7532         0.19.0-10-g1c3d812   ← 10 commits behind, PRE-v0.20.0
```

launchd's plist already pointed at the correct path, and `task install` had replaced that file — but a running supervisor keeps serving the inode it exec'd. Every MCP session was getting pre-v0.20.0 code, **including the P0 construct-loss bug (`mache-c725e9`) that release exists to fix**, with nothing anywhere reporting the mismatch.

Same shape as `mache-0acdf6` (stale leyline shadowing the pin on PATH): the install succeeds and the thing actually serving you is older.

**Fix:** `mache daemon restart`, called from both install paths — `mache install` (only when the binary actually changed; `sameFile` and `--dry-run` must not disturb a running daemon) and the Taskfile `install` target, which copies the binary directly and never routes through the subcommand.

### Restart only, never start

`launchctl kickstart -k` / `systemctl --user try-restart` are the restart-if-running forms. `bootstrap` / `enable --now` would conjure a background daemon on a machine whose owner never ran `mache init --global` — installing a binary must not do that. Deciding to run a daemon belongs to that command.

A not-loaded supervisor stays **silent** rather than erroring, or worse, claiming a restart that did not happen — which would imply the daemon is current when it is not.

### Why there's a `runSupervisorCmd` seam

The load-bearing guarantee is the **argv shape**, and restart-form-vs-start-form is not observable from a return code. The seam is what makes it assertable.

It also fixed a real mistake: the first draft of these tests executed the real command and **restarted my own daemon as a side effect**. A test must not touch live system state.

**Falsified:** mutating `kickstart -k` → `bootstrap` fails `TestRestartDaemonAgent_UsesRestartNotStart` on exactly the three assertions separating restarting from starting. Reverted after.

## 2. `.mcp.json` registered stdio, which ADR-0022 says never to register

The checked-in Claude Code template declared `"type": "stdio"` with `args: ["serve", "--stdio", "."]`. README.md:23 says the opposite, citing ADR-0022: *"HTTP is the canonical transport … `--stdio` … is never registered for editor use."*

`.mcp.json` **is** an editor registration — so the one artifact a new user consumes contradicted the guidance three lines into the README. It predates ADR-0022 (file dated 2026-05-19) and was never updated.

The replacement is **not hand-authored**: it is byte-identical to what mache itself writes via `httpServerEntry()` (`cmd/config.go:167`) using `macheHTTPURL` (`cmd/daemon_agent.go:20`) — the same entry `mache init` merges. Template and generated registration now agree by construction, so a future change to `macheHTTPURL` disagrees visibly in one place instead of silently in two.

Not a stdio deprecation — `mache serve --stdio` remains supported for CI/sandbox use. Note the find-smells action uses neither stdio nor MCP (it shells out to `mache build` + `mache find-smells`), so nothing in CI depended on this template.

## Verification

- `task check` green (`REAL_EXIT=0`), including the new `install:verify` suite
- `task install` run end to end: prints the restart, and daemon/binary now report identical versions where they had diverged
- `.mcp.json`'s URL driven exactly as an editor would — `initialize` → HTTP 200, `tools/list` → 18 tools, matching the README's claim

Beads: `mache-e418ce` (this defect, with residues), `mache-e797ce` (separate: sheaf e2e orphans — 84 reaped by hand today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)