### PR TITLE
[mache-088304] fix(ingest): DeleteFileNodes indexed by node_id — no more per-file full scan of node_refs/node_defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **`DeleteFileNodes` no longer scans the whole graph per file** (`mache-088304`).
+  `node_refs` and `node_defs` are keyed `(token, node_id)`, so deleting a
+  file's rows BY `node_id` had no index and planned as a full `SCAN` of a
+  table that grows with every file ingested — O(files × refs) on every build.
+  Measured on a fresh build of this repo (929 files), where every one of those
+  deletes was a no-op: 7.25 s, 34% of the whole schema projection, which drops
+  from 22.5 s to 15.4 s with `idx_refs_node` / `idx_defs_node` in place. The
+  same statements serve the incremental path, so re-parsing ONE changed file
+  in a large repo paid the same scan. A plan-shape test now asserts that no
+  statement `DeleteFileNodes` runs plans as a `SCAN` — the complexity class is
+  pinned machine-independently, where a timing gate would only have flaked.
+
 - **A `go.work`/`go.mod` directive mismatch now fails first, and says what it
   is** (`mache-49b87e`). When the two disagree, every `go` command aborts before
   doing anything, so the gate surfaced it as a wall of unrelated red checks —

--- a/internal/fixturedb/schema_standalone.go
+++ b/internal/fixturedb/schema_standalone.go
@@ -70,6 +70,8 @@ var standaloneTables = map[string]string{
 var standaloneIndexes = map[string]string{
 	"idx_parent_name": `CREATE INDEX idx_parent_name ON nodes(parent_id, name)`,
 	"idx_source_file": `CREATE INDEX idx_source_file ON nodes(source_file)`,
+	"idx_refs_node":   `CREATE INDEX idx_refs_node ON node_refs(node_id)`,
+	"idx_defs_node":   `CREATE INDEX idx_defs_node ON node_defs(node_id)`,
 }
 
 // standaloneViews are the PERSISTENT v_defs / v_refs SQLiteWriter installs.

--- a/internal/fixturedb/schema_standalone_conformance_test.go
+++ b/internal/fixturedb/schema_standalone_conformance_test.go
@@ -5,8 +5,10 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"maps"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"testing"
 
@@ -17,9 +19,14 @@ import (
 // The other derivation, re-run — and unlike the ley-line one this needs no
 // binary, so it is UNGATED and runs on every `go test ./...`.
 //
-// It reads internal/ingest/sqlite_writer.go's own schema literal out of the Go
-// AST, executes it into a scratch database, and diffs sqlite_master against
-// [standaloneTables] / [standaloneIndexes] / [standaloneViews].
+// It reads the DDL NewSQLiteWriter executes out of internal/ingest/sqlite_writer.go's
+// Go AST — the non-literal `db.Exec(...)` argument, with each identifier resolved
+// to its package-level string constant — executes it into a scratch database,
+// and diffs sqlite_master against [standaloneTables] / [standaloneIndexes] /
+// [standaloneViews] in BOTH directions: every object the fixture models must
+// match the writer, and every object the writer creates must be modelled. The
+// second direction is what catches an index added to the writer and forgotten
+// here — a fixture missing it plans queries differently from a real .db.
 //
 // Reading the AST rather than importing internal/ingest is deliberate twice
 // over: internal/ingest pulls tree-sitter and therefore CGO, which fixtures must
@@ -27,6 +34,13 @@ import (
 // repo ratchets against (internal/lint's regexpAllowlist).
 func TestStandaloneSchema_MatchesSQLiteWriter(t *testing.T) {
 	got := deriveWriterSchema(t)
+
+	var modelled []string
+	for _, m := range []map[string]string{standaloneTables, standaloneIndexes, standaloneViews} {
+		modelled = append(modelled, slices.Sorted(maps.Keys(m))...)
+	}
+	assert.ElementsMatch(t, modelled, sortedNames(got),
+		"objects created by ingest.SQLiteWriter and objects modelled by the Standalone fixture differ")
 
 	for name, want := range standaloneTables {
 		g, ok := got[name]
@@ -67,7 +81,8 @@ func TestStandaloneSchema_HasNoProducerTables(t *testing.T) {
 	assert.Zero(t, n, "a Standalone fixture with no AST rows must have no _ast table")
 }
 
-// deriveWriterSchema pulls the schema literal out of NewSQLiteWriter and runs it.
+// deriveWriterSchema evaluates the DDL expression NewSQLiteWriter hands to
+// db.Exec and runs it.
 func deriveWriterSchema(t *testing.T) map[string]string {
 	t.Helper()
 
@@ -79,33 +94,57 @@ func deriveWriterSchema(t *testing.T) map[string]string {
 	file, err := parser.ParseFile(token.NewFileSet(), writerPath, nil, 0)
 	require.NoError(t, err, "parse %s", writerPath)
 
-	var ddl string
-	ast.Inspect(file, func(n ast.Node) bool {
-		asn, isAssign := n.(*ast.AssignStmt)
-		if !isAssign || len(asn.Lhs) != 1 || len(asn.Rhs) != 1 {
-			return true
+	consts := map[string]string{}
+	for _, decl := range file.Decls {
+		gd, isGen := decl.(*ast.GenDecl)
+		if !isGen || gd.Tok != token.CONST {
+			continue
 		}
-		ident, isIdent := asn.Lhs[0].(*ast.Ident)
-		if !isIdent || ident.Name != "schema" {
-			return true
+		for _, spec := range gd.Specs {
+			vs := spec.(*ast.ValueSpec)
+			for i, name := range vs.Names {
+				if lit, isLit := vs.Values[i].(*ast.BasicLit); isLit && lit.Kind == token.STRING {
+					unquoted, uerr := strconv.Unquote(lit.Value)
+					require.NoError(t, uerr)
+					consts[name.Name] = unquoted
+				}
+			}
 		}
-		lit, isLit := asn.Rhs[0].(*ast.BasicLit)
-		if !isLit || lit.Kind != token.STRING {
-			return true
+	}
+
+	var ddl []string
+	for _, decl := range file.Decls {
+		fn, isFunc := decl.(*ast.FuncDecl)
+		if !isFunc || fn.Name.Name != "NewSQLiteWriter" {
+			continue
 		}
-		unquoted, uerr := strconv.Unquote(lit.Value)
-		require.NoError(t, uerr)
-		ddl = unquoted
-		return false
-	})
-	require.NotEmpty(t, ddl,
-		"could not find the `schema := ...` literal in %s — if the writer was "+
-			"restructured, update this derivation rather than snapshotting its output", writerPath)
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			call, isCall := n.(*ast.CallExpr)
+			if !isCall || len(call.Args) != 1 {
+				return true
+			}
+			sel, isSel := call.Fun.(*ast.SelectorExpr)
+			if !isSel || sel.Sel.Name != "Exec" {
+				return true
+			}
+			// PRAGMAs and the ALTERs are literals; the schema is the one
+			// expression built from named constants.
+			if _, isLit := call.Args[0].(*ast.BasicLit); isLit {
+				return true
+			}
+			ddl = append(ddl, evalStringExpr(t, call.Args[0], consts))
+			return true
+		})
+	}
+	require.Len(t, ddl, 1,
+		"expected exactly one non-literal db.Exec(...) in NewSQLiteWriter in %s — if the "+
+			"writer was restructured, update this derivation rather than snapshotting its output",
+		writerPath)
 
 	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "writer.db"))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
-	_, err = db.Exec(ddl)
+	_, err = db.Exec(ddl[0])
 	require.NoError(t, err)
 
 	rows, err := db.Query(`SELECT name, sql FROM sqlite_master WHERE sql IS NOT NULL`)
@@ -120,4 +159,29 @@ func deriveWriterSchema(t *testing.T) map[string]string {
 	}
 	require.NoError(t, rows.Err())
 	return out
+}
+
+// evalStringExpr resolves a string expression made of literals, package-level
+// string constants and `+` concatenation — the grammar NewSQLiteWriter's
+// schema argument is written in.
+func evalStringExpr(t *testing.T, e ast.Expr, consts map[string]string) string {
+	t.Helper()
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		require.Equal(t, token.STRING, x.Kind)
+		v, err := strconv.Unquote(x.Value)
+		require.NoError(t, err)
+		return v
+	case *ast.Ident:
+		v, ok := consts[x.Name]
+		require.True(t, ok, "%s is not a package-level string constant", x.Name)
+		return v
+	case *ast.BinaryExpr:
+		require.Equal(t, token.ADD, x.Op)
+		return evalStringExpr(t, x.X, consts) + evalStringExpr(t, x.Y, consts)
+	case *ast.ParenExpr:
+		return evalStringExpr(t, x.X, consts)
+	}
+	require.Failf(t, "unsupported expression", "%T in NewSQLiteWriter's schema argument", e)
+	return ""
 }

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -95,6 +95,17 @@ func NewSQLiteWriter(dbPath string) (*SQLiteWriter, error) {
 		PRIMARY KEY (token, node_id)
 	) WITHOUT ROWID;
 
+	-- node_id-leading indexes for DeleteFileNodes. The primary keys lead
+	-- with token, so a delete BY node_id has no index to use and plans as a
+	-- full SCAN of a table that grows with every file ingested — O(files x
+	-- refs) on every build, and 34% of the whole projection of this repo
+	-- measured on a fresh build where each delete was a no-op. The same
+	-- statements serve the incremental path, so re-parsing ONE changed file
+	-- in a big repo paid the same scan (mache-088304). Named as leyline
+	-- names its own copy of the first (internal/fixturedb/schema_leyline.go).
+	CREATE INDEX IF NOT EXISTS idx_refs_node ON node_refs(node_id);
+	CREATE INDEX IF NOT EXISTS idx_defs_node ON node_defs(node_id);
+
 	CREATE TABLE IF NOT EXISTS file_index (
 		path TEXT PRIMARY KEY,
 		mod_time INTEGER NOT NULL,
@@ -562,19 +573,31 @@ func (w *SQLiteWriter) AddFileChildren(parent *graph.Node, files []*graph.Node) 
 	w.AddNode(parent)
 }
 
+// deleteFileNodesSQL is the statement sequence DeleteFileNodes executes, in
+// order: refs and defs for the file's nodes, then the nodes. Package-level so
+// the plan-shape test asserts the plans of the statements that actually run
+// rather than of a copy that can drift (mache-088304).
+var deleteFileNodesSQL = [...]string{
+	`DELETE FROM node_refs WHERE node_id IN (
+		SELECT id FROM nodes WHERE source_file = ?
+	)`,
+	`DELETE FROM node_defs WHERE node_id IN (
+		SELECT id FROM nodes WHERE source_file = ?
+	)`,
+	`DELETE FROM nodes WHERE source_file = ?`,
+}
+
+// DeleteFileNodes removes every node that originated from filePath, with its
+// refs and defs. Every statement is index-driven (idx_source_file on the
+// subquery, idx_refs_node / idx_defs_node on the outer delete), so the cost
+// is proportional to the file's own rows, not to the size of the graph.
 func (w *SQLiteWriter) DeleteFileNodes(filePath string) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	// Delete refs and defs for nodes originating from this file,
-	// then delete the nodes themselves using the indexed source_file column.
-	_, _ = w.tx.Exec(`DELETE FROM node_refs WHERE node_id IN (
-		SELECT id FROM nodes WHERE source_file = ?
-	)`, filePath)
-	_, _ = w.tx.Exec(`DELETE FROM node_defs WHERE node_id IN (
-		SELECT id FROM nodes WHERE source_file = ?
-	)`, filePath)
-	_, _ = w.tx.Exec(`DELETE FROM nodes WHERE source_file = ?`, filePath)
+	for _, q := range deleteFileNodesSQL {
+		_, _ = w.tx.Exec(q, filePath)
+	}
 }
 
 func (w *SQLiteWriter) Close() error {

--- a/internal/ingest/sqlite_writer.go
+++ b/internal/ingest/sqlite_writer.go
@@ -33,6 +33,91 @@ type SQLiteWriter struct {
 	mu           sync.Mutex
 }
 
+// writerTablesDDL is the base table/index schema NewSQLiteWriter installs.
+// The canonical views live in CanonicalViewsDDL (one definition, executed
+// here and by EnsureCanonicalViews for databases some other producer wrote).
+const writerTablesDDL = `
+CREATE TABLE IF NOT EXISTS nodes (
+	id TEXT PRIMARY KEY,
+	parent_id TEXT,
+	name TEXT NOT NULL,
+	kind INTEGER NOT NULL,
+	size INTEGER DEFAULT 0,
+	mtime INTEGER NOT NULL,
+	record_id TEXT,
+	-- TEXT, not JSON. SQLite has no JSON storage class, and "JSON" contains
+	-- none of the substrings that select an affinity, so it falls through to
+	-- NUMERIC — which silently rewrites any TEXT value that parses as a
+	-- number ('007' -> 7, '1.10' -> 1.1). Ingest binds n.Data as []byte and
+	-- BLOBs bypass the conversion, which is why this stayed latent;
+	-- WritableGraph.UpdateRecord binds string(content) and does not
+	-- (mache-4b8a42).
+	record TEXT,
+	source_file TEXT,
+	-- context holds the imports/types visible to a construct scope,
+	-- served by the context virtual file (vfs.ContextHandler). Set at
+	-- ingest (engine_walk.go) and must survive the SQLite round-trip so
+	-- cat-context works on a mounted .db (mache-b8fe72).
+	context BLOB,
+	-- props holds the node's Properties (lang/pkg/imports/location/ast_*)
+	-- as real nested JSON, so json_extract(props,'$.lang') is queryable.
+	-- These were previously base64'd into the record column, which also
+	-- made that column mean three different things (mache-90b89b).
+	props JSON
+);
+CREATE INDEX IF NOT EXISTS idx_parent_name ON nodes(parent_id, name);
+CREATE INDEX IF NOT EXISTS idx_source_file ON nodes(source_file);
+
+CREATE TABLE IF NOT EXISTS node_refs (
+	token TEXT,
+	node_id TEXT,
+	PRIMARY KEY (token, node_id)
+) WITHOUT ROWID;
+
+CREATE TABLE IF NOT EXISTS node_defs (
+	token TEXT,
+	node_id TEXT,
+	PRIMARY KEY (token, node_id)
+) WITHOUT ROWID;
+
+-- node_id-leading indexes for DeleteFileNodes. The primary keys lead
+-- with token, so a delete BY node_id has no index to use and plans as a
+-- full SCAN of a table that grows with every file ingested — O(files x
+-- refs) on every build, and 34% of the whole projection of this repo
+-- measured on a fresh build where each delete was a no-op. The same
+-- statements serve the incremental path, so re-parsing ONE changed file
+-- in a big repo paid the same scan (mache-088304). Named as leyline
+-- names its own copy of the first (internal/fixturedb/schema_leyline.go).
+CREATE INDEX IF NOT EXISTS idx_refs_node ON node_refs(node_id);
+CREATE INDEX IF NOT EXISTS idx_defs_node ON node_defs(node_id);
+
+CREATE TABLE IF NOT EXISTS file_index (
+	path TEXT PRIMARY KEY,
+	mod_time INTEGER NOT NULL,
+	size INTEGER NOT NULL
+);
+
+-- _index_coverage records which producer indexed each source file at
+-- which fidelity level, per ADR-0013. Consumers that need to
+-- distinguish "no binding row exists" from "no binding row was looked
+-- for" join against this. PRIMARY KEY (source_id, producer) means a
+-- re-index replaces the prior coverage row for that producer.
+--
+-- fidelity values: 'mention' (tree-sitter), 'binding' (LSP),
+-- 'reachability' (future SSA / call-graph).
+-- complete: 1 if the indexer claims full coverage of the source,
+-- 0 if it gave up partway (out-of-memory, timeout, parse errors
+-- prevented analysis, etc.).
+CREATE TABLE IF NOT EXISTS _index_coverage (
+	source_id TEXT NOT NULL,
+	producer TEXT NOT NULL,
+	fidelity TEXT NOT NULL,
+	indexed_at INTEGER NOT NULL,
+	complete INTEGER NOT NULL,
+	PRIMARY KEY (source_id, producer)
+) WITHOUT ROWID;
+`
+
 // NewSQLiteWriter creates a new writer and initializes the schema.
 func NewSQLiteWriter(dbPath string) (*SQLiteWriter, error) {
 	db, err := sql.Open("sqlite", dbPath)
@@ -50,112 +135,7 @@ func NewSQLiteWriter(dbPath string) (*SQLiteWriter, error) {
 		return nil, err
 	}
 
-	// 1. Create Tables
-	schema := `
-	CREATE TABLE IF NOT EXISTS nodes (
-		id TEXT PRIMARY KEY,
-		parent_id TEXT,
-		name TEXT NOT NULL,
-		kind INTEGER NOT NULL,
-		size INTEGER DEFAULT 0,
-		mtime INTEGER NOT NULL,
-		record_id TEXT,
-		-- TEXT, not JSON. SQLite has no JSON storage class, and "JSON" contains
-		-- none of the substrings that select an affinity, so it falls through to
-		-- NUMERIC — which silently rewrites any TEXT value that parses as a
-		-- number ('007' -> 7, '1.10' -> 1.1). Ingest binds n.Data as []byte and
-		-- BLOBs bypass the conversion, which is why this stayed latent;
-		-- WritableGraph.UpdateRecord binds string(content) and does not
-		-- (mache-4b8a42).
-		record TEXT,
-		source_file TEXT,
-		-- context holds the imports/types visible to a construct scope,
-		-- served by the context virtual file (vfs.ContextHandler). Set at
-		-- ingest (engine_walk.go) and must survive the SQLite round-trip so
-		-- cat-context works on a mounted .db (mache-b8fe72).
-		context BLOB,
-		-- props holds the node's Properties (lang/pkg/imports/location/ast_*)
-		-- as real nested JSON, so json_extract(props,'$.lang') is queryable.
-		-- These were previously base64'd into the record column, which also
-		-- made that column mean three different things (mache-90b89b).
-		props JSON
-	);
-	CREATE INDEX IF NOT EXISTS idx_parent_name ON nodes(parent_id, name);
-	CREATE INDEX IF NOT EXISTS idx_source_file ON nodes(source_file);
-
-	CREATE TABLE IF NOT EXISTS node_refs (
-		token TEXT,
-		node_id TEXT,
-		PRIMARY KEY (token, node_id)
-	) WITHOUT ROWID;
-
-	CREATE TABLE IF NOT EXISTS node_defs (
-		token TEXT,
-		node_id TEXT,
-		PRIMARY KEY (token, node_id)
-	) WITHOUT ROWID;
-
-	-- node_id-leading indexes for DeleteFileNodes. The primary keys lead
-	-- with token, so a delete BY node_id has no index to use and plans as a
-	-- full SCAN of a table that grows with every file ingested — O(files x
-	-- refs) on every build, and 34% of the whole projection of this repo
-	-- measured on a fresh build where each delete was a no-op. The same
-	-- statements serve the incremental path, so re-parsing ONE changed file
-	-- in a big repo paid the same scan (mache-088304). Named as leyline
-	-- names its own copy of the first (internal/fixturedb/schema_leyline.go).
-	CREATE INDEX IF NOT EXISTS idx_refs_node ON node_refs(node_id);
-	CREATE INDEX IF NOT EXISTS idx_defs_node ON node_defs(node_id);
-
-	CREATE TABLE IF NOT EXISTS file_index (
-		path TEXT PRIMARY KEY,
-		mod_time INTEGER NOT NULL,
-		size INTEGER NOT NULL
-	);
-
-	-- _index_coverage records which producer indexed each source file at
-	-- which fidelity level, per ADR-0013. Consumers that need to
-	-- distinguish "no binding row exists" from "no binding row was looked
-	-- for" join against this. PRIMARY KEY (source_id, producer) means a
-	-- re-index replaces the prior coverage row for that producer.
-	--
-	-- fidelity values: 'mention' (tree-sitter), 'binding' (LSP),
-	-- 'reachability' (future SSA / call-graph).
-	-- complete: 1 if the indexer claims full coverage of the source,
-	-- 0 if it gave up partway (out-of-memory, timeout, parse errors
-	-- prevented analysis, etc.).
-	CREATE TABLE IF NOT EXISTS _index_coverage (
-		source_id TEXT NOT NULL,
-		producer TEXT NOT NULL,
-		fidelity TEXT NOT NULL,
-		indexed_at INTEGER NOT NULL,
-		complete INTEGER NOT NULL,
-		PRIMARY KEY (source_id, producer)
-	) WITHOUT ROWID;
-
-	-- v_defs / v_refs: canonical views per ADR-0013 Step 3. Consumers
-	-- query these instead of node_defs / node_refs directly so they're
-	-- producer-agnostic — when LSP-resolved rows land (Step 1, sister
-	-- bead ley-line-453f7e), the view definition expands with a
-	-- UNION ALL and consumer SQL doesn't change.
-	--
-	-- Today the views surface mention-fidelity rows only; Step 1 adds
-	-- referrer_node_id + ref_token columns to _lsp_refs so the binding
-	-- rows can be unioned in trivially. The fidelity column is the
-	-- forward-looking marker — currently always 'mention' from these
-	-- producers.
-	CREATE VIEW IF NOT EXISTS v_defs AS
-		SELECT token, node_id, 'mention' AS fidelity FROM node_defs;
-
-	CREATE VIEW IF NOT EXISTS v_refs AS
-		SELECT node_id AS referrer_node_id,
-		       token,
-		       NULL  AS target_node_id,
-		       NULL  AS ref_uri,
-		       NULL  AS ref_line,
-		       'mention' AS fidelity
-		FROM node_refs;
-	`
-	if _, err := db.Exec(schema); err != nil {
+	if _, err := db.Exec(writerTablesDDL + CanonicalViewsDDL); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("create schema: %w", err)
 	}

--- a/internal/ingest/sqlite_writer_test.go
+++ b/internal/ingest/sqlite_writer_test.go
@@ -3,8 +3,10 @@ package ingest
 import (
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -475,4 +477,90 @@ func TestEnsureCanonicalViews_Idempotent(t *testing.T) {
 	assert.Equal(t, "mention", defs[0].fidelity)
 
 	require.NoError(t, db.Close())
+}
+
+// newDeleteFixtureWriter opens a fresh writer holding nodes, refs and defs
+// from two source files, so a delete of one can be checked against the
+// survival of the other.
+func newDeleteFixtureWriter(t *testing.T) (*SQLiteWriter, string, string) {
+	t.Helper()
+	w, err := NewSQLiteWriter(filepath.Join(t.TempDir(), "test.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	fileA, fileB := "/src/a.go", "/src/b.go"
+	for i, f := range []string{fileA, fileB} {
+		id := fmt.Sprintf("pkg/functions/F%d", i)
+		w.AddNode(&graph.Node{
+			ID:      id,
+			ModTime: time.Unix(1700000000, 0),
+			Origin:  &graph.SourceOrigin{FilePath: f},
+		})
+		require.NoError(t, w.AddRef("callee", id))
+		require.NoError(t, w.AddDef(fmt.Sprintf("F%d", i), id))
+	}
+	return w, fileA, fileB
+}
+
+// countRows counts rows in table matching where, inside the writer's open
+// transaction so the test sees uncommitted state exactly as the engine does.
+func countRows(t *testing.T, w *SQLiteWriter, table, where string, args ...any) int {
+	t.Helper()
+	var n int
+	require.NoError(t, w.tx.QueryRow("SELECT COUNT(*) FROM "+table+" WHERE "+where, args...).Scan(&n))
+	return n
+}
+
+// TestSQLiteWriter_DeleteFileNodes_RemovesOnlyThatFile is the behavioural
+// contract of the incremental "atomic swap" (engine_treesitter.go step 8): a
+// re-parsed file's old nodes, refs and defs go; every other file's stay. It
+// was previously untested on the SQLite path — the call sites were marked
+// coverage:ignore (mache-088304).
+func TestSQLiteWriter_DeleteFileNodes_RemovesOnlyThatFile(t *testing.T) {
+	w, fileA, fileB := newDeleteFixtureWriter(t)
+
+	w.DeleteFileNodes(fileA)
+
+	assert.Equal(t, 0, countRows(t, w, "nodes", "source_file = ?", fileA), "a.go's node must be gone")
+	assert.Equal(t, 0, countRows(t, w, "node_refs", "node_id = ?", "pkg/functions/F0"), "a.go's ref must be gone")
+	assert.Equal(t, 0, countRows(t, w, "node_defs", "node_id = ?", "pkg/functions/F0"), "a.go's def must be gone")
+
+	assert.Equal(t, 1, countRows(t, w, "nodes", "source_file = ?", fileB), "b.go's node must survive")
+	assert.Equal(t, 1, countRows(t, w, "node_refs", "node_id = ?", "pkg/functions/F1"), "b.go's ref must survive")
+	assert.Equal(t, 1, countRows(t, w, "node_defs", "node_id = ?", "pkg/functions/F1"), "b.go's def must survive")
+}
+
+// TestSQLiteWriter_DeleteFileNodes_EveryStatementIsIndexed pins the
+// complexity class of DeleteFileNodes, machine-independently: no statement
+// it runs may plan as a full table SCAN. Before idx_refs_node / idx_defs_node
+// existed, the ref and def deletes scanned tables that grow with every file
+// ingested — O(files x refs) on a fresh build, and the same cost to re-parse
+// one changed file (mache-088304). A timing test would have caught this only
+// on a big repo and only on a quiet machine; the plan is the same everywhere.
+//
+// The statements come from deleteFileNodesSQL — the array DeleteFileNodes
+// executes — so this cannot pass against a stale copy of the SQL.
+func TestSQLiteWriter_DeleteFileNodes_EveryStatementIsIndexed(t *testing.T) {
+	w, fileA, _ := newDeleteFixtureWriter(t)
+
+	for _, q := range deleteFileNodesSQL {
+		rows, err := w.tx.Query("EXPLAIN QUERY PLAN "+q, fileA)
+		require.NoError(t, err)
+		var plan []string
+		for rows.Next() {
+			var id, parent, notused int
+			var detail string
+			require.NoError(t, rows.Scan(&id, &parent, &notused, &detail))
+			plan = append(plan, detail)
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+		require.NotEmpty(t, plan, "EXPLAIN QUERY PLAN returned nothing for %q", q)
+
+		for _, step := range plan {
+			assert.NotRegexp(t, `^SCAN `, step,
+				"%q plans a full table scan — its cost grows with the graph, not the file:\n%s",
+				q, strings.Join(plan, "\n"))
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Bead **mache-088304** (P1). `SQLiteWriter.DeleteFileNodes` planned as a full `SCAN` of `node_refs` / `node_defs` for every file ingested — O(files × refs) on every build, including fresh ones where each delete is a no-op, and the same cost on the incremental (`ReIngestFile`) path where re-parsing one file in a big repo paid the whole scan.

**Root cause:** both tables are `PRIMARY KEY (token, node_id) WITHOUT ROWID` with no `node_id`-leading index, so `DELETE … WHERE node_id IN (SELECT id FROM nodes WHERE source_file = ?)` has nothing to seek on.

**Fix:** `idx_refs_node ON node_refs(node_id)` and `idx_defs_node ON node_defs(node_id)`. Fixes the complexity class for both paths — not a skip-on-fresh-build backstop.

**Measured** (mache self, 929 files, leyline v0.19.1, same pre-parsed db, `projectTopology` only): **22.5 s → 15.4 s (−32%)**; `DeleteFileNodes` gone from the CPU profile (was 34%).

## Gate

`TestSQLiteWriter_DeleteFileNodes_EveryStatementIsIndexed` runs `EXPLAIN QUERY PLAN` over each statement in `deleteFileNodesSQL` and fails on any `^SCAN` step — a machine-independent complexity gate in the same discipline as the sqlcount statement-count gate. Mutation-verified (dropping either index fails it).

## Also in this PR

- `NewSQLiteWriter` was 154 lines, ~100 of them a DDL string literal, and its view DDL duplicated `CanonicalViewsDDL` verbatim. The tables DDL is now `writerTablesDDL`; the writer executes `writerTablesDDL + CanonicalViewsDDL`, so the views are defined once. (The content-addressed `long_function` ratchet flagged the edited function as new debt — correctly — this is the fix rather than a baseline regen.)
- `internal/fixturedb`'s Standalone fixture gains the two indexes, and `TestStandaloneSchema_MatchesSQLiteWriter` is now **bidirectional** (every writer object must be modelled, not just every modelled object must exist) and derives the DDL from the expression `NewSQLiteWriter` actually hands to `db.Exec`. Previously an index added to the writer and forgotten in the fixture — exactly this change — passed silently; mutation-verified.

## Test plan

- [x] `task check` green on the rebased tree (smell ratchet 0 NEW)
- [x] plan-shape gate mutation-verified
- [x] fixture parity gate mutation-verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs
