### PR TITLE
fix(leyline): pin v0.18.2 Terraform refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **Terraform address references now reach Mache's caller graph**
+  (`mache-91beb0`). Mache pins the official ley-line-open `v0.18.2` binaries
+  and their four platform SHA-256 digests. That release repairs the HCL
+  extraction dispatcher, so `leyline parse` serializes `env:` variable and
+  `mod:` module-source tokens into `node_refs` instead of producing a complete
+  `_ast` with an empty reference table. The paired Apache-2.0 Go schema client
+  is `v0.18.1`, matching the binary's unchanged public-schema handshake; wire
+  major `1`, compatibility floor `v0.6.0`, and `merkle-ast-v2` lineage are
+  unchanged. A real released-binary regression now proves those rows survive
+  through `find_callers`.
+
 - **The root listed itself as its own child, so a recursive browse never
   terminated** (`mache-77cf75`). ley-line writes a root node whose `id` and
   `parent_id` are both empty, and `NodesTableReader`'s root query matched it —

--- a/cmd/terraform_leyline_refs_test.go
+++ b/cmd/terraform_leyline_refs_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/graph"
+	machetmpl "github.com/agentic-research/mache/internal/template"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLeylineProjection_TerraformAddressRefsReachFindCallers protects the
+// producer/consumer seam that v0.18.2 repairs. The pre-v0.18.2 Leyline HCL
+// dispatcher emitted a complete _ast but never ran its registered address-ref
+// extractor, leaving node_refs empty and making Mache's caller view lie by
+// omission.
+func TestLeylineProjection_TerraformAddressRefsReachFindCallers(t *testing.T) {
+	requirePinnedLeyline(t)
+
+	src := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(src, "main.tf"), []byte(`
+variable "bucket_name" {
+  type = string
+}
+
+variable "region" {
+  default = "us-east-1"
+}
+
+module "logging" {
+  source = "./modules/logging"
+}
+
+resource "aws_s3_bucket" "main" {
+  bucket = var.bucket_name
+}
+`), 0o644))
+
+	dbPath, cleanup, err := autoInvokeLeylineParse(src)
+	require.NoError(t, err)
+	defer cleanup()
+
+	sg, err := graph.OpenSQLiteGraph(dbPath, &api.Topology{Version: api.SchemaVersion}, machetmpl.Render)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sg.Close()) }()
+
+	rows, err := sg.QueryRefs("SELECT token FROM node_refs ORDER BY token")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	var tokens []string
+	for rows.Next() {
+		var token string
+		require.NoError(t, rows.Scan(&token))
+		tokens = append(tokens, token)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{"env:bucket_name", "env:region", "mod:./modules/logging"}, tokens,
+		"the released Leyline artifact must serialize the registered Terraform address refs")
+
+	handler := makeFindCallersHandler(sg)
+	for _, token := range tokens {
+		result, err := handler(context.Background(), makeRequest(map[string]any{"token": token}))
+		require.NoError(t, err)
+		require.False(t, result.IsError, resultText(t, result))
+
+		var callers []string
+		require.NoError(t, json.Unmarshal([]byte(resultText(t, result)), &callers))
+		sort.Strings(callers)
+		assert.NotEmptyf(t, callers, "find_callers must expose the serialized %s ref", token)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	capnproto.org/go/capnp/v3 v3.1.0-alpha.2
 	github.com/BurntSushi/toml v1.6.0
 	github.com/RoaringBitmap/roaring v1.9.4
-	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.0
+	github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.1
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-git/go-billy/v5 v5.9.1
 	github.com/go-task/task/v3 v3.52.0

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAw
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.0 h1:JmWDAfLU87RAWfMLcohqZT3864rDuRRkRir86ieDjVU=
-github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.0/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.1 h1:frGexP6skm2J25wm9DSr4GvMSu4jvJSc5aMrJMZZRHc=
+github.com/agentic-research/ley-line-open/clients/go/leyline-schema v0.18.1/go.mod h1:/oPn4aVm3BOQiWPflmduFOKGjwHxBsGbzbuGqpxV28g=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew1u1fNQOlOtuGxQY=

--- a/internal/fixturedb/schema_leyline.go
+++ b/internal/fixturedb/schema_leyline.go
@@ -20,7 +20,7 @@ package fixturedb
 
 // leylineSchemaVersion is the ley-line-open release these statements were
 // derived from. The conformance test asserts the pinned binary still reports it.
-const leylineSchemaVersion = "v0.18.0"
+const leylineSchemaVersion = "v0.18.2"
 
 // leylineTables is the ley-line-owned subset fixtures model, keyed by table
 // name. Deliberately not every table ley-line writes — `capnp_blobs`,

--- a/internal/leyline/binary_pin.go
+++ b/internal/leyline/binary_pin.go
@@ -31,12 +31,12 @@ const BinaryVersion = leylineBinaryVersion
 // Regenerate on a leylineBinaryVersion bump:
 //
 //	gh release view <tag> --repo agentic-research/ley-line-open --json assets \
-//	  --jq '.assets[]|select(.name|startswith("leyline-"))|"\(.name) \(.digest)"'
+//	  --jq '.assets[]|select(.name|test("^leyline-(darwin|linux)-(amd64|arm64)$"))|"\(.name) \(.digest)"'
 var leylinePinnedSHA256 = map[string]string{
-	"darwin-amd64": "5c69900ffd18cf92e460d7e9b76d62fc7ee8974c1959a9ce64ee339dde2d933a",
-	"darwin-arm64": "324601b2893520e0f23bfb9e2d6156d52db8de736ff94d0fc7800b8131467614",
-	"linux-amd64":  "d383b0035588cab17c5d8dd58c53284f39257939451ad6a8130e1f710ca84523",
-	"linux-arm64":  "d62cb535a6760427928217c15a0dfd3a91b6c7908e8f23c4251449f5a0971e39",
+	"darwin-amd64": "b4186b9ad5091fb9113dcde3f89afb3ea9e046663e1fb99ecfda07082d2b9c73",
+	"darwin-arm64": "1b2898a883265457ea0b93976e9746e4d7874530df9ccc23d4b13881c34a5362",
+	"linux-amd64":  "bfbc6b8380f44e1e560709ec786862073213fd00f0854f4d02d8d8f2912a6b8b",
+	"linux-arm64":  "2854496f050fe8880d431da1ea1eef1ae61554fb2eb7303066e2e903542922e7",
 }
 
 // leylineVersionMatchesPin runs `<path> --version` and reports whether the

--- a/internal/leyline/binary_pin_test.go
+++ b/internal/leyline/binary_pin_test.go
@@ -72,7 +72,7 @@ func TestExtractSemver(t *testing.T) {
 }
 
 func TestPinnedBinaryReleaseMatchesAdoptedContract(t *testing.T) {
-	assert.Equal(t, "v0.18.0", leylineBinaryVersion)
+	assert.Equal(t, "v0.18.2", leylineBinaryVersion)
 }
 
 func TestPinnedBinarySHA256CoversSupportedPlatforms(t *testing.T) {

--- a/internal/leyline/socket.go
+++ b/internal/leyline/socket.go
@@ -949,30 +949,28 @@ func (c *SocketClient) Prioritize(files []string) error {
 // The go.mod leyline-schema pin only needs bumping when a schema module tag is
 // published. The parity gate enforces the [floor, binary] compatibility range.
 //
-// v0.15.1 -> v0.18.0 DOES NOT CROSS AN IR LINEAGE BOUNDARY. IR_SCHEMA_VERSION
-// is "merkle-ast-v2" at both tags, so node addresses are derived identically
-// and .db artifacts built by the previous pin stay valid — no forced rebuild,
-// unlike the v0.11.0 merkle-ast-v1 -> v2 bump (mache-438104). LLO's
-// compat_min_schema_version is still 0.4.1, below mache's stricter v0.6.0
-// floor, so the floor is unmoved. Nothing in v0.16.0-v0.18.0 touches _ast,
-// node_defs or node_refs; the release content is confinement grants, the CDC
-// target selector, and the --reset-arena fix.
+// v0.18.0 -> v0.18.2 DOES NOT CROSS AN IR LINEAGE BOUNDARY.
+// IR_SCHEMA_VERSION remains "merkle-ast-v2", so node addresses stay
+// comparable with artifacts built by the previous pin — unlike the v0.11.0
+// merkle-ast-v1 -> v2 bump (mache-438104). The wire major remains 1 and the
+// compatibility floor remains v0.6.0. The public schema client advances only
+// to v0.18.1: v0.18.2 is deliberately a binary-only release.
 //
-// Two of those exist because mache asked for them, and this bump is what
-// consumes them:
+// The emitted FACTS do change. v0.18.2 runs the registered HCL address-ref
+// extractor, so Terraform variable blocks and literal module sources finally
+// populate node_refs with env: and mod: tokens. LLO raises its extraction
+// epoch from 4 to 5 so an existing arena is reprojected; Mache also namespaces
+// its downloaded binary and source-projection cache by this exact pin. A
+// caller supplying a pre-built v0.18.0 .db may continue to read it, but must
+// re-run `leyline parse` to gain the repaired Terraform refs (mache-91beb0,
+// ley-line-open-55c1cc).
 //
-//   - --cdc-target reaches the daemon (ley-line-open-c3d746). Before it, the
-//     daemon hardcoded the `nodes` walk, so mache could not select the
-//     cost-neutral target no matter what it passed.
-//   - --reset-arena actually works (ley-line-open-e37e03). It previously
-//     failed even on a fresh arena, while being the remedy leyline's own
-//     cross-source refusal told operators to use.
-//
-// Doubles as this build's leyline schema-client version for the startup
+// This binary pin bounds the schema-client version accepted by the startup
 // wire-compat handshake (VerifyReachableDaemonVersion, mache-8kif): mache
 // queries the daemon's leyline_version op and refuses on a structural
-// mismatch.
-const leylineBinaryVersion = "v0.18.0"
+// mismatch. The actual client version is the independently tagged go.mod
+// dependency described below.
+const leylineBinaryVersion = "v0.18.2"
 
 // leylineSchemaCompatFloor is the OLDEST leyline-schema Go client version
 // whose wire format the pinned binary still accepts (ley-line-open's

--- a/server.json
+++ b/server.json
@@ -82,7 +82,7 @@
     "io.github.agentic-research.mache/required-deps": {
       "io.github.agentic-research/ley-line-open": {
         "purpose": "Required. `leyline parse` is mache's sole source parser since v0.18.0 (ADR-0012 step 4) — it produces the _ast tables every source projection reads. Also supplies _lsp_* tables (get_type_info, get_diagnostics) and embeddings (semantic_search).",
-        "minimum-version": "0.18.0"
+        "minimum-version": "0.18.2"
       }
     },
     "io.github.agentic-research.mache/source-acceptance": {


### PR DESCRIPTION
## Summary
- pin the official ley-line-open v0.18.2 daemon release and all four published SHA-256 asset digests
- pair binary v0.18.2 with the independently tagged Apache-2.0 schema client v0.18.1; wire major 1, compatibility floor v0.6.0, and merkle-ast-v2 remain unchanged
- add a real released-binary Terraform regression proving node_refs contains env:bucket_name, env:region, and mod:./modules/logging and that find_callers exposes each ref
- document that prebuilt v0.18.0 databases must be reparsed to gain the repaired facts

## Validation
- red: the Terraform regression failed against v0.18.0 with node_refs empty
- green: the regression passes against SHA-verified v0.18.2
- task leyline:verify-release
- task leyline:adoption
- task install
- task install:verify BIN=/Users/jamesgardner/.local/bin/mache
- task daemon:verify
- task ci

## Upstream release note
The LLO release postflight verified every public asset against SHA256SUMS, including all four daemon binaries, then failed only because its schema-module check requested the binary tag v0.18.2 instead of the intentionally retained schema tag v0.18.1. That release-tooling bug is tracked as ley-line-open-b52c9d and does not change these verified artifact bytes.

Bead: mache-91beb0