### PR TITLE
[mache-956488] doctor readiness check — liveness could not see a wedged daemon

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -77,15 +77,15 @@ func runDoctor(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("resolve working directory: %w", err)
 	}
 
-	daemonVersion, daemonErr := probeDaemonVersion(cmd.Context())
-
+	probe := probeDaemon(cmd.Context())
 	root := workspaceRootFor(cwd)
 
 	checks := []check{
 		checkLocalBinary(),
-		checkDaemon(daemonVersion, daemonErr),
+		checkDaemon(probe.version, probe.err),
 		checkCrashLoop(time.Now()),
-		checkVersionSkew(daemonVersion, daemonErr),
+		checkReadiness(probe.ready, probe.readyDetail),
+		checkVersionSkew(probe.version, probe.err),
 		checkPinnedLeyline(),
 		checkArena(root),
 		checkProjectRegistration(root),
@@ -541,6 +541,159 @@ func probeDaemonVersion(parent context.Context) (string, error) {
 		return "", err
 	}
 	return serverVersionFromMCPReply(raw)
+}
+
+// daemonProbe is everything one interrogation of the daemon learned. The two
+// questions travel together — readiness is only meaningful once liveness is
+// established — so they are asked and carried as one.
+type daemonProbe struct {
+	version     string
+	err         error
+	ready       readiness
+	readyDetail string
+}
+
+// probeDaemon asks both questions in the right order: nothing can be ready if
+// nothing is answering.
+func probeDaemon(ctx context.Context) daemonProbe {
+	version, err := probeDaemonVersion(ctx)
+	p := daemonProbe{version: version, err: err, ready: readyUnknown}
+	if err == nil {
+		p.ready, p.readyDetail = probeDaemonReadiness(ctx)
+	}
+	return p
+}
+
+// readiness is what a tool call actually found, as distinct from whether the
+// daemon answered a handshake.
+type readiness int
+
+const (
+	readyUnknown    readiness = iota // could not ask (daemon not answering)
+	readyServing                     // a real tool call returned real content
+	readyBuilding                    // answering, graph still being built — transient
+	readyNotServing                  // answering, but a tool call does not complete
+)
+
+// readinessProbeTimeout is deliberately longer than doctorProbeTimeout: the
+// handshake is a round trip, while a first tool call may legitimately be
+// building a graph. Past this, "still building" stops being an explanation.
+var readinessProbeTimeout = 10 * time.Second
+
+// probeDaemonReadiness answers the question `initialize` cannot: not "is
+// something listening" but "would a tool call actually return anything".
+//
+// Why the distinction is load-bearing (mache-956488): the MCP handshake is
+// served by the HTTP layer and answers immediately, while the per-session
+// graph is built lazily on first use. A daemon whose graph build is wedged
+// therefore answers `initialize` perfectly and serves nothing — and every
+// probe mache had, including the one gating `daemon start`, reported that
+// state as healthy. Liveness is not readiness.
+//
+// The probe runs a real get_overview on the session initialize allocated,
+// and classifies the reply rather than merely checking for an error, because
+// "graph is still loading" is a DIFFERENT state from "the call failed": one
+// resolves itself and one does not.
+func probeDaemonReadiness(parent context.Context) (readiness, string) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, readinessProbeTimeout)
+	defer cancel()
+
+	req, err := newInitializeRequest(ctx)
+	if err != nil {
+		return readyUnknown, err.Error()
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return readyUnknown, err.Error()
+	}
+	sid := resp.Header.Get("Mcp-Session-Id")
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return readyUnknown, fmt.Sprintf("initialize returned HTTP %d", resp.StatusCode)
+	}
+	if sid == "" {
+		return readyUnknown, "daemon issued no session id"
+	}
+	defer releaseMCPSession(parent, sid)
+
+	body, err := callOverview(ctx, sid)
+	if err != nil {
+		return readyNotServing, err.Error()
+	}
+	switch {
+	case strings.Contains(body, "still loading"), strings.Contains(body, "still be parsing"):
+		return readyBuilding, "the session graph is still being built"
+	case strings.Contains(body, `"result"`):
+		return readyServing, ""
+	default:
+		return readyNotServing, "a tool call returned neither a result nor a known building state"
+	}
+}
+
+// callOverview issues get_overview on an established session. get_overview is
+// the probe because it is the one tool that must touch the session's graph to
+// answer at all — a handshake-only daemon cannot fake it.
+func callOverview(ctx context.Context, sessionID string) (string, error) {
+	payload := []byte(`{"jsonrpc":"2.0","id":2,"method":"tools/call",` +
+		`"params":{"name":"get_overview","arguments":{}}}`)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, projcfg.MacheHTTPURL, bytes.NewReader(payload))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Session-Id", sessionID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("tool call returned HTTP %d", resp.StatusCode)
+	}
+	return string(raw), nil
+}
+
+// checkReadiness reports whether the daemon can actually serve, separately
+// from whether it answers.
+func checkReadiness(state readiness, detail string) check {
+	switch state {
+	case readyServing:
+		return check{
+			Name:   "readiness",
+			Status: statusOK,
+			Detail: "a real tool call returns content — the daemon is serving, not merely answering",
+		}
+	case readyBuilding:
+		return check{
+			Name:   "readiness",
+			Status: statusWarn,
+			Detail: "answering, but " + detail + " — tool calls will be thin until it finishes",
+		}
+	case readyNotServing:
+		return check{
+			Name:   "readiness",
+			Status: statusFail,
+			Detail: fmt.Sprintf(
+				"the daemon answers the MCP handshake but does not serve tool calls (%s) — "+
+					"liveness probes cannot see this state", detail),
+			Fix: "mache daemon restart   # then check " + daemonLogHint(),
+		}
+	default:
+		return check{
+			Name:   "readiness",
+			Status: statusWarn,
+			Detail: "not asked: the daemon is not answering (see the daemon check)",
+		}
+	}
 }
 
 // releaseMCPSession terminates the session initialize allocated. Errors are

--- a/cmd/doctor_readiness_test.go
+++ b/cmd/doctor_readiness_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentic-research/mache/internal/projcfg"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeMCPDaemon serves an MCP handshake and hands tool calls to toolReply.
+// It exists to build the state real probes could not see: a daemon that
+// answers initialize perfectly and cannot serve.
+func fakeMCPDaemon(t *testing.T, toolReply func(w http.ResponseWriter)) {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if r.Header.Get("Mcp-Session-Id") == "" {
+			// initialize: always healthy, which is the whole point.
+			w.Header().Set("Mcp-Session-Id", "mcp-session-fake")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":{"serverInfo":{"name":"mache","version":"9.9.9"}}}`))
+			return
+		}
+		toolReply(w)
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := projcfg.MacheHTTPURL
+	projcfg.MacheHTTPURL = srv.URL
+	t.Cleanup(func() { projcfg.MacheHTTPURL = prev })
+}
+
+// TestProbeDaemonReadiness_SeesWhatLivenessCannot is the point of the whole
+// check (mache-956488): every probe mache had asked the MCP handshake, which
+// the HTTP layer answers before any graph exists. A daemon whose graph build
+// is wedged therefore reported as healthy while serving nothing.
+func TestProbeDaemonReadiness_SeesWhatLivenessCannot(t *testing.T) {
+	t.Run("serving", func(t *testing.T) {
+		fakeMCPDaemon(t, func(w http.ResponseWriter) {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"{}"}]}}`))
+		})
+		state, _ := probeDaemonReadiness(context.Background())
+		assert.Equal(t, readyServing, state)
+	})
+
+	t.Run("building is distinguished from broken", func(t *testing.T) {
+		fakeMCPDaemon(t, func(w http.ResponseWriter) {
+			_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text","text":"Graph is still loading — the daemon is parsing source files."}]}}`))
+		})
+		state, detail := probeDaemonReadiness(context.Background())
+		require.Equal(t, readyBuilding, state,
+			"a building graph resolves itself; reporting it as broken would cry wolf on every fresh daemon")
+		assert.Contains(t, detail, "still being built")
+	})
+
+	t.Run("answers the handshake but cannot serve", func(t *testing.T) {
+		// THE case liveness cannot see: initialize is perfect, tool calls fail.
+		fakeMCPDaemon(t, func(w http.ResponseWriter) {
+			w.WriteHeader(http.StatusInternalServerError)
+		})
+		state, detail := probeDaemonReadiness(context.Background())
+		require.Equal(t, readyNotServing, state,
+			"a daemon that handshakes and cannot serve must NOT read as healthy — that is the whole defect")
+		assert.Contains(t, detail, "500")
+	})
+
+	t.Run("a wedged tool call is not-serving, not building", func(t *testing.T) {
+		readinessProbeTimeout = 300 * time.Millisecond
+		t.Cleanup(func() { readinessProbeTimeout = 10 * time.Second })
+		// Block until released rather than sleeping a guess: the handler must
+		// outlast the probe window without making the test wait for it. The
+		// release MUST be registered after fakeMCPDaemon — t.Cleanup is LIFO,
+		// so registering it first lets httptest's Close (which waits for
+		// in-flight handlers) run before the unblock and deadlock the test.
+		wedged := make(chan struct{})
+		fakeMCPDaemon(t, func(w http.ResponseWriter) { <-wedged })
+		t.Cleanup(func() { close(wedged) })
+		state, _ := probeDaemonReadiness(context.Background())
+		assert.Equal(t, readyNotServing, state,
+			"a tool call that never returns is the wedged-build symptom the bead describes")
+	})
+
+	t.Run("no daemon at all is unknown, not broken", func(t *testing.T) {
+		prev := projcfg.MacheHTTPURL
+		projcfg.MacheHTTPURL = "http://127.0.0.1:1/mcp" // nothing listens
+		t.Cleanup(func() { projcfg.MacheHTTPURL = prev })
+		state, _ := probeDaemonReadiness(context.Background())
+		assert.Equal(t, readyUnknown, state,
+			"absence of a daemon is the daemon check's business; readiness must not double-report it")
+	})
+}
+
+// TestCheckReadiness_StatusPerState pins how each state renders, because the
+// value of the check is that an operator can tell them apart at a glance.
+func TestCheckReadiness_StatusPerState(t *testing.T) {
+	assert.Equal(t, statusOK, checkReadiness(readyServing, "").Status)
+	assert.Equal(t, statusWarn, checkReadiness(readyBuilding, "building").Status,
+		"transient state must warn, not fail")
+	assert.Equal(t, statusWarn, checkReadiness(readyUnknown, "").Status)
+
+	broken := checkReadiness(readyNotServing, "HTTP 500")
+	assert.Equal(t, statusFail, broken.Status,
+		"answering-but-not-serving is a failure: something LOOKS healthy and is not")
+	assert.Contains(t, broken.Fix, "mache daemon restart")
+}


### PR DESCRIPTION
Closes the last item of this bead's hardening residue: **liveness is not readiness**.

Every probe mache had asked the MCP handshake. The HTTP layer answers `initialize` before any graph exists — per-session graphs are built lazily on first use — so a daemon whose graph build is wedged answers the handshake perfectly and serves nothing. Every probe reported that state as healthy.

doctor now runs a **real `get_overview`** on the session `initialize` allocated, and classifies the reply rather than merely checking for an error — because "graph is still loading" is a different state from "the call failed": one resolves itself, one does not.

| state | meaning | status |
|---|---|---|
| serving | a tool call returns content | ok |
| building | answering, graph still being built | warn (transient) |
| **not-serving** | **answers the handshake, serves nothing** | **FAIL** |
| unknown | no daemon answering | warn (the daemon check owns that) |

`get_overview` is the probe because it is the one tool that must touch the session's graph to answer at all — a handshake-only daemon cannot fake it. Its timeout is deliberately longer than the handshake's: a first tool call may legitimately be building, and past that window "still building" stops being an explanation.

The daemon verbs keep gating on **liveness**, which is the correct question for "did the supervisor start it". Readiness is a diagnosis, not a start gate.

## Verification

Tested against a fake MCP daemon that answers `initialize` perfectly and fails tool calls — the state real probes could not construct. Five cells including the wedged-call case (a handler that blocks past the probe window rather than sleeping a guess; the unblock is registered *after* the server so LIFO cleanup doesn't deadlock on httptest's in-flight wait — it did, first try).

Mutation-verified: `failed-call-reads-as-serving`, `building-reads-as-serving`, and `not-serving-only-warns` all killed.

The smell gate flagged `runDoctor` for fan-out; the two daemon probes are one concern (readiness is only meaningful once liveness is established) and now travel together as `probeDaemon`, which cuts the fan-out honestly rather than relocating it.

`task check` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs
