### PR TITLE
fix(schema): rust implementations is an index, not a 12KB blob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,22 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **Rust `implementations/<Type>` is an index, not a 12KB blob** (`mache-c777ef`).
+  The node selected `impl_item` and emitted `{{.scope}}` — the entire impl
+  block. Measured on ley-line's `rs/`: 43 such nodes holding **95,249 bytes**,
+  the largest 12,670 on its own. A 12KB "construct" defeats construct-granular
+  retrieval, since reading it costs more than reading most whole files, and it
+  bought nothing: every method body inside is already captured individually
+  under `functions/`. The index of which types have impls stays; the body goes.
+
+- **`task build` now rebuilds when a preset schema changes**. `sources:` listed
+  three of the four `//go:embed`ed assets, omitting `schema/presets/*.json`, so
+  editing a shipped schema left a **stale binary** that silently projected with
+  the old one — an edit that appears to do nothing. The Taskfile already carried
+  a comment asking for this list to be kept in sync after `mache-46af85` hit the
+  same failure with smell rules; it is now enforced by a test that fails when
+  any embed is unlisted.
+
 - **Engine `_file_level:` sentinels no longer leak into consumer-facing
   aggregations** (`mache-8f6abf`). `RefsMap()` feeds community detection,
   architecture layering and `mache pack`, and it returned the engine's

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -143,6 +143,7 @@ tasks:
       - "internal/smells/rules/*.json"
       - "internal/smells/schemas/sarif.tmpl"
       - "internal/buildinfo/version.txt"
+      - "schema/presets/*.json"
     generates:
       - "{{.BINARY_NAME}}"
     # The ldflags above inject GIT_COMMIT / GIT_VERSION — real build INPUTS

--- a/examples/rust-schema.json
+++ b/examples/rust-schema.json
@@ -84,13 +84,7 @@
         {
           "name": "{{.name}}",
           "selector": "(impl_item type: (type_identifier) @name) @scope",
-          "include": ["lsp"],
-          "files": [
-            {
-              "name": "source",
-              "content_template": "{{.scope}}"
-            }
-          ]
+          "include": ["lsp"]
         }
       ]
     },

--- a/internal/lint/embed_sources_test.go
+++ b/internal/lint/embed_sources_test.go
@@ -1,0 +1,129 @@
+package lint
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentic-research/mache/internal/testutil"
+)
+
+// TestBuildSourcesCoverEveryEmbed enforces what the Taskfile's `build` task
+// only asked for in a comment: every `//go:embed`ed asset must appear in
+// `sources:`.
+//
+// Task's up-to-date check skips the rebuild when no listed source changed, so
+// an unlisted embed means editing that asset leaves a STALE binary — one that
+// still carries the old bytes while the tree says otherwise. mache-46af85
+// recorded this once already, for the smell rules: the gate ran the stale
+// binary and produced phantom "NEW findings".
+//
+// The comment did not prevent a recurrence. `schema/presets/*.json` was
+// omitted, and editing a shipped preset schema silently projected with the old
+// one — the edit appeared to do nothing, which is the most expensive shape a
+// build bug can take. This test is that comment, enforced.
+func TestBuildSourcesCoverEveryEmbed(t *testing.T) {
+	root := testutil.MacheRepoRoot(t)
+
+	sources := buildTaskSources(t, filepath.Join(root, "Taskfile.yml"))
+	require.NotEmpty(t, sources, "could not parse the build task's sources: list")
+
+	for _, e := range embedDirectives(t, root) {
+		covered := false
+		for _, src := range sources {
+			if globCovers(src, e) {
+				covered = true
+				break
+			}
+		}
+		assert.Truef(t, covered,
+			"//go:embed %s is baked into the binary but matches no entry in the build task's "+
+				"sources: — editing it will NOT trigger a rebuild, so the binary keeps the old "+
+				"bytes while the tree says otherwise. Add a glob covering it.", e)
+	}
+}
+
+// buildTaskSources extracts the `sources:` list from the `build:` task.
+// Deliberately a small hand parser rather than a YAML dependency: the file is
+// the CI contract, and a test that reads it the way a human does catches
+// formatting the schema would silently accept.
+func buildTaskSources(t *testing.T, taskfile string) []string {
+	t.Helper()
+	data, err := os.ReadFile(taskfile)
+	require.NoError(t, err)
+
+	var out []string
+	inBuild, inSources := false, false
+	for _, line := range strings.Split(string(data), "\n") {
+		switch {
+		case strings.HasPrefix(line, "  build:"):
+			inBuild = true
+		case inBuild && strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "   ") &&
+			strings.HasSuffix(strings.TrimSpace(line), ":") && !strings.Contains(line, "build:"):
+			// Next task at the same indent ends the build task.
+			inBuild, inSources = false, false
+		case inBuild && strings.TrimSpace(line) == "sources:":
+			inSources = true
+		case inSources:
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "- ") {
+				out = append(out, strings.Trim(strings.TrimPrefix(trimmed, "- "), `"'`))
+			} else if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				inSources = false
+			}
+		}
+	}
+	return out
+}
+
+// embedDirectives returns every //go:embed pattern in non-test Go files,
+// resolved to a repo-relative path.
+func embedDirectives(t *testing.T, root string) []string {
+	t.Helper()
+	var out []string
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") ||
+			strings.HasSuffix(path, "_test.go") || strings.Contains(path, "/testdata/") {
+			return nil
+		}
+		data, rErr := os.ReadFile(path)
+		if rErr != nil {
+			return nil
+		}
+		dir, rErr := filepath.Rel(root, filepath.Dir(path))
+		if rErr != nil {
+			return nil
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			if pattern, ok := strings.CutPrefix(strings.TrimSpace(line), "//go:embed "); ok {
+				for _, p := range strings.Fields(pattern) {
+					out = append(out, filepath.Join(dir, p))
+				}
+			}
+		}
+		return nil
+	}))
+	require.NotEmpty(t, out, "found no //go:embed directives — the walk is broken, not the repo")
+	return out
+}
+
+// globCovers reports whether a sources: entry covers an embedded path. `**/*.go`
+// covers Go files at any depth; otherwise the directory must match and the
+// basename pattern must match.
+func globCovers(source, embedded string) bool {
+	if source == "**/*.go" {
+		return strings.HasSuffix(embedded, ".go")
+	}
+	if source == embedded {
+		return true
+	}
+	if filepath.Dir(source) != filepath.Dir(embedded) {
+		return false
+	}
+	ok, err := filepath.Match(filepath.Base(source), filepath.Base(embedded))
+	return err == nil && ok
+}

--- a/internal/schemainfer/preset_schemas_test.go
+++ b/internal/schemainfer/preset_schemas_test.go
@@ -112,3 +112,40 @@ func TestPresetNames(t *testing.T) {
 	// Must be sorted (doc contract)
 	assert.IsNonDecreasing(t, names)
 }
+
+// TestRustPreset_ImplementationsIsAnIndexNotABlob pins a granularity
+// invariant, not a style preference.
+//
+// `implementations/<Type>` selected `impl_item` and emitted `{{.scope}}`, which
+// is the ENTIRE impl block. Measured on ley-line's rs/ (36 files): 43 such
+// nodes holding 95,249 bytes, the largest 12,670 bytes on its own. A 12KB
+// "construct" defeats the point of construct-granular retrieval — reading it
+// costs more than reading most whole files.
+//
+// It bought nothing, either: every method body inside those blocks is already
+// captured individually under `functions/`, so the blob was a second, coarser
+// copy of content the projection already had.
+//
+// The node stays as an index of which types have impls; only the body goes.
+func TestRustPreset_ImplementationsIsAnIndexNotABlob(t *testing.T) {
+	topo, err := LoadPresetSchema("rust")
+	require.NoError(t, err)
+
+	var impl *api.Node
+	for i := range topo.Nodes {
+		if topo.Nodes[i].Name == "implementations" {
+			impl = &topo.Nodes[i]
+			break
+		}
+	}
+	require.NotNil(t, impl, "the rust preset must still expose an implementations index")
+	require.Len(t, impl.Children, 1)
+
+	child := impl.Children[0]
+	assert.Empty(t, child.Files,
+		"implementations/<Type> must not carry a source file: its selector matches the whole "+
+			"impl_item, so {{.scope}} is the entire block (95KB across 43 nodes on ley-line's rs/), "+
+			"duplicating method bodies already captured per-construct under functions/")
+	assert.Contains(t, child.Selector, "impl_item",
+		"the index itself must survive — this test is about the body, not the node")
+}

--- a/schema/presets/rust.json
+++ b/schema/presets/rust.json
@@ -120,13 +120,7 @@
         {
           "name": "{{.name}}",
           "selector": "(impl_item type: (type_identifier) @name) @scope",
-          "include": ["lsp"],
-          "files": [
-            {
-              "name": "source",
-              "content_template": "{{.scope}}"
-            }
-          ]
+          "include": ["lsp"]
         }
       ]
     },


### PR DESCRIPTION
Defect 2 of the bead is fixed. **Defect 1 is blocked upstream, not skipped** — filed as `ley-line-open-87ff3a` with the measurement.

## Defect 2 — the impl blob

`implementations/<Type>` selected `impl_item` and emitted `{{.scope}}`: the **entire impl block**. Measured on ley-line's `rs/` (36 files): 43 such nodes holding **95,249 bytes**, the largest **12,670 on its own**. A 12KB "construct" defeats construct-granular retrieval — reading it costs more than reading most whole files.

It bought nothing either. Every method body inside those blocks is already captured individually under `functions/` — verified, not assumed — so the blob was a second, coarser copy of content the projection already had.

The node stays as an index of which types have impls; only the body goes. **43 blobs → 0, 95,249 bytes → 0, 570 function nodes unchanged.**

## Two things found on the way

**The bead targets a file that doesn't ship.** `--schema rust`, project detection and serve all read `schema/presets/rust.json` (`//go:embed presets/*.json`). `examples/rust-schema.json` is documentation, and the two have already **drifted** — the preset carries an `imports` node the example lacks. Fixing only the example would have fixed nothing for any user. Both corrected here; the drift affects **4 of 9** example/preset pairs and is filed as `mache-8a892a`.

**`task build` did not rebuild when a preset changed.** `sources:` listed three of the four `//go:embed`ed assets and omitted `schema/presets/*.json`, so the first fix appeared to do nothing — the binary kept projecting with the old embedded schema while the tree said otherwise.

The Taskfile *already carried a comment* asking for that list to be kept in sync with the `//go:embed` directives, added after `mache-46af85` hit exactly this with smell rules and produced phantom "NEW findings" from a stale binary. A comment did not prevent the recurrence, so it is now a test: `TestBuildSourcesCoverEveryEmbed` fails, with the reason and the fix, when any embedded asset matches no `sources:` entry. Verified by deleting the entry again.

## Defect 1 — blocked, with proof

The `methods` node **is** expressible and works. This probe:

```
(impl_item type: (type_identifier) @receiver
           body: (declaration_list (function_item name: (identifier) @name) @scope))
```

produced **all 159** impl methods — exactly the 159 `function_item`s that `_ast` says live inside `impl_item`s — correctly paired per method (`AdaptiveRepair` got 7 distinct methods, not a cross-product), each with a per-method body of 61–1052 bytes instead of the blob.

But the receiver is wrong for trait impls. **`impl Default for AdaptiveRepair` came out as `Default.default`** — named by the trait.

Root cause is two layers deep. ASTWalker's selector parser discards field labels outright (`if strings.HasSuffix(tok, ":") { // field: label — skip it }`), so `type:` and `trait:` are the same query. That alone would be a mache fix — except `_ast` has **no field column** to restore it from:

```
node_id source_id node_kind start_byte end_byte start_row start_col end_row end_col node_hash blob_ord
```

Position is not a substitute: `impl Foo` has one `type_identifier`, `impl Trait for Foo` has two, `impl<T> Foo<T>` wraps it in `generic_type`.

Measured on the same corpus: 43 impls with bodies, **32 unambiguous, 9 (21%) would be misnamed**, 2 correct only by accident of the trait being a `scoped_type_identifier`. 21% wrong identifiers is worse than none — `Default.default` asserts a receiver that is not the type — so this waits on `ley-line-open-87ff3a`.

The bead's own prediction held exactly: *"Fixing the engine stops the data loss but leaves the names wrong."* The engine dedup **has** since been fixed — 18 `fn new(` now yield 18 distinct nodes, no silent drop — and what remains is precisely the naming.

Both new invariants are mutation-verified: restoring the blob fails the schema test, unlisting the preset embed fails the build-sources test. `task check` green.
