### PR TITLE
fix(build): rebuild when the git stamp moves, not just when a file does

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -125,6 +125,24 @@ tasks:
       - "internal/buildinfo/version.txt"
     generates:
       - "{{.BINARY_NAME}}"
+    # The ldflags above inject GIT_COMMIT / GIT_VERSION — real build INPUTS
+    # that appear in no `sources:` entry, because a rebase or `commit --amend`
+    # changes the embedded stamp while every listed file stays byte-identical.
+    # Task then reports "up to date" and leaves a binary stamped with a commit
+    # this tree can no longer reach. install:verify catches that and says
+    # "Run `task build`" — which, before this check, was a NO-OP in exactly the
+    # situation it diagnosed.
+    #
+    # Same class as mache-46af85 (go:embed assets missing from `sources:` left
+    # a stale binary the smell gate then ran against), one input further out:
+    # there the input was a file, here it is the git position itself.
+    #
+    # A failing status command means "not up to date", so a missing or
+    # unrunnable binary correctly forces a rebuild rather than erroring.
+    status:
+      - |
+        test "$(git rev-parse --short HEAD 2>/dev/null)" = \
+             "$({{.BINARY_NAME}} version 2>/dev/null | sed -n 's/.*commit \([0-9a-f][0-9a-f]*\).*/\1/p')"
 
   version:
     desc: Print the canonical mache version (internal/buildinfo/version.txt)


### PR DESCRIPTION
`task build` injects `GIT_COMMIT` and `GIT_VERSION` through ldflags. Those are real build **inputs**, and they appear in no `sources:` entry — so a rebase or `commit --amend` changes the embedded stamp while every listed file stays byte-identical. Task reports "up to date" and leaves a binary stamped with a commit the tree can no longer reach.

## It made a gate's remedy unrunnable

`install:verify` correctly detected the stale binary and said:

```
built from commit de11d1f, which is not an ancestor of HEAD — this tree knows
that commit but cannot reach it — you amended or rebased after building, and
`task build` skips a rebuild when no .go file changed. Run `task build`.
```

Running `task build` then printed "up to date" and did nothing. The diagnosis was right; the instruction was a dead end. The only way out was `rm -f bin/mache` first. Hit twice while pushing #589.

## Same class as mache-46af85, one input further out

The `sources:` block already carries a comment about this exact failure mode — `go:embed`'d assets missing from the list left a stale binary that the smell gate then ran against, producing phantom "NEW findings". There the missing input was a **file**. Here it is the **git position itself**, which no file pattern can express.

## Why `status:` and not more `sources:`

Adding `.git/HEAD` or `.git/refs/**` would be fragile: packed-refs, worktrees (this repo uses them heavily), and detached HEAD all break the assumption that a ref's file mtime tracks the commit. The `status:` check compares the binary's embedded commit to HEAD directly, which is the actual invariant.

A failing status command means "not up to date", so a missing or unrunnable binary correctly forces a rebuild rather than erroring.

## Verified both directions

A staleness check that always rebuilds is as wrong as one that never does:

| case | result |
|---|---|
| already up to date | still skips — `Task "build" is up to date`, no wasteful rebuild |
| after `--amend` | **rebuilds**; stamp moves `21019b7` → `aac6ed6` (previously: "up to date") |
| `BINARY_NAME=/tmp/mache-ci` (the CI override shape) | builds once, then skips |
| `TestInstalledMacheReportsExpectedVersion` (the gate that surfaced this) | passes |

It also proved itself in the course of this PR: after rebasing onto main, `task build` rebuilt and stamped `e2e09d1` where it would previously have left the old stamp and failed the pre-push gate.

`task check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)