### PR TITLE
[mache-c0537f] test(ingest): growth-class gate — ExtractCalls must not issue more SQL as files grow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,34 @@ bumps may include breaking changes.
   It found two defects on its first run, in an API that had just been
   deliberately reviewed.
 
+### Added
+
+- **A growth-class gate on projection call extraction** (`mache-c0537f`). mache
+  shipped an `O(nodes²)` projection regression through green CI
+  (`mache-4f3840`); its fix was proven afterwards by a hand-built byte diff
+  between two binaries, and nothing has stood between that path and a repeat
+  since.
+
+  The gate asserts a **count of SQL statements**, not a duration.
+  `ExtractCalls` issues one query per registered call pattern, so the count is a
+  property of the language and must not vary with how many calls a file
+  contains — measured, it is **19 statements at 10, 100 and 500 calls**.
+  Reintroducing a per-scope query loop takes it to 519 at 500 calls, which the
+  gate reports with the numbers and the reason.
+
+  A count rather than a time because wall-clock cannot separate "slower runner"
+  from "wrong complexity class", and timing gates in this repo have receipts:
+  `baselines.toml` pins a `wall_ms` needing manual bumps, and `mache-434ecc` is
+  an open flake where a 50ms ticker missed an 80ms window under CI load.
+  `docs/reference/projection-performance.md` records the fix as `n^2.02` →
+  `n^0.92` and warns against quoting any single "N× faster" figure; a gate
+  pinning one wall-time would be that same mistake in gate form.
+
+  The sweep is per-**file** call count, not repo size — the quadratic was
+  per-file, so a large repo of small files barely exercises it. New package
+  `internal/sqlcount` provides the counter, calibrated by its own test against
+  known statement counts.
+
 ### Fixed
 
 - **A `go.work`/`go.mod` directive mismatch now fails first, and says what it

--- a/internal/ingest/ast_walker_bench_test.go
+++ b/internal/ingest/ast_walker_bench_test.go
@@ -15,12 +15,16 @@ import (
 //
 // The shape is intentionally similar to what `leyline parse` produces for
 // real Go source: each call gets a unique id with the kind chain encoded.
-func seedManyCalls(b *testing.B, dir string, nCalls int) *sql.DB {
-	b.Helper()
+// Takes testing.TB so the growth-class GATE
+// (ast_walker_growth_test.go) can seed the same shape the benchmark
+// measures — one fixture, so the gate cannot drift from what is
+// benchmarked (mache-c0537f).
+func seedManyCalls(tb testing.TB, dir string, nCalls int) *sql.DB {
+	tb.Helper()
 	dbPath := filepath.Join(dir, "bench.db")
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	if _, err := db.Exec(`
@@ -44,17 +48,17 @@ func seedManyCalls(b *testing.B, dir string, nCalls int) *sql.DB {
 
 		INSERT INTO _source VALUES ('main.go', 'go', '');
 	`); err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 
 	tx, err := db.Begin()
 	if err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 	run := func(query string, args ...any) {
-		b.Helper()
+		tb.Helper()
 		if _, err := tx.Exec(query, args...); err != nil {
-			b.Fatalf("seed: %v\nquery=%s\nargs=%v", err, query, args)
+			tb.Fatalf("seed: %v\nquery=%s\nargs=%v", err, query, args)
 		}
 	}
 	for i := range nCalls {
@@ -83,7 +87,7 @@ func seedManyCalls(b *testing.B, dir string, nCalls int) *sql.DB {
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		b.Fatal(err)
+		tb.Fatal(err)
 	}
 	return db
 }

--- a/internal/ingest/ast_walker_growth_test.go
+++ b/internal/ingest/ast_walker_growth_test.go
@@ -1,0 +1,116 @@
+package ingest
+
+import (
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/sqlcount"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Growth-class gate for the projection's call extraction (mache-c0537f).
+//
+// mache shipped an O(nodes²) projection regression through green CI
+// (mache-4f3840). Its correctness fix was proven afterwards by a hand-built
+// byte diff between two binaries, not by a test, and nothing has stood between
+// that path and a repeat since.
+//
+// What is asserted is a COUNT of SQL statements, not a duration. That choice is
+// the whole point:
+//
+//   - Wall-clock cannot separate "slower runner" from "wrong complexity class",
+//     and this repo has the receipts on timing gates — testdata/snapshots/
+//     baselines.toml pins a wall_ms that needs manual bumps, and mache-434ecc
+//     is an open flake where a 50ms ticker missed an 80ms window on a loaded
+//     CI runner.
+//   - The regression's actual signature is a query explosion. The old code ran
+//     a per-scope query loop; ExtractCalls now issues one query per registered
+//     pattern. That is a CONSTANT, and a constant is a far sharper thing to
+//     assert than a number of milliseconds.
+//
+// docs/reference/projection-performance.md records the fix as n^2.02 -> n^0.92
+// and warns against quoting any single "N× faster" figure, since the ratio is
+// itself proportional to n. A gate that pinned one wall-time would be that same
+// mistake in gate form.
+//
+// Note the sweep is per-FILE call count, not repo size. The quadratic was
+// per-file: a repo of many small files barely exercises it, which is why this
+// is a synthetic sweep rather than a large external corpus.
+
+// extractCallsStatements counts the SQL statements one ExtractCalls run issues
+// against a file seeded with nCalls calls.
+func extractCallsStatements(t *testing.T, nCalls int) int64 {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Seed through the ordinary driver: seeding work is not under measurement.
+	seeded := seedManyCalls(t, dir, nCalls)
+	require.NoError(t, seeded.Close())
+
+	// Re-open the same file through the counting driver, so the only statements
+	// recorded are the ones ExtractCalls itself issues.
+	sqlcount.RegisterDriver()
+	db, err := sql.Open(sqlcount.DriverName, filepath.Join(dir, "bench.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1)
+
+	w := NewASTWalker(db)
+	// Warm once: the first run may prepare statements or populate caches, and
+	// that one-time cost is not part of the growth question.
+	_, err = w.ExtractCalls("main.go", "go")
+	require.NoError(t, err)
+
+	count := sqlcount.Reset()
+	calls, err := w.ExtractCalls("main.go", "go")
+	require.NoError(t, err)
+	require.NotEmpty(t, calls, "fixture produced no calls — the gate would be vacuous")
+	return count()
+}
+
+// TestExtractCalls_StatementCountDoesNotGrowWithFileSize is the gate.
+//
+// ExtractCalls issues one query per registered call pattern, so the count is a
+// property of the LANGUAGE, not of the file. A file with fifty times the calls
+// must cost the same number of statements; anything else means a per-node or
+// per-scope loop came back.
+func TestExtractCalls_StatementCountDoesNotGrowWithFileSize(t *testing.T) {
+	const small, large = 10, 500
+
+	atSmall := extractCallsStatements(t, small)
+	atLarge := extractCallsStatements(t, large)
+
+	require.Positive(t, atSmall, "no statements counted — the instrument is not wired to the walker")
+	assert.Equal(t, atSmall, atLarge, fmt.Sprintf(
+		"ExtractCalls issued %d statements for %d calls but %d for %d.\n\n"+
+			"The count must be independent of how many calls a file contains — it is one\n"+
+			"query per registered call pattern. Growth here means a per-scope or per-node\n"+
+			"query loop is back, which is the shape of the O(nodes²) projection regression\n"+
+			"(mache-4f3840) that shipped through green CI once already.",
+		atSmall, small, atLarge, large))
+}
+
+// TestExtractCalls_ResultIsUnchangedAcrossSizes keeps the gate honest.
+//
+// A statement count is easy to hold flat by extracting nothing. This pins that
+// the work still happens: the call count scales with the file, even though the
+// statement count does not.
+func TestExtractCalls_ResultIsUnchangedAcrossSizes(t *testing.T) {
+	countCalls := func(n int) int {
+		dir := t.TempDir()
+		db := seedManyCalls(t, dir, n)
+		t.Cleanup(func() { _ = db.Close() })
+		calls, err := NewASTWalker(db).ExtractCalls("main.go", "go")
+		require.NoError(t, err)
+		return len(calls)
+	}
+
+	small, large := countCalls(10), countCalls(500)
+	assert.Greater(t, large, small,
+		"a bigger file must yield more calls — otherwise a flat statement count proves nothing")
+	assert.GreaterOrEqual(t, large, 400,
+		"the large fixture should extract on the order of its seeded call count")
+}

--- a/internal/sqlcount/sqlcount.go
+++ b/internal/sqlcount/sqlcount.go
@@ -1,0 +1,150 @@
+// Package sqlcount counts SQL statements, so a test can assert how work
+// GROWS rather than how long it takes.
+//
+// It lives in its own package because internal/testutil imports
+// internal/ingest, and the walker's own tests need this.
+package sqlcount
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"sync"
+	"sync/atomic"
+)
+
+// SQL QUERY counting for growth-class assertions.
+//
+// The point is to measure WORK in a machine-independent unit. mache already
+// shipped an O(nodes²) projection regression through green CI (mache-4f3840),
+// and wall-clock cannot tell a slow runner from a wrong complexity class —
+// while a statement count can. It also has no flake surface, which timing
+// gates in this repo demonstrably do.
+//
+// The wrapper deliberately implements ONLY driver.Conn. database/sql promotes
+// a connection to the fast path when it satisfies driver.QueryerContext, and
+// an embedded interface field does not carry that through a type assertion —
+// so every statement is forced down Prepare + Stmt, where exactly one count is
+// recorded per execution. Implementing both paths would double-count some
+// statements and not others, which is worse than counting nothing.
+
+var (
+	countingOnce sync.Once
+	sqlQueries   atomic.Int64
+)
+
+// Only QUERIES are counted, not writes.
+//
+// A query count is what separates O(n) from O(n²) on a read path: the
+// regression this exists to catch (mache-4f3840) was a per-scope SELECT loop.
+// Counting writes as well would mean implementing the exec half of
+// database/sql's dual interface, whose methods are structurally identical to
+// the query half and differ only in return type — real duplication, reported
+// as such by duplicate_code, bought for a number no gate currently reads.
+//
+// Writes pass through the embedded statement untouched. When a write-path gate
+// needs them, add the exec family then, with a use for the number.
+
+// DriverName is the driver to open a database with when the test wants
+// its statements counted. Call Register first.
+const DriverName = "sqlite-counting"
+
+// RegisterDriver registers the counting driver, once per process.
+//
+// The base driver is taken from an opened "sqlite" handle rather than
+// constructed, so this stays correct if the sqlite package changes how it
+// exports its driver.
+func RegisterDriver() {
+	countingOnce.Do(func() {
+		probe, err := sql.Open("sqlite", ":memory:")
+		if err != nil {
+			panic("testutil: open sqlite to borrow its driver: " + err.Error())
+		}
+		base := probe.Driver()
+		_ = probe.Close()
+		sql.Register(DriverName, &countingDriver{base: base})
+	})
+}
+
+// Reset zeroes the counter and returns a func reading it.
+//
+// The counter is process-global, so a test that reads it must not run in
+// parallel with another that issues statements.
+func Reset() (count func() int64) {
+	sqlQueries.Store(0)
+	return sqlQueries.Load
+}
+
+type countingDriver struct{ base driver.Driver }
+
+func (d *countingDriver) Open(name string) (driver.Conn, error) {
+	c, err := d.base.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &countingConn{Conn: c}, nil
+}
+
+// countingConn intentionally exposes only driver.Conn — see the file comment.
+type countingConn struct{ driver.Conn }
+
+func (c *countingConn) Prepare(query string) (driver.Stmt, error) {
+	s, err := c.Conn.Prepare(query)
+	return wrapStmt(s, err)
+}
+
+func (c *countingConn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	pc, ok := c.Conn.(driver.ConnPrepareContext)
+	if !ok {
+		return c.Prepare(query)
+	}
+	s, err := pc.PrepareContext(ctx, query)
+	return wrapStmt(s, err)
+}
+
+// wrapStmt resolves the context interfaces ONCE, when the statement is
+// created, and refuses the statement if either is missing.
+//
+// Checking per execution would repeat the same branch down four paths and put
+// it in the hot path; checking here fails loudly at the only moment the answer
+// can change. A wrapper that silently fell back to the deprecated methods
+// would count nothing on that path while appearing to work, which is the one
+// outcome worse than not counting at all.
+func wrapStmt(s driver.Stmt, err error) (driver.Stmt, error) {
+	if err != nil {
+		return nil, err
+	}
+	qc, ok := s.(driver.StmtQueryContext)
+	if !ok {
+		_ = s.Close()
+		return nil, fmt.Errorf("sqlcount: wrapped statement lacks StmtQueryContext; " +
+			"counting would silently miss executions")
+	}
+	return &countingStmt{Stmt: s, query: qc}, nil
+}
+
+type countingStmt struct {
+	driver.Stmt
+	query driver.StmtQueryContext
+}
+
+func (s *countingStmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	sqlQueries.Add(1)
+	return s.query.QueryContext(ctx, args)
+}
+
+// Query routes into QueryContext rather than into the wrapped statement, so
+// either entry point database/sql might choose counts exactly once and no
+// deprecated driver method is called downstream.
+func (s *countingStmt) Query(args []driver.Value) (driver.Rows, error) {
+	return s.QueryContext(context.Background(), valuesToNamed(args))
+}
+
+func valuesToNamed(args []driver.Value) []driver.NamedValue {
+	named := make([]driver.NamedValue, len(args))
+	for i, v := range args {
+		named[i] = driver.NamedValue{Ordinal: i + 1, Value: v}
+	}
+	return named
+}

--- a/internal/sqlcount/sqlcount_test.go
+++ b/internal/sqlcount/sqlcount_test.go
@@ -1,0 +1,55 @@
+package sqlcount_test
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/sqlcount"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	_ "modernc.org/sqlite"
+)
+
+// TestSQLCount_IsCalibrated checks the instrument before anything relies on
+// it. A statement counter that silently misses the fast path, or counts each
+// execution twice, would make every growth-class assertion built on it
+// meaningless — and it would look like it was working.
+func TestSQLCount_IsCalibrated(t *testing.T) {
+	sqlcount.RegisterDriver()
+	db, err := sql.Open(sqlcount.DriverName, ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	db.SetMaxOpenConns(1) // one conn, so nothing is executed on a second connection
+
+	_, err = db.Exec(`CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)`)
+	require.NoError(t, err)
+
+	for _, n := range []int{1, 5, 20} {
+		t.Run(fmt.Sprintf("%d statements", n), func(t *testing.T) {
+			count := sqlcount.Reset()
+			for i := range n {
+				rows, err := db.Query(`SELECT v FROM t WHERE id = ?`, i)
+				require.NoError(t, err)
+				require.NoError(t, rows.Close())
+			}
+			assert.Equal(t, int64(n), count(),
+				"exactly one count per query — no missed fast path, no double count")
+		})
+	}
+
+	t.Run("writes are deliberately not counted", func(t *testing.T) {
+		count := sqlcount.Reset()
+		for i := range 4 {
+			_, err := db.Exec(`INSERT INTO t (v) VALUES (?)`, fmt.Sprint(i))
+			require.NoError(t, err)
+		}
+		assert.Equal(t, int64(0), count(),
+			"only queries are counted — see the note in sqlcount.go on why writes are out")
+	})
+
+	t.Run("reset actually resets", func(t *testing.T) {
+		count := sqlcount.Reset()
+		assert.Equal(t, int64(0), count())
+	})
+}


### PR DESCRIPTION
## Why

The O(n²) projection regression shipped uncaught because nothing measured the **shape** of the work, only its duration — and duration gates flake on CI hardware (see mache-434ecc for the flusher timing flake this same week).

## What

A machine-independent growth-class gate: count SQL statements, not milliseconds.

- `internal/sqlcount` — a `database/sql` driver wrapper that counts queries. It embeds `driver.Conn` **only**, so `database/sql` cannot take the fast paths that bypass `Prepare`; every statement passes through exactly once (calibration test proves 1/5/20 count exactly). Query-only: no gate reads write counts, and the Exec twins were irreducible `duplicate_code`.
- `internal/ingest/ast_walker_growth_test.go` — `ExtractCalls` issues one query per registered pattern regardless of file size (19 today). A per-scope loop creeping back shows up as **519 at 500 calls**, on any machine. A second test asserts the result actually scales with input so the count test cannot pass vacuously.
- `seedManyCalls` takes `testing.TB` so the bench seeder serves the gate too (no duplicate seeder).

## Verified

`task check` green locally on f8cd99e; `task smells`: 0 NEW.

Closes mache-c0537f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs