### PR TITLE
feat(refs): expose Go imports as gomod subgraph refs

### DIFF
--- a/cmd/cli_test.go
+++ b/cmd/cli_test.go
@@ -57,6 +57,40 @@ func TestBuild_ProducesDB(t *testing.T) {
 	assert.Greater(t, info.Size(), int64(0), "output DB should be non-empty")
 }
 
+// TestBuild_RegisteredGoImportRefsReachNodeRefs exercises the production
+// leyline-parse -> ASTWalker -> Engine path. The lower-level query tests prove
+// registration, but this guards the actual `mache build --schema go` output
+// consumed by graph callers: an import must survive as a typed gomod token in
+// node_refs, not merely exist in the temporary _ast database.
+func TestBuild_RegisteredGoImportRefsReachNodeRefs(t *testing.T) {
+	requirePinnedLeyline(t)
+	tmpDir := t.TempDir()
+	srcDir := filepath.Join(tmpDir, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "go.mod"),
+		[]byte("module example.com/app\n\ngo 1.23\n\nrequire example.com/acme/dep v0.0.0\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "main.go"), []byte(
+		"package main\n\nimport dep \"example.com/acme/dep\"\n\nfunc main() { dep.Run() }\n",
+	), 0o644))
+
+	outDB := filepath.Join(tmpDir, "out.db")
+	oldSchemaPath := schemaPath
+	schemaPath = "go"
+	defer func() { schemaPath = oldSchemaPath }()
+	require.NoError(t, buildCmd.RunE(buildCmd, []string{srcDir, outDB}))
+
+	db, err := sql.Open("sqlite", outDB)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	var refs int
+	require.NoError(t, db.QueryRow(
+		`SELECT count(*) FROM node_refs WHERE token = ?`, "gomod:example.com/acme/dep",
+	).Scan(&refs))
+	assert.GreaterOrEqual(t, refs, 1,
+		"mache build must project registered Go import refs into node_refs.token")
+}
+
 // inferGoFCASchema runs the SURVIVING source-code FCA inference path
 // (ADR-0012 step 4): leyline-parse the tree into an `_ast` db, run
 // pure-Go lattice.InferFromASTDB via inferLanguages, and unwrap the

--- a/internal/ingest/address_refs_test.go
+++ b/internal/ingest/address_refs_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/agentic-research/mache/api"
@@ -65,7 +66,13 @@ func main() {
 	require.NoError(t, err)
 	assert.Contains(t, refs, "env:DATABASE_URL")
 	assert.Contains(t, refs, "env:API_KEY")
-	assert.Len(t, refs, 2, "should find exactly two env refs")
+	var envRefs []string
+	for _, ref := range refs {
+		if strings.HasPrefix(ref, "env:") {
+			envRefs = append(envRefs, ref)
+		}
+	}
+	assert.Len(t, envRefs, 2, "should find exactly two env refs")
 }
 
 func TestExtractAddressRefs_GoOsGetenv_Dedup(t *testing.T) {
@@ -83,7 +90,13 @@ func main() {
 
 	refs, err := w.ExtractAddressRefs("main.go", "go")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"env:SAME_VAR"}, refs, "duplicates should be deduplicated")
+	var envRefs []string
+	for _, ref := range refs {
+		if strings.HasPrefix(ref, "env:") {
+			envRefs = append(envRefs, ref)
+		}
+	}
+	assert.Equal(t, []string{"env:SAME_VAR"}, envRefs, "duplicates should be deduplicated")
 }
 
 func TestExtractAddressRefs_GoOsGetenv_NotMatched(t *testing.T) {
@@ -101,7 +114,9 @@ func main() {
 
 	refs, err := w.ExtractAddressRefs("main.go", "go")
 	require.NoError(t, err)
-	assert.Empty(t, refs, "fmt.Println should not emit env refs")
+	for _, ref := range refs {
+		assert.NotContains(t, ref, "env:", "fmt.Println should not emit env refs")
+	}
 }
 
 func TestExtractAddressRefs_HCLVariable(t *testing.T) {
@@ -162,6 +177,79 @@ resource "aws_instance" "web" {
 		assert.NotContains(t, ref, "aws_instance", "resource source attributes must not produce mod refs")
 		assert.NotContains(t, ref, "this should not match", "non-module block sources must not match")
 	}
+}
+
+func TestExtractAddressRefs_GoImports(t *testing.T) {
+	w, _ := parseSourceToASTWalker(t, "go", map[string]string{
+		"main.go": `package main
+
+import (
+	std "fmt"
+	_ ` + "`example.com/blank`" + `
+	. "example.com/dot"
+	"example.com/normal"
+)
+
+func main() {
+	std.Println(normal.Name)
+	_ = Name
+}
+`,
+	})
+
+	refs, err := w.ExtractAddressRefs("main.go", "go")
+	require.NoError(t, err)
+	assert.Contains(t, refs, "gomod:fmt")
+	assert.Contains(t, refs, "gomod:example.com/blank")
+	assert.Contains(t, refs, "gomod:example.com/dot")
+	assert.Contains(t, refs, "gomod:example.com/normal")
+	assert.Len(t, refs, 4, "aliases, blank imports, dot imports, and raw literals must not affect import identity")
+}
+
+func TestEngine_AddressRefs_GoImportsReachNodeRefs(t *testing.T) {
+	bin, err := leyline.ResolveBinary(false)
+	if err != nil {
+		t.Skipf("pinned leyline unavailable (%v)", err)
+	}
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(`package main
+
+import dep "example.com/acme/dep"
+
+func UseDep() {
+	_ = dep.Value
+}
+`), 0o644))
+
+	schemaJSON := `{
+  "version": "v1",
+  "nodes": [{
+    "name": "functions",
+    "selector": "$",
+    "language": "go",
+    "children": [{"name": "{{.name}}", "selector": "(function_declaration name: (identifier) @name) @scope", "files": [{"name": "source", "content_template": "{{.scope}}"}]}]
+  }]
+}`
+	var schema api.Topology
+	require.NoError(t, json.Unmarshal([]byte(schemaJSON), &schema))
+
+	dbPath := filepath.Join(t.TempDir(), "ast.db")
+	out, err := exec.Command(bin, "parse", tmpDir, "-o", dbPath).CombinedOutput() //nolint:gosec // test-only, pinned binary
+	require.NoError(t, err, "leyline parse failed: %s", string(out))
+	astDB, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	defer func() { _ = astDB.Close() }()
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(&schema, store)
+	engine.SetASTWalker(NewASTWalker(astDB))
+	require.NoError(t, engine.Ingest(tmpDir))
+
+	callers, err := store.GetCallers("gomod:example.com/acme/dep")
+	require.NoError(t, err)
+	require.Len(t, callers, 1)
+	assert.Equal(t, "functions/UseDep/source", callers[0].ID)
 }
 
 // TestEngine_AddressRefs_CrossLanguageBridge — a mixed Go + HCL project where

--- a/internal/ingest/engine_languages.go
+++ b/internal/ingest/engine_languages.go
@@ -87,6 +87,19 @@ func init() {
 			(#eq? @_func "Getenv"))
 	`)
 
+	// Go imports become typed module references. The resolver layer decides
+	// whether the path is stdlib, part of the main module, or an external
+	// module; keeping the import path in node_refs preserves the cross-graph
+	// join even when resolution is deferred.
+	RegisterAddressRefQuery("go", "gomod", `
+		(import_spec
+			path: (interpreted_string_literal) @ref)
+	`)
+	RegisterAddressRefQuery("go", "gomod", `
+		(import_spec
+			path: (raw_string_literal) @ref)
+	`)
+
 	// HCL: variable "VAR_NAME" { ... } → env:VAR_NAME
 	RegisterAddressRefQuery("terraform", "env", `
 		(block

--- a/internal/ingest/git_test.go
+++ b/internal/ingest/git_test.go
@@ -17,6 +17,10 @@ func TestLoadGitCommits(t *testing.T) {
 	runGit(t, tmpDir, "init")
 	runGit(t, tmpDir, "config", "user.name", "Tester")
 	runGit(t, tmpDir, "config", "user.email", "test@example.com")
+	// Keep the fixture independent of a developer's global Git signing policy.
+	// Some machines enable commit.gpgsign globally, which makes this synthetic
+	// repository fail before LoadGitCommits is exercised.
+	runGit(t, tmpDir, "config", "commit.gpgsign", "false")
 
 	// Commit 1
 	runGit(t, tmpDir, "commit", "--allow-empty", "-m", "Initial commit")


### PR DESCRIPTION
## Summary
- project Go import specs into typed `gomod:` address refs during Mache ingestion
- route those refs through existing GoModResolver/resolve_ref subgraph joins
- add direct extraction and end-to-end node_refs/callers regressions
- make the temporary Git fixture independent of global commit signing policy

## Validation
- `task ci`
- `go test ./internal/ingest -run TestLoadGitCommits -count=1`
- pinned Ley-Line v0.18.2

Closes mache-da2a40