### PR TITLE
[mache-7555da] internal/fixturedb: remove a test's ability to state a schema

### DIFF
--- a/cmd/duplicate_definitions_rust_test.go
+++ b/cmd/duplicate_definitions_rust_test.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
 )
 
 // mache-22fecf — duplicate_definitions false-positives on leyline-parsed Rust
@@ -28,54 +26,37 @@ import (
 // Ground truth captured from `leyline parse` of a two-struct/one-trait Rust
 // file; this fixture reproduces the exact node_id shapes it emits.
 
-// rustDupFixture builds a nodes + node_defs db mirroring leyline's Rust output.
+// rustDupFixture mirrors leyline's Rust output. fixturedb.Leyline is what makes
+// "mirrors leyline" a fact rather than a claim — the DDL it produces is derived
+// from the pinned binary's own sqlite_master (mache-7555da).
 func rustDupFixture(t *testing.T) *smellTestGraph {
 	t.Helper()
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "rustdup.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	db.SetMaxOpenConns(1)
-
-	_, err = db.Exec(`
-		CREATE TABLE nodes (
-			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
-			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
-			record_id TEXT, record TEXT, source_file TEXT
-		);
-		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-
-		-- Rust impl/trait methods: bare tokens, impl_item / trait_item paths.
-		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file) VALUES
-			('src/lib.rs/impl_item_0/declaration_list/function_item_0', NULL, 'new',     1, 0, 'src/lib.rs'),
-			('src/lib.rs/impl_item_1/declaration_list/function_item_0', NULL, 'new',     1, 0, 'src/lib.rs'),
-			('src/lib.rs/impl_item_0/declaration_list/function_item_1', NULL, 'compute', 1, 0, 'src/lib.rs'),
-			('src/lib.rs/impl_item_1/declaration_list/function_item_1', NULL, 'compute', 1, 0, 'src/lib.rs'),
-			('src/lib.rs/impl_item_2/declaration_list/function_item',   NULL, 'run',     1, 0, 'src/lib.rs'),
-			('src/lib.rs/impl_item_3/declaration_list/function_item',   NULL, 'run',     1, 0, 'src/lib.rs'),
-			('src/lib.rs/trait_item/declaration_list/function_signature_item', NULL, 'run', 1, 0, 'src/lib.rs'),
-			-- A genuine free-function duplicate (top-level function_item in two
-			-- files): this SHOULD still be flagged — the fix must be targeted,
-			-- not a blanket disable of duplicate detection.
-			('a.rs/function_item_0', NULL, 'dup_free', 1, 0, 'a.rs'),
-			('b.rs/function_item_0', NULL, 'dup_free', 1, 0, 'b.rs'),
-			-- A unique free function: never flagged (copies == 1).
-			('src/lib.rs/function_item_9', NULL, 'solo', 1, 0, 'src/lib.rs');
-
-		INSERT INTO node_defs (token, node_id) VALUES
-			('new',      'src/lib.rs/impl_item_0/declaration_list/function_item_0'),
-			('new',      'src/lib.rs/impl_item_1/declaration_list/function_item_0'),
-			('compute',  'src/lib.rs/impl_item_0/declaration_list/function_item_1'),
-			('compute',  'src/lib.rs/impl_item_1/declaration_list/function_item_1'),
-			('run',      'src/lib.rs/impl_item_2/declaration_list/function_item'),
-			('run',      'src/lib.rs/impl_item_3/declaration_list/function_item'),
-			('run',      'src/lib.rs/trait_item/declaration_list/function_signature_item'),
-			('dup_free', 'a.rs/function_item_0'),
-			('dup_free', 'b.rs/function_item_0'),
-			('solo',     'src/lib.rs/function_item_9');
-	`)
-	require.NoError(t, err)
-	return &smellTestGraph{db: db}
+	return newSmellFixture(t, fixturedb.Leyline, func(b *fixturedb.Builder) {
+		for _, d := range []struct {
+			token string
+			in    fixturedb.ConstructID
+			kind  fixturedb.CanonicalKind
+		}{
+			// Rust impl/trait methods: bare tokens, impl_item / trait_item paths.
+			{"new", "src/lib.rs/impl_item_0/declaration_list/function_item_0", fixturedb.Method},
+			{"new", "src/lib.rs/impl_item_1/declaration_list/function_item_0", fixturedb.Method},
+			{"compute", "src/lib.rs/impl_item_0/declaration_list/function_item_1", fixturedb.Method},
+			{"compute", "src/lib.rs/impl_item_1/declaration_list/function_item_1", fixturedb.Method},
+			{"run", "src/lib.rs/impl_item_2/declaration_list/function_item", fixturedb.Method},
+			{"run", "src/lib.rs/impl_item_3/declaration_list/function_item", fixturedb.Method},
+			{"run", "src/lib.rs/trait_item/declaration_list/function_signature_item", fixturedb.Method},
+			// A genuine free-function duplicate (top-level function_item in two
+			// files): this SHOULD still be flagged — the fix must be targeted,
+			// not a blanket disable of duplicate detection.
+			{"dup_free", "a.rs/function_item_0", fixturedb.Function},
+			{"dup_free", "b.rs/function_item_0", fixturedb.Function},
+			// A unique free function: never flagged (copies == 1).
+			{"solo", "src/lib.rs/function_item_9", fixturedb.Function},
+		} {
+			b.Construct(d.in, fixturedb.Where{Name: d.token})
+			b.Def(d.token, d.in, d.kind)
+		}
+	})
 }
 
 func runDuplicateDefinitions(t *testing.T, tg *smellTestGraph) []smellFinding {
@@ -155,42 +136,28 @@ func tokenFromNodeID(nodeID string) string {
 // token exactly like Rust. (The mache Go-SCHEMA's `methods/` path is a
 // tree-sitter+go-schema artifact, absent from every leyline projection.)
 func TestDuplicateDefinitions_LeylineGoMethods_NotFlagged(t *testing.T) {
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "llogo.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	db.SetMaxOpenConns(1)
+	tg := newSmellFixture(t, fixturedb.Leyline, func(b *fixturedb.Builder) {
+		for _, d := range []struct {
+			token string
+			in    fixturedb.ConstructID
+			kind  fixturedb.CanonicalKind
+		}{
+			// LLO-Go methods: bare token under method_declaration_N.
+			{"New", "main.go/method_declaration_0", fixturedb.Method},
+			{"New", "main.go/method_declaration_2", fixturedb.Method},
+			{"Compute", "main.go/method_declaration_1", fixturedb.Method},
+			{"Compute", "main.go/method_declaration_3", fixturedb.Method},
+			// Genuine free-function duplicate (top-level function_declaration in
+			// two files) — must still be flagged.
+			{"DupFree", "a.go/function_declaration_0", fixturedb.Function},
+			{"DupFree", "b.go/function_declaration_0", fixturedb.Function},
+		} {
+			b.Construct(d.in, fixturedb.Where{Name: d.token})
+			b.Def(d.token, d.in, d.kind)
+		}
+	})
 
-	_, err = db.Exec(`
-		CREATE TABLE nodes (
-			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
-			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
-			record_id TEXT, record TEXT, source_file TEXT
-		);
-		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-
-		-- LLO-Go methods: bare token under method_declaration_N (Foo.New, Bar.New, ...).
-		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file) VALUES
-			('main.go/method_declaration_0', NULL, 'New',     1, 0, 'main.go'),
-			('main.go/method_declaration_2', NULL, 'New',     1, 0, 'main.go'),
-			('main.go/method_declaration_1', NULL, 'Compute', 1, 0, 'main.go'),
-			('main.go/method_declaration_3', NULL, 'Compute', 1, 0, 'main.go'),
-			-- Genuine free-function duplicate (top-level function_declaration in
-			-- two files) — must still be flagged.
-			('a.go/function_declaration_0', NULL, 'DupFree', 1, 0, 'a.go'),
-			('b.go/function_declaration_0', NULL, 'DupFree', 1, 0, 'b.go');
-
-		INSERT INTO node_defs (token, node_id) VALUES
-			('New',     'main.go/method_declaration_0'),
-			('New',     'main.go/method_declaration_2'),
-			('Compute', 'main.go/method_declaration_1'),
-			('Compute', 'main.go/method_declaration_3'),
-			('DupFree', 'a.go/function_declaration_0'),
-			('DupFree', 'b.go/function_declaration_0');
-	`)
-	require.NoError(t, err)
-
-	findings := runDuplicateDefinitions(t, &smellTestGraph{db: db})
+	findings := runDuplicateDefinitions(t, tg)
 
 	var sawDupFree bool
 	for _, f := range findings {

--- a/cmd/fixturedb_test.go
+++ b/cmd/fixturedb_test.go
@@ -1,0 +1,36 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/agentic-research/mache/internal/fixturedb"
+	"github.com/agentic-research/mache/internal/graph"
+)
+
+// Tests in this package build their .db fixtures through internal/fixturedb,
+// which owns the producer DDL and forbids a test from stating a schema. See
+// that package's doc comment for why (mache-7555da).
+//
+// The canonical views are installed by fixturedb itself, from the installer
+// registered here — so no test can build a fixture and forget them, which is the
+// failure the "26 tests that build fixtures by hand" note in smell_refs_views.go
+// describes.
+func init() {
+	fixturedb.RegisterViewInstaller(func(qg fixturedb.RefsQuerier) error {
+		return ensureCanonicalViews(qg)
+	})
+}
+
+// newSmellFixture builds a producer-shaped fixture and wraps it as the graph
+// backend the find_smells handlers take.
+//
+// p is not defaulted and never inferred: every fixture must SAY which producer
+// it models, because ensureCanonicalViews emits a structurally different v_refs
+// per producer and the choice decides which SQL the rule under test runs.
+func newSmellFixture(t *testing.T, p fixturedb.Producer, seed func(*fixturedb.Builder)) *smellTestGraph {
+	t.Helper()
+	b := fixturedb.New(t, p)
+	seed(b)
+	path, f := b.Build()
+	return &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: f.DB(), path: path}
+}

--- a/cmd/leyline_crosslang_smells_test.go
+++ b/cmd/leyline_crosslang_smells_test.go
@@ -2,14 +2,12 @@ package cmd
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
 )
 
 // mache-caaae9 — after LLO v0.7.0 (qualified tokens + Python/JS/TS extraction +
@@ -27,23 +25,30 @@ import (
 //
 // Node_id shapes below are the real ones emitted by `leyline parse` (v0.7.0).
 
-func newCrossLangGraph(t *testing.T, ddl string) *smellTestGraph {
+// crossLangDef is one leyline-emitted definition: a token, the construct that
+// defines it, and its κ kind.
+type crossLangDef struct {
+	token  string
+	nodeID fixturedb.ConstructID
+	kind   fixturedb.CanonicalKind
+	name   string // nodes.name; defaults to the id's last segment
+}
+
+// newCrossLangGraph builds the fixture for these tests.
+//
+// It used to take a `ddl string` — a helper PARAMETERIZED ON SQL, on top of a
+// hardcoded two-column node_defs. That was the mache-projection shape, while
+// every node_id below is a real `leyline parse` path and the file's own header
+// says so. The producer and the shape disagreed, and nothing in the test said
+// which one it meant (mache-7555da).
+func newCrossLangGraph(t *testing.T, defs []crossLangDef) *smellTestGraph {
 	t.Helper()
-	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "xlang.db"))
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-	db.SetMaxOpenConns(1)
-	_, err = db.Exec(`
-		CREATE TABLE nodes (
-			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
-			kind INTEGER NOT NULL, size INTEGER, mtime INTEGER NOT NULL,
-			record_id TEXT, record TEXT, source_file TEXT
-		);
-		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-	` + ddl)
-	require.NoError(t, err)
-	return &smellTestGraph{db: db}
+	return newSmellFixture(t, fixturedb.Leyline, func(b *fixturedb.Builder) {
+		for _, d := range defs {
+			b.Construct(d.nodeID, fixturedb.Where{Name: d.name})
+			b.Def(d.token, d.nodeID, d.kind)
+		}
+	})
 }
 
 func findingsFor(t *testing.T, tg *smellTestGraph, rule string) []smellFinding {
@@ -63,22 +68,20 @@ func findingsFor(t *testing.T, tg *smellTestGraph, rule string) []smellFinding {
 // under class_definition/block/function_definition) must not be flagged; a
 // genuine free-function duplicate still is.
 func TestDuplicateDefinitions_PythonMethods_NotFlagged(t *testing.T) {
-	tg := newCrossLangGraph(t, `
-		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file) VALUES
-			('m.py/class_definition_0', NULL, 'Foo', 1, 0, 'm.py'),
-			('m.py/class_definition_0/block/function_definition_0', NULL, 'new', 1, 0, 'm.py'),
-			('m.py/class_definition_1', NULL, 'Bar', 1, 0, 'm.py'),
-			('m.py/class_definition_1/block/function_definition_0', NULL, 'new', 1, 0, 'm.py'),
-			('m.py/function_definition_0', NULL, 'dup_free', 1, 0, 'm.py'),
-			('n.py/function_definition_0', NULL, 'dup_free', 1, 0, 'n.py');
-		INSERT INTO node_defs (token, node_id) VALUES
-			('Foo.new', 'm.py/class_definition_0/block/function_definition_0'),
-			('new',     'm.py/class_definition_0/block/function_definition_0'),
-			('Bar.new', 'm.py/class_definition_1/block/function_definition_0'),
-			('new',     'm.py/class_definition_1/block/function_definition_0'),
-			('dup_free', 'm.py/function_definition_0'),
-			('dup_free', 'n.py/function_definition_0');
-	`)
+	// leyline DUAL-REGISTERS a method: the qualified `Foo.new` AND the bare
+	// `new`, both at the same construct. Two rows at one node_id is exactly
+	// what ley-line's missing primary key permits and the mache projection's
+	// PRIMARY KEY (token, node_id) would have silently collapsed.
+	tg := newCrossLangGraph(t, []crossLangDef{
+		{"Foo", "m.py/class_definition_0", fixturedb.Type, "Foo"},
+		{"Foo.new", "m.py/class_definition_0/block/function_definition_0", fixturedb.Method, "new"},
+		{"new", "m.py/class_definition_0/block/function_definition_0", fixturedb.Method, "new"},
+		{"Bar", "m.py/class_definition_1", fixturedb.Type, "Bar"},
+		{"Bar.new", "m.py/class_definition_1/block/function_definition_0", fixturedb.Method, "new"},
+		{"new", "m.py/class_definition_1/block/function_definition_0", fixturedb.Method, "new"},
+		{"dup_free", "m.py/function_definition_0", fixturedb.Function, "dup_free"},
+		{"dup_free", "n.py/function_definition_0", fixturedb.Function, "dup_free"},
+	})
 	var sawMethod, sawDupFree bool
 	for _, f := range findingsFor(t, tg, "duplicate_definitions") {
 		if f.NodeID == "m.py/class_definition_0/block/function_definition_0" ||
@@ -96,16 +99,12 @@ func TestDuplicateDefinitions_PythonMethods_NotFlagged(t *testing.T) {
 // TestDuplicateDefinitions_JSMethods_NotFlagged — JS methods (method_definition
 // under class_body) must not be flagged.
 func TestDuplicateDefinitions_JSMethods_NotFlagged(t *testing.T) {
-	tg := newCrossLangGraph(t, `
-		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file) VALUES
-			('m.js/class_declaration_0/class_body/method_definition_0', NULL, 'create', 1, 0, 'm.js'),
-			('m.js/class_declaration_1/class_body/method_definition_0', NULL, 'create', 1, 0, 'm.js');
-		INSERT INTO node_defs (token, node_id) VALUES
-			('Foo.create', 'm.js/class_declaration_0/class_body/method_definition_0'),
-			('create',     'm.js/class_declaration_0/class_body/method_definition_0'),
-			('Bar.create', 'm.js/class_declaration_1/class_body/method_definition_0'),
-			('create',     'm.js/class_declaration_1/class_body/method_definition_0');
-	`)
+	tg := newCrossLangGraph(t, []crossLangDef{
+		{"Foo.create", "m.js/class_declaration_0/class_body/method_definition_0", fixturedb.Method, "create"},
+		{"create", "m.js/class_declaration_0/class_body/method_definition_0", fixturedb.Method, "create"},
+		{"Bar.create", "m.js/class_declaration_1/class_body/method_definition_0", fixturedb.Method, "create"},
+		{"create", "m.js/class_declaration_1/class_body/method_definition_0", fixturedb.Method, "create"},
+	})
 	for _, f := range findingsFor(t, tg, "duplicate_definitions") {
 		assert.NotContains(t, f.NodeID, "method_definition",
 			"JS method (bare `create` under class_body) must not be a duplicate (mache-caaae9)")
@@ -116,18 +115,12 @@ func TestDuplicateDefinitions_JSMethods_NotFlagged(t *testing.T) {
 // struct_item/trait_item, Python class_definition) as dead now that leyline
 // populates source_file; a genuinely-dead free function still is.
 func TestDeadCode_LeylineTypesNotFlagged(t *testing.T) {
-	tg := newCrossLangGraph(t, `
-		INSERT INTO nodes (id, parent_id, name, kind, mtime, source_file) VALUES
-			('src/lib.rs/struct_item_0', NULL, 'Foo', 1, 0, 'src/lib.rs'),
-			('src/lib.rs/trait_item', NULL, 'Runner', 1, 0, 'src/lib.rs'),
-			('m.py/class_definition_0', NULL, 'Widget', 1, 0, 'm.py'),
-			('src/lib.rs/function_item_1', NULL, 'never_called', 1, 0, 'src/lib.rs');
-		INSERT INTO node_defs (token, node_id) VALUES
-			('Foo', 'src/lib.rs/struct_item_0'),
-			('Runner', 'src/lib.rs/trait_item'),
-			('Widget', 'm.py/class_definition_0'),
-			('never_called', 'src/lib.rs/function_item_1');
-	`)
+	tg := newCrossLangGraph(t, []crossLangDef{
+		{"Foo", "src/lib.rs/struct_item_0", fixturedb.Type, "Foo"},
+		{"Runner", "src/lib.rs/trait_item", fixturedb.Interface, "Runner"},
+		{"Widget", "m.py/class_definition_0", fixturedb.Type, "Widget"},
+		{"never_called", "src/lib.rs/function_item_1", fixturedb.Function, "never_called"},
+	})
 	var sawType, sawDeadFn bool
 	for _, f := range findingsFor(t, tg, "dead_code") {
 		switch f.NodeID {

--- a/cmd/serve_find_smells_fanout_test.go
+++ b/cmd/serve_find_smells_fanout_test.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"database/sql"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	_ "modernc.org/sqlite"
@@ -47,36 +47,27 @@ var b6RealTopASTHash = []byte{
 // ALL its occurrences. A consumer that (wrongly) grouped by node_hash
 // would collapse them to one — this test would catch that.
 func TestEnsureCanonicalViews_NodeHashFanOut(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "fanout.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
+	// Three occurrences of `dup` are ONE deduped subtree living at three
+	// distinct node_ids. One unrelated def `solo` is its own subtree.
+	//
+	// The fixture states the SHARING, not the bytes: node_hash is the
+	// producer's content identity, and a test that types a hash literal is
+	// asserting on something it does not own.
+	b := fixturedb.New(t, fixturedb.Leyline)
+	b.Def("dup", "a.go/dup", fixturedb.Function, fixturedb.Detail{Subtree: "dup"})
+	b.Def("dup", "b.go/dup", fixturedb.Function, fixturedb.Detail{Subtree: "dup"})
+	b.Def("dup", "c.go/dup", fixturedb.Function, fixturedb.Detail{Subtree: "dup"})
+	b.Def("solo", "d.go/solo", fixturedb.Function)
+	_, f := b.Build()
+	db := f.DB()
 
-	// Three occurrences of `dup` share ONE node_hash (a deduped
-	// subtree) but live at three distinct node_ids. One unrelated def
-	// `solo` carries its own hash.
-	_, err = db.Exec(`
-		CREATE TABLE node_defs (
-			token TEXT NOT NULL, node_id TEXT NOT NULL,
-			source_id TEXT NOT NULL, node_hash BLOB
-		);
-		CREATE TABLE node_refs (
-			token TEXT NOT NULL, node_id TEXT NOT NULL,
-			source_id TEXT NOT NULL, node_hash BLOB
-		);
-		INSERT INTO node_defs VALUES ('dup', 'a/dup', 'a.go', X'DEAD');
-		INSERT INTO node_defs VALUES ('dup', 'b/dup', 'b.go', X'DEAD');
-		INSERT INTO node_defs VALUES ('dup', 'c/dup', 'c.go', X'DEAD');
-		INSERT INTO node_defs VALUES ('solo', 'd/solo', 'd.go', X'BEEF');
-	`)
-	require.NoError(t, err)
-
-	qg := &sqlDBQuerier{db: db}
-	require.NoError(t, ensureCanonicalViews(qg))
+	dupHash := fixtureSubtreeHash(t, db, "node_defs", "dup")
+	soloHash := fixtureSubtreeHash(t, db, "node_defs", "solo")
+	require.NotEqual(t, dupHash, soloHash, "unrelated subtrees must not collide")
 
 	// The duplicated node_hash must map to THREE distinct occurrences.
 	rows, err := db.Query(
-		`SELECT node_id FROM v_defs WHERE token='dup' AND node_hash=X'DEAD' ORDER BY node_id`)
+		`SELECT node_id FROM v_defs WHERE token='dup' AND node_hash=? ORDER BY node_id`, dupHash)
 	require.NoError(t, err)
 	defer func() { _ = rows.Close() }()
 	var got []string
@@ -86,14 +77,14 @@ func TestEnsureCanonicalViews_NodeHashFanOut(t *testing.T) {
 		got = append(got, id)
 	}
 	require.NoError(t, rows.Err())
-	assert.Equal(t, []string{"a/dup", "b/dup", "c/dup"}, got,
+	assert.Equal(t, []string{"a.go/dup", "b.go/dup", "c.go/dup"}, got,
 		"one node_hash → many occurrences; v_defs must not collapse the fan-out")
 
 	// Sanity: grouping BY node_hash would wrongly report 1 row for the
 	// duplicated subtree — pin that the raw occurrence count is 3.
 	var occurrences int
 	require.NoError(t, db.QueryRow(
-		`SELECT COUNT(*) FROM v_defs WHERE node_hash=X'DEAD'`).Scan(&occurrences))
+		`SELECT COUNT(*) FROM v_defs WHERE node_hash=?`, dupHash).Scan(&occurrences))
 	assert.Equal(t, 3, occurrences, "node_hash is one-to-many, not one-to-one")
 }
 

--- a/cmd/serve_find_smells_nodehash_test.go
+++ b/cmd/serve_find_smells_nodehash_test.go
@@ -2,12 +2,11 @@ package cmd
 
 import (
 	"database/sql"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
 )
 
 // Additive node_hash passthrough (B4, mache-ff9a9d).
@@ -26,29 +25,18 @@ import (
 // v_refs expose it, and the existing token/node_id/fidelity columns
 // stay byte-identical.
 func TestEnsureCanonicalViews_NodeHashPassthrough(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "nodehash.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
+	// The merkle producer IS ley-line: node_hash is its additive column, so
+	// this arm is only reachable on that producer. Saying so names the arm
+	// instead of implying it through a hand-written column list.
+	b := fixturedb.New(t, fixturedb.Leyline)
+	b.Def("Foo", "pkg.go/functions/Foo", fixturedb.Function, fixturedb.Detail{Subtree: "foo-def"})
+	b.Ref("Foo", "pkg.go/functions/Bar", "", "", fixturedb.Detail{Subtree: "foo-ref"})
+	_, f := b.Build()
+	db := f.DB()
 
-	// Mirror the merkle-producer schema: node_defs / node_refs with the
-	// additive node_hash BLOB column referencing node_content.
-	_, err = db.Exec(`
-		CREATE TABLE node_defs (
-			token TEXT NOT NULL, node_id TEXT NOT NULL,
-			source_id TEXT NOT NULL, node_hash BLOB
-		);
-		CREATE TABLE node_refs (
-			token TEXT NOT NULL, node_id TEXT NOT NULL,
-			source_id TEXT NOT NULL, node_hash BLOB
-		);
-		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo', 'pkg.go', X'AABB');
-		INSERT INTO node_refs VALUES ('Foo', 'pkg/Bar', 'pkg.go', X'CCDD');
-	`)
-	require.NoError(t, err)
-
-	qg := &sqlDBQuerier{db: db}
-	require.NoError(t, ensureCanonicalViews(qg))
+	defHashWant := fixtureSubtreeHash(t, db, "node_defs", "Foo")
+	refHashWant := fixtureSubtreeHash(t, db, "node_refs", "Foo")
+	require.NotEqual(t, defHashWant, refHashWant, "distinct subtrees must not collide")
 
 	// v_defs: existing columns unchanged, node_hash exposed.
 	var (
@@ -59,9 +47,9 @@ func TestEnsureCanonicalViews_NodeHashPassthrough(t *testing.T) {
 		`SELECT token, node_id, fidelity, node_hash FROM v_defs WHERE fidelity='mention'`,
 	).Scan(&token, &nodeID, &fidelity, &nodeHash))
 	assert.Equal(t, "Foo", token)
-	assert.Equal(t, "pkg/Foo", nodeID)
+	assert.Equal(t, "pkg.go/functions/Foo", nodeID)
 	assert.Equal(t, "mention", fidelity)
-	assert.Equal(t, []byte{0xAA, 0xBB}, nodeHash, "v_defs must passthrough node_defs.node_hash")
+	assert.Equal(t, defHashWant, nodeHash, "v_defs must passthrough node_defs.node_hash")
 
 	// v_refs: existing columns unchanged, node_hash exposed.
 	var (
@@ -71,10 +59,12 @@ func TestEnsureCanonicalViews_NodeHashPassthrough(t *testing.T) {
 	require.NoError(t, db.QueryRow(
 		`SELECT referrer_node_id, token, qualifier, node_hash FROM v_refs WHERE fidelity='mention'`,
 	).Scan(&refReferrer, &refToken, &refQualifier, &refHash))
-	assert.Equal(t, "pkg/Bar", refReferrer)
+	assert.Equal(t, "pkg.go/functions/Bar", refReferrer,
+		"the referrer is the ENCLOSING construct — on ley-line that is container_node_id, "+
+			"not the call-site leaf in node_id")
 	assert.Equal(t, "Foo", refToken)
 	assert.Equal(t, "", refQualifier)
-	assert.Equal(t, []byte{0xCC, 0xDD}, refHash, "v_refs must passthrough node_refs.node_hash")
+	assert.Equal(t, refHashWant, refHash, "v_refs must passthrough node_refs.node_hash")
 }
 
 // TestEnsureCanonicalViews_NodeHashAbsentBackCompat (B4b) is the
@@ -83,22 +73,13 @@ func TestEnsureCanonicalViews_NodeHashPassthrough(t *testing.T) {
 // identical to today, and node_hash must read as NULL (stable trailing
 // column shape) rather than erroring with "no such column".
 func TestEnsureCanonicalViews_NodeHashAbsentBackCompat(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "no_nodehash.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	defer func() { _ = db.Close() }()
-
-	// Legacy standalone shape: no node_hash column at all.
-	_, err = db.Exec(`
-		CREATE TABLE node_defs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-		CREATE TABLE node_refs (token TEXT, node_id TEXT, PRIMARY KEY (token, node_id)) WITHOUT ROWID;
-		INSERT INTO node_defs VALUES ('Foo', 'pkg/Foo');
-		INSERT INTO node_refs VALUES ('Foo', 'pkg/Bar');
-	`)
-	require.NoError(t, err)
-
-	qg := &sqlDBQuerier{db: db}
-	require.NoError(t, ensureCanonicalViews(qg))
+	// "A standalone-mache db has no node_hash column" is not a legacy quirk to
+	// be re-typed per fixture — it is what fixturedb.Standalone IS.
+	b := fixturedb.New(t, fixturedb.Standalone)
+	b.Def("Foo", "pkg/functions/Foo", fixturedb.Function)
+	b.Ref("Foo", "pkg/functions/Bar", "", "")
+	_, f := b.Build()
+	db := f.DB()
 
 	// Existing rows byte-identical to today.
 	var token, nodeID string
@@ -106,7 +87,7 @@ func TestEnsureCanonicalViews_NodeHashAbsentBackCompat(t *testing.T) {
 		`SELECT token, node_id FROM v_defs WHERE fidelity='mention'`,
 	).Scan(&token, &nodeID))
 	assert.Equal(t, "Foo", token)
-	assert.Equal(t, "pkg/Foo", nodeID)
+	assert.Equal(t, "pkg/functions/Foo", nodeID)
 
 	// node_hash column present in shape, resolves to NULL (not an error).
 	var defHash, refHash []byte
@@ -121,4 +102,23 @@ func TestEnsureCanonicalViews_NodeHashAbsentBackCompat(t *testing.T) {
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_refs`).Scan(&refCount))
 	assert.Equal(t, 1, defCount)
 	assert.Equal(t, 1, refCount)
+}
+
+// fixtureSubtreeHash reads back the node_hash a fixture assigned to a token's
+// occurrence. Tests assert against THIS rather than a literal, because a
+// fixture states which occurrences share a subtree — never the bytes that
+// identify one.
+func fixtureSubtreeHash(t *testing.T, db *sql.DB, table, token string) []byte {
+	t.Helper()
+	var h []byte
+	switch table {
+	case "node_defs":
+		require.NoError(t, db.QueryRow(
+			`SELECT node_hash FROM node_defs WHERE token = ?`, token).Scan(&h))
+	default:
+		require.NoError(t, db.QueryRow(
+			`SELECT node_hash FROM node_refs WHERE token = ?`, token).Scan(&h))
+	}
+	require.NotEmpty(t, h, "the fixture must have stamped a node_hash")
+	return h
 }

--- a/cmd/smell_doc_refs_test.go
+++ b/cmd/smell_doc_refs_test.go
@@ -1,14 +1,11 @@
 package cmd
 
 import (
-	"database/sql"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // TestDocRefsView_ScopesToRustAndStripsCallSyntax pins the view's shape
@@ -17,26 +14,27 @@ import (
 // filtered before any consumer sees them, and a trailing '()' is stripped
 // into a separate bare column without mutating the original token.
 func TestDocRefsView_ScopesToRustAndStripsCallSyntax(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "docrefs.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(1)
-	t.Cleanup(func() { _ = db.Close() })
-
-	_, err = db.Exec(`
-		CREATE TABLE node_refs (token TEXT, node_id TEXT, source_id TEXT, container_node_id TEXT, qualifier TEXT);
-		INSERT INTO node_refs (token, node_id, source_id) VALUES
-		  ('epic::is_dominated_by', 'doc.md/span0', 'doc.md'),
-		  ('Stdio::null()', 'doc.md/span1', 'doc.md'),
-		  ('MaxRetries', 'doc.md/span2', 'doc.md'),
-		  ('cmd/serve.go::registerMCPTools', 'doc.md/span3', 'doc.md'),
-		  ('Foo:: bar', 'doc.md/span4', 'doc.md'),
-		  ('epic::is_dominated_by', 'main.go/call0', 'main.go');
-	`)
-	require.NoError(t, err)
-
-	_, err = db.Exec("CREATE TEMP TABLE v_doc_refs AS " + docRefsViewSQL(true))
-	require.NoError(t, err)
+	// v_doc_refs is only reachable when node_refs carries source_id — which is
+	// the ley-line shape, and only that. Naming the producer is what makes
+	// "with source_id" a fact about a real .db rather than a column a fixture
+	// chose to type.
+	b := fixturedb.New(t, fixturedb.Leyline)
+	for _, r := range []struct {
+		token string
+		site  fixturedb.SiteID
+		in    fixturedb.ConstructID
+	}{
+		{"epic::is_dominated_by", "doc.md/span0", "doc.md"},
+		{"Stdio::null()", "doc.md/span1", "doc.md"},
+		{"MaxRetries", "doc.md/span2", "doc.md"},
+		{"cmd/serve.go::registerMCPTools", "doc.md/span3", "doc.md"},
+		{"Foo:: bar", "doc.md/span4", "doc.md"},
+		{"epic::is_dominated_by", "main.go/call0", "main.go"},
+	} {
+		b.Ref(r.token, r.in, r.site, "")
+	}
+	_, f := b.Build()
+	db := f.DB()
 
 	rows, err := db.Query(`SELECT token, node_id, source_id, bare FROM v_doc_refs ORDER BY node_id`)
 	require.NoError(t, err)
@@ -66,17 +64,11 @@ func TestDocRefsView_ScopesToRustAndStripsCallSyntax(t *testing.T) {
 // — that's the entire reason this is a Go-probed view and not an inline
 // query in the consuming rule.
 func TestDocRefsView_DegradesToEmptyWithoutSourceID(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "nosourceid.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(1)
-	defer func() { _ = db.Close() }()
-
-	_, err = db.Exec(`CREATE TABLE node_refs (token TEXT, node_id TEXT)`)
-	require.NoError(t, err)
-
-	_, err = db.Exec("CREATE TEMP TABLE v_doc_refs AS " + docRefsViewSQL(false))
-	require.NoError(t, err, "the no-source_id form must be valid SQL against a node_refs missing that column")
+	// "node_refs without a source_id column" is exactly the mache projection.
+	_, f := fixturedb.New(t, fixturedb.Standalone).
+		Ref("epic::is_dominated_by", "doc.md/span0", "", "").
+		Build()
+	db := f.DB()
 
 	var n int
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_doc_refs`).Scan(&n))

--- a/cmd/smell_test_nodes_test.go
+++ b/cmd/smell_test_nodes_test.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"database/sql"
-	"path/filepath"
 	"testing"
 
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	_ "modernc.org/sqlite"
 )
 
 // v_test_nodes detects Rust test code STRUCTURALLY: Rust states test-ness in an
@@ -30,32 +28,21 @@ import (
 // ATTRIBUTE and silently miss the module — which is why the query filters to
 // function_item/mod_item when finding the target.
 
-type testNodeFixtureRow struct {
-	nodeID string
-	kind   string
-	sb, eb int
-	token  string // non-empty only for identifier rows
-}
-
-// buildTestNodesFixture writes an _ast + node_content pair shaped like leyline
-// parse output. Byte ranges are what encode both containment and the
-// attribute→item association, so they are chosen to be unambiguous.
+// buildTestNodesFixture writes an `_ast` + `node_content` pair shaped like
+// ley-line parse output — with fixturedb.Leyline saying so, rather than a
+// hand-written CREATE TABLE implying it. Byte ranges encode both containment
+// and the attribute→item association, so they are chosen to be unambiguous.
 func buildTestNodesFixture(t *testing.T) *sql.DB {
 	t.Helper()
-	dbPath := filepath.Join(t.TempDir(), "tn.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(1) // TEMP tables are per-connection
-	t.Cleanup(func() { _ = db.Close() })
 
-	_, err = db.Exec(`
-		CREATE TABLE _ast (
-			node_id TEXT PRIMARY KEY, source_id TEXT NOT NULL, node_kind TEXT NOT NULL,
-			start_byte INTEGER NOT NULL, end_byte INTEGER NOT NULL, node_hash BLOB);
-		CREATE TABLE node_content (node_hash BLOB PRIMARY KEY, token TEXT);`)
-	require.NoError(t, err)
-
-	rows := []testNodeFixtureRow{
+	b := fixturedb.New(t, fixturedb.Leyline)
+	b.Source("f.rs", "rust", "")
+	for _, r := range []struct {
+		nodeID string
+		kind   string
+		sb, eb int
+		token  string // non-empty only for identifier rows
+	}{
 		// a production function — must stay unmarked
 		{"f/prod_fn", "function_item", 0, 50, ""},
 
@@ -79,23 +66,12 @@ func buildTestNodesFixture(t *testing.T) *sql.DB {
 		{"f/attr4/id", "identifier", 327, 332, "allow"},
 		{"f/mod_stacked", "mod_item", 350, 450, ""},
 		{"f/mod_stacked/s_fn", "function_item", 380, 430, ""},
+	} {
+		b.ASTNode(r.nodeID, r.kind, "f.rs", fixturedb.Bytes(r.sb, r.eb),
+			fixturedb.Detail{Token: r.token})
 	}
-	for i, r := range rows {
-		var hash any
-		if r.token != "" {
-			h := []byte{byte(i + 1)}
-			hash = h
-			_, err = db.Exec(`INSERT OR IGNORE INTO node_content(node_hash, token) VALUES (?, ?)`, h, r.token)
-			require.NoError(t, err)
-		}
-		_, err = db.Exec(`INSERT INTO _ast(node_id, source_id, node_kind, start_byte, end_byte, node_hash)
-			VALUES (?, 'f.rs', ?, ?, ?, ?)`, r.nodeID, r.kind, r.sb, r.eb, hash)
-		require.NoError(t, err)
-	}
-
-	_, err = db.Exec("CREATE TEMP TABLE v_test_nodes AS " + testNodesViewSQL(true))
-	require.NoError(t, err)
-	return db
+	_, f := b.Build()
+	return f.DB()
 }
 
 func markedTestNodes(t *testing.T, db *sql.DB) map[string]bool {
@@ -156,14 +132,13 @@ func TestTestNodesView_DoesNotMarkTheAttributeNodes(t *testing.T) {
 // must yield an empty set rather than an error, so every rule's SQL stays
 // identical across backends instead of branching.
 func TestTestNodesView_EmptyWithoutAST(t *testing.T) {
-	dbPath := filepath.Join(t.TempDir(), "noast.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	db.SetMaxOpenConns(1)
-	defer func() { _ = db.Close() }()
-
-	_, err = db.Exec("CREATE TEMP TABLE v_test_nodes AS " + testNodesViewSQL(false))
-	require.NoError(t, err, "the no-AST form must be valid SQL on a db with no _ast at all")
+	// "a projection with no _ast" is not a shape to be hand-typed: it is what
+	// fixturedb.Standalone IS, and Build installs the degraded v_test_nodes
+	// through the real ensureCanonicalViews rather than a test-local CREATE.
+	_, f := fixturedb.New(t, fixturedb.Standalone).
+		Def("Run", "pkg/functions/Run", fixturedb.Function).
+		Build()
+	db := f.DB()
 
 	var n int
 	require.NoError(t, db.QueryRow(`SELECT COUNT(*) FROM v_test_nodes`).Scan(&n))

--- a/cmd/untested_function_leyline_test.go
+++ b/cmd/untested_function_leyline_test.go
@@ -2,15 +2,12 @@ package cmd
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
-	"path/filepath"
 	"testing"
 
-	"github.com/agentic-research/mache/internal/graph"
+	"github.com/agentic-research/mache/internal/fixturedb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	_ "modernc.org/sqlite"
 )
 
 // buildLeylineGoProjectionFixture seeds a leyline-_ast-SHAPED db for the
@@ -32,80 +29,42 @@ import (
 func buildLeylineGoProjectionFixture(t *testing.T) *smellTestGraph {
 	t.Helper()
 
-	dbPath := filepath.Join(t.TempDir(), "leyline_go.db")
-	db, err := sql.Open("sqlite", dbPath)
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = db.Close() })
-
-	// Leyline column shape: node_defs carries canonical_kind, node_refs
-	// carries container_node_id — the probes in ensureCanonicalViews
-	// activate the leyline arms only when these columns exist.
-	_, err = db.Exec(`
-		CREATE TABLE nodes (
-			id TEXT PRIMARY KEY, parent_id TEXT, name TEXT NOT NULL,
-			kind INTEGER NOT NULL, size INTEGER DEFAULT 0,
-			mtime INTEGER NOT NULL DEFAULT 0, record_id TEXT, record TEXT,
-			source_file TEXT
-		);
-		CREATE TABLE node_defs (
-			token TEXT, node_id TEXT, source_id TEXT,
-			node_hash BLOB, canonical_kind TEXT,
-			PRIMARY KEY (token, node_id)
-		) WITHOUT ROWID;
-		CREATE TABLE node_refs (
-			token TEXT, node_id TEXT, source_id TEXT,
-			node_hash BLOB, container_node_id TEXT,
-			PRIMARY KEY (token, node_id)
-		) WITHOUT ROWID;
-	`)
-	require.NoError(t, err)
-
-	type def struct{ token, nodeID, sourceFile, kind string }
-	defs := []def{
+	// fixturedb.Leyline is what makes the comment above TRUE rather than
+	// aspirational. The hand-written DDL this replaced described itself as "the
+	// Leyline column shape" while omitting node_refs.qualifier, omitting
+	// node_defs.container_node_id, and ADDING a PRIMARY KEY ... WITHOUT ROWID
+	// that ley-line does not have — so ensureCanonicalViews ran a different
+	// v_refs body here than in production (mache-e3f3bf, mache-7555da).
+	return newSmellFixture(t, fixturedb.Leyline, func(b *fixturedb.Builder) {
 		// Uncovered exported Go function — the one expected finding.
-		{"Orphan", "pkg/orphan.go/function_declaration_0", "pkg/orphan.go", "function"},
+		b.Def("Orphan", "pkg/orphan.go/function_declaration_0", fixturedb.Function)
 		// Covered ONLY by a test caller: no TestServed def exists, so
 		// coverage must come from the container_node_id join arm.
-		{"Served", "pkg/served.go/function_declaration_0", "pkg/served.go", "function"},
+		b.Def("Served", "pkg/served.go/function_declaration_0", fixturedb.Function)
 		// The test function that calls Served.
-		{"TestServedEndToEnd", "pkg/served_test.go/function_declaration_0", "pkg/served_test.go", "function"},
+		b.Def("TestServedEndToEnd", "pkg/served_test.go/function_declaration_0", fixturedb.Function)
 		// The non-test caller that refs Orphan (must NOT grant coverage).
-		{"runAll", "pkg/run.go/function_declaration_0", "pkg/run.go", "function"},
+		b.Def("runAll", "pkg/run.go/function_declaration_0", fixturedb.Function)
 		// Rust function: canonical_kind='function' too, but the TestFoo
 		// convention is Go-only — the .go scope must exclude it.
-		{"RustHelper", "src/lib.rs/function_item_0", "src/lib.rs", "function"},
+		b.Def("RustHelper", "src/lib.rs/function_item_0", fixturedb.Function)
 		// testdata corpus: Go by extension, excluded by directory.
-		{"FixtureFn", "testdata/sample.go/function_declaration_0", "testdata/sample.go", "function"},
-		{"NestedFixtureFn", "internal/x/testdata/deep.go/function_declaration_0", "internal/x/testdata/deep.go", "function"},
+		b.Def("FixtureFn", "testdata/sample.go/function_declaration_0", fixturedb.Function)
+		b.Def("NestedFixtureFn", "internal/x/testdata/deep.go/function_declaration_0", fixturedb.Function)
 		// Method: uppercase, uncovered, but canonical_kind='method'.
-		{"Handle", "pkg/recv.go/method_declaration_0", "pkg/recv.go", "method"},
-	}
-	for _, d := range defs {
-		_, err = db.Exec("INSERT INTO node_defs (token, node_id, source_id, canonical_kind) VALUES (?, ?, ?, ?)",
-			d.token, d.nodeID, d.sourceFile, d.kind)
-		require.NoError(t, err)
-		_, err = db.Exec("INSERT INTO nodes (id, parent_id, name, kind, mtime, record, source_file) VALUES (?, '', ?, 1, 0, '', ?)",
-			d.nodeID, d.token, d.sourceFile)
-		require.NoError(t, err)
-	}
+		b.Def("Handle", "pkg/recv.go/method_declaration_0", fixturedb.Method)
 
-	type ref struct{ token, nodeID, container string }
-	refs := []ref{
-		// Served is called from inside TestServedEndToEnd: the ref's own
-		// node_id is the call-site LEAF (never a def node_id, and never
-		// matching the tree-sitter '%/Test%/source' path shapes) — the
-		// caller identity is ONLY recoverable via container_node_id.
-		{"Served", "pkg/served_test.go/function_declaration_0/block/statement_list/expression_statement/call_expression", "pkg/served_test.go/function_declaration_0"},
+		// Served is called from INSIDE TestServedEndToEnd. `from` is the
+		// enclosing test function; `at` is the call-site leaf. On ley-line
+		// those are different columns, and the caller identity is only
+		// recoverable from the first — which is exactly why they are two
+		// parameters now instead of one implicit convention.
+		b.Ref("Served", "pkg/served_test.go/function_declaration_0",
+			"pkg/served_test.go/function_declaration_0/block/statement_list/expression_statement/call_expression", "")
 		// Orphan is called — but from a NON-test function. Must not count.
-		{"Orphan", "pkg/run.go/function_declaration_0/block/statement_list/expression_statement/call_expression", "pkg/run.go/function_declaration_0"},
-	}
-	for _, r := range refs {
-		_, err = db.Exec("INSERT INTO node_refs (token, node_id, source_id, container_node_id) VALUES (?, ?, '', ?)",
-			r.token, r.nodeID, r.container)
-		require.NoError(t, err)
-	}
-
-	return &smellTestGraph{MemoryStore: graph.NewMemoryStore(), db: db}
+		b.Ref("Orphan", "pkg/run.go/function_declaration_0",
+			"pkg/run.go/function_declaration_0/block/statement_list/expression_statement/call_expression", "")
+	})
 }
 
 // TestFindSmells_UntestedFunctionLeylineProjection is the leyline parity

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -1468,11 +1468,6 @@
     },
     {
       "rule_id": "god_file",
-      "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/session.rs",
-      "count": 1
-    },
-    {
-      "rule_id": "god_file",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/tests.rs",
       "count": 1
     },
@@ -1959,6 +1954,11 @@
     {
       "rule_id": "long_function",
       "source_id": "internal/leyline/trigger.go",
+      "count": 1
+    },
+    {
+      "rule_id": "long_function",
+      "source_id": "internal/lint/llo_boundary_test.go",
       "count": 1
     },
     {

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -104,7 +104,7 @@
     {
       "rule_id": "duplicate_code",
       "source_id": "cmd/serve_find_smells_test.go",
-      "count": 31
+      "count": 29
     },
     {
       "rule_id": "duplicate_code",
@@ -174,6 +174,11 @@
     {
       "rule_id": "duplicate_code",
       "source_id": "internal/control/control_test.go",
+      "count": 1
+    },
+    {
+      "rule_id": "duplicate_code",
+      "source_id": "internal/fixturedb/build.go",
       "count": 1
     },
     {
@@ -584,11 +589,6 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "cmd/testdata/preset_fixtures/sql/schema.sql",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "cmd/untested_function_leyline_test.go",
       "count": 1
     },
     {
@@ -1464,6 +1464,11 @@
     {
       "rule_id": "god_file",
       "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/mod.rs",
+      "count": 1
+    },
+    {
+      "rule_id": "god_file",
+      "source_id": "testdata/snapshots/medium-rust-rosary/src/dispatch/session.rs",
       "count": 1
     },
     {

--- a/internal/fixturedb/build.go
+++ b/internal/fixturedb/build.go
@@ -1,0 +1,125 @@
+package fixturedb
+
+import (
+	"database/sql"
+	"maps"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// FixtureDB is a built fixture: a real on-disk SQLite database whose shape is the
+// producer's, with the canonical views already installed.
+//
+// It satisfies [RefsQuerier] and cmd's dbPathProvider, so it drops directly into
+// the production call path.
+type FixtureDB struct {
+	t    *testing.T
+	db   *sql.DB
+	path string
+}
+
+// QueryRefs implements [RefsQuerier].
+func (f *FixtureDB) QueryRefs(query string, args ...any) (*sql.Rows, error) {
+	return f.db.Query(query, args...)
+}
+
+// DBPath implements the dbPathProvider opt-in, which is what enables capnp
+// binding readthrough from the sibling .bindings.capnp log.
+func (f *FixtureDB) DBPath() string { return f.path }
+
+// DB exposes the connection so a test can assert on rows directly.
+//
+// It is NOT an escape hatch for DDL: the fixture's shape is already fixed by the
+// producer, and internal/lint's LLO boundary rule fails any test that writes an
+// LLO-owned table.
+func (f *FixtureDB) DB() *sql.DB { return f.db }
+
+// Build materialises the fixture and returns its path alongside it.
+//
+// The connection is capped at ONE so the TEMP views survive across queries —
+// TEMP objects are per-connection, and a fixture whose pool hands out a second
+// connection loses v_defs / v_refs / v_test_nodes non-deterministically. Getting
+// that wrong was a per-fixture coin flip before this package; now it is settled
+// in one place.
+//
+// The canonical views are installed here, not by the caller, so a test cannot
+// forget them.
+func (b *Builder) Build() (string, *FixtureDB) {
+	t := b.t
+	t.Helper()
+
+	dbPath := filepath.Join(t.TempDir(), "fixture.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("fixturedb: open %s: %v", dbPath, err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, stmt := range b.schemaStatements() {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("fixturedb(%s): create schema: %v\n%s", b.producer, err, stmt)
+		}
+	}
+	b.insertRows(db)
+
+	f := &FixtureDB{t: t, db: db, path: dbPath}
+	if viewInstaller != nil {
+		if err := viewInstaller(f); err != nil {
+			t.Fatalf("fixturedb(%s): install canonical views: %v", b.producer, err)
+		}
+	}
+	return dbPath, f
+}
+
+// schemaStatements returns the producer's DDL, plus the ley-line-owned
+// `_ast` / `_source` / `node_content` / `_imports` tables when this fixture
+// carries rows for them.
+//
+// Presence is deliberately CONDITIONAL on [Standalone] and unconditional on
+// [Leyline], because that is what the producers do — and because
+// ensureCanonicalViews PROBES for `_ast`: creating it unconditionally would flip
+// every Standalone fixture onto the v_test_nodes arm that real mache .db files
+// never reach.
+func (b *Builder) schemaStatements() []string {
+	var stmts []string
+	add := func(names []string, from map[string]string) {
+		for _, n := range names {
+			stmts = append(stmts, from[n])
+		}
+	}
+
+	switch b.producer {
+	case Leyline:
+		add(leylineTableOrder, leylineTables)
+		add(slices.Sorted(maps.Keys(leylineIndexes)), leylineIndexes)
+	default: // Standalone
+		add(standaloneTableOrder, standaloneTables)
+		add(slices.Sorted(maps.Keys(standaloneIndexes)), standaloneIndexes)
+		add(slices.Sorted(maps.Keys(standaloneViews)), standaloneViews)
+		// The cache-hydration path (cmd/cache.go) materialises ley-line's
+		// parse output onto a mache-projection .db. Model it only when the
+		// fixture actually declares such rows.
+		if len(b.ast) > 0 {
+			stmts = append(stmts, leylineTables["node_content"], leylineTables["_ast"])
+		}
+		if len(b.sources) > 0 {
+			stmts = append(stmts, leylineTables["_source"])
+		}
+	}
+	if len(b.lspDefs) > 0 {
+		stmts = append(stmts, lspDefsTable)
+	}
+	return stmts
+}
+
+// lspDefsTable is the LSP-enrichment def table ley-line's ll-open/lsp crate
+// writes. Not a producer table: it is optional on both producers.
+const lspDefsTable = `CREATE TABLE _lsp_defs (
+	node_id TEXT NOT NULL,
+	def_token TEXT NOT NULL DEFAULT '',
+	def_uri TEXT NOT NULL,
+	def_start_line INTEGER NOT NULL, def_start_col INTEGER NOT NULL,
+	def_end_line INTEGER NOT NULL, def_end_col INTEGER NOT NULL
+)`

--- a/internal/fixturedb/builder.go
+++ b/internal/fixturedb/builder.go
@@ -1,0 +1,227 @@
+package fixturedb
+
+import (
+	"crypto/sha256"
+	"path"
+	"strconv"
+	"strings"
+	"testing"
+
+	_ "modernc.org/sqlite" // pure-Go driver; fixtures must not need CGO
+)
+
+// Builder accumulates a fixture's CONTENT. It has no method that accepts SQL,
+// DDL, a column name or a table name — that absence is the design, not an
+// oversight, and adding such a method re-opens the defect this package closed.
+//
+// Every method returns the receiver so calls chain.
+type Builder struct {
+	t        *testing.T
+	producer Producer
+
+	constructs map[ConstructID]*construct
+	order      []ConstructID
+	defs       []defSpec
+	refs       []refSpec
+	ast        []astSpec
+	sources    map[SourceID]*sourceSpec
+	srcOrder   []SourceID
+	imports    []importSpec
+	lspDefs    []lspDefSpec
+
+	siteSeq map[ConstructID]int
+	subtree int
+}
+
+type lspDefSpec struct {
+	nodeID, token, uri  string
+	startLine, startCol int
+	endLine, endCol     int
+}
+
+// New starts a fixture for the given producer. p is MANDATORY and must be one
+// of [Leyline] / [Standalone]; the zero Producer fails the test immediately,
+// which is how "a fixture cannot exist without naming its producer" is enforced
+// at the one place a fixture can be created.
+func New(t *testing.T, p Producer) *Builder {
+	t.Helper()
+	if !p.valid() {
+		t.Fatal("fixturedb.New: producer is required — pass fixturedb.Leyline or fixturedb.Standalone")
+	}
+	return &Builder{
+		t:          t,
+		producer:   p,
+		constructs: map[ConstructID]*construct{},
+		sources:    map[SourceID]*sourceSpec{},
+		siteSeq:    map[ConstructID]int{},
+	}
+}
+
+// Producer reports which producer shape this fixture reproduces, so a test can
+// assert on it or branch its expectations explicitly rather than by accident.
+func (b *Builder) Producer() Producer { return b.producer }
+
+// Construct declares an enclosing definition and its `nodes` row. Declaring the
+// same id twice fills in whatever [Where] adds rather than duplicating the
+// construct, so a fixture can name a construct before it knows its source.
+func (b *Builder) Construct(id ConstructID, where ...Where) *Builder {
+	c, ok := b.constructs[id]
+	if !ok {
+		c = &construct{id: id, source: inferSource(id), name: path.Base(string(id))}
+		b.constructs[id] = c
+		b.order = append(b.order, id)
+	}
+	w := first(where)
+	if w.Source != "" {
+		c.source = w.Source
+	}
+	if w.Name != "" {
+		c.name = w.Name
+	}
+	if w.Parent != "" {
+		c.parent = w.Parent
+	}
+	if w.Directory {
+		c.dirKind = true
+	}
+	return b
+}
+
+// Def declares that `token` is DEFINED by construct `in`, with κ kind `kind`.
+//
+// On [Leyline] this writes token / node_id / source_id / container_node_id /
+// canonical_kind / node_hash. On [Standalone] it writes token and node_id and
+// DROPS the rest, because the mache projection has nowhere to put them — which
+// is the point: the same test source now produces the shape it claims.
+func (b *Builder) Def(token string, in ConstructID, kind CanonicalKind, detail ...Detail) *Builder {
+	b.Construct(in)
+	d := first(detail)
+	spec := defSpec{
+		token: token, nodeID: in, kind: kind,
+		container: d.Container, subtree: d.label(b.nextSubtree()),
+	}
+	if spec.container != "" {
+		b.Construct(spec.container)
+	}
+	b.defs = append(b.defs, spec)
+	return b
+}
+
+// Ref declares that `token` is REFERENCED from inside construct `from`, at
+// occurrence `at`, through selector `qualifier`.
+//
+// `from` and `at` are separate parameters because `node_refs.node_id` means two
+// incompatible things:
+//
+//   - [Leyline] writes node_id = at (the call-SITE leaf), container_node_id =
+//     from (the enclosing def), plus source_id / qualifier / node_hash.
+//   - [Standalone] writes node_id = from (the enclosing CONSTRUCT) and has no
+//     column for at or qualifier at all.
+//
+// An empty `at` means "an unnamed occurrence": the builder synthesises a unique
+// ley-line-shaped call-site leaf under `from`. An empty `qualifier` is stored as
+// NULL, which is what ley-line writes for a bare (unqualified) call.
+func (b *Builder) Ref(token string, from ConstructID, at SiteID, qualifier string, detail ...Detail) *Builder {
+	b.Construct(from)
+	d := first(detail)
+	if at == "" {
+		at = b.nextSite(from)
+	}
+	b.refs = append(b.refs, refSpec{
+		token: token, from: from, at: at, qualifier: qualifier,
+		subtree: d.label(b.nextSubtree()),
+	})
+	return b
+}
+
+// nextSite synthesises a ley-line-shaped call-site leaf under from, so two
+// unnamed occurrences in one construct stay two distinct rows.
+func (b *Builder) nextSite(from ConstructID) SiteID {
+	n := b.siteSeq[from]
+	b.siteSeq[from] = n + 1
+	return SiteID(string(from) +
+		"/block/statement_list/expression_statement/call_expression_" + strconv.Itoa(n))
+}
+
+// ASTNode declares one `_ast` row: a parse-tree node of tree-sitter kind `kind`
+// spanning `span` in source `in`.
+func (b *Builder) ASTNode(id, kind string, in SourceID, span Span, detail ...Detail) *Builder {
+	d := first(detail)
+	b.ast = append(b.ast, astSpec{
+		nodeID: id, kind: kind, source: in, span: span,
+		token: d.Token, subtree: d.label(b.nextSubtree()),
+	})
+	b.Source(in, "", "")
+	return b
+}
+
+// Source declares a source file. lang may be empty when the test does not care;
+// content may be empty, in which case `_source.content` is NULL — which is what
+// ley-line v0.13.0 writes (it stores bytes in source_blobs and only a path
+// here). Pass content when the test is about snippet extraction.
+//
+// Re-declaring a source fills in whichever of lang/content was previously empty
+// rather than replacing it, so ASTNode's implicit declaration never clobbers an
+// explicit one.
+func (b *Builder) Source(id SourceID, lang, content string) *Builder {
+	s, ok := b.sources[id]
+	if !ok {
+		s = &sourceSpec{id: id, path: "/synthetic/" + string(id)}
+		b.sources[id] = s
+		b.srcOrder = append(b.srcOrder, id)
+	}
+	if lang != "" {
+		s.lang = lang
+	}
+	if content != "" {
+		s.content = content
+	}
+	return b
+}
+
+// Import declares one `_imports` row: `alias` bound to module `importPath`
+// inside source `in`. Only [Leyline] has this table; on [Standalone] the call is
+// dropped.
+func (b *Builder) Import(alias, importPath string, in SourceID) *Builder {
+	b.imports = append(b.imports, importSpec{alias: alias, importPath: importPath, source: in})
+	b.Source(in, "", "")
+	return b
+}
+
+// LSPDef declares one `_lsp_defs` row — a binding-fidelity definition, which
+// ensureCanonicalViews unions into v_defs when `_lsp_defs.def_token` exists.
+// The table is LSP-enrichment output, not a producer table, so it is available
+// on both producers.
+func (b *Builder) LSPDef(token string, in ConstructID, uri string, startLine, startCol, endLine, endCol int) *Builder {
+	b.lspDefs = append(b.lspDefs, lspDefSpec{
+		nodeID: string(in), token: token, uri: uri,
+		startLine: startLine, startCol: startCol, endLine: endLine, endCol: endCol,
+	})
+	return b
+}
+
+func (b *Builder) nextSubtree() string {
+	b.subtree++
+	return "seq:" + strconv.Itoa(b.subtree)
+}
+
+// inferSource returns the longest leading path prefix of id whose final segment
+// looks like a file name (contains a '.'), which is how ley-line composes node
+// ids: "<source_id>/<tree-sitter path>".
+func inferSource(id ConstructID) SourceID {
+	segs := strings.Split(string(id), "/")
+	for i := len(segs) - 1; i >= 0; i-- {
+		if strings.Contains(segs[i], ".") {
+			return SourceID(strings.Join(segs[:i+1], "/"))
+		}
+	}
+	return ""
+}
+
+// subtreeHash maps a subtree LABEL to a stable 32-byte merkle-shaped hash. Two
+// occurrences with the same label get the same hash; different labels
+// (including the per-occurrence sequence labels) get different ones.
+func subtreeHash(label string) []byte {
+	sum := sha256.Sum256([]byte(label))
+	return sum[:]
+}

--- a/internal/fixturedb/builder_test.go
+++ b/internal/fixturedb/builder_test.go
@@ -1,0 +1,256 @@
+package fixturedb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRef_NodeIDMeansDifferentThingsPerProducer is the property this package
+// exists for. `node_refs.node_id` has TWO incompatible meanings, and before
+// fixturedb a test picked one implicitly, by what it INSERTed, with nothing in
+// the test saying which. Now the meaning is two typed parameters and the
+// producer decides where each lands.
+func TestRef_NodeIDMeansDifferentThingsPerProducer(t *testing.T) {
+	const (
+		from = ConstructID("pkg/served_test.go/function_declaration_0")
+		at   = SiteID("pkg/served_test.go/function_declaration_0/block/call_expression")
+	)
+
+	t.Run("leyline puts the SITE in node_id and the CONSTRUCT in container", func(t *testing.T) {
+		b := New(t, Leyline)
+		b.Construct(from)
+		b.Ref("Served", from, at, "")
+		_, f := b.Build()
+
+		var nodeID, container, source string
+		require.NoError(t, f.DB().QueryRow(
+			`SELECT node_id, container_node_id, source_id FROM node_refs WHERE token='Served'`,
+		).Scan(&nodeID, &container, &source))
+
+		assert.Equal(t, string(at), nodeID)
+		assert.Equal(t, string(from), container)
+		assert.Equal(t, "pkg/served_test.go", source, "source_id inferred from the construct id")
+	})
+
+	t.Run("standalone puts the CONSTRUCT in node_id and has nowhere for the site", func(t *testing.T) {
+		b := New(t, Standalone)
+		b.Construct(from)
+		b.Ref("Served", from, at, "")
+		_, f := b.Build()
+
+		var nodeID string
+		require.NoError(t, f.DB().QueryRow(
+			`SELECT node_id FROM node_refs WHERE token='Served'`).Scan(&nodeID))
+		assert.Equal(t, string(from), nodeID)
+
+		assert.False(t, hasColumn(t, f.DB(), "node_refs", "container_node_id"),
+			"the mache projection has no container column at all")
+	})
+}
+
+// TestRef_ProducerSelectsTheReferrerArm walks the consequence all the way to the
+// SQL: ensureCanonicalViews emits a COALESCE over container_node_id
+// when the column exists and a bare `node_id` when it does not, so the two
+// producers make v_refs.referrer_node_id resolve to different things from the
+// SAME test source. That divergence used to be selected by a fixture's CREATE
+// TABLE literal.
+func TestRef_ProducerSelectsTheReferrerArm(t *testing.T) {
+	const (
+		from = ConstructID("pkg/run.go/function_declaration_0")
+		at   = SiteID("pkg/run.go/function_declaration_0/block/call_expression")
+	)
+
+	// Without an installed view this asserts on the raw shape, which is the
+	// input ensureCanonicalViews probes. The end-to-end assertion lives in
+	// cmd, where the real installer is registered.
+	for _, tc := range []struct {
+		producer     Producer
+		wantReferrer string
+	}{
+		{Leyline, string(from)},
+		{Standalone, string(from)},
+	} {
+		t.Run(tc.producer.String(), func(t *testing.T) {
+			b := New(t, tc.producer)
+			b.Ref("Orphan", from, at, "")
+			_, f := b.Build()
+
+			var referrer string
+			q := `SELECT COALESCE(NULLIF(container_node_id,''), node_id) FROM node_refs`
+			if !hasColumn(t, f.DB(), "node_refs", "container_node_id") {
+				q = `SELECT node_id FROM node_refs`
+			}
+			require.NoError(t, f.DB().QueryRow(q).Scan(&referrer))
+			assert.Equal(t, tc.wantReferrer, referrer,
+				"both producers must agree on the CALLER; only the column they store it in differs")
+		})
+	}
+}
+
+// TestRef_EmptySiteSynthesisesDistinctLeaves pins that two unnamed occurrences
+// in one construct are two rows on ley-line, not one. Collapsing them is the
+// fan_out_skew miscount (mache-50e939).
+func TestRef_EmptySiteSynthesisesDistinctLeaves(t *testing.T) {
+	b := New(t, Leyline)
+	b.Ref("helper", "a.go/function_declaration_0", "", "")
+	b.Ref("helper", "a.go/function_declaration_0", "", "")
+	_, f := b.Build()
+
+	rows, err := f.DB().Query(`SELECT DISTINCT node_id FROM node_refs WHERE token='helper'`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	var ids []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		ids = append(ids, id)
+	}
+	require.NoError(t, rows.Err())
+	assert.Len(t, ids, 2, "two call sites are two leaves")
+}
+
+// TestRef_EmptyQualifierIsNULL matches ley-line exactly: a bare call stores NULL,
+// not the empty string. ensureCanonicalViews wraps it in a COALESCE to the
+// empty string, so a fixture that stored one directly never exercised it.
+func TestRef_EmptyQualifierIsNULL(t *testing.T) {
+	b := New(t, Leyline)
+	b.Ref("Alpha", "a.go/function_declaration_1", "", "")
+	b.Ref("Println", "a.go/function_declaration_0", "", "fmt")
+	_, f := b.Build()
+
+	var bare sql.NullString
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT qualifier FROM node_refs WHERE token='Alpha'`).Scan(&bare))
+	assert.False(t, bare.Valid, "ley-line writes NULL for an unqualified call")
+
+	var qualified sql.NullString
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT qualifier FROM node_refs WHERE token='Println'`).Scan(&qualified))
+	assert.Equal(t, "fmt", qualified.String)
+}
+
+// TestDef_CanonicalKindOnlyExistsOnLeyline pins that the κ vocabulary is a
+// ley-line column. A Standalone fixture cannot carry it, so a rule that filters
+// on canonical_kind must degrade there rather than appear to work.
+func TestDef_CanonicalKindOnlyExistsOnLeyline(t *testing.T) {
+	bl := New(t, Leyline)
+	bl.Def("Handle", "pkg/recv.go/method_declaration_0", Method)
+	_, fl := bl.Build()
+
+	var kind string
+	require.NoError(t, fl.DB().QueryRow(
+		`SELECT canonical_kind FROM node_defs WHERE token='Handle'`).Scan(&kind))
+	assert.Equal(t, "method", kind)
+
+	bs := New(t, Standalone)
+	bs.Def("Handle", "pkg/recv.go/method_declaration_0", Method)
+	_, fs := bs.Build()
+	assert.False(t, hasColumn(t, fs.DB(), "node_defs", "canonical_kind"))
+}
+
+// TestDetailSubtree_SharesOneNodeHash pins the merkle one-to-many invariant
+// without any test ever writing hash bytes: occurrences labelled the same share
+// a node_hash, differently-labelled ones do not.
+func TestDetailSubtree_SharesOneNodeHash(t *testing.T) {
+	b := New(t, Leyline)
+	b.Def("dup", "a.go/fn_0", Function, Detail{Subtree: "shared"})
+	b.Def("dup", "b.go/fn_0", Function, Detail{Subtree: "shared"})
+	b.Def("solo", "c.go/fn_0", Function)
+	_, f := b.Build()
+
+	var shared int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(DISTINCT node_hash) FROM node_defs WHERE token='dup'`).Scan(&shared))
+	assert.Equal(t, 1, shared, "one deduped subtree behind two occurrences")
+
+	var occurrences int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM node_defs WHERE token='dup'`).Scan(&occurrences))
+	assert.Equal(t, 2, occurrences, "…and the occurrences must not collapse")
+
+	var overlap int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM node_defs WHERE token='solo'
+		   AND node_hash IN (SELECT node_hash FROM node_defs WHERE token='dup')`).Scan(&overlap))
+	assert.Zero(t, overlap, "unrelated subtrees must not collide")
+}
+
+// TestNew_RejectsTheZeroProducer is the constructor's half of the closed set:
+// Producer's only field is unexported, so no caller can build a third value, and
+// the zero value is refused here.
+func TestNew_RejectsTheZeroProducer(t *testing.T) {
+	assert.False(t, Producer{}.valid())
+	assert.Equal(t, "invalid(zero-value Producer)", Producer{}.String())
+	assert.True(t, Leyline.valid())
+	assert.True(t, Standalone.valid())
+}
+
+// TestInferSource pins the id→source_id inference, which is how ley-line
+// composes node ids ("<source_id>/<tree-sitter path>").
+func TestInferSource(t *testing.T) {
+	for _, tc := range []struct{ id, want string }{
+		{"pkg/orphan.go/function_declaration_0", "pkg/orphan.go"},
+		{"src/lib.rs/function_item_0", "src/lib.rs"},
+		{"internal/x/testdata/deep.go/function_declaration_0", "internal/x/testdata/deep.go"},
+		{"a.go", "a.go"},
+		{"pkg/functions/Run", ""}, // mache-schema path: no file segment
+	} {
+		assert.Equal(t, SourceID(tc.want), inferSource(ConstructID(tc.id)), tc.id)
+	}
+}
+
+// TestSource_ContentIsNULLWhenUnset matches ley-line v0.13.0, which stores bytes
+// in source_blobs and leaves _source.content NULL — the assumption
+// smell_test_nodes.go's structural detection is built on.
+func TestSource_ContentIsNULLWhenUnset(t *testing.T) {
+	b := New(t, Leyline)
+	b.Source("a.go", "go", "")
+	b.Source("b.go", "go", "package b\n")
+	_, f := b.Build()
+
+	var empty sql.RawBytes
+	var got sql.NullString
+	_ = empty
+	require.NoError(t, f.DB().QueryRow(`SELECT content FROM _source WHERE id='a.go'`).Scan(&got))
+	assert.False(t, got.Valid, "ley-line leaves _source.content NULL")
+
+	require.NoError(t, f.DB().QueryRow(`SELECT content FROM _source WHERE id='b.go'`).Scan(&got))
+	assert.Equal(t, "package b\n", got.String)
+}
+
+// TestBuild_SingleConnection pins the TEMP-object requirement centrally: TEMP
+// views are per-connection, so a fixture that let the pool hand out a second
+// connection would lose v_defs / v_refs non-deterministically. Before fixturedb
+// each fixture decided this for itself, and most did not.
+func TestBuild_SingleConnection(t *testing.T) {
+	b := New(t, Leyline)
+	b.Def("Run", "a.go/fn_0", Function)
+	_, f := b.Build()
+
+	_, err := f.DB().Exec(`CREATE TEMP VIEW probe AS SELECT 1 AS x`)
+	require.NoError(t, err)
+	for range 8 {
+		var x int
+		require.NoError(t, f.DB().QueryRow(`SELECT x FROM probe`).Scan(&x),
+			"the TEMP view must survive every query — one connection only")
+	}
+}
+
+func hasColumn(t *testing.T, db *sql.DB, table, col string) bool {
+	t.Helper()
+	rows, err := db.Query(`SELECT name FROM pragma_table_info(?)`, table)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var n string
+		require.NoError(t, rows.Scan(&n))
+		if n == col {
+			return true
+		}
+	}
+	require.NoError(t, rows.Err())
+	return false
+}

--- a/internal/fixturedb/emit.go
+++ b/internal/fixturedb/emit.go
@@ -1,0 +1,162 @@
+package fixturedb
+
+import "database/sql"
+
+// Emission: the ONE place a spec becomes columns.
+//
+// Every producer difference in this package lives here, in a `switch
+// b.producer` — never in a caller, never in a `CREATE TABLE` a test wrote. That
+// is what makes "which producer did this test mean?" a question with an answer.
+
+// emitter carries the per-build state the row writers share.
+type emitter struct {
+	b  *Builder
+	db *sql.DB
+	// hasNodeContent reports whether this fixture has a node_content table to
+	// point node_hash values at. Ley-line always does; a Standalone fixture only
+	// does when it modelled the cache-hydration path.
+	hasNodeContent bool
+}
+
+func (b *Builder) insertRows(db *sql.DB) {
+	b.t.Helper()
+	e := &emitter{b: b, db: db, hasNodeContent: b.producer == Leyline || len(b.ast) > 0}
+	e.emitNodes()
+	e.emitDefs()
+	e.emitRefs()
+	e.emitAST()
+	e.emitSources()
+	e.emitImports()
+	e.emitLSPDefs()
+}
+
+func (e *emitter) exec(q string, args ...any) {
+	e.b.t.Helper()
+	if _, err := e.db.Exec(q, args...); err != nil {
+		e.b.t.Fatalf("fixturedb(%s): %v\n%s", e.b.producer, err, q)
+	}
+}
+
+// subtree records a deduped merkle subtree in node_content and returns the hash
+// occurrences point at. Returns nil when the fixture has no node_content table,
+// so node_hash lands NULL rather than dangling.
+func (e *emitter) subtree(label, kind, token string) []byte {
+	if !e.hasNodeContent {
+		return nil
+	}
+	h := subtreeHash(label)
+	e.exec(`INSERT OR IGNORE INTO node_content (node_hash, node_tag, kind, raw_kind, lang, token, arity)
+		VALUES (?, 0, ?, ?, '', ?, 0)`, h, kind, kind, nullIfEmpty(token))
+	return h
+}
+
+func (e *emitter) emitNodes() {
+	for _, id := range e.b.order {
+		c := e.b.constructs[id]
+		kind := 1
+		if c.dirKind {
+			kind = 0
+		}
+		e.exec(`INSERT OR REPLACE INTO nodes (id, parent_id, name, kind, size, mtime, record_id, record, source_file)
+			VALUES (?, ?, ?, ?, 0, 0, '', '', ?)`,
+			string(c.id), string(c.parent), c.name, kind, string(c.source))
+	}
+}
+
+func (e *emitter) emitDefs() {
+	for _, d := range e.b.defs {
+		if e.b.producer != Leyline {
+			// The mache projection carries two columns. Everything the spec
+			// says about kind, container and content identity is DROPPED —
+			// which is the honest outcome, not a lossy shortcut.
+			e.exec(`INSERT OR IGNORE INTO node_defs (token, node_id) VALUES (?, ?)`,
+				d.token, string(d.nodeID))
+			continue
+		}
+		h := e.subtree(d.subtree, string(d.kind), d.token)
+		e.exec(`INSERT INTO node_defs (token, node_id, source_id, container_node_id, canonical_kind, node_hash)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			d.token, string(d.nodeID), string(e.b.sourceOf(d.nodeID)),
+			nullIfEmpty(string(d.container)), nullIfEmpty(string(d.kind)), h)
+	}
+}
+
+func (e *emitter) emitRefs() {
+	for _, r := range e.b.refs {
+		if e.b.producer != Leyline {
+			// No site column and no qualifier column: the ENCLOSING CONSTRUCT
+			// is what lands in node_id, and duplicate (token, node_id) pairs
+			// collapse under the primary key.
+			e.exec(`INSERT OR IGNORE INTO node_refs (token, node_id) VALUES (?, ?)`,
+				r.token, string(r.from))
+			continue
+		}
+		h := e.subtree(r.subtree, "call_expression", r.token)
+		e.exec(`INSERT INTO node_refs (token, node_id, source_id, container_node_id, qualifier, node_hash)
+			VALUES (?, ?, ?, ?, ?, ?)`,
+			r.token, string(r.at), string(e.b.sourceOf(r.from)), string(r.from),
+			nullIfEmpty(r.qualifier), h)
+	}
+}
+
+func (e *emitter) emitAST() {
+	for _, a := range e.b.ast {
+		h := e.subtree(a.subtree, a.kind, a.token)
+		e.exec(`INSERT OR REPLACE INTO _ast
+			(node_id, source_id, node_kind, start_byte, end_byte, start_row, start_col, end_row, end_col, node_hash)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			a.nodeID, string(a.source), a.kind,
+			a.span.StartByte, a.span.EndByte,
+			a.span.StartRow, a.span.StartCol, a.span.EndRow, a.span.EndCol, h)
+	}
+}
+
+func (e *emitter) emitSources() {
+	if e.b.producer != Leyline && len(e.b.sources) == 0 {
+		return
+	}
+	for _, id := range e.b.srcOrder {
+		s := e.b.sources[id]
+		var body any
+		if s.content != "" {
+			body = []byte(s.content)
+		}
+		e.exec(`INSERT OR REPLACE INTO _source (id, language, content, path, content_hash)
+			VALUES (?, ?, ?, ?, NULL)`, string(s.id), s.lang, body, s.path)
+	}
+}
+
+func (e *emitter) emitImports() {
+	if e.b.producer != Leyline {
+		return // the mache projection has no _imports table
+	}
+	for _, im := range e.b.imports {
+		e.exec(`INSERT INTO _imports (alias, path, source_id) VALUES (?, ?, ?)`,
+			im.alias, im.importPath, string(im.source))
+	}
+}
+
+func (e *emitter) emitLSPDefs() {
+	for _, d := range e.b.lspDefs {
+		e.exec(`INSERT INTO _lsp_defs
+			(node_id, def_token, def_uri, def_start_line, def_start_col, def_end_line, def_end_col)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			d.nodeID, d.token, d.uri, d.startLine, d.startCol, d.endLine, d.endCol)
+	}
+}
+
+// sourceOf resolves a construct's source file, falling back to inference so
+// Def/Ref never depend on declaration order.
+func (b *Builder) sourceOf(id ConstructID) SourceID {
+	if c, ok := b.constructs[id]; ok {
+		return c.source
+	}
+	return inferSource(id)
+}
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/fixturedb/options.go
+++ b/internal/fixturedb/options.go
@@ -1,0 +1,69 @@
+package fixturedb
+
+// Optional facts, stated declaratively.
+//
+// These are STRUCTS rather than functional options on purpose. Every field
+// names something true about the code being modelled — the file it lives in,
+// the construct that contains it, the deduped subtree it shares — and never a
+// column, a table, or a fragment of SQL. A struct literal reads as a claim; a
+// pile of one-line closures reads as configuration, and duplicates itself.
+
+// Where states where a construct lives. The zero value means "infer it", which
+// is the common case: [Builder.Construct] derives the source from the id's
+// longest leading path prefix whose last segment has a file extension —
+// "pkg/served_test.go/function_declaration_0" infers "pkg/served_test.go",
+// which is exactly how ley-line composes these ids.
+type Where struct {
+	// Source pins the construct's source file instead of inferring it.
+	Source SourceID
+	// Name sets `nodes.name`. Defaults to the id's last path segment.
+	Name string
+	// Parent sets `nodes.parent_id`.
+	Parent ConstructID
+	// Directory marks a directory node (`nodes.kind` 0) rather than a leaf (1).
+	Directory bool
+}
+
+// Detail states the optional facts about a definition, a reference or an `_ast`
+// row. Fields that do not apply to the row kind are ignored, and every field is
+// dropped on [Standalone] when the mache projection has no column for it.
+type Detail struct {
+	// Container is the construct a DEFINITION is nested inside —
+	// `node_defs.container_node_id`, which ley-line populates for a method in an
+	// impl/type block and leaves NULL for a top-level item.
+	Container ConstructID
+
+	// Subtree labels a deduped merkle subtree. Occurrences carrying the same
+	// label share one node_hash; an empty label means "unique to this
+	// occurrence".
+	//
+	// It is a NAME, not bytes. node_hash is one-to-many by construction (one
+	// content row, many occurrences), and a fan-out test needs to say "these
+	// are the same subtree" without any test ever writing a hash literal.
+	Subtree string
+
+	// Token is an `_ast` node's token text, which the builder stores in
+	// `node_content` and points at from `_ast.node_hash` — the same indirection
+	// ley-line uses, and the one v_test_nodes' attribute detection walks.
+	Token string
+}
+
+// first returns the single optional value, or the zero value when none was
+// given. Passing more than one is a caller error and the extras are ignored;
+// the variadic exists only to make the argument optional.
+func first[T any](vals []T) T {
+	var zero T
+	if len(vals) == 0 {
+		return zero
+	}
+	return vals[0]
+}
+
+// label turns a Detail's subtree name into the hash label, defaulting to a
+// per-occurrence unique one so distinct occurrences never collide by accident.
+func (d Detail) label(unique string) string {
+	if d.Subtree == "" {
+		return unique
+	}
+	return "label:" + d.Subtree
+}

--- a/internal/fixturedb/options_test.go
+++ b/internal/fixturedb/options_test.go
@@ -1,0 +1,168 @@
+package fixturedb
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWhere_ShapesTheNodesRow covers every field of [Where].
+// They matter because enrichLocations and several rules join back through
+// `nodes`, so a fixture that gets parent_id or source_file wrong changes what
+// the rule under test reports without changing what it queries.
+func TestWhere_ShapesTheNodesRow(t *testing.T) {
+	b := New(t, Leyline)
+	b.Construct("pkg", Where{Directory: true})
+	b.Construct("pkg/orphan.go/function_declaration_0",
+		Where{Parent: "pkg", Name: "Orphan", Source: "pkg/orphan.go"})
+	_, f := b.Build()
+
+	var parent, name string
+	var kind int
+	var source string
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT parent_id, name, kind, source_file FROM nodes WHERE id=?`,
+		"pkg/orphan.go/function_declaration_0").Scan(&parent, &name, &kind, &source))
+	assert.Equal(t, "pkg", parent)
+	assert.Equal(t, "Orphan", name)
+	assert.Equal(t, 1, kind, "a construct is a leaf node")
+	assert.Equal(t, "pkg/orphan.go", source)
+
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT kind FROM nodes WHERE id='pkg'`).Scan(&kind))
+	assert.Equal(t, 0, kind, "Where{Directory:true} marks a directory node")
+}
+
+// TestDetailContainer_PopulatesTheDefContainer covers node_defs.container_node_id,
+// which ley-line populates for a method inside an impl/type block and leaves
+// NULL for a top-level item. The self-described "Leyline column shape" fixture
+// this package replaced omitted the column entirely (mache-e3f3bf).
+func TestDetailContainer_PopulatesTheDefContainer(t *testing.T) {
+	b := New(t, Leyline)
+	b.Def("Handle", "src/lib.rs/impl_item_0/function_item_0", Method,
+		Detail{Container: "src/lib.rs/impl_item_0"})
+	b.Def("free", "src/lib.rs/function_item_1", Function)
+	_, f := b.Build()
+
+	var container sql.NullString
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT container_node_id FROM node_defs WHERE token='Handle'`).Scan(&container))
+	assert.Equal(t, "src/lib.rs/impl_item_0", container.String)
+
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT container_node_id FROM node_defs WHERE token='free'`).Scan(&container))
+	assert.False(t, container.Valid, "ley-line leaves a top-level item's container NULL")
+}
+
+// TestDetailSubtree_OnRefs mirrors the def-side test: two call sites that are
+// the same deduped subtree share one node_hash.
+func TestDetailSubtree_OnRefs(t *testing.T) {
+	b := New(t, Leyline)
+	b.Ref("log", "a.go/fn_0", "", "", Detail{Subtree: "logcall"})
+	b.Ref("log", "b.go/fn_0", "", "", Detail{Subtree: "logcall"})
+	b.Ref("log", "c.go/fn_0", "", "")
+	_, f := b.Build()
+
+	var shared int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM node_refs WHERE node_hash = (
+		    SELECT node_hash FROM node_refs WHERE node_id LIKE 'a.go/%')`).Scan(&shared))
+	assert.Equal(t, 2, shared, "two occurrences of one deduped subtree")
+}
+
+// TestASTNode_TokenLandsInNodeContent covers Detail.Token and Detail.Subtree.
+// v_test_nodes' Rust attribute detection reads the token through the
+// `_ast.node_hash -> node_content.token` indirection, so a fixture that stored
+// the token anywhere else silently makes that detection unreachable.
+func TestASTNode_TokenLandsInNodeContent(t *testing.T) {
+	b := New(t, Leyline)
+	b.ASTNode("f/attr1", "attribute_item", "f.rs", Bytes(60, 68))
+	b.ASTNode("f/attr1/id", "identifier", "f.rs", Bytes(62, 66), Detail{Token: "test"})
+	b.ASTNode("f/attr2/id", "identifier", "f.rs", Bytes(72, 76),
+		Detail{Token: "test", Subtree: "testattr"})
+	_, f := b.Build()
+
+	var tok string
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT c.token FROM _ast a JOIN node_content c ON c.node_hash = a.node_hash
+		  WHERE a.node_id = 'f/attr1/id'`).Scan(&tok))
+	assert.Equal(t, "test", tok)
+
+	var span Span
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT start_byte, end_byte FROM _ast WHERE node_id='f/attr1'`).
+		Scan(&span.StartByte, &span.EndByte))
+	assert.Equal(t, Bytes(60, 68), span)
+
+	var distinct int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(DISTINCT node_hash) FROM _ast WHERE node_id LIKE '%/id'`).Scan(&distinct))
+	assert.Equal(t, 2, distinct, "only the labelled pair would share; these are two labels")
+}
+
+// TestImport_OnlyExistsOnLeyline: _imports is producer output, and fatal_call's
+// stdlib-vs-local resolution reads it. A Standalone fixture has no such table,
+// so the call is dropped rather than fabricating a shape mache never sees.
+func TestImport_OnlyExistsOnLeyline(t *testing.T) {
+	bl := New(t, Leyline)
+	bl.Import("fmt", "fmt", "a.go")
+	_, fl := bl.Build()
+
+	var p string
+	require.NoError(t, fl.DB().QueryRow(
+		`SELECT path FROM _imports WHERE alias='fmt' AND source_id='a.go'`).Scan(&p))
+	assert.Equal(t, "fmt", p)
+
+	bs := New(t, Standalone)
+	bs.Import("fmt", "fmt", "a.go")
+	_, fs := bs.Build()
+	var n int
+	require.NoError(t, fs.DB().QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE name='_imports'`).Scan(&n))
+	assert.Zero(t, n)
+}
+
+// TestLSPDef_UnionsIntoTheBindingArm covers the LSP-enrichment table, which
+// ensureCanonicalViews unions into v_defs only when `_lsp_defs.def_token`
+// exists. It is available on both producers because it is enrichment output,
+// not producer output.
+func TestLSPDef_UnionsIntoTheBindingArm(t *testing.T) {
+	b := New(t, Standalone)
+	b.Def("Validate", "auth/functions/Validate", Function)
+	b.LSPDef("Validate", "auth/functions/Validate", "file:///auth/auth.go", 10, 5, 10, 13)
+	_, f := b.Build()
+
+	var uri string
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT def_uri FROM _lsp_defs WHERE def_token='Validate'`).Scan(&uri))
+	assert.Equal(t, "file:///auth/auth.go", uri)
+}
+
+// TestProducer_IsReadableFromTheBuilder so a table-driven test can branch on the
+// producer EXPLICITLY rather than by whatever its DDL implied.
+func TestProducer_IsReadableFromTheBuilder(t *testing.T) {
+	assert.Equal(t, Leyline, New(t, Leyline).Producer())
+	assert.Equal(t, Standalone, New(t, Standalone).Producer())
+	assert.Equal(t, "leyline", Leyline.String())
+	assert.Equal(t, "standalone", Standalone.String())
+}
+
+// TestSource_RedeclarationFillsGaps: ASTNode declares its source implicitly, and
+// that implicit declaration must never clobber an explicit one — otherwise
+// statement order silently decides whether _source.language is set.
+func TestSource_RedeclarationFillsGaps(t *testing.T) {
+	b := New(t, Leyline)
+	b.ASTNode("a.go/fn_0", "function_declaration", "a.go", Bytes(0, 10))
+	b.Source("a.go", "go", "package a\n")
+	b.ASTNode("a.go/fn_1", "function_declaration", "a.go", Bytes(11, 20))
+	_, f := b.Build()
+
+	var lang string
+	var content sql.NullString
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT language, content FROM _source WHERE id='a.go'`).Scan(&lang, &content))
+	assert.Equal(t, "go", lang)
+	assert.Equal(t, "package a\n", content.String)
+}

--- a/internal/fixturedb/producer.go
+++ b/internal/fixturedb/producer.go
@@ -1,0 +1,95 @@
+// Package fixturedb builds SQLite test fixtures whose TABLE SHAPE is the shape
+// a real producer writes, and removes a test's ability to state a schema at all.
+//
+// # Why this exists
+//
+// Before this package, ~34 test files hand-wrote `CREATE TABLE node_refs (...)`,
+// in ten mutually incompatible spellings, and zero of them reproduced ley-line's
+// real shape. That was not a cosmetic problem. `ensureCanonicalViews` PROBES for
+// columns and emits a structurally DIFFERENT `v_refs` / `v_defs` body per
+// combination — most sharply:
+//
+//	refsReferrerExpr := "node_id"
+//	if hasRefsContainer {
+//	    refsReferrerExpr = "COALESCE(NULLIF(container_node_id, ''), node_id)"
+//	}
+//
+// So a fixture's `CREATE TABLE` literal was a HIDDEN TEST PARAMETER selecting
+// which SQL the rule under test actually executed. A rule tested against a
+// two-column node_refs exercised the degraded arm while production exercised the
+// full arm, and neither side noticed.
+//
+// Compounding it, `node_refs.node_id` has two incompatible meanings: the
+// mache/tree-sitter projection puts the ENCLOSING CONSTRUCT there; ley-line puts
+// the CALL-SITE LEAF there and the enclosing def in `container_node_id`. A
+// fixture picked a meaning implicitly, by what it INSERTed, with nowhere in the
+// test saying which.
+//
+// This is the same defect class as mache-e3d9bb (`Node.Children` had two
+// accessors that silently disagreed; the fix was removing the second way to
+// ask), one layer down. The fix shape is the same: remove the second way to
+// state a schema.
+//
+// # The three properties that carry the weight
+//
+//  1. NO method on Builder accepts SQL, DDL, a column name, or a table name.
+//     That absence IS the design. The DDL in schema.go is unexported and there
+//     is no escape hatch.
+//
+//  2. [Builder.Ref] takes `from` and `at` as SEPARATE TYPED PARAMETERS, so the
+//     two meanings of node_id become distinct arguments instead of an undeclared
+//     convention. [Leyline] writes node_id=<at>, container_node_id=<from>;
+//     [Standalone] writes node_id=<from> and structurally cannot express <at>.
+//
+//  3. [Builder.Build] returns a fixture already wired through the canonical view
+//     installer, so a test cannot forget the install (a real past problem — see
+//     the note in cmd/smell_refs_views.go about "the 26 tests that build
+//     fixtures by hand").
+//
+// # Provenance
+//
+// The [Leyline] DDL is DERIVED, not hand-written: see schema_leyline.go and the
+// conformance test that re-derives it from the pinned binary and fails on drift.
+// The [Standalone] DDL is likewise conformance-tested against what
+// ingest.NewSQLiteWriter actually creates.
+package fixturedb
+
+// Producer names the tool whose table shape a fixture reproduces.
+//
+// The set is CLOSED: the only values are [Leyline] and [Standalone]. The single
+// field is unexported, so the zero value is invalid and a caller outside this
+// package cannot construct a third. A fixture therefore cannot exist without
+// naming the producer it models — which is precisely what the 34 hand-written
+// fixtures never did.
+type Producer struct{ name string }
+
+var (
+	// Leyline is the ley-line-open parse output: node_refs carries
+	// source_id / container_node_id / qualifier / node_hash and has NO
+	// primary key, so duplicate (token, node_id) rows SURVIVE. node_id is
+	// the call-SITE leaf; the enclosing definition is container_node_id.
+	// This is the shape production reads.
+	Leyline = Producer{name: "leyline"}
+
+	// Standalone is mache's own schema projection (internal/ingest.SQLiteWriter):
+	// node_refs is (token, node_id) with PRIMARY KEY (token, node_id) WITHOUT
+	// ROWID, so duplicate rows are DEDUPED. node_id is the ENCLOSING CONSTRUCT;
+	// there is no place to put a call site or a qualifier.
+	//
+	// The dedupe is not incidental. Any COUNT/AVG-over-v_refs rule measures a
+	// different quantity here than on [Leyline] — the fan_out_skew class
+	// (mache-50e939).
+	Standalone = Producer{name: "standalone"}
+)
+
+// String returns the producer's name, for test failure messages.
+func (p Producer) String() string {
+	if p.name == "" {
+		return "invalid(zero-value Producer)"
+	}
+	return p.name
+}
+
+// valid reports whether p is one of the two package-declared producers rather
+// than the zero value. Only [New] consults it.
+func (p Producer) valid() bool { return p.name != "" }

--- a/internal/fixturedb/schema_leyline.go
+++ b/internal/fixturedb/schema_leyline.go
@@ -1,0 +1,124 @@
+package fixturedb
+
+// The ley-line-open table contract, DERIVED not authored.
+//
+// Every statement below was copied verbatim out of `sqlite_master` after
+// running the PINNED ley-line binary on a two-file corpus:
+//
+//	$ leyline parse ./src -o out.db
+//	$ sqlite3 out.db "SELECT sql FROM sqlite_master ORDER BY type, name"
+//
+// Hand-writing it would reproduce the bug this package exists to remove — one
+// wrong spelling instead of thirty-four. TestLeylineSchema_MatchesPinnedBinary
+// (schema_leyline_conformance_test.go) re-runs that derivation and fails on any
+// drift, so a ley-line release that changes shape breaks HERE, loudly, instead
+// of silently flipping which arm of ensureCanonicalViews the whole test suite
+// exercises.
+//
+// PATCH RELEASES CHANGE THIS SCHEMA. The pin must stay exact; see
+// reference_leyline_noderefs_parity_gap.
+
+// leylineSchemaVersion is the ley-line-open release these statements were
+// derived from. The conformance test asserts the pinned binary still reports it.
+const leylineSchemaVersion = "v0.13.0"
+
+// leylineTables is the ley-line-owned subset fixtures model, keyed by table
+// name. Deliberately not every table ley-line writes — `capnp_blobs`,
+// `query_blobs`, `source_blobs`, `_queries`, `_meta`, `_ast_pointer` and
+// `_file_index` carry no signal any smell rule or canonical view reads, and
+// modelling them would only create more surface to drift.
+//
+// The values are byte-identical to the pinned producer's `sqlite_master.sql`.
+var leylineTables = map[string]string{
+	"nodes": `CREATE TABLE nodes (
+    id TEXT PRIMARY KEY,
+    parent_id TEXT,
+    name TEXT NOT NULL,
+    kind INTEGER NOT NULL,
+    size INTEGER DEFAULT 0,
+    mtime INTEGER NOT NULL,
+    record_id TEXT,
+    record TEXT,
+    source_file TEXT
+)`,
+
+	// NO PRIMARY KEY and NOT `WITHOUT ROWID` — duplicate (token, node_id) rows
+	// SURVIVE here. ley-line dual-emits a qualified and a bare row for the same
+	// call site (`fmt.Println` with qualifier NULL, `Println` with qualifier
+	// 'fmt'), both at the same node_id. Any fixture that adds a primary key
+	// silently dedupes rows production keeps.
+	"node_defs": `CREATE TABLE node_defs (
+    token TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    container_node_id TEXT,
+    canonical_kind TEXT
+, node_hash BLOB REFERENCES node_content(node_hash))`,
+
+	"node_refs": `CREATE TABLE node_refs (
+    token TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    container_node_id TEXT,
+    qualifier TEXT
+, node_hash BLOB REFERENCES node_content(node_hash))`,
+
+	"_ast": `CREATE TABLE _ast (
+    node_id TEXT PRIMARY KEY,
+    source_id TEXT NOT NULL,
+    node_kind TEXT NOT NULL,
+    start_byte INTEGER NOT NULL,
+    end_byte INTEGER NOT NULL,
+    start_row INTEGER NOT NULL,
+    start_col INTEGER NOT NULL,
+    end_row INTEGER NOT NULL,
+    end_col INTEGER NOT NULL
+, node_hash BLOB REFERENCES node_content(node_hash))`,
+
+	"_source": `CREATE TABLE _source (
+    id TEXT PRIMARY KEY,
+    language TEXT NOT NULL,
+    content BLOB,
+    path TEXT,
+    content_hash BLOB
+)`,
+
+	"_imports": `CREATE TABLE _imports (
+    alias TEXT NOT NULL,
+    path TEXT NOT NULL,
+    source_id TEXT NOT NULL
+)`,
+
+	"node_content": `CREATE TABLE node_content (
+    node_hash BLOB PRIMARY KEY,
+    node_tag  INTEGER NOT NULL,
+    kind      TEXT    NOT NULL,
+    raw_kind  TEXT    NOT NULL,
+    lang      TEXT    NOT NULL,
+    token     TEXT,
+    arity     INTEGER NOT NULL
+)`,
+}
+
+// leylineIndexes are the indexes the pinned producer creates on the tables in
+// [leylineTables]. Included because query plans are part of the shape a fixture
+// claims to reproduce, and because the conformance test can then assert on them
+// too — an index ley-line drops is a signal, not noise.
+var leylineIndexes = map[string]string{
+	"idx_ast_node_hash":       `CREATE INDEX idx_ast_node_hash ON _ast(node_hash)`,
+	"idx_ast_source":          `CREATE INDEX idx_ast_source ON _ast(source_id)`,
+	"idx_defs_canonical_kind": `CREATE INDEX idx_defs_canonical_kind ON node_defs(canonical_kind) WHERE canonical_kind IS NOT NULL`,
+	"idx_defs_container":      `CREATE INDEX idx_defs_container ON node_defs(container_node_id) WHERE container_node_id IS NOT NULL`,
+	"idx_defs_token":          `CREATE INDEX idx_defs_token ON node_defs(token)`,
+	"idx_imports_source":      `CREATE INDEX idx_imports_source ON _imports(source_id)`,
+	"idx_parent_name":         `CREATE INDEX idx_parent_name ON nodes(parent_id, name)`,
+	"idx_refs_container":      `CREATE INDEX idx_refs_container ON node_refs(container_node_id) WHERE container_node_id IS NOT NULL`,
+	"idx_refs_node":           `CREATE INDEX idx_refs_node ON node_refs(node_id)`,
+	"idx_refs_token":          `CREATE INDEX idx_refs_token ON node_refs(token)`,
+}
+
+// leylineTableOrder is creation order: node_content first because node_defs /
+// node_refs / _ast carry REFERENCES into it.
+var leylineTableOrder = []string{
+	"node_content", "nodes", "node_defs", "node_refs", "_ast", "_source", "_imports",
+}

--- a/internal/fixturedb/schema_leyline_conformance_test.go
+++ b/internal/fixturedb/schema_leyline_conformance_test.go
@@ -1,0 +1,164 @@
+package fixturedb
+
+import (
+	"database/sql"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/leyline"
+	"github.com/agentic-research/mache/internal/lltest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The derivation, re-run.
+//
+// [leylineTables] and [leylineIndexes] claim to be the pinned producer's own
+// `sqlite_master` output. This test makes that claim FALSIFIABLE: it runs the
+// pinned binary on a two-file corpus and diffs, so a ley-line release that
+// changes shape fails here — instead of silently flipping which arm of
+// ensureCanonicalViews the entire suite exercises, which is exactly how the
+// pre-fixturedb fixtures drifted to ten mutually incompatible spellings without
+// anyone noticing.
+//
+// GATED, never downloads: skips when no cached binary matches the pin, matching
+// every other pinned gate in this repo.
+func TestLeylineSchema_MatchesPinnedBinary(t *testing.T) {
+	bin := lltest.PinnedBinaryOrSkip(t)
+
+	require.Equal(t, leyline.PinnedBinaryVersion(), leylineSchemaVersion,
+		"the DDL in schema_leyline.go was derived from %s but the build now pins %s — "+
+			"re-derive it (leyline parse; SELECT sql FROM sqlite_master) rather than editing by hand",
+		leylineSchemaVersion, leyline.PinnedBinaryVersion())
+
+	got := derivePinnedSchema(t, bin)
+
+	for name, want := range leylineTables {
+		g, ok := got[name]
+		require.True(t, ok, "pinned leyline %s no longer creates table %s", leylineSchemaVersion, name)
+		assert.Equal(t, normalizeDDL(want), normalizeDDL(g),
+			"table %s drifted from the pinned producer; re-derive schema_leyline.go", name)
+	}
+	for name, want := range leylineIndexes {
+		g, ok := got[name]
+		require.True(t, ok, "pinned leyline %s no longer creates index %s", leylineSchemaVersion, name)
+		assert.Equal(t, normalizeDDL(want), normalizeDDL(g),
+			"index %s drifted from the pinned producer; re-derive schema_leyline.go", name)
+	}
+}
+
+// TestLeylineSchema_NodeRefsHasNoPrimaryKey pins the property that made 13
+// pre-fixturedb fixtures wrong in a way no column diff would show: ley-line's
+// node_refs has NO primary key, so duplicate (token, node_id) rows SURVIVE.
+// Every fixture that added `PRIMARY KEY (token, node_id) WITHOUT ROWID` deduped
+// rows production keeps, so any COUNT/AVG-over-v_refs rule measured a different
+// quantity in test than in prod (the fan_out_skew class, mache-50e939).
+func TestLeylineSchema_NodeRefsHasNoPrimaryKey(t *testing.T) {
+	for _, tbl := range []string{"node_refs", "node_defs"} {
+		ddl := strings.ToUpper(leylineTables[tbl])
+		assert.NotContains(t, ddl, "PRIMARY KEY", "%s: ley-line has no primary key here", tbl)
+		assert.NotContains(t, ddl, "WITHOUT ROWID", "%s: ley-line keeps the rowid here", tbl)
+	}
+
+	// And the behaviour that follows from it, end to end.
+	b := New(t, Leyline)
+	b.Construct("a.go/function_declaration_0", Where{Source: "a.go"})
+	b.Ref("Println", "a.go/function_declaration_0", "a.go/call_0", "fmt")
+	b.Ref("Println", "a.go/function_declaration_0", "a.go/call_0", "fmt")
+	_, f := b.Build()
+
+	var n int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM node_refs WHERE token='Println'`).Scan(&n))
+	assert.Equal(t, 2, n, "ley-line keeps duplicate occurrences; a primary key would hide one")
+}
+
+// TestStandaloneSchema_NodeRefsDedupes is the mirror: the mache projection DOES
+// collapse them, and a test must be able to see that difference rather than
+// inherit whichever one its hand-written DDL happened to encode.
+func TestStandaloneSchema_NodeRefsDedupes(t *testing.T) {
+	b := New(t, Standalone)
+	b.Ref("Println", "pkg/functions/Run", "", "fmt")
+	b.Ref("Println", "pkg/functions/Run", "", "fmt")
+	_, f := b.Build()
+
+	var n int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM node_refs WHERE token='Println'`).Scan(&n))
+	assert.Equal(t, 1, n, "PRIMARY KEY (token, node_id) collapses the two occurrences")
+}
+
+// derivePinnedSchema runs the pinned binary on a tiny corpus and returns
+// sqlite_master keyed by object name.
+func derivePinnedSchema(t *testing.T, bin string) map[string]string {
+	t.Helper()
+
+	// /tmp rather than t.TempDir(): the parse writes a .db next to a corpus and
+	// deep nesting has bitten the sibling helpers here before.
+	dir, err := os.MkdirTemp("/tmp", "fxdbderive")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	src := filepath.Join(dir, "src")
+	require.NoError(t, os.MkdirAll(src, 0o755))
+	// Two languages and a qualified call, so every modelled table gets rows:
+	// _imports needs an import, node_refs needs a call, node_content needs
+	// tokens.
+	require.NoError(t, os.WriteFile(filepath.Join(src, "a.go"),
+		[]byte("package a\n\nimport \"fmt\"\n\nfunc Alpha() { fmt.Println(\"hi\") }\n\nfunc Beta() { Alpha() }\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "b.py"),
+		[]byte("def gamma():\n    return 1\n"), 0o644))
+
+	out := filepath.Join(dir, "out.db")
+	cmd := exec.Command(bin, "parse", src, "-o", out)
+	if combined, cerr := cmd.CombinedOutput(); cerr != nil {
+		t.Fatalf("fixturedb: leyline parse failed: %v\n%s", cerr, combined)
+	}
+
+	db, err := sql.Open("sqlite", out)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	rows, err := db.Query(`SELECT name, sql FROM sqlite_master WHERE sql IS NOT NULL`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	got := map[string]string{}
+	for rows.Next() {
+		var name, ddl string
+		require.NoError(t, rows.Scan(&name, &ddl))
+		got[name] = ddl
+	}
+	require.NoError(t, rows.Err())
+	require.NotEmpty(t, got, "leyline parse produced no schema")
+	return got
+}
+
+// normalizeDDL collapses formatting so the comparison catches SHAPE changes
+// (columns, constraints, WITHOUT ROWID) and not indentation. SQLite stores `--`
+// comments verbatim in sqlite_master.sql, and mache's own writer embeds long
+// ones, so they are stripped too.
+func normalizeDDL(s string) string {
+	var kept []string
+	for _, line := range strings.Split(s, "\n") {
+		if i := strings.Index(line, "--"); i >= 0 {
+			line = line[:i]
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(strings.Fields(strings.Join(kept, " ")), " ")
+}
+
+// sortedNames is a test-local helper for stable failure output.
+func sortedNames(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/fixturedb/schema_standalone.go
+++ b/internal/fixturedb/schema_standalone.go
@@ -1,0 +1,99 @@
+package fixturedb
+
+// The mache-standalone table contract, DERIVED not authored.
+//
+// Every statement below was copied out of `sqlite_master` after running
+// ingest.NewSQLiteWriter on an empty path, with the explanatory `--` comments
+// (which SQLite stores verbatim in sqlite_master.sql) dropped.
+// TestStandaloneSchema_MatchesSQLiteWriter re-derives it from
+// internal/ingest/sqlite_writer.go's own schema literal and fails on drift.
+//
+// This is the shape 13 of the pre-fixturedb test files reproduced exactly —
+// while believing, in several cases, that they were modelling ley-line.
+
+// standaloneTables is the mache-projection subset fixtures model, keyed by table
+// name.
+//
+// `_ast`, `_source`, `node_content` and `_imports` are deliberately ABSENT:
+// SQLiteWriter does not write them. When a Standalone fixture needs them (the
+// cache-hydration path in cmd/cache.go materialises `_ast` onto a mache .db),
+// they are created with the LEY-LINE shape from [leylineTables] — those tables
+// are ley-line-owned and have exactly one contract, which is the whole point of
+// the LLO boundary rule in internal/lint.
+var standaloneTables = map[string]string{
+	"nodes": `CREATE TABLE nodes (
+		id TEXT PRIMARY KEY,
+		parent_id TEXT,
+		name TEXT NOT NULL,
+		kind INTEGER NOT NULL,
+		size INTEGER DEFAULT 0,
+		mtime INTEGER NOT NULL,
+		record_id TEXT,
+		record TEXT,
+		source_file TEXT,
+		context BLOB,
+		props JSON
+	)`,
+
+	// PRIMARY KEY (token, node_id) WITHOUT ROWID — duplicate rows are DEDUPED,
+	// which is the opposite of ley-line. Any COUNT/AVG-over-v_refs rule measures
+	// a different quantity here (mache-50e939). There is no column for a call
+	// site, a qualifier, or a source: node_id IS the enclosing construct.
+	"node_refs": `CREATE TABLE node_refs (
+		token TEXT,
+		node_id TEXT,
+		PRIMARY KEY (token, node_id)
+	) WITHOUT ROWID`,
+
+	"node_defs": `CREATE TABLE node_defs (
+		token TEXT,
+		node_id TEXT,
+		PRIMARY KEY (token, node_id)
+	) WITHOUT ROWID`,
+
+	"file_index": `CREATE TABLE file_index (
+		path TEXT PRIMARY KEY,
+		mod_time INTEGER NOT NULL,
+		size INTEGER NOT NULL
+	)`,
+
+	"_index_coverage": `CREATE TABLE _index_coverage (
+		source_id TEXT NOT NULL,
+		producer TEXT NOT NULL,
+		fidelity TEXT NOT NULL,
+		indexed_at INTEGER NOT NULL,
+		complete INTEGER NOT NULL,
+		PRIMARY KEY (source_id, producer)
+	) WITHOUT ROWID`,
+}
+
+var standaloneIndexes = map[string]string{
+	"idx_parent_name": `CREATE INDEX idx_parent_name ON nodes(parent_id, name)`,
+	"idx_source_file": `CREATE INDEX idx_source_file ON nodes(source_file)`,
+}
+
+// standaloneViews are the PERSISTENT v_defs / v_refs SQLiteWriter installs.
+//
+// They matter because ensureCanonicalViews relies on TEMP objects SHADOWING
+// same-named main-schema objects for the current connection (see its doc
+// comment). A fixture that omits these never exercises the shadowing, so a
+// regression in it would be invisible — exactly the hidden-parameter problem
+// this package removes.
+var standaloneViews = map[string]string{
+	"v_defs": `CREATE VIEW v_defs AS
+		SELECT token, node_id, 'mention' AS fidelity FROM node_defs`,
+
+	"v_refs": `CREATE VIEW v_refs AS
+		SELECT node_id AS referrer_node_id,
+		       token,
+		       NULL  AS target_node_id,
+		       NULL  AS ref_uri,
+		       NULL  AS ref_line,
+		       'mention' AS fidelity
+		FROM node_refs`,
+}
+
+// standaloneTableOrder is creation order.
+var standaloneTableOrder = []string{
+	"nodes", "node_refs", "node_defs", "file_index", "_index_coverage",
+}

--- a/internal/fixturedb/schema_standalone_conformance_test.go
+++ b/internal/fixturedb/schema_standalone_conformance_test.go
@@ -1,0 +1,123 @@
+package fixturedb
+
+import (
+	"database/sql"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The other derivation, re-run — and unlike the ley-line one this needs no
+// binary, so it is UNGATED and runs on every `go test ./...`.
+//
+// It reads internal/ingest/sqlite_writer.go's own schema literal out of the Go
+// AST, executes it into a scratch database, and diffs sqlite_master against
+// [standaloneTables] / [standaloneIndexes] / [standaloneViews].
+//
+// Reading the AST rather than importing internal/ingest is deliberate twice
+// over: internal/ingest pulls tree-sitter and therefore CGO, which fixtures must
+// never require; and matching the file as text would need a regexp, which this
+// repo ratchets against (internal/lint's regexpAllowlist).
+func TestStandaloneSchema_MatchesSQLiteWriter(t *testing.T) {
+	got := deriveWriterSchema(t)
+
+	for name, want := range standaloneTables {
+		g, ok := got[name]
+		require.True(t, ok,
+			"ingest.SQLiteWriter no longer creates table %s (it creates %v)", name, sortedNames(got))
+		assert.Equal(t, normalizeDDL(want), normalizeDDL(g),
+			"table %s drifted from internal/ingest/sqlite_writer.go", name)
+	}
+	for name, want := range standaloneIndexes {
+		g, ok := got[name]
+		require.True(t, ok, "ingest.SQLiteWriter no longer creates index %s", name)
+		assert.Equal(t, normalizeDDL(want), normalizeDDL(g), "index %s drifted", name)
+	}
+	for name, want := range standaloneViews {
+		g, ok := got[name]
+		require.True(t, ok, "ingest.SQLiteWriter no longer creates view %s", name)
+		assert.Equal(t, normalizeDDL(want), normalizeDDL(g), "view %s drifted", name)
+	}
+}
+
+// TestStandaloneSchema_HasNoProducerTables pins the boundary the other way: the
+// mache projection writes NONE of ley-line's parse output. A Standalone fixture
+// that silently grew an `_ast` table would flip ensureCanonicalViews onto the
+// v_test_nodes arm that a real mache .db never reaches.
+func TestStandaloneSchema_HasNoProducerTables(t *testing.T) {
+	for _, tbl := range []string{"_ast", "_source", "node_content", "_imports"} {
+		_, ok := standaloneTables[tbl]
+		assert.False(t, ok, "%s is ley-line-owned; the mache projection does not write it", tbl)
+	}
+
+	b := New(t, Standalone)
+	b.Def("Run", "pkg/functions/Run", Function)
+	_, f := b.Build()
+
+	var n int
+	require.NoError(t, f.DB().QueryRow(
+		`SELECT COUNT(*) FROM sqlite_master WHERE name='_ast'`).Scan(&n))
+	assert.Zero(t, n, "a Standalone fixture with no AST rows must have no _ast table")
+}
+
+// deriveWriterSchema pulls the schema literal out of NewSQLiteWriter and runs it.
+func deriveWriterSchema(t *testing.T) map[string]string {
+	t.Helper()
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	writerPath := filepath.Join(repoRoot, "internal", "ingest", "sqlite_writer.go")
+
+	file, err := parser.ParseFile(token.NewFileSet(), writerPath, nil, 0)
+	require.NoError(t, err, "parse %s", writerPath)
+
+	var ddl string
+	ast.Inspect(file, func(n ast.Node) bool {
+		asn, isAssign := n.(*ast.AssignStmt)
+		if !isAssign || len(asn.Lhs) != 1 || len(asn.Rhs) != 1 {
+			return true
+		}
+		ident, isIdent := asn.Lhs[0].(*ast.Ident)
+		if !isIdent || ident.Name != "schema" {
+			return true
+		}
+		lit, isLit := asn.Rhs[0].(*ast.BasicLit)
+		if !isLit || lit.Kind != token.STRING {
+			return true
+		}
+		unquoted, uerr := strconv.Unquote(lit.Value)
+		require.NoError(t, uerr)
+		ddl = unquoted
+		return false
+	})
+	require.NotEmpty(t, ddl,
+		"could not find the `schema := ...` literal in %s — if the writer was "+
+			"restructured, update this derivation rather than snapshotting its output", writerPath)
+
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "writer.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	_, err = db.Exec(ddl)
+	require.NoError(t, err)
+
+	rows, err := db.Query(`SELECT name, sql FROM sqlite_master WHERE sql IS NOT NULL`)
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	out := map[string]string{}
+	for rows.Next() {
+		var name, s string
+		require.NoError(t, rows.Scan(&name, &s))
+		out[name] = s
+	}
+	require.NoError(t, rows.Err())
+	return out
+}

--- a/internal/fixturedb/spec.go
+++ b/internal/fixturedb/spec.go
@@ -1,0 +1,50 @@
+package fixturedb
+
+// The row specs a [Builder] accumulates. They are the fixture's CONTENT —
+// what is true about the code being modelled — and carry no shape: which
+// columns each becomes is decided per producer at emit time (emit.go).
+
+type construct struct {
+	id      ConstructID
+	source  SourceID
+	name    string
+	parent  ConstructID
+	dirKind bool
+}
+
+type defSpec struct {
+	token     string
+	nodeID    ConstructID
+	container ConstructID
+	kind      CanonicalKind
+	subtree   string
+}
+
+type refSpec struct {
+	token     string
+	from      ConstructID
+	at        SiteID
+	qualifier string
+	subtree   string
+}
+
+type astSpec struct {
+	nodeID  string
+	kind    string
+	source  SourceID
+	span    Span
+	token   string
+	subtree string
+}
+
+type sourceSpec struct {
+	id      SourceID
+	lang    string
+	content string
+	path    string
+}
+
+type importSpec struct {
+	alias, importPath string
+	source            SourceID
+}

--- a/internal/fixturedb/types.go
+++ b/internal/fixturedb/types.go
@@ -1,0 +1,81 @@
+package fixturedb
+
+import "database/sql"
+
+// ConstructID identifies an enclosing DEFINITION — a function, method, type or
+// module. On both producers this is what lands in `node_defs.node_id`.
+type ConstructID string
+
+// SiteID identifies one distinct OCCURRENCE inside a construct: a single call
+// expression, not the function containing it. The empty SiteID means "an
+// unnamed occurrence" and the builder synthesises a unique leaf path for it.
+//
+// SiteID exists as its own type because `node_refs.node_id` means a site on
+// [Leyline] and a construct on [Standalone]. Making them two parameters of two
+// types is the whole reason a migrated test can no longer be ambiguous about
+// which producer it modelled.
+type SiteID string
+
+// SourceID is a source file's ley-line identity: its path RELATIVE to the parse
+// root ("pkg/orphan.go"), never an absolute path and never a bare basename.
+type SourceID string
+
+// CanonicalKind is ley-line's closed κ vocabulary, written to
+// `node_defs.canonical_kind`. It normalises per-language tree-sitter kinds
+// (function_declaration / function_item / function_definition) to one value.
+//
+// [Standalone] has no column for it; a kind passed to a Standalone fixture is
+// dropped, exactly as the mache projection drops it.
+type CanonicalKind string
+
+// The κ values ley-line emits. NoKind is for defs whose kind ley-line leaves
+// NULL.
+const (
+	NoKind    CanonicalKind = ""
+	Function  CanonicalKind = "function"
+	Method    CanonicalKind = "method"
+	Type      CanonicalKind = "type"
+	Module    CanonicalKind = "module"
+	Constant  CanonicalKind = "constant"
+	Variable  CanonicalKind = "variable"
+	Field     CanonicalKind = "field"
+	Interface CanonicalKind = "interface"
+)
+
+// Span is a byte-and-row range in a source file, as `_ast` records it.
+type Span struct {
+	StartByte, EndByte int
+	StartRow, StartCol int
+	EndRow, EndCol     int
+}
+
+// Bytes is the common case: a byte range with rows/cols left at zero.
+func Bytes(start, end int) Span { return Span{StartByte: start, EndByte: end} }
+
+// RefsQuerier is the query surface a fixture presents. It is deliberately the
+// same shape as cmd's refsQuerier so a fixture drops straight into the
+// production call path.
+type RefsQuerier interface {
+	QueryRefs(query string, args ...any) (*sql.Rows, error)
+}
+
+// viewInstaller is the canonical-view installer the consuming package registers
+// once, in an init(). fixturedb cannot import cmd (cmd imports fixturedb), and
+// installing the views must not be a per-test responsibility — a forgotten
+// install is precisely the class of bug this package exists to remove. So the
+// consumer hands the installer over ONCE and [Builder.Build] applies it to every
+// fixture it ever produces.
+//
+// Packages with no canonical views (internal/graph, internal/ingest) leave it
+// unset and Build simply skips the step.
+var viewInstaller func(RefsQuerier) error
+
+// RegisterViewInstaller records the canonical-view installer for this test
+// binary. Call it from an init() in the package under test; calling it twice is
+// a programming error and panics rather than silently taking the last write.
+func RegisterViewInstaller(install func(RefsQuerier) error) {
+	if viewInstaller != nil {
+		panic("fixturedb: view installer registered twice")
+	}
+	viewInstaller = install
+}

--- a/internal/leyline/binary_cache_path.go
+++ b/internal/leyline/binary_cache_path.go
@@ -83,3 +83,13 @@ func resolveCachedPinned() string {
 	}
 	return ""
 }
+
+// CachedPinnedBinary returns a cached leyline binary matching this build's pin,
+// or "" when none is cached. It NEVER downloads.
+//
+// Exported for gated tests (internal/lltest, internal/fixturedb), which must
+// resolve the pin the same way production does. Resolving it by hand meant
+// hardcoding the LEGACY unversioned ~/.mache/bin/leyline path — which
+// pinnedCachePath deliberately stopped writing, so those gates skipped
+// unconditionally on any machine that had moved past the legacy file.
+func CachedPinnedBinary() string { return resolveCachedPinned() }

--- a/internal/leyline/binary_cache_path_test.go
+++ b/internal/leyline/binary_cache_path_test.go
@@ -98,3 +98,40 @@ func TestResolveCachedPinned_NamespacedTakesPrecedence(t *testing.T) {
 	stubLeyline(t, legacy, v)
 	assert.Equal(t, p, resolveCachedPinned())
 }
+
+// CachedPinnedBinary is the exported entry gated tests resolve the pin through.
+// It exists because internal/lltest hardcoded the LEGACY unversioned path, so
+// every pinned-daemon gate skipped unconditionally once the cache became
+// namespaced and nothing wrote that path any more (mache-7555da).
+func TestCachedPinnedBinary(t *testing.T) {
+	pinned := strings.TrimPrefix(leylineBinaryVersion, "v")
+	for _, tc := range []struct {
+		name      string
+		namespace bool // stub at the version-namespaced path rather than the legacy one
+		version   string
+		wantHit   bool
+	}{
+		{"resolves the namespaced pin", true, pinned, true},
+		{"resolves a legacy copy that IS the pin", false, pinned, true},
+		{"reports nothing for a foreign build's binary", false, "0.0.3", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			at := pinnedCachePath
+			if !tc.namespace {
+				at = legacyCachePath
+			}
+			p, err := at()
+			require.NoError(t, err)
+			stubLeyline(t, p, tc.version)
+
+			got := CachedPinnedBinary()
+			if !tc.wantHit {
+				assert.Empty(t, got, "a gate must SKIP rather than run against a foreign binary")
+				return
+			}
+			assert.Equal(t, p, got)
+		})
+	}
+}

--- a/internal/lint/llo_boundary_test.go
+++ b/internal/lint/llo_boundary_test.go
@@ -8,9 +8,11 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,6 +70,20 @@ var lloOwnedTables = []string{
 	"content_manifest_meta",
 }
 
+// fixtureShapedTables is the table set the TEST-file half of this rule guards.
+// It is lloOwnedTables PLUS node_defs / node_refs.
+//
+// Those two are absent from lloOwnedTables because mache legitimately WRITES
+// them in production (internal/ingest.SQLiteWriter) — that is the contract. But
+// a TEST that hand-builds one is a different defect: node_refs is precisely the
+// table whose column set decides which arm of ensureCanonicalViews runs, and
+// whose node_id column means the ENCLOSING CONSTRUCT on the mache projection
+// and the CALL-SITE LEAF on ley-line. A fixture picks one of those meanings by
+// what it INSERTs, with nothing in the test saying which. So for tests the
+// question is not "who owns the table" but "did this fixture invent a shape",
+// and the answer must be no (mache-7555da).
+var fixtureShapedTables = append(append([]string{}, lloOwnedTables...), "node_defs", "node_refs")
+
 // sqlWriteVerbs are the statement kinds that constitute WRITING. Reading LLO's
 // output is the entire point of the consumer relationship and is never a
 // violation.
@@ -112,25 +128,92 @@ var lloWriterAllowlist = map[string]string{
 	// name and a subset of its columns, so it drifts silently when LLO changes
 	// shape, with no version or lineage marker to notice by.
 	"internal/linter/linter.go": "synthesises a reduced in-memory _ast for lint queries — encodes LLO's schema shape",
+
+	// THE ONE SANCTIONED WRITER, and the reason the test-file half of this rule
+	// can exist at all (mache-7555da).
+	//
+	// internal/fixturedb is where every test fixture's LLO-shaped DDL now
+	// lives. It is a violation of the same layering — but a SINGLE one, whose
+	// statements are DERIVED from the pinned producer's own sqlite_master and
+	// re-derived by a conformance test that fails on drift. That is strictly
+	// stronger than the 34 hand-written spellings it replaced, none of which
+	// matched ley-line at all. When delegation lands these disappear with the
+	// rest.
+	"internal/fixturedb/schema_leyline.go": "the DERIVED ley-line DDL, conformance-tested against the pinned binary (mache-7555da)",
+	"internal/fixturedb/build.go":          "creates the derived tables for a fixture (mache-7555da)",
+	"internal/fixturedb/emit.go":           "inserts fixture rows into the derived tables (mache-7555da)",
+}
+
+// lloTestFixtureAllowlist is the frozen set of TEST files still hand-building
+// LLO-shaped tables, as repo-relative paths. It is a RATCHET: it may only
+// SHRINK, and the way to shrink it is to build the fixture with
+// internal/fixturedb instead.
+//
+// It is a SEPARATE list from lloWriterAllowlist on purpose. Folding thirty
+// fixture files into that map would bury the handful of production entries that
+// actually describe the boundary, and a rule whose signal is buried stops being
+// read. These entries share one reason, so they are a list rather than a map.
+//
+// Why they are a violation at all, when they are "just tests": each states its
+// OWN idea of ley-line's schema, and ensureCanonicalViews emits a structurally
+// different v_refs / v_defs body per column combination. So the DDL literal in
+// a fixture is a hidden parameter selecting which SQL the rule under test
+// executes — a rule tested against a two-column node_refs runs the degraded arm
+// while production runs the full arm, and neither side notices. See
+// internal/fixturedb's package doc for the measurement (mache-7555da).
+var lloTestFixtureAllowlist = []string{
+	"cmd/build_leyline_coverage_test.go",
+	"cmd/cache_ast_test.go",
+	"cmd/cache_test.go",
+	"cmd/call_extractor_ast_test.go",
+	"cmd/dead_code_skip_list_retreat_test.go",
+	"cmd/duplicate_definitions_rust_test.go",
+	"cmd/falsifiability_lsp_projection_test.go",
+	"cmd/falsifiability_skip_list_ablation_test.go",
+	"cmd/find_smells_cli_test.go",
+	"cmd/find_smells_duplicate_code_test.go",
+	"cmd/kind_discriminator_leyline_ast_test.go",
+	"cmd/leyline_callees_test.go",
+	"cmd/leyline_crosslang_smells_test.go",
+	"cmd/leyline_test.go",
+	"cmd/serve_find_smells_bench_test.go",
+	"cmd/serve_find_smells_test.go",
+	"cmd/serve_find_smells_views_test.go",
+	"cmd/serve_lsp_step5_test.go",
+	"cmd/smell_findings_incremental_test.go",
+	"internal/graph/graph_suite_test.go",
+	"internal/graph/props_sql_test.go",
+	"internal/graph/sqlite_graph_lookupdef_test.go",
+	"internal/graph/sqlite_graph_nodehash_test.go",
+	"internal/ingest/ast_flatten_db_test.go",
+	"internal/ingest/ast_walker_bench_test.go",
+	"internal/ingest/ast_walker_callees_e2e_test.go",
+	"internal/ingest/ast_walker_calls_test.go",
+	"internal/ingest/ast_walker_core_test.go",
+	"internal/ingest/ast_walker_test.go",
+	"internal/ingest/inner_scope_test.go",
+	"internal/ingest/invalidate_test.go",
+	"internal/ingest/sqlite_writer_test.go",
 }
 
 // TestLLOBoundary_NoNewWritersOfLLOOwnedTables fails when a file not on the
-// allowlist writes a table LLO owns.
+// relevant allowlist writes a table LLO owns.
 //
-// Scoped to PRODUCTION files. Test files are excluded, and that is a scope
-// judgement rather than an oversight: 24 of them hand-build LLO-shaped tables
-// as fixtures, which is a real problem (a fixture asserts against mache's IDEA
-// of LLO's schema, so the two drift without either side noticing) but a
-// DIFFERENT one from a layering violation. Allowlisting 24 files here would
-// bury the three production entries that actually describe the boundary, and a
-// rule whose signal is buried stops being read. Fixture drift is tracked
-// separately as mache-7555da; when it is fixed, widening this rule to tests is
-// a one-line change.
+// Covers PRODUCTION and TEST files, against two separate allowlists. Test files
+// used to be skipped outright, with the note that fixture drift was "a real
+// problem but a DIFFERENT one". internal/fixturedb closed that problem
+// (mache-7555da), so the skip became the thing holding a 35th hand-built
+// fixture's door open — and this is the widening that was promised there.
 func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 	root := repoRootForBoundary(t)
 
+	testAllowed := map[string]bool{}
+	for _, rel := range lloTestFixtureAllowlist {
+		testAllowed[rel] = true
+	}
+
 	type violation struct{ file, table, verb string }
-	var found []violation
+	var found, foundTests []violation
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -143,7 +226,7 @@ func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 			}
 			return nil
 		}
-		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+		if !strings.HasSuffix(path, ".go") {
 			return nil
 		}
 		rel, relErr := filepath.Rel(root, path)
@@ -151,7 +234,12 @@ func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 			return relErr
 		}
 		rel = filepath.ToSlash(rel)
-		if _, allowed := lloWriterAllowlist[rel]; allowed {
+		isTest := strings.HasSuffix(rel, "_test.go")
+		if isTest {
+			if testAllowed[rel] {
+				return nil
+			}
+		} else if _, allowed := lloWriterAllowlist[rel]; allowed {
 			return nil
 		}
 
@@ -162,6 +250,14 @@ func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 			return nil //nolint:nilerr // not this invariant's concern
 		}
 
+		// Test files are held to the WIDER table set: a fixture that invents a
+		// node_defs / node_refs shape is the hidden-parameter defect even
+		// though production legitimately writes those tables.
+		guarded := lloOwnedTables
+		if isTest {
+			guarded = fixtureShapedTables
+		}
+
 		// Walk string literals rather than matching the file as text: SQL in
 		// this repo lives in string literals, and reading the AST avoids
 		// importing regexp (see regexpAllowlist in this package).
@@ -170,14 +266,20 @@ func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 			if !ok || lit.Kind != token.STRING {
 				return true
 			}
-			upper := strings.ToUpper(lit.Value)
+			upper := sqlText(lit)
 			for _, verb := range sqlWriteVerbs {
 				if !strings.Contains(upper, verb) {
 					continue
 				}
-				for _, tbl := range lloOwnedTables {
-					if writesTable(upper, verb, tbl) {
-						found = append(found, violation{rel, tbl, strings.TrimSpace(verb)})
+				for _, tbl := range guarded {
+					if !writesTable(upper, verb, tbl) {
+						continue
+					}
+					v := violation{rel, tbl, strings.TrimSpace(verb)}
+					if isTest {
+						foundTests = append(foundTests, v)
+					} else {
+						found = append(found, v)
 					}
 				}
 			}
@@ -187,31 +289,69 @@ func TestLLOBoundary_NoNewWritersOfLLOOwnedTables(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	if len(found) == 0 {
-		return
+	if len(found) > 0 {
+		sort.Slice(found, func(i, j int) bool { return found[i].file < found[j].file })
+		var b strings.Builder
+		b.WriteString("files outside the allowlist write LLO-owned tables:\n")
+		for _, v := range found {
+			b.WriteString("  " + v.file + ": " + v.verb + " " + v.table + "\n")
+		}
+		b.WriteString("\nmache is the CONTROL plane; LLO owns the data plane (ley-line-open-2037b4).\n")
+		b.WriteString("Writing LLO's schema from mache is a layering violation. Obtain the data\n")
+		b.WriteString("from LLO, or — if this is genuinely unavoidable — add the file to\n")
+		b.WriteString("lloWriterAllowlist with a one-line reason. The allowlist may only SHRINK.\n")
+		t.Error(b.String())
 	}
-	sort.Slice(found, func(i, j int) bool { return found[i].file < found[j].file })
-	var b strings.Builder
-	b.WriteString("files outside the allowlist write LLO-owned tables:\n")
-	for _, v := range found {
-		b.WriteString("  " + v.file + ": " + v.verb + " " + v.table + "\n")
+
+	if len(foundTests) > 0 {
+		sort.Slice(foundTests, func(i, j int) bool { return foundTests[i].file < foundTests[j].file })
+		var b strings.Builder
+		b.WriteString("test files outside lloTestFixtureAllowlist hand-build LLO-owned tables:\n")
+		for _, v := range foundTests {
+			b.WriteString("  " + v.file + ": " + v.verb + " " + v.table + "\n")
+		}
+		b.WriteString("\nBuild the fixture with internal/fixturedb instead. A hand-written\n")
+		b.WriteString("CREATE TABLE is a HIDDEN TEST PARAMETER: ensureCanonicalViews probes for\n")
+		b.WriteString("columns and emits a structurally different v_refs/v_defs per combination,\n")
+		b.WriteString("so the DDL a fixture happens to type decides which SQL the rule under\n")
+		b.WriteString("test actually runs. fixturedb.New(t, fixturedb.Leyline|Standalone) makes\n")
+		b.WriteString("that choice explicit and derives the shape from the real producer.\n")
+		b.WriteString("The allowlist may only SHRINK (mache-7555da).\n")
+		t.Error(b.String())
 	}
-	b.WriteString("\nmache is the CONTROL plane; LLO owns the data plane (ley-line-open-2037b4).\n")
-	b.WriteString("Writing LLO's schema from mache is a layering violation. Obtain the data\n")
-	b.WriteString("from LLO, or — if this is genuinely unavoidable — add the file to\n")
-	b.WriteString("lloWriterAllowlist with a one-line reason. The allowlist may only SHRINK.\n")
-	t.Fatal(b.String())
 }
 
-// writesTable reports whether an uppercased SQL literal writes tbl with verb.
-// Matches the table name as a whole token so `_ast` does not match
-// `_ast_pointer` and `_lsp` does not match `_lsp_defs` — those are separate
-// entries and should be reported separately.
+// sqlText returns a string literal's VALUE — escapes resolved, quotes gone —
+// uppercased for matching.
+//
+// Unquoting is load-bearing, not tidiness. This used to match against
+// lit.Value, the raw source text, where a newline inside an interpreted string
+// is the two characters `\` `n`. The whitespace cutset therefore had to include
+// a backslash and an `n` — and since the text was uppercased first, an `N`. That
+// cutset then ate the leading `N` of any table name starting with one, so
+// `nodes`, `node_content`, `node_defs` and `node_refs` could NEVER match. One of
+// those, node_content, is in lloOwnedTables: the rule has been silently unable
+// to enforce it since it was written (found while widening this rule for
+// mache-7555da).
+func sqlText(lit *ast.BasicLit) string {
+	unquoted, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		// Not a form strconv understands; fall back to the raw text rather than
+		// dropping the literal from the scan entirely.
+		return strings.ToUpper(lit.Value)
+	}
+	return strings.ToUpper(unquoted)
+}
+
+// writesTable reports whether an uppercased SQL string (see [sqlText]) writes
+// tbl with verb. Matches the table name as a whole token so `_ast` does not
+// match `_ast_pointer` and `_lsp` does not match `_lsp_defs` — those are
+// separate entries and should be reported separately.
 func writesTable(upperSQL, verb, tbl string) bool {
 	target := strings.ToUpper(tbl)
 	idx := strings.Index(upperSQL, verb)
 	for idx >= 0 {
-		rest := strings.TrimLeft(upperSQL[idx+len(verb):], " \t\\N\"`")
+		rest := strings.TrimLeft(upperSQL[idx+len(verb):], " \t\n\r")
 		// CREATE TABLE may carry IF NOT EXISTS before the name.
 		rest = strings.TrimPrefix(rest, "IF NOT EXISTS ")
 		rest = strings.TrimLeft(rest, " \t")
@@ -246,10 +386,50 @@ func repoRootForBoundary(t *testing.T) string {
 // exemption that would silently re-permit a violation if the path came back.
 func TestLLOBoundary_AllowlistEntriesStillExist(t *testing.T) {
 	root := repoRootForBoundary(t)
+	rels := make([]string, 0, len(lloWriterAllowlist)+len(lloTestFixtureAllowlist))
 	for rel := range lloWriterAllowlist {
+		rels = append(rels, rel)
+	}
+	rels = append(rels, lloTestFixtureAllowlist...)
+	for _, rel := range rels {
 		_, err := parser.ParseFile(token.NewFileSet(), filepath.Join(root, rel), nil, parser.PackageClauseOnly)
 		require.NoError(t, err,
 			"allowlisted file %s no longer parses or does not exist — remove the entry "+
 				"rather than leaving a stale exemption", rel)
+	}
+}
+
+// TestLLOBoundary_TestFixtureAllowlistIsStillEarned is the shrink half of the
+// ratchet: an entry for a file that no longer hand-builds an LLO table is a
+// stale exemption, and leaving it lets the next hand-built fixture back in
+// under cover of a migration that already happened.
+func TestLLOBoundary_TestFixtureAllowlistIsStillEarned(t *testing.T) {
+	root := repoRootForBoundary(t)
+	for _, rel := range lloTestFixtureAllowlist {
+		path := filepath.Join(root, rel)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		require.NoError(t, err, "parse %s", rel)
+
+		writes := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			lit, ok := n.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			upper := sqlText(lit)
+			for _, verb := range sqlWriteVerbs {
+				for _, tbl := range fixtureShapedTables {
+					if writesTable(upper, verb, tbl) {
+						writes = true
+						return false
+					}
+				}
+			}
+			return true
+		})
+		assert.True(t, writes,
+			"%s no longer writes an LLO-owned table — it was migrated to "+
+				"internal/fixturedb, so DELETE its lloTestFixtureAllowlist entry "+
+				"rather than leaving the exemption behind", rel)
 	}
 }

--- a/internal/lint/llo_boundary_test.go
+++ b/internal/lint/llo_boundary_test.go
@@ -174,7 +174,6 @@ var lloTestFixtureAllowlist = []string{
 	"cmd/find_smells_duplicate_code_test.go",
 	"cmd/kind_discriminator_leyline_ast_test.go",
 	"cmd/leyline_callees_test.go",
-	"cmd/leyline_crosslang_smells_test.go",
 	"cmd/leyline_test.go",
 	"cmd/serve_find_smells_bench_test.go",
 	"cmd/serve_find_smells_test.go",

--- a/internal/lint/llo_boundary_test.go
+++ b/internal/lint/llo_boundary_test.go
@@ -167,7 +167,6 @@ var lloTestFixtureAllowlist = []string{
 	"cmd/cache_test.go",
 	"cmd/call_extractor_ast_test.go",
 	"cmd/dead_code_skip_list_retreat_test.go",
-	"cmd/duplicate_definitions_rust_test.go",
 	"cmd/falsifiability_lsp_projection_test.go",
 	"cmd/falsifiability_skip_list_ablation_test.go",
 	"cmd/find_smells_cli_test.go",

--- a/internal/lltest/pinned_unix.go
+++ b/internal/lltest/pinned_unix.go
@@ -64,15 +64,22 @@ func StartPinnedDaemon(t *testing.T) string {
 	return awaitSocket(t, filepath.Join(dir, "d.sock"))
 }
 
-// pinnedBinaryOrSkip resolves ~/.mache/bin/leyline and verifies it reports
-// the pinned version, skipping the test otherwise.
-func pinnedBinaryOrSkip(t *testing.T) string {
+// PinnedBinaryOrSkip resolves the SHA-pinned leyline binary the same way
+// production does — version-namespaced ~/.mache/bin/leyline-<pin> first, legacy
+// unversioned path only when it happens to hold the pin — and SKIPS the test
+// when none is cached. It never downloads.
+//
+// Resolving the legacy path DIRECTLY (as this did until mache-7555da) made every
+// pinned gate skip unconditionally once the cache became version-namespaced:
+// nothing writes ~/.mache/bin/leyline any more, so on a machine whose legacy
+// file was left behind by an older pin the gate could never fire.
+func PinnedBinaryOrSkip(t *testing.T) string {
 	t.Helper()
-	home, err := os.UserHomeDir()
-	if err != nil {
-		t.Skipf("lltest: no home dir, cannot locate pinned leyline: %v", err)
+	bin := leyline.CachedPinnedBinary()
+	if bin == "" {
+		t.Skipf("lltest: no cached leyline matching pin %s (never downloading in tests)",
+			leyline.PinnedBinaryVersion())
 	}
-	bin := filepath.Join(home, ".mache", "bin", "leyline")
 	out, err := exec.Command(bin, "--version").Output()
 	if err != nil {
 		t.Skipf("lltest: pinned leyline not runnable at %s (never downloading in tests): %v", bin, err)
@@ -82,6 +89,12 @@ func pinnedBinaryOrSkip(t *testing.T) string {
 		t.Skipf("lltest: leyline at %s reports %q, want pinned %s — skipping (never downloading in tests)", bin, strings.TrimSpace(string(out)), want)
 	}
 	return bin
+}
+
+// pinnedBinaryOrSkip is the in-package alias kept for the existing call sites.
+func pinnedBinaryOrSkip(t *testing.T) string {
+	t.Helper()
+	return PinnedBinaryOrSkip(t)
 }
 
 // awaitSocket polls until a UDS listener answers at sock or the deadline


### PR DESCRIPTION
Closes the fixture-drift half of **mache-7555da**, and **mache-e3f3bf** with it.

## The defect

~34 test files hand-wrote `CREATE TABLE` for `node_refs` / `node_defs` / `_ast` — **10 distinct spellings of node_refs**, 4 of `_ast`. **Zero reproduced ley-line's real shape**; 13 reproduced mache-standalone's exactly, several while documenting themselves as "the Leyline column shape".

That is not cosmetic. `ensureCanonicalViews` **probes for columns and emits a structurally different `v_refs` / `v_defs` body per combination** — most sharply:

```go
refsReferrerExpr := "node_id"
if hasRefsContainer {
    refsReferrerExpr = "COALESCE(NULLIF(container_node_id, ''), node_id)"
}
```

So **a fixture's `CREATE TABLE` literal was a hidden test parameter selecting which SQL the rule under test executed.** A rule tested against a two-column `node_refs` ran the degraded arm while production ran the full arm, and neither side noticed. Compounding it, `node_refs.node_id` has two incompatible meanings (enclosing construct on mache, call-site leaf on ley-line) and a fixture picked one implicitly, by what it INSERTed.

Same defect class as **mache-e3d9bb** (`Node.Children` had two accessors that silently disagreed; the fix was removing the second way to ask), one layer down — so the same fix shape.

## `internal/fixturedb`

- **`Producer` is a closed set** (`Leyline` | `Standalone`) with an unexported field: the zero value and third-party construction are unrepresentable, so a fixture cannot exist without naming its producer.
- **No method accepts SQL, DDL, a column name, or a table name.** The DDL is unexported and there is no escape hatch. That absence is the design.
- **`Ref(token, from, at, qualifier)` takes the two meanings of `node_id` as separate typed parameters.** `Leyline` writes `node_id=<at>, container_node_id=<from>`; `Standalone` writes `node_id=<from>` and structurally cannot express `<at>`.
- **`Build()` returns a fixture already wired through `ensureCanonicalViews`** (registered once by `cmd`), so a test cannot forget the install — and caps the pool at one connection, since TEMP views are per-connection.
- Optional facts are **declarative structs** (`Where`, `Detail`), not functional options: a field names something true about the code, never a column.

**Both DDLs are DERIVED, not authored, and both derivations are re-run as tests:**

| | source of truth | gated? |
|---|---|---|
| `Leyline` | the pinned binary's own `sqlite_master`, from `leyline parse` on a two-file corpus | yes — skips without a cached pin, never downloads |
| `Standalone` | `internal/ingest/sqlite_writer.go`'s own schema literal, read from the Go AST and executed | no — pure Go, no CGO, no regexp |

Both proven to fail on mutation (add a PK to ley-line's `node_refs` → red; drop `nodes.context` from the writer → red).

## Exit ratchet

`internal/lint/llo_boundary_test.go` now walks `_test.go` too, against a **separate** `lloTestFixtureAllowlist` (so the production entries stay readable) and a **wider** table set — `lloOwnedTables` **plus `node_defs` / `node_refs`**, because for a test the question is not "who owns the table" but "did this fixture invent a shape". Both directions mutation-proven: a 35th hand-built fixture fails; an allowlist entry left behind after a migration fails.

## Bugs found

1. **`writesTable` could never match any table starting with `N`.** It matched raw source text, where a newline in an interpreted string is `\` + `n`; the whitespace cutset therefore carried a backslash and (post-uppercase) an `N`, which ate the leading `N` of `nodes` / `node_content` / `node_defs` / `node_refs`. `node_content` is in `lloOwnedTables` — **the rule has been silently unable to enforce it since it was written.** Fixed by unquoting the literal.
2. **The pinned-leyline test gate was dead.** `lltest.pinnedBinaryOrSkip` resolved the LEGACY unversioned `~/.mache/bin/leyline`. The cache became version-namespaced in mache-0acdf6 and nothing writes that path any more, so every gated e2e SKIPPED unconditionally on any machine past the legacy file. Now resolves the pin the way production does.
3. **`cmd/cache.go`'s `_ast` DDL has drifted from ley-line's** — no `node_hash`, and `NOT NULL` missing on the row/col columns. Not fixed here (it is the allowlisted `mache-e64f36` violation); recorded on the bead.

## Migrated so far — 7 files, ratchet list 32 → 30

`untested_function_leyline_test.go`, `serve_find_smells_nodehash_test.go`, `serve_find_smells_fanout_test.go`, `smell_doc_refs_test.go`, `smell_test_nodes_test.go`, `leyline_crosslang_smells_test.go`, `duplicate_definitions_rust_test.go`.

Three of those documented themselves as ley-line ground truth ("the real node_id shapes emitted by `leyline parse`", "mirrors leyline's Rust output") while hand-writing the **mache projection**'s two-column `node_defs` with `PRIMARY KEY ... WITHOUT ROWID`. One of them, `newCrossLangGraph`, took a `ddl string` — a fixture helper parameterized on SQL. The last one previously called `testNodesViewSQL(true/false)` **directly**, bypassing the `hasAST` / `hasContent` probe entirely; it now goes through the real installer, so the probe is covered rather than assumed. No test changed its result when given the shape it claimed.

32 fixture files remain on the ratchet list and shrink in follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RCvc7GSqCgD9JoVkPEaUro