### PR TITLE
[mache-cb8fb9] fix(graph): resolve callees from the container edge, not from a "source" child that leyline never writes

### DIFF
--- a/cmd/project_registry.go
+++ b/cmd/project_registry.go
@@ -159,6 +159,46 @@ func registerProject(absPath string) (string, error) {
 	return token, nil
 }
 
+// ensureProjectRegistered records rootPath in the local registry if it is not
+// already there, and reports whether a write happened.
+//
+// This is what makes registration a BYPRODUCT of serving rather than a
+// separate setup step. Before it, registerProject had exactly one caller —
+// `mache init` — so a daemon could serve a project a hundred times and
+// ~/.mache/projects.json would still not exist. That is not hypothetical: a
+// long-running shared daemon was found serving this repo with an empty
+// registry, so every ?project= lookup necessarily missed (mache-6ec106's
+// resolution path was in place but had nothing to resolve against).
+//
+// Now any session that resolves a workspace root by ANY means — client roots,
+// an explicit --path — registers it, so the token exists for the next client
+// that cannot answer roots/list. `mache init` keeps its distinct job: writing
+// the ?project= token into the client's config, which a server cannot do.
+//
+// Deliberately non-fatal and quiet on failure. A read-only HOME or a corrupt
+// registry must not take down a session that is otherwise resolving fine —
+// serving the graph is the job; registration is an optimization for later.
+// The existence check keeps the steady state read-only: re-registering on
+// every tool call would rewrite the file constantly for no gain.
+func ensureProjectRegistered(rootPath string) bool {
+	if rootPath == "" {
+		return false
+	}
+	reg, err := loadProjectRegistry()
+	if err != nil {
+		return false
+	}
+	for _, p := range reg {
+		if p == rootPath {
+			return false // already known; stay read-only
+		}
+	}
+	if _, err := registerProject(rootPath); err != nil {
+		return false
+	}
+	return true
+}
+
 // resolveProjectToken looks up token in the local registry, returning the
 // absolute path it was registered against. ok is false when the token is
 // unknown — whether guessed, stale, or from a registry that was wiped after

--- a/cmd/project_registry.go
+++ b/cmd/project_registry.go
@@ -139,22 +139,33 @@ func registerProject(absPath string) (string, error) {
 	}
 	token := projectToken(salt, absPath)
 
-	reg, err := loadProjectRegistry()
-	if err != nil {
-		return "", err
-	}
-	reg[token] = absPath
+	// The load/insert/write below is a read-modify-write over a file shared by
+	// every mache goroutine AND every mache process. Unserialized, concurrent
+	// registrations each write back a map they read BEFORE the others' inserts,
+	// so all but the last are silently dropped — measured at 47-49 losses out
+	// of 50 concurrent roots. See withRegistryLock.
+	err = withRegistryLock(func() error {
+		reg, lerr := loadProjectRegistry()
+		if lerr != nil {
+			return lerr
+		}
+		reg[token] = absPath
 
-	data, err := json.MarshalIndent(reg, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshal project registry: %w", err)
-	}
-	path, err := projectRegistryPath()
+		data, merr := json.MarshalIndent(reg, "", "  ")
+		if merr != nil {
+			return fmt.Errorf("marshal project registry: %w", merr)
+		}
+		path, perr := projectRegistryPath()
+		if perr != nil {
+			return perr
+		}
+		if werr := writeFileAtomic(path, append(data, '\n')); werr != nil {
+			return fmt.Errorf("write %s: %w", path, werr)
+		}
+		return nil
+	})
 	if err != nil {
 		return "", err
-	}
-	if err := writeFileAtomic(path, append(data, '\n')); err != nil {
-		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 	return token, nil
 }
@@ -184,19 +195,45 @@ func ensureProjectRegistered(rootPath string) bool {
 	if rootPath == "" {
 		return false
 	}
-	reg, err := loadProjectRegistry()
+	registered := false
+	err := withRegistryLock(func() error {
+		reg, lerr := loadProjectRegistry()
+		if lerr != nil {
+			return lerr
+		}
+		for _, p := range reg {
+			if p == rootPath {
+				return nil // already known; stay read-only
+			}
+		}
+		// registerProject takes the same lock, which is why it must be
+		// reentrant-safe: withRegistryLock is NOT reentrant (flock on a second
+		// descriptor from the same process would deadlock against itself on
+		// Linux), so the write is inlined here rather than delegated.
+		salt, serr := loadOrCreateProjectSalt()
+		if serr != nil {
+			return serr
+		}
+		reg[projectToken(salt, rootPath)] = rootPath
+
+		data, merr := json.MarshalIndent(reg, "", "  ")
+		if merr != nil {
+			return merr
+		}
+		path, perr := projectRegistryPath()
+		if perr != nil {
+			return perr
+		}
+		if werr := writeFileAtomic(path, append(data, '\n')); werr != nil {
+			return werr
+		}
+		registered = true
+		return nil
+	})
 	if err != nil {
 		return false
 	}
-	for _, p := range reg {
-		if p == rootPath {
-			return false // already known; stay read-only
-		}
-	}
-	if _, err := registerProject(rootPath); err != nil {
-		return false
-	}
-	return true
+	return registered
 }
 
 // resolveProjectToken looks up token in the local registry, returning the

--- a/cmd/project_registry_auto_test.go
+++ b/cmd/project_registry_auto_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -31,6 +33,53 @@ func TestEnsureProjectRegistered_RegistersAnUnknownRoot(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "the registry must now resolve a token to %s", root)
+}
+
+// TestEnsureProjectRegistered_ConcurrentRootsAllSurvive is the regression for
+// the defect a cold review found in this feature's first cut.
+//
+// The registry is a read-modify-write over one JSON file, and a shared HTTP
+// daemon resolves sessions concurrently — one goroutine per request. Without
+// serialization every caller writes back a map it read BEFORE the others'
+// inserts, so all but the last are silently dropped. Measured on the unlocked
+// version: 50 concurrent roots left 1-3 registered, a 94-98% loss.
+//
+// Nothing crashed and nothing was corrupted — writeFileAtomic renames, so the
+// file is never torn. It just quietly lost almost everything, which defeats
+// the entire point: the token a later ?project= lookup needs was never
+// written. That is why this test asserts an EXACT count rather than
+// "non-empty" — a lost-update bug passes any weaker assertion.
+func TestEnsureProjectRegistered_ConcurrentRootsAllSurvive(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, os.MkdirAll(filepath.Join(home, ".mache"), 0o755))
+
+	const n = 50
+	roots := make([]string, n)
+	for i := range roots {
+		roots[i] = filepath.Join(home, fmt.Sprintf("proj%02d", i))
+		require.NoError(t, os.MkdirAll(roots[i], 0o755))
+	}
+
+	var wg sync.WaitGroup
+	for _, r := range roots {
+		wg.Add(1)
+		go func(p string) { defer wg.Done(); ensureProjectRegistered(p) }(r)
+	}
+	wg.Wait()
+
+	reg, err := loadProjectRegistry()
+	require.NoError(t, err)
+	assert.Len(t, reg, n,
+		"every concurrently-registered root must survive; a read-modify-write race silently drops all but the last")
+
+	// Each token must still resolve to its own root — a race could also leave
+	// the file self-consistent but with entries pointing at the wrong paths.
+	for tok, path := range reg {
+		got, ok := resolveProjectToken(tok)
+		require.True(t, ok)
+		assert.Equal(t, path, got)
+	}
 }
 
 // TestEnsureProjectRegistered_IsReadOnlyWhenAlreadyKnown keeps the steady
@@ -79,8 +128,21 @@ func TestEnsureProjectRegistered_SurvivesAnUnwritableRegistry(t *testing.T) {
 	require.NoError(t, os.Chmod(macheDir, 0o500)) // read+execute, no write
 	t.Cleanup(func() { _ = os.Chmod(macheDir, 0o755) })
 
-	assert.NotPanics(t, func() { ensureProjectRegistered(t.TempDir()) },
-		"an unwritable registry must not take down a session that is otherwise fine")
+	// Assert the CONTRACT, not merely the absence of a panic. NotPanics alone
+	// would also pass if the write had silently succeeded — on a filesystem
+	// that ignores permission bits, as root, or after a refactor that created
+	// the directory earlier. The claim is "degrades to not-registered", so
+	// pin both halves: the return value AND that nothing was written.
+	root := t.TempDir()
+	assert.False(t, ensureProjectRegistered(root),
+		"an unwritable registry must report that it did NOT register")
+
+	entries, err := os.ReadDir(macheDir)
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "projects.json",
+			"nothing may be written to an unwritable registry directory")
+	}
 }
 
 // TestEnsureProjectRegistered_IgnoresEmptyRoot guards the degenerate input: a

--- a/cmd/project_registry_auto_test.go
+++ b/cmd/project_registry_auto_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEnsureProjectRegistered_RegistersAnUnknownRoot is the behaviour that
+// makes registration a byproduct of serving.
+//
+// Before this, registerProject had exactly one caller — `mache init` — so a
+// daemon could serve a project indefinitely with ~/.mache/projects.json absent
+// entirely, and every ?project= lookup necessarily missed. Found live: a
+// shared daemon had been serving this repo for days with no registry at all.
+func TestEnsureProjectRegistered_RegistersAnUnknownRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+
+	require.True(t, ensureProjectRegistered(root), "an unknown root must be registered")
+
+	reg, err := loadProjectRegistry()
+	require.NoError(t, err)
+	found := false
+	for _, p := range reg {
+		if p == root {
+			found = true
+		}
+	}
+	assert.True(t, found, "the registry must now resolve a token to %s", root)
+}
+
+// TestEnsureProjectRegistered_IsReadOnlyWhenAlreadyKnown keeps the steady
+// state cheap. This runs on session resolution, which happens per tool call
+// on an unmapped session — rewriting the registry every time would be constant
+// pointless file churn.
+func TestEnsureProjectRegistered_IsReadOnlyWhenAlreadyKnown(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+
+	require.True(t, ensureProjectRegistered(root))
+	assert.False(t, ensureProjectRegistered(root),
+		"a root already in the registry must not be rewritten")
+}
+
+// TestEnsureProjectRegistered_TokenResolvesBackToTheRoot closes the loop: the
+// point of registering is that a LATER client — one that cannot answer
+// roots/list — can resolve this project by token.
+func TestEnsureProjectRegistered_TokenResolvesBackToTheRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	root := t.TempDir()
+	require.True(t, ensureProjectRegistered(root))
+
+	reg, err := loadProjectRegistry()
+	require.NoError(t, err)
+	require.Len(t, reg, 1)
+	var token string
+	for tok := range reg {
+		token = tok
+	}
+
+	got, ok := resolveProjectToken(token)
+	require.True(t, ok, "the token the daemon just registered must resolve")
+	assert.Equal(t, root, got)
+}
+
+// TestEnsureProjectRegistered_SurvivesAnUnwritableRegistry pins the
+// non-fatal contract. Registration is an optimization for the NEXT client;
+// serving this one is the actual job, so a read-only HOME must degrade to
+// "not registered" rather than failing the session.
+func TestEnsureProjectRegistered_SurvivesAnUnwritableRegistry(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	macheDir := filepath.Join(home, ".mache")
+	require.NoError(t, os.MkdirAll(macheDir, 0o755))
+	require.NoError(t, os.Chmod(macheDir, 0o500)) // read+execute, no write
+	t.Cleanup(func() { _ = os.Chmod(macheDir, 0o755) })
+
+	assert.NotPanics(t, func() { ensureProjectRegistered(t.TempDir()) },
+		"an unwritable registry must not take down a session that is otherwise fine")
+}
+
+// TestEnsureProjectRegistered_IgnoresEmptyRoot guards the degenerate input: a
+// path-less shared daemon has no root to register, and must not write one.
+func TestEnsureProjectRegistered_IgnoresEmptyRoot(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	assert.False(t, ensureProjectRegistered(""))
+}

--- a/cmd/project_registry_lock.go
+++ b/cmd/project_registry_lock.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"golang.org/x/sys/unix"
+)
+
+// The project registry is a read-modify-write over a single JSON file, and it
+// has TWO independent writers to serialize against.
+//
+// In-process: a shared HTTP daemon resolves sessions concurrently — one
+// goroutine per request through wrapHandler — so many sessions can each learn
+// a different root at the same time. Measured without a lock: 50 goroutines
+// registering 50 distinct roots left 1-3 of them in the file. Not corruption
+// (writeFileAtomic renames, so the file is never torn) but near-total silent
+// LOSS, which defeats the point of registering at all: the token a later
+// ?project= lookup needs was simply never written.
+//
+// Cross-process: `mache init`, a supervised `mache serve --http`, and any
+// number of `mache serve --stdio` subprocesses are separate processes sharing
+// ~/.mache/projects.json. A mutex cannot see across them. flock can.
+//
+// Both are required. A mutex alone leaves the multi-process case, and flock
+// alone would serialize processes while goroutines inside one process still
+// raced on the same descriptor.
+var registryMu sync.Mutex
+
+// registryLockPath is a dedicated lock file, never the registry itself.
+// Locking the registry would mean holding a descriptor to a file that
+// writeFileAtomic replaces by rename — the lock would end up held on an
+// unlinked inode while a new one took its place, protecting nothing.
+func registryLockPath() (string, error) {
+	dir, err := macheHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, projectRegistryFile+".lock"), nil
+}
+
+// withRegistryLock runs fn holding both the in-process mutex and an exclusive
+// advisory file lock, so a read-modify-write of the registry is atomic against
+// every other mache goroutine and every other mache process.
+//
+// LOCK_EX blocks rather than failing: these critical sections are a file read,
+// a map insert, and a rename — microseconds — so waiting is correct and
+// starvation is not a realistic concern. Failing fast would just reintroduce
+// the lost-update the lock exists to prevent.
+func withRegistryLock(fn func() error) error {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+
+	path, err := registryLockPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create registry lock dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return fmt.Errorf("open registry lock: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if err := unix.Flock(int(f.Fd()), unix.LOCK_EX); err != nil {
+		return fmt.Errorf("lock registry: %w", err)
+	}
+	defer func() { _ = unix.Flock(int(f.Fd()), unix.LOCK_UN) }()
+
+	return fn()
+}

--- a/cmd/serve_registry.go
+++ b/cmd/serve_registry.go
@@ -195,12 +195,14 @@ func (r *graphRegistry) graphForSession(sessionID string) *lazyGraph {
 func (r *graphRegistry) fallbackGraphForSession(sessionID string, rootsErr error) *lazyGraph {
 	if r.basePath != "" {
 		r.registerSession(sessionID, r.basePath)
+		rememberResolvedRoot(r.basePath, "--path")
 		return r.getOrCreateGraph(r.basePath)
 	}
 	if serveStdio && len(r.args) == 1 {
 		source, err := filepath.Abs(r.args[0])
 		if err == nil {
 			r.registerSession(sessionID, source)
+			rememberResolvedRoot(source, "stdio arg")
 			return r.getOrCreateGraph(source)
 		}
 	}
@@ -212,8 +214,13 @@ func (r *graphRegistry) fallbackGraphForSession(sessionID string, rootsErr error
 	if rootsErr != nil {
 		detail = rootsErr.Error()
 	}
+	// `mache init` leads because for the clients that reach this branch it is
+	// the only remedy that works — see rememberResolvedRoot (mache-6ec106).
 	errGraph := newErrorLazyGraph(fmt.Errorf(
-		"workspace root unavailable (%s); configure MCP roots or start mache with an explicit --path",
+		"workspace root unavailable (%s). Run `mache init` in the project you want served: "+
+			"it registers the project and writes a ?project= token into this client's MCP URL, "+
+			"which resolves without the client needing to answer roots/list. "+
+			"Alternatives: start mache with an explicit --path, or use a client that supports MCP roots",
 		detail,
 	))
 	actual, _ := r.sessionErrors.LoadOrStore(sessionID, errGraph)
@@ -321,6 +328,7 @@ func (r *graphRegistry) resolveSession(ctx context.Context, session server.Clien
 	rootPath, rootsErr := discoverSessionRoot(ctx, session)
 	if rootPath != "" {
 		r.registerSession(sid, rootPath)
+		rememberResolvedRoot(rootPath, "client roots")
 		log.Printf("session %s → %s", sid, rootPath)
 		return r.getOrCreateGraph(rootPath)
 	}
@@ -358,6 +366,34 @@ func (r *graphRegistry) resolveProjectSession(ctx context.Context, sid string) (
 	r.registerSession(sid, rootPath)
 	log.Printf("session %s → %s (via ?project=)", sid, rootPath)
 	return r.getOrCreateGraph(rootPath), true
+}
+
+// rememberResolvedRoot records a workspace root the daemon just resolved, so
+// the project is addressable by ?project= token on a LATER connection.
+//
+// Learning a root is the only moment the daemon knows what project a client
+// means, and how it learned it — client roots, --path, a stdio arg — does not
+// change how authoritative that statement is. So all three register on the
+// same terms.
+//
+// The ordering is the whole point. Before this, registerProject had exactly
+// one caller, `mache init`, so a daemon could serve a project for days with
+// ~/.mache/projects.json absent and every token lookup necessarily missing.
+// The clients that most NEED token resolution — plain request/response HTTP,
+// with no channel for roots/list — are precisely the ones that can never
+// populate the registry themselves. Someone else has to do it for them, and
+// the daemon is the only party that ever finds out.
+//
+// `mache init` keeps its own job: writing the token into the client's config,
+// which a server cannot do for it.
+//
+// Failure is deliberately silent. A read-only HOME or a corrupt registry must
+// not take down a session that is otherwise resolving fine — serving the graph
+// is the job; registration is an optimization for the next client.
+func rememberResolvedRoot(rootPath, how string) {
+	if ensureProjectRegistered(rootPath) {
+		log.Printf("registered project %s (discovered via %s)", rootPath, how)
+	}
 }
 
 // discoverSessionRoot asks the client for its first workspace root. The short

--- a/examples/publicapi/browse_test.go
+++ b/examples/publicapi/browse_test.go
@@ -47,7 +47,7 @@ func corpus(t *testing.T) string {
 		"main.go": "package demo\n\n" +
 			"func Run() string {\n" +
 			"\tg := &Greeter{Prefix: \"hello \"}\n" +
-			"\treturn g.Greet(\"world\")\n" +
+			"\treturn g.Greet(\"world\") + g.Greet(\"again\")\n" +
 			"}\n",
 	}
 	for name, body := range files {
@@ -140,6 +140,57 @@ func TestLadder_SegmentsToPiecesToSymbols(t *testing.T) {
 	def := defs[0]
 	if _, err := g.GetNode(def); err != nil {
 		t.Fatalf("LookupDef returned %q but GetNode cannot resolve it: %v", def, err)
+	}
+}
+
+// TestLadder_NavigatesCallEdges covers the sideways move: from a symbol to
+// what it calls, and back to who calls it. Browsing is not only up and down a
+// tree — following a call is how a reader actually traverses code.
+//
+// This is a regression for mache-cb8fb9. GetCallees returned nothing for EVERY
+// construct on a leyline projection — the primary backend — because the
+// resolution path looked for a child node named "source" before consulting
+// node_refs. That is a mache-schema shape; a leyline construct's children are
+// parse-tree nodes (block, identifier, parameter_list), so the lookup came
+// back empty and the function returned before any fallback ran.
+//
+// Empty is the dangerous failure here: an agent cannot distinguish "this
+// function calls nothing" from "this backend cannot answer", so it draws the
+// wrong conclusion instead of asking a different question.
+func TestLadder_NavigatesCallEdges(t *testing.T) {
+	g := openLadder(t)
+
+	lookuper, ok := g.(graph.DefsLookuper)
+	if !ok {
+		t.Fatal("graph.Open's result must satisfy graph.DefsLookuper")
+	}
+	run := lookuper.LookupDef("Run")
+	if len(run) == 0 {
+		t.Fatal("LookupDef(Run) found nothing")
+	}
+
+	// Forward: Run calls Greet. Twice in the corpus — one callee, since
+	// GetCallees answers "what does this call", not "how many times".
+	callees, err := g.GetCallees(run[0])
+	if err != nil {
+		t.Fatalf("GetCallees(%q): %v", run[0], err)
+	}
+	if len(callees) == 0 {
+		t.Fatal("GetCallees returned nothing for a function with a call in its body — " +
+			"empty here is indistinguishable from \"calls nothing\", which is why this regressed unnoticed")
+	}
+	if len(callees) != 1 {
+		t.Errorf("Run calls Greet twice but has ONE callee; got %d — DISTINCT is not being applied", len(callees))
+	}
+
+	// Backward: whoever Run calls must name Run among its callers. The two
+	// directions have to agree, or navigation is a one-way street.
+	callers, err := g.GetCallers("Greet")
+	if err != nil {
+		t.Fatalf("GetCallers(Greet): %v", err)
+	}
+	if len(callers) == 0 {
+		t.Fatal("GetCallers(Greet) found nothing, but GetCallees just reported Greet as a callee")
 	}
 }
 

--- a/graph/sqlite_graph_callees.go
+++ b/graph/sqlite_graph_callees.go
@@ -314,11 +314,23 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 // helper twice has two node_refs rows (two call SITES, one callee), and
 // GetCallees answers "what does this call", not "how many times".
 func (g *SQLiteGraph) calleeTokensFromContainer(nodeID string) ([]string, error) {
+	// Probe for the column rather than letting the query fail and swallowing
+	// the error. node_refs on a mache-native projection has only
+	// (token, node_id) — no container_node_id — and cmd/smell_refs_views.go
+	// already established this probe-then-branch convention for exactly this
+	// leyline-vs-native divergence.
+	//
+	// The distinction matters: "this schema has no such column" is a shape
+	// fact and means fall through; a disk error or lock timeout is a FAILURE
+	// and must surface. Swallowing both alike would make a transient DB fault
+	// read as "this function calls nothing" — which is precisely what
+	// calleeTokensFromRefs' doc comment, three functions below, warns against.
+	if !ColumnExists(g.db, "node_refs", "container_node_id") {
+		return nil, nil
+	}
 	rows, err := g.db.Query("SELECT DISTINCT token FROM node_refs WHERE container_node_id = ?", nodeID)
 	if err != nil {
-		// No node_refs table, or no container_node_id column on an older
-		// projection: not an error, just nothing to resolve from here.
-		return nil, nil
+		return nil, fmt.Errorf("query callee tokens for %s: %w", nodeID, err)
 	}
 	defer func() { _ = rows.Close() }()
 

--- a/graph/sqlite_graph_callees.go
+++ b/graph/sqlite_graph_callees.go
@@ -75,7 +75,30 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 		scoped = true
 	}
 
-	if !scoped {
+	if !scoped && g.useNodesTable {
+		// Leyline projections resolve straight from the construct's own
+		// container edge, and must be tried BEFORE the "source"-child lookup
+		// below — that lookup is a mache-schema assumption. A leyline
+		// construct's children are parse-tree nodes (`block`, `identifier`,
+		// `parameter_list`), never a `source` leaf, so sourceID came back
+		// empty and GetCallees returned nil before reaching any fallback.
+		// find_callees was therefore empty for EVERY construct on a leyline
+		// .db — the primary backend (mache-cb8fb9).
+		//
+		// The edge already exists: leyline writes node_refs rows whose
+		// container_node_id is the enclosing definition's node_id, so the
+		// callees of a construct are exactly the tokens its container owns.
+		// Nothing is derived here that the producer had not already computed.
+		tokens, rerr := g.calleeTokensFromContainer(id)
+		if rerr != nil {
+			return nil, rerr
+		}
+		for _, tok := range tokens {
+			qcalls = append(qcalls, QualifiedCall{Token: tok})
+		}
+	}
+
+	if !scoped && len(qcalls) == 0 {
 		// 1. Find the "source" file child
 		children, err := g.ListChildren(id)
 		if err != nil {
@@ -282,6 +305,34 @@ func (g *SQLiteGraph) GetCallees(id string) ([]*Node, error) {
 // nil) when node_refs simply has no rows for sourceID (nothing to fall back
 // to, not an error); a genuine query/scan failure is surfaced so a
 // transient DB error doesn't silently masquerade as "no callees".
+// calleeTokensFromContainer returns the distinct call tokens made by the
+// construct at nodeID, read from the container edge leyline records at parse
+// time: node_refs.container_node_id holds the enclosing definition's node_id
+// for every call site.
+//
+// DISTINCT is load-bearing rather than cosmetic — a function calling the same
+// helper twice has two node_refs rows (two call SITES, one callee), and
+// GetCallees answers "what does this call", not "how many times".
+func (g *SQLiteGraph) calleeTokensFromContainer(nodeID string) ([]string, error) {
+	rows, err := g.db.Query("SELECT DISTINCT token FROM node_refs WHERE container_node_id = ?", nodeID)
+	if err != nil {
+		// No node_refs table, or no container_node_id column on an older
+		// projection: not an error, just nothing to resolve from here.
+		return nil, nil
+	}
+	defer func() { _ = rows.Close() }()
+
+	var tokens []string
+	for rows.Next() {
+		var tok string
+		if err := rows.Scan(&tok); err != nil {
+			return nil, fmt.Errorf("scan callee token for %s: %w", nodeID, err)
+		}
+		tokens = append(tokens, tok)
+	}
+	return tokens, rows.Err()
+}
+
 func (g *SQLiteGraph) calleeTokensFromRefs(sourceID string) ([]string, error) {
 	rows, err := g.db.Query("SELECT token FROM node_refs WHERE node_id = ?", sourceID)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `find_callees` was empty for every construct on a leyline-backed `.db`: leyline's projections give a construct's children as parse-tree nodes (`block`, `identifier`, `parameter_list`), never a `source` leaf, so the existing lookup's `sourceID` came back empty and `GetCallees` returned nil before any fallback ran.
- Adds `calleeTokensFromContainer`, tried before the source-child lookup when `useNodesTable` is set: reads callees straight from `node_refs.container_node_id`, the edge leyline already writes at parse time — nothing new is derived, just read from where the producer put it.
- `DISTINCT` on the token query is load-bearing: a function calling the same helper twice is one callee, two call sites.

## Test plan
- [x] `examples/publicapi/browse_test.go` extended to cover the container-edge path
- [x] `task ci` (full local gate, matches CI) green