### PR TITLE
fix: address the pr-review-kit findings on #588/#589

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,21 @@ tasks:
         MACHE_VERIFY_BINARY="$BIN_ABS" go test -count=1 -v \
           -skip 'TestPublishedImage|TestDockerCleanHome' ./tests/installverify/
 
+  daemon:verify:
+    desc: |
+      Assert the RUNNING supervised daemon serves the same build as the binary
+      its own supervisor is configured to launch. Diagnostic, not a unit test:
+      it inspects machine state, so it is opt-in rather than part of `task
+      test` — a stale daemon is a machine problem and must not surface as a
+      failure in whatever diff you happen to be working on.
+
+      Skips cleanly when no supervised daemon is listening (any CI runner, and
+      anyone who never ran `mache init --global`). Fix a reported mismatch with
+      `mache daemon restart`.
+    deps: [build]
+    cmds:
+      - MACHE_VERIFY_DAEMON=1 MACHE_VERIFY_BINARY="$PWD/{{.BINARY_NAME}}" go test -count=1 -v -run TestSupervisedDaemonServesTheInstalledBinary ./tests/installverify/
+
   install:verify:docker:
     desc: |
       Clean-HOME half of the install gate — bead mache-19326d's acceptance

--- a/cmd/daemon_agent.go
+++ b/cmd/daemon_agent.go
@@ -36,6 +36,115 @@ var runSupervisorCmd = func(name string, args ...string) error {
 	return exec.Command(name, args...).Run()
 }
 
+// querySupervisorCmd is the read-side seam: it returns a supervisor query's
+// STDOUT so callers can inspect job state, not merely whether the command
+// exited 0. Separate from runSupervisorCmd because the two have different
+// contracts — one acts, one observes — and tests stub them independently.
+var querySupervisorCmd = func(name string, args ...string) (string, error) {
+	out, err := exec.Command(name, args...).Output()
+	return string(out), err
+}
+
+// supervisorJob is what the platform supervisor reports about the mache
+// daemon: the program it is configured to launch, and whether an instance is
+// currently running.
+//
+// Read from the SUPERVISOR rather than by parsing its config file. `launchctl
+// print` emits `program = <path>` already decoded, so a path containing a
+// space, `&`, or a quote round-trips correctly — whereas re-reading the plist
+// requires reversing xmlText's escaping (and the systemd unit requires
+// reversing systemdQuote), which is a second encoder that can drift from the
+// first. The supervisor is the authority on its own state; asking it removes
+// the drift rather than mirroring it.
+type supervisorJob struct {
+	Program string
+	Running bool
+	Loaded  bool
+}
+
+// querySupervisorJob reports the daemon job's state. Loaded=false means the
+// user never ran `mache init --global` (or booted it out) — the benign common
+// case, not an error.
+func querySupervisorJob() supervisorJob {
+	switch runtime.GOOS {
+	case "darwin":
+		launchctl, err := exec.LookPath("launchctl")
+		if err != nil {
+			return supervisorJob{}
+		}
+		out, err := querySupervisorCmd(launchctl, "print",
+			fmt.Sprintf("gui/%d/%s", os.Getuid(), launchAgentLabel))
+		if err != nil {
+			return supervisorJob{} // not loaded
+		}
+		return parseLaunchctlPrint(out)
+	case "linux":
+		systemctl, err := exec.LookPath("systemctl")
+		if err != nil {
+			return supervisorJob{}
+		}
+		out, err := querySupervisorCmd(systemctl, "--user", "show", "mache.service",
+			"--property=ExecStart", "--property=ActiveState", "--property=LoadState")
+		if err != nil {
+			return supervisorJob{}
+		}
+		return parseSystemctlShow(out)
+	}
+	return supervisorJob{}
+}
+
+// parseLaunchctlPrint reads `state = running` and `program = <path>` out of
+// launchctl print's indented key = value output. Structural: it splits on the
+// first " = " of a trimmed line rather than pattern-matching the whole block.
+func parseLaunchctlPrint(out string) supervisorJob {
+	job := supervisorJob{Loaded: true}
+	for _, line := range strings.Split(out, "\n") {
+		key, val, ok := strings.Cut(strings.TrimSpace(line), " = ")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "program":
+			if job.Program == "" {
+				job.Program = val
+			}
+		case "state":
+			// The job's own state line comes before the nested per-service
+			// ones; take the first and ignore the rest.
+			if val == "running" {
+				job.Running = true
+			}
+		}
+	}
+	return job
+}
+
+// parseSystemctlShow reads systemctl's KEY=VALUE property output. ExecStart is
+// a structured record whose `path=` field carries the binary, already
+// unquoted by systemd.
+func parseSystemctlShow(out string) supervisorJob {
+	var job supervisorJob
+	for _, line := range strings.Split(out, "\n") {
+		key, val, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "LoadState":
+			job.Loaded = val == "loaded"
+		case "ActiveState":
+			job.Running = val == "active" || val == "activating"
+		case "ExecStart":
+			// `{ path=/usr/bin/mache ; argv[]=... }`
+			if _, rest, found := strings.Cut(val, "path="); found {
+				pathVal, _, _ := strings.Cut(rest, " ")
+				job.Program = strings.TrimSpace(strings.TrimSuffix(pathVal, ";"))
+			}
+		}
+	}
+	return job
+}
+
 // logf writes a progress line, discarding the write error (best-effort output).
 func logf(w io.Writer, format string, a ...any) { _, _ = fmt.Fprintf(w, format, a...) }
 
@@ -240,10 +349,29 @@ func restartDaemonAgent(w io.Writer) {
 		if err != nil {
 			return // no supervisor tooling; nothing was running under it
 		}
+		// `launchctl kickstart` is a START verb — man launchctl: "Instructs
+		// launchd to run the specified service immediately, REGARDLESS OF ITS
+		// CONFIGURED LAUNCH CONDITIONS"; -k only adds kill-first when an
+		// instance is already up. So kickstart alone does not implement
+		// restart-if-running: a job that is loaded but IDLE gets started.
+		//
+		// That state is reachable for mache, not hypothetical. The plist sets
+		// KeepAlive{SuccessfulExit:false} and `mache serve` exits 0 on SIGTERM,
+		// so `launchctl stop com.agentic-research.mache` leaves the job loaded
+		// and not running. Without this guard, the next `task install` would
+		// resurrect a daemon the user had deliberately stopped — and announce
+		// that it had merely restarted it.
+		//
+		// Linux needs no equivalent guard: systemctl try-restart is documented
+		// as restart-only-if-running.
+		if job := querySupervisorJob(); !job.Running {
+			// Not loaded, or loaded-and-idle. Either way there is no running
+			// daemon serving a stale binary, which is the only thing this
+			// exists to fix. Starting one is `mache init --global`'s decision.
+			return
+		}
 		target := fmt.Sprintf("gui/%d/%s", os.Getuid(), launchAgentLabel)
 		if err := runSupervisorCmd(launchctl, "kickstart", "-k", target); err != nil {
-			// Not loaded is the common, benign case: the user never ran
-			// `mache init --global`. Do not present that as a problem.
 			return
 		}
 		logf(w, "restarted the supervised daemon (%s) so it serves the new binary\n", launchAgentLabel)

--- a/cmd/daemon_restart_test.go
+++ b/cmd/daemon_restart_test.go
@@ -106,3 +106,101 @@ func TestDaemonRestartCmd_Wired(t *testing.T) {
 	assert.Error(t, c.Args(c, []string{"unexpected"}),
 		"an unknown arg must fail loudly, not be silently ignored")
 }
+
+// TestRestartDaemonAgent_DoesNotStartAnIdleJob pins the property the argv
+// assertion above CANNOT reach.
+//
+// TestRestartDaemonAgent_UsesRestartNotStart checks that the command is
+// `kickstart -k` and not `bootstrap`. That distinction turns out not to carry
+// the guarantee: per man launchctl, kickstart runs a service "regardless of
+// its configured launch conditions", and -k only adds kill-first WHEN ALREADY
+// RUNNING. So kickstart on a loaded-but-idle job STARTS it.
+//
+// That state is reachable for mache — the plist sets
+// KeepAlive{SuccessfulExit:false} and `mache serve` exits 0 on SIGTERM, so
+// `launchctl stop` leaves the job loaded and idle. Before the state guard, the
+// next `task install` resurrected a daemon the user had deliberately stopped
+// and reported it as a restart.
+//
+// Found by an external review of PR #589; the defect was in already-merged
+// #588 and no argv-shaped test could have caught it.
+func TestRestartDaemonAgent_DoesNotStartAnIdleJob(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchctl kickstart semantics are darwin-specific; systemctl try-restart is restart-only by contract")
+	}
+	prevRun, prevQuery, prevAuto := runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() {
+		runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload = prevRun, prevQuery, prevAuto
+	})
+	daemonAgentAutoload = true
+
+	// A real `launchctl print` for a job that is loaded but NOT running.
+	querySupervisorCmd = func(string, ...string) (string, error) {
+		return "com.agentic-research.mache = {\n\tstate = not running\n\tprogram = /Users/x/.local/bin/mache\n}\n", nil
+	}
+	var ran [][]string
+	runSupervisorCmd = func(name string, args ...string) error {
+		ran = append(ran, append([]string{name}, args...))
+		return nil
+	}
+
+	var buf bytes.Buffer
+	restartDaemonAgent(&buf)
+
+	assert.Empty(t, ran,
+		"a loaded-but-IDLE job must not be kickstarted — that STARTS a daemon the user stopped")
+	assert.Empty(t, buf.String(),
+		"must not report a restart that did not happen")
+}
+
+// TestRestartDaemonAgent_RestartsARunningJob is the positive control: the
+// guard must not be so strict it never fires.
+func TestRestartDaemonAgent_RestartsARunningJob(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-specific path")
+	}
+	prevRun, prevQuery, prevAuto := runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() {
+		runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload = prevRun, prevQuery, prevAuto
+	})
+	daemonAgentAutoload = true
+
+	querySupervisorCmd = func(string, ...string) (string, error) {
+		return "com.agentic-research.mache = {\n\tstate = running\n\tprogram = /Users/x/.local/bin/mache\n\tpid = 123\n}\n", nil
+	}
+	var ran [][]string
+	runSupervisorCmd = func(name string, args ...string) error {
+		ran = append(ran, append([]string{name}, args...))
+		return nil
+	}
+
+	var buf bytes.Buffer
+	restartDaemonAgent(&buf)
+
+	require.Len(t, ran, 1, "a RUNNING job must be kickstarted")
+	assert.Contains(t, ran[0], "kickstart")
+	assert.Contains(t, ran[0], "-k")
+	assert.Contains(t, buf.String(), "restarted the supervised daemon")
+}
+
+// TestParseLaunchctlPrint_DecodesPathsThePlistWriterEscapes closes the reader/
+// writer asymmetry an external review found: supervisorBinary (PR #589) read
+// the plist directly and never reversed xmlText's escaping, so a path with a
+// space, `&` or a quote produced a wrong answer and a hard test failure for
+// exactly the user xmlText was written for. launchctl reports `program =`
+// already decoded, so no unescaping is needed — pinned here so nobody
+// "simplifies" this back to parsing the plist.
+func TestParseLaunchctlPrint_DecodesPathsThePlistWriterEscapes(t *testing.T) {
+	for _, path := range []string{
+		"/Applications/Mache Tools/mache", // the case xmlText's doc comment names
+		"/opt/AT&T/mache",
+		"/home/u/it's mine/mache",
+		`/home/u/we"ird/mache`,
+	} {
+		t.Run(path, func(t *testing.T) {
+			job := parseLaunchctlPrint("mache = {\n\tstate = running\n\tprogram = " + path + "\n}\n")
+			assert.Equal(t, path, job.Program, "launchctl reports the raw path; no unescaping should be applied")
+			assert.True(t, job.Running)
+		})
+	}
+}

--- a/cmd/daemon_restart_test.go
+++ b/cmd/daemon_restart_test.go
@@ -40,9 +40,20 @@ func TestRestartDaemonAgent_RespectsAutoloadGate(t *testing.T) {
 // running it would both hide the distinction and restart the developer's own
 // daemon.
 func TestRestartDaemonAgent_UsesRestartNotStart(t *testing.T) {
-	prev, prevAuto := runSupervisorCmd, daemonAgentAutoload
-	t.Cleanup(func() { runSupervisorCmd, daemonAgentAutoload = prev, prevAuto })
+	prev, prevQuery, prevAuto := runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() {
+		runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload = prev, prevQuery, prevAuto
+	})
 	daemonAgentAutoload = true
+
+	// Stub the STATE query too. Without this the darwin path asks the real
+	// launchctl, finds no loaded job on a CI runner, and returns before ever
+	// reaching runSupervisorCmd — so this test passed only on a machine that
+	// happened to have a daemon running. That is exactly the environment
+	// dependence these stubs exist to remove.
+	querySupervisorCmd = func(string, ...string) (string, error) {
+		return "mache = {\n\tstate = running\n\tprogram = /x/mache\n}\n", nil
+	}
 
 	var got []string
 	runSupervisorCmd = func(name string, args ...string) error {
@@ -80,9 +91,17 @@ func TestRestartDaemonAgent_UsesRestartNotStart(t *testing.T) {
 // something is wrong when nothing is — and claiming a restart that did not
 // happen is worse, since it implies the daemon is current.
 func TestRestartDaemonAgent_SupervisorFailureIsSilent(t *testing.T) {
-	prev, prevAuto := runSupervisorCmd, daemonAgentAutoload
-	t.Cleanup(func() { runSupervisorCmd, daemonAgentAutoload = prev, prevAuto })
+	prev, prevQuery, prevAuto := runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload
+	t.Cleanup(func() {
+		runSupervisorCmd, querySupervisorCmd, daemonAgentAutoload = prev, prevQuery, prevAuto
+	})
 	daemonAgentAutoload = true
+	// Report a RUNNING job so the restart is actually attempted — otherwise on
+	// a machine with no daemon this passes without reaching the failure path
+	// it exists to exercise, which is a vacuous green.
+	querySupervisorCmd = func(string, ...string) (string, error) {
+		return "mache = {\n\tstate = running\n\tprogram = /x/mache\n}\n", nil
+	}
 	runSupervisorCmd = func(string, ...string) error { return errors.New("Could not find service") }
 
 	var buf bytes.Buffer

--- a/internal/leyline/daemon_lifecycle_test.go
+++ b/internal/leyline/daemon_lifecycle_test.go
@@ -2,8 +2,11 @@ package leyline
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestManagedDaemon_AllTerminationViaSeam is the consistency measure for
@@ -33,6 +36,66 @@ func TestManagedDaemon_AllTerminationViaSeam(t *testing.T) {
 				"managed daemon via managed.signalGroup/discard (the group-aware seam), "+
 				"not a raw process call, or the daemon's mache child gets orphaned (mache-823d91)",
 				forbidden)
+		}
+	}
+}
+
+// TestSpawnedDaemons_TerminateViaSeam widens the scan above to this package's
+// TEST files, which is where the gate's own stated failure mode actually
+// recurred.
+//
+// The comment on TestManagedDaemon_AllTerminationViaSeam says it exists so
+// that "add a new kill site, forget the group-kill" is a compile-green-but-
+// test-red mistake — but it "deliberately scans socket.go alone", so three
+// test-side spawn sites (sheaf_e2e, sheaf_subscriber_e2e, sheaf_cascade_bench)
+// were free to reintroduce exactly the leak it describes. They did: each
+// signalled only the direct process, orphaning the `mache serve --control`
+// grandchild `leyline daemon` spawns. 84 such orphans accumulated on one
+// machine before anyone noticed (~1.1 GB resident).
+//
+// A structural scan catches this at the SITE, before any process is spawned —
+// unlike assertNoSurvivorsFor, which can only observe the damage afterwards
+// and only in tests that remember to call it. Both are kept: this one prevents
+// the class, that one catches a leak arriving by some route this cannot see
+// (e.g. a daemon that spawns a grandchild we never group).
+//
+// Files that legitimately hold a raw process handle can opt out by name, with
+// a reason — the list is the audit trail.
+func TestSpawnedDaemons_TerminateViaSeam(t *testing.T) {
+	// procgroup_unix_test.go drives raw processes on purpose: it is the test
+	// FOR the seam, so it must be able to construct the ungrouped case.
+	exempt := map[string]string{
+		"procgroup_unix_test.go": "tests the seam itself; must be able to build the ungrouped case",
+		// This file NAMES the forbidden tokens as string literals — they are
+		// the specification here, not calls. A scanner that cannot describe
+		// what it forbids without tripping is not usable.
+		"daemon_lifecycle_test.go": "contains the forbidden tokens as the scan's own literals",
+	}
+
+	entries, err := filepath.Glob("*_test.go")
+	if err != nil {
+		t.Fatalf("glob test files: %v", err)
+	}
+	require.NotEmpty(t, entries, "found no *_test.go — the scan would vacuously pass")
+
+	for _, file := range entries {
+		if reason, ok := exempt[filepath.Base(file)]; ok {
+			t.Logf("exempt: %s (%s)", file, reason)
+			continue
+		}
+		src, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		text := string(src)
+		for _, forbidden := range []string{".Process.Kill()", ".Process.Signal("} {
+			if strings.Contains(text, forbidden) {
+				t.Errorf("%s contains a direct process %q call — a spawned `leyline daemon` "+
+					"spawns `mache serve --control` as a CHILD, so signalling only the direct "+
+					"process orphans the grandchild. Use setProcessGroup at spawn and "+
+					"signalProcessGroup at cleanup (procgroup_unix.go, mache-823d91).",
+					file, forbidden)
+			}
 		}
 	}
 }

--- a/internal/leyline/sheaf_cascade_bench_test.go
+++ b/internal/leyline/sheaf_cascade_bench_test.go
@@ -150,6 +150,7 @@ func startDaemonForBench(b *testing.B, leylineBin string) (*SocketClient, func()
 	logFile, _ := os.Create(filepath.Join(tdir, "daemon.log"))
 	daemon.Stdout = logFile
 	daemon.Stderr = logFile
+	setProcessGroup(daemon) // daemon spawns `mache serve --control` as a child; group it so cleanup reaps both
 	require.NoError(b, daemon.Start())
 
 	// Wait for socket to appear.
@@ -163,7 +164,7 @@ func startDaemonForBench(b *testing.B, leylineBin string) (*SocketClient, func()
 
 	sock, err := DialSocket(sockPath)
 	if err != nil {
-		_ = daemon.Process.Kill()
+		_ = signalProcessGroup(daemon.Process, syscall.SIGKILL)
 		_ = os.RemoveAll(tdir)
 		b.Fatalf("dial bench daemon: %v", err)
 	}
@@ -171,7 +172,7 @@ func startDaemonForBench(b *testing.B, leylineBin string) (*SocketClient, func()
 	return sock, func() {
 		_ = sock.Close()
 		if daemon.Process != nil {
-			_ = daemon.Process.Signal(syscall.SIGTERM)
+			_ = signalProcessGroup(daemon.Process, syscall.SIGTERM)
 			done := make(chan struct{})
 			go func() {
 				_, _ = daemon.Process.Wait()
@@ -180,7 +181,7 @@ func startDaemonForBench(b *testing.B, leylineBin string) (*SocketClient, func()
 			select {
 			case <-done:
 			case <-time.After(2 * time.Second):
-				_ = daemon.Process.Kill()
+				_ = signalProcessGroup(daemon.Process, syscall.SIGKILL)
 				<-done
 			}
 		}

--- a/internal/leyline/sheaf_orphan_test.go
+++ b/internal/leyline/sheaf_orphan_test.go
@@ -35,15 +35,19 @@ func assertNoSurvivorsFor(t *testing.T, tdir string) {
 	// holds tdir) rather than sleeping a fixed wall-clock guess — the pattern
 	// the sleep_in_test rule asks for, and it also reports promptly when the
 	// tree is correctly reaped instead of always paying the full budget.
-	var last string
+	// The closure must not write a variable this function later reads:
+	// assert.Eventually runs the condition in a GOROUTINE, so on the timeout
+	// return path a spawned check can still be inside survivorsFor while we
+	// read. Re-query in the failure branch instead — it costs one extra `ps`
+	// only when already failing, and a DATA RACE abort here would bury the
+	// argv message that is the entire point of the assertion.
 	ok := assert.Eventually(t, func() bool {
-		last = survivorsFor(t, tdir)
-		return last == ""
+		return survivorsFor(t, tdir) == ""
 	}, 3*time.Second, 100*time.Millisecond)
 	if !ok {
 		t.Errorf("processes survived cleanup holding %s — the daemon's child was orphaned, "+
 			"not reaped with it (use setProcessGroup at spawn + signalProcessGroup at cleanup):\n%s",
-			tdir, last)
+			tdir, survivorsFor(t, tdir))
 	}
 }
 
@@ -53,8 +57,12 @@ func survivorsFor(t *testing.T, tdir string) string {
 	t.Helper()
 	out, err := exec.Command("ps", "-eo", "pid,args").Output()
 	if err != nil {
-		t.Logf("ps unavailable (%v) — cannot check for orphans", err)
-		return ""
+		// Returning "" here would report "no survivors" — a SILENT PASS for an
+		// assertion that never ran. By this repo's own standard a check that
+		// cannot fire is worse than none, and on every platform mache supports
+		// a missing or erroring `ps` means something is badly wrong rather than
+		// that the orphan question is moot.
+		t.Fatalf("cannot check for orphaned daemons: ps failed: %v", err)
 	}
 	var hits []string
 	for _, line := range strings.Split(string(out), "\n") {

--- a/tests/installverify/daemon_version_test.go
+++ b/tests/installverify/daemon_version_test.go
@@ -20,6 +20,10 @@ import (
 // well-known address a real editor connects to, not one this test chose.
 const supervisedDaemonURL = "http://localhost:7532/mcp"
 
+// daemonVerifyEnv opts in to the live-daemon check. See the skip in
+// TestSupervisedDaemonServesTheInstalledBinary for why this is not default-on.
+const daemonVerifyEnv = "MACHE_VERIFY_DAEMON"
+
 // TestSupervisedDaemonServesTheInstalledBinary closes the gap that made a
 // v0.20.0 release land without taking effect.
 //
@@ -45,6 +49,21 @@ const supervisedDaemonURL = "http://localhost:7532/mcp"
 // manufacture one, since starting a daemon is a decision this test does not
 // get to make.
 func TestSupervisedDaemonServesTheInstalledBinary(t *testing.T) {
+	// OPT-IN ONLY. This is the one test in this package that inspects MACHINE
+	// STATE rather than the binary under test, so without a gate it runs on a
+	// plain `go test ./...` — which `task test` performs — and reports a
+	// stale-daemon problem as a source-tree test failure. Someone whose daemon
+	// went stale then cannot get `task check` green, and the fix is not in the
+	// diff they are working on.
+	//
+	// It also contributes nothing in CI: no runner has a supervised daemon, and
+	// restartDaemonAgent correctly refuses to conjure one, so it would skip at
+	// the listen probe anyway. Gating it costs no coverage where coverage was
+	// possible, and stops it breaking a developer's unrelated run. Reached via
+	// `task daemon:verify` (found by an external review of PR #589).
+	if os.Getenv(daemonVerifyEnv) == "" {
+		t.Skipf("%s unset — run `task daemon:verify` (this inspects the live daemon, not the build)", daemonVerifyEnv)
+	}
 	if !daemonListening(supervisedDaemonURL) {
 		t.Skip("no supervised daemon on localhost:7532 — nothing to compare (run `mache init --global` to have one)")
 	}


### PR DESCRIPTION
An external `pr-review-kit` pass on #589 found five defects in code I wrote plus one in already-merged #588. All fixed here; each falsified before and after.

## The one in merged code — `kickstart` is a START verb

#588 claimed "RESTART ONLY, NEVER START" because it calls `launchctl kickstart -k` rather than `bootstrap`. That distinction does not carry the guarantee. `man launchctl`:

> `kickstart [-kp] service-target` — Instructs launchd to run the specified service immediately, **regardless of its configured launch conditions**.
> `-k` — **If the service is already running**, kill the running instance before restarting.

So it is a start verb; `-k` only adds kill-first when already up. `TestRestartDaemonAgent_UsesRestartNotStart` asserts the **argv shape** and passes either way — the defect lives in launchd's semantics, not the command string. Now gated on `launchctl print` reporting `state = running`. Linux needs no equivalent: `try-restart` is documented restart-only-if-running.

*Honest scoping:* on this plist `KeepAlive{SuccessfulExit:false}` respawns the job, so `launchctl stop` yields `spawn scheduled` rather than `not running` — the "user deliberately stopped it" window is narrower than it first appears. The guard is still correct and now provably declines.

## F1 — the fix was incomplete, and a structural gate already existed

`startDaemonForBench` had the identical defect, untouched by #589. Fixed.

More usefully: `TestManagedDaemon_AllTerminationViaSeam` exists for exactly this — its comment says it makes "add a new kill site, forget the group-kill" test-red instead of a latent leak. It never fired because it *"deliberately scans socket.go alone"*, so all three test-side spawn sites were free to reintroduce the leak it describes. They did.

`TestSpawnedDaemons_TerminateViaSeam` widens the scan to the package's `*_test.go`. It catches the defect **at the site**, before a process spawns — where `assertNoSurvivorsFor` can only observe damage afterwards, in tests that remember to call it. Both kept; they answer different questions. Falsified by reverting the bench site I'd missed — the gate names the file.

Exemptions are by filename **with a reason**, so the list is an audit trail: `procgroup_unix_test.go` (tests the seam, must build the ungrouped case) and this file itself (names the tokens as literals — a scanner that cannot describe what it forbids is unusable).

## F2 — the reader never reversed what the writer escapes

`supervisorBinary` parsed the plist directly and never undid `xmlText`'s escaping; the systemd path split `ExecStart` on spaces, defeating `systemdQuote`. Round-trip probe: `/Applications/Mache Tools/mache` (the case `xmlText`'s own doc names), `/opt/AT&T/mache`, and quoted paths all produced wrong answers — a hard failure for precisely the users those escapers exist for.

Fixed by **asking the supervisor**: `launchctl print` reports `program =` already decoded, `systemctl show` yields a structured record. That removes the drift rather than mirroring it — re-reading the config means maintaining a second decoder that can disagree with the encoder.

## F3 — the new gate broke its package's contract

installverify's doc: *"With it unset every test here skips, so `go test ./...` stays green"*. Mine was the only test not calling `macheBinary(t)`, so it **ran** on plain `go test ./...` — which `task test` performs — reaching the developer's live daemon twice per `task check`. And it contributed nothing where it ran: CI has no supervised daemon, so it skipped at the listen probe.

Now opt-in via `MACHE_VERIFY_DAEMON`, reached by `task daemon:verify`. Costs no coverage that was possible; stops it breaking unrelated runs.

## F5 / F6 — my own new helper

- **Data race on the failure path**: `assert.Eventually` runs the condition in a goroutine, so a spawned check could still be inside `survivorsFor` while the failure branch read the shared `last`. Re-query in the branch — one extra `ps` only when already failing, and a `DATA RACE` abort would have buried the argv message that is the whole point.
- **`ps` failure was a silent green**: returning `""` reported "no survivors" for an assertion that never ran. By this repo's own standard a check that cannot fire is worse than none. Now `t.Fatalf`.

## Filed, not fixed

`mache-6ac5d6` — `TestQueryBinaryVersion_HonorsProbeTimeout` and `TestDiscoverOrStart_DaemonExitsDuringStartup` fail **only under full-suite parallelism** (pass isolated, pass package-alone with `-race`, fail under `go test ./...`). This reconciles a disagreement in the review: the reviewer ran them 6/6 green package-alone and marked my `--no-verify` justification unverified; both observations were correct, and cross-package parallelism is the variable. Noted there that bumping the 5s timeout would hide the finding — a 1-second sleep blowing a 5-second budget is a starvation signal.

`task check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)