### PR TITLE
[mache-95a33d] fix(ingest): evict walker caches per file, stop reading source bytes — 1.7 GB → 1.05 GB peak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,28 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **A build no longer holds every file's walker cache, or the whole corpus,
+  until it finishes** (`mache-95a33d`). Projecting mache's own 929 files
+  peaked at 1.7 GB RSS; 650 MB of that was the `ASTWalker`'s per-file caches
+  (index, source, language, package, address-ref, call-token), retained for
+  the walker's lifetime although nothing reads them once a file is projected —
+  serve-time callee extraction builds its own walkers. `processSourceFileResult`
+  now evicts a file's caches as soon as its nodes are written; peak drops to
+  1.06 GB at no wall-clock cost with a byte-identical projection.
+
+  The second half was older: the parallel Phase 1 worker pool still read every
+  source file's bytes into memory, a vestige of in-process tree-sitter, and
+  after ADR-0012 nothing consumed them. The pool is gone — the walk resolves
+  paths, the results are sorted exactly as before, the projection runs
+  sequentially as it already did — and `parsedSourceFile` no longer has a
+  `content` field to fill. Two gates: one asserts zero retained cache entries
+  after `Ingest`; the other makes the source unreadable between ley-line parse
+  and mache projection and requires the projection to succeed anyway.
+
+  This is the mache half of the cold-path budget (`mache-93e84b` tracks the
+  leyline half, projection-v5). A laptop should not need a workstation's memory
+  to index a medium repo.
+
 - **`DeleteFileNodes` no longer scans the whole graph per file** (`mache-088304`).
   `node_refs` and `node_defs` are keyed `(token, node_id)`, so deleting a
   file's rows BY `node_id` had no index and planned as a full `SCAN` of a

--- a/internal/ingest/ast_walker.go
+++ b/internal/ingest/ast_walker.go
@@ -176,12 +176,14 @@ func TuneReadConnForBuild(db *sql.DB) {
 // ReIngestFile would re-project from the walker's immortal caches and never see
 // the edit.
 //
-// It also bounds cache growth on long-lived daemons: the per-file caches
+// It also bounds cache growth: the per-file caches
 // (indexCache/sourceCache/langCache/pkgCache/addrRefCache/callTokenCache)
 // otherwise accumulate O(repo) node rows + source bytes for the walker's
-// lifetime. That ceiling is bounded by the projected repo's file count; a
-// one-shot `mache build` walker is short-lived so it needs no eviction, and a
-// serve/mount daemon evicts per-file on change here (mache-024e9c).
+// lifetime. A serve/mount daemon evicts per-file on change here
+// (mache-024e9c), and the engine evicts each file as soon as its projection
+// is written (processSourceFileResult) — a one-shot build walker is
+// short-lived, but for that lifetime it held every file's full index at once,
+// which was the build's peak RSS, not a rounding error (mache-95a33d).
 func (w *ASTWalker) InvalidateSource(sourceID string) {
 	w.indexCache.Delete(sourceID)
 	w.sourceCache.Delete(sourceID)

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -63,15 +63,15 @@ type sourceFileJob struct {
 
 // parsedSourceFile is the per-file work item for processSourceFileResult.
 // The AST lives in the `_ast` db (queried by source_id); the fields here carry
-// file content plus the file-level extracts the ASTWalker resolves from SQL.
+// the file's paths plus the file-level extracts the ASTWalker resolves from
+// SQL. The file's bytes are deliberately absent: nothing on this path reads
+// them (mache-95a33d).
 type parsedSourceFile struct {
 	job           sourceFileJob
 	realPath      string
-	content       []byte
 	context       []byte            // extracted imports/globals context
 	imports       map[string]string // structured imports: alias → path (Go only, nil for others)
 	fileLevelRefs []string          // identifiers captured at the file root (Go: top-level cobra refs etc., mache-02r9)
-	readErr       error             // non-nil if file read failed
 }
 
 func NewEngine(schema *api.Topology, store IngestionTarget) *Engine {
@@ -162,7 +162,7 @@ func (e *Engine) Ingest(path string) error {
 					"(call SetASTWalker with a ley-line-parsed _ast db before Ingest); " +
 					"in-process tree-sitter was removed in ADR-0012 step 4")
 			}
-			return e.ingestSourceParallel(realPath)
+			return e.ingestSourceTree(realPath)
 		}
 
 		return filepath.WalkDir(realPath, func(p string, d os.DirEntry, err error) error { // coverage:ignore

--- a/internal/ingest/engine.go
+++ b/internal/ingest/engine.go
@@ -61,6 +61,13 @@ type sourceFileJob struct {
 	modTime  time.Time
 }
 
+// rawFile is a non-source file the source-tree walk defers until every
+// source file is projected.
+type rawFile struct {
+	path    string
+	modTime time.Time
+}
+
 // parsedSourceFile is the per-file work item for processSourceFileResult.
 // The AST lives in the `_ast` db (queried by source_id); the fields here carry
 // the file's paths plus the file-level extracts the ASTWalker resolves from
@@ -124,13 +131,9 @@ func (e *Engine) Ingest(path string) error {
 	e.childSeen = make(map[string]map[string]bool)
 	e.claimedIDs = make(map[string]int)
 
-	absPath, err := filepath.Abs(path)
+	realPath, err := realPathOf(path)
 	if err != nil { // coverage:ignore
 		return err // coverage:ignore
-	} // coverage:ignore
-	realPath, err := filepath.EvalSymlinks(absPath)
-	if err != nil { // coverage:ignore
-		realPath = absPath // coverage:ignore
 	} // coverage:ignore
 	e.RootPath = realPath
 
@@ -138,102 +141,52 @@ func (e *Engine) Ingest(path string) error {
 	if err != nil { // coverage:ignore
 		return err // coverage:ignore
 	} // coverage:ignore
-
-	if info.IsDir() {
-		// Load .gitignore patterns when enabled (default: true).
-		if e.RespectGitignore {
-			e.gitignore = LoadGitignore(realPath)
-		}
-
-		// Determine which file types this schema can process.
-		// Source (tree-sitter S-expression) schemas operate on source code
-		// (.go, .py); JSONPath schemas operate on data files (.json, .db).
-		// Ingesting the wrong type is harmless but wastes time and
-		// can produce confusing errors (e.g. S-expression as JSONPath).
-		if SchemaUsesTreeSitter(e.Schema) {
-			// Post-CGO-removal (ADR-0012 step 4): the ASTWalker is the sole
-			// walker for source schemas. Callers MUST wire one via
-			// SetASTWalker (leyline parses source into an `_ast` db first —
-			// see runBuildViaLeylineSchema and the serve/mount source paths).
-			// A missing ASTWalker means the caller skipped that step; fail
-			// loudly rather than silently projecting an empty graph.
-			if e.astWalker == nil {
-				return fmt.Errorf("engine: source schema requires an ASTWalker " +
-					"(call SetASTWalker with a ley-line-parsed _ast db before Ingest); " +
-					"in-process tree-sitter was removed in ADR-0012 step 4")
-			}
-			return e.ingestSourceTree(realPath)
-		}
-
-		return filepath.WalkDir(realPath, func(p string, d os.DirEntry, err error) error { // coverage:ignore
-			if err != nil { // coverage:ignore
-				return err // coverage:ignore
-			} // coverage:ignore
-			if d.IsDir() { // coverage:ignore
-				if p != realPath && ShouldSkipDir(d.Name()) { // coverage:ignore
-					return filepath.SkipDir // coverage:ignore
-				} // coverage:ignore
-				// Check gitignore for directories
-				if e.gitignore != nil && p != realPath { // coverage:ignore
-					rel, relErr := filepath.Rel(realPath, p) // coverage:ignore
-					if relErr == nil {                       // coverage:ignore
-						rel = filepath.ToSlash(rel)       // coverage:ignore
-						if e.gitignore.Match(rel, true) { // coverage:ignore
-							return filepath.SkipDir // coverage:ignore
-						} // coverage:ignore
-					} // coverage:ignore
-				} // coverage:ignore
-				return nil // coverage:ignore
-			} // coverage:ignore
-			// Check gitignore for files
-			if e.gitignore != nil { // coverage:ignore
-				rel, relErr := filepath.Rel(realPath, p) // coverage:ignore
-				if relErr == nil {                       // coverage:ignore
-					rel = filepath.ToSlash(rel)        // coverage:ignore
-					if e.gitignore.Match(rel, false) { // coverage:ignore
-						return nil // coverage:ignore
-					} // coverage:ignore
-				} // coverage:ignore
-			} // coverage:ignore
-			// Skip symlinks to directories (e.g., kodata/templates -> ../templates)
-			// WalkDir doesn't follow symlinks, so d.IsDir() is false for them,
-			// but os.ReadFile will follow and fail with "is a directory".
-			if d.Type()&os.ModeSymlink != 0 { // coverage:ignore
-				target, err := os.Stat(p)         // coverage:ignore
-				if err == nil && target.IsDir() { // coverage:ignore
-					return nil // coverage:ignore
-				} // coverage:ignore
-			} // coverage:ignore
-			// Determine if we should parse or treat as raw based on schema type
-			ext := filepath.Ext(p) // coverage:ignore
-			info, err := d.Info()  // coverage:ignore
-			if err != nil {        // coverage:ignore
-				return err // coverage:ignore
-			} // coverage:ignore
-			if ShouldSkipFile(p, info.Size()) { // coverage:ignore
-				return nil // coverage:ignore
-			} // coverage:ignore
-			shouldParse := false // coverage:ignore
-			switch ext {         // coverage:ignore
-			case ".json", ".db": // coverage:ignore
-				shouldParse = true // coverage:ignore
-			} // coverage:ignore
-
-			if shouldParse { // coverage:ignore
-				return e.ingestFile(p, info.ModTime()) // coverage:ignore
-			} // coverage:ignore
-			// Skip binary files (executables, object files, images, etc.)
-			if isBinaryFile(p) { // coverage:ignore
-				return nil // coverage:ignore
-			} // coverage:ignore
-			return e.ingestRawFile(p, info.ModTime()) // coverage:ignore
-		}) // coverage:ignore
+	if !info.IsDir() {
+		return e.ingestFile(path, info.ModTime())
 	}
-	info, err = os.Stat(realPath)
-	if err != nil { // coverage:ignore
-		return err // coverage:ignore
-	} // coverage:ignore
-	return e.ingestFile(path, info.ModTime())
+
+	// Load .gitignore patterns when enabled (default: true).
+	if e.RespectGitignore {
+		e.gitignore = LoadGitignore(realPath)
+	}
+
+	// Determine which file types this schema can process.
+	// Source (tree-sitter S-expression) schemas operate on source code
+	// (.go, .py); JSONPath schemas operate on data files (.json, .db).
+	// Ingesting the wrong type is harmless but wastes time and
+	// can produce confusing errors (e.g. S-expression as JSONPath).
+	if !SchemaUsesTreeSitter(e.Schema) {
+		return e.ingestDataTree(realPath)
+	}
+	// Post-CGO-removal (ADR-0012 step 4): the ASTWalker is the sole
+	// walker for source schemas. Callers MUST wire one via
+	// SetASTWalker (leyline parses source into an `_ast` db first —
+	// see runBuildViaLeylineSchema and the serve/mount source paths).
+	// A missing ASTWalker means the caller skipped that step; fail
+	// loudly rather than silently projecting an empty graph.
+	if e.astWalker == nil {
+		return fmt.Errorf("engine: source schema requires an ASTWalker " +
+			"(call SetASTWalker with a ley-line-parsed _ast db before Ingest); " +
+			"in-process tree-sitter was removed in ADR-0012 step 4")
+	}
+	return e.ingestSourceTree(realPath)
+}
+
+// ingestDataTree projects a directory under a data schema (JSONPath / SQL):
+// .json and .db files are parsed, every other non-binary file lands as a raw
+// file.
+func (e *Engine) ingestDataTree(root string) error {
+	return e.walkProjectFiles(root, func(p string, info os.FileInfo) error {
+		switch filepath.Ext(p) {
+		case ".json", ".db":
+			return e.ingestFile(p, info.ModTime())
+		}
+		// Skip binary files (executables, object files, images, etc.)
+		if isBinaryFile(p) {
+			return nil
+		}
+		return e.ingestRawFile(p, info.ModTime())
+	})
 }
 
 // RenderTemplate delegates to internal/template.Render.
@@ -251,13 +204,9 @@ func RenderTemplateWithFuncs(tmpl string, values map[string]any, extraFuncs temp
 // Used by the live graph refresher to update stale nodes without a full walk.
 // After re-ingestion, the store's file mtime is updated.
 func (e *Engine) ReIngestFile(path string) error {
-	absPath, err := filepath.Abs(path)
+	realPath, err := realPathOf(path)
 	if err != nil { // coverage:ignore
 		return err // coverage:ignore
-	} // coverage:ignore
-	realPath, err := filepath.EvalSymlinks(absPath)
-	if err != nil { // coverage:ignore
-		realPath = absPath // coverage:ignore
 	} // coverage:ignore
 
 	info, err := os.Stat(realPath)

--- a/internal/ingest/engine_cache_eviction_test.go
+++ b/internal/ingest/engine_cache_eviction_test.go
@@ -1,0 +1,57 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/agentic-research/mache/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cachedSources counts entries across every per-file cache the walker keeps.
+func (w *ASTWalker) cachedSources() int {
+	n := 0
+	for _, m := range []*sync.Map{
+		&w.indexCache, &w.sourceCache, &w.langCache, &w.pkgCache, &w.addrRefCache, &w.callTokenCache,
+	} {
+		m.Range(func(_, _ any) bool { n++; return true })
+	}
+	return n
+}
+
+// TestEngine_Ingest_EvictsWalkerCachesPerFile is the memory-class gate for
+// mache-95a33d: a one-shot build must not retain every file's ASTWalker cache
+// until the walker dies. On a 929-file repo that retention was 650 MB of a
+// 1.7 GB peak — the difference between a laptop and a workstation.
+//
+// Asserted as a COUNT of retained cache entries rather than an RSS figure, for
+// the same reason the growth gate counts statements instead of milliseconds:
+// the failure signature is "entries survive the file's projection", and zero
+// is a sharper thing to assert than a number of bytes on a particular machine.
+func TestEngine_Ingest_EvictsWalkerCachesPerFile(t *testing.T) {
+	schema := loadGoSchema(t)
+	tmpDir := t.TempDir()
+	for name, src := range map[string]string{
+		"a.go": "package shared\n\nfunc FuncA() { FuncB() }\n",
+		"b.go": "package shared\n\nfunc FuncB() {}\n",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, name), []byte(src), 0o644))
+	}
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	attachLeylineAST(t, engine, tmpDir)
+	require.NoError(t, engine.Ingest(tmpDir))
+
+	// Non-vacuity: the walker did project both files through its caches.
+	_, err := store.GetNode("shared/functions/FuncA/source")
+	require.NoError(t, err)
+	_, err = store.GetNode("shared/functions/FuncB/source")
+	require.NoError(t, err)
+
+	assert.Zero(t, engine.astWalker.cachedSources(),
+		"ASTWalker retained per-file cache entries after the build finished")
+}

--- a/internal/ingest/engine_cache_eviction_test.go
+++ b/internal/ingest/engine_cache_eviction_test.go
@@ -55,3 +55,33 @@ func TestEngine_Ingest_EvictsWalkerCachesPerFile(t *testing.T) {
 	assert.Zero(t, engine.astWalker.cachedSources(),
 		"ASTWalker retained per-file cache entries after the build finished")
 }
+
+// TestEngine_Ingest_NeverReadsSourceBytes pins the contract that makes the
+// projection's memory footprint independent of the corpus size: after ley-line
+// has parsed a tree into the `_ast` db, mache projects from that db alone. The
+// old Phase 1 worker pool read every file into memory and held the whole
+// corpus for the length of the projection, for nothing to consume
+// (mache-95a33d). Here the bytes are made unreadable between parse and
+// projection; a projection that reads them fails, one that does not is
+// unaffected.
+func TestEngine_Ingest_NeverReadsSourceBytes(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file modes; the unreadable-file probe cannot fire")
+	}
+	schema := loadGoSchema(t)
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "a.go")
+	require.NoError(t, os.WriteFile(src, []byte("package shared\n\nfunc FuncA() {}\n"), 0o644))
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	attachLeylineAST(t, engine, tmpDir)
+
+	require.NoError(t, os.Chmod(src, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(src, 0o644) })
+
+	require.NoError(t, engine.Ingest(tmpDir),
+		"projection must come from the _ast db, not from re-reading the file")
+	_, err := store.GetNode("shared/functions/FuncA/source")
+	require.NoError(t, err)
+}

--- a/internal/ingest/engine_filter.go
+++ b/internal/ingest/engine_filter.go
@@ -83,6 +83,74 @@ func ShouldSkipFile(path string, size int64) bool {
 	return false
 }
 
+// realPathOf resolves path to its absolute, symlink-evaluated form — the
+// identity every store key, file_index row and _ast source_id derives from,
+// so the five call sites that used to inline this could not drift. A path
+// whose symlinks cannot be evaluated (a dangling link, a component that
+// vanished mid-walk) keeps its absolute form; the caller's own os.Stat then
+// reports the real error rather than this guessing at one.
+func realPathOf(path string) (string, error) {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", err // coverage:ignore
+	} // coverage:ignore
+	realPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return absPath, nil // coverage:ignore
+	} // coverage:ignore
+	return realPath, nil
+}
+
+// walkProjectFiles walks root in lexical order and calls visit for every
+// regular file the project skip rules admit: hidden and build directories
+// (ShouldSkipDir), .gitignore matches when Ingest loaded one, symlinks to
+// directories (WalkDir does not follow them, and a read would fail with "is
+// a directory"), and ShouldSkipFile's extension and size rules. The source
+// and data tree ingests both walk through here, so the rules cannot drift
+// between them.
+func (e *Engine) walkProjectFiles(root string, visit func(p string, info os.FileInfo) error) error {
+	return filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err // coverage:ignore
+		} // coverage:ignore
+		if d.IsDir() {
+			if p != root && (ShouldSkipDir(d.Name()) || e.gitignored(root, p, true)) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if e.gitignored(root, p, false) {
+			return nil
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			target, err := os.Stat(p)         // coverage:ignore
+			if err == nil && target.IsDir() { // coverage:ignore
+				return nil // coverage:ignore
+			} // coverage:ignore
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err // coverage:ignore
+		} // coverage:ignore
+		if ShouldSkipFile(p, info.Size()) {
+			return nil
+		}
+		return visit(p, info)
+	})
+}
+
+// gitignored reports whether p, under root, matches the loaded .gitignore.
+func (e *Engine) gitignored(root, p string, isDir bool) bool {
+	if e.gitignore == nil {
+		return false
+	}
+	rel, err := filepath.Rel(root, p)
+	if err != nil {
+		return false // coverage:ignore
+	} // coverage:ignore
+	return e.gitignore.Match(filepath.ToSlash(rel), isDir)
+}
+
 // ensureFile returns an error if path does not exist or is a directory.
 func ensureFile(path, kind string) (os.FileInfo, error) {
 	info, err := os.Stat(path)

--- a/internal/ingest/engine_ingest.go
+++ b/internal/ingest/engine_ingest.go
@@ -49,10 +49,9 @@ func (e *Engine) ingestJSON(path string, modTime time.Time) error {
 	} // coverage:ignore
 
 	// Clear old nodes from this file (if any)
-	absPath, _ := filepath.Abs(path)
-	realPath, err := filepath.EvalSymlinks(absPath)
+	realPath, err := realPathOf(path)
 	if err != nil {
-		realPath = absPath // coverage:ignore
+		return err // coverage:ignore
 	} // coverage:ignore
 	e.Store.DeleteFileNodes(realPath)
 

--- a/internal/ingest/engine_treesitter.go
+++ b/internal/ingest/engine_treesitter.go
@@ -252,6 +252,13 @@ func (e *Engine) processSourceFileResult(result *parsedSourceFile) error {
 	// ley-line keys _ast/_source (mache-30edfa) — NOT filepath.Base,
 	// which would miss every file below the root.
 	sourceID := e.sourceIDFor(result.realPath)
+	// Every walker query below is keyed by this file's sourceID, and nothing
+	// reads the engine walker's caches after the file is projected (serve-time
+	// callee extraction builds its own walkers). Holding them for the whole
+	// build was 650 MB of a 1.7 GB peak on a 929-file repo (mache-95a33d).
+	// ReIngestFile invalidates before re-ingesting, so this adds no reload on
+	// the daemon path. Deferred so the _project_files early returns evict too.
+	defer w.InvalidateSource(sourceID)
 	root := ASTRoot{
 		DB:           w.db,
 		SourceID:     sourceID,

--- a/internal/ingest/engine_treesitter.go
+++ b/internal/ingest/engine_treesitter.go
@@ -5,194 +5,137 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/agentic-research/mache/graph"
 )
 
-// ingestSourceParallel projects a source directory using parallel workers.
-// The AST was pre-parsed by ley-line into the engine's `_ast` db; mache runs
-// NO tree-sitter (ADR-0012 step 4). Phase 1 walks the directory and reads file
-// content in parallel; Phase 2 applies results sequentially (processNode + store
-// mutations) with the ASTWalker resolving every construct from SQL.
-func (e *Engine) ingestSourceParallel(rootPath string) error {
-	numWorkers := runtime.NumCPU()
-	jobs := make(chan sourceFileJob, numWorkers*4)
-	parsed := make(chan parsedSourceFile, numWorkers*4)
-
-	// Phase 1: Workers read file content in parallel. No CGO, no tree-sitter
-	// parser allocation, and no LockOSThread pin — the AST already lives in
-	// the `_ast` db, so there is no CGO bridge to keep on a stable OS thread
-	// (this is where the historical mache-2y9w SIGSEGV source disappears).
-	var workerWg sync.WaitGroup
-	for range numWorkers {
-		workerWg.Go(func() {
-			for job := range jobs {
-				result := parsedSourceFile{job: job}
-				absPath, err := filepath.Abs(job.path)
-				if err != nil {
-					result.readErr = err // coverage:ignore
-					parsed <- result     // coverage:ignore
-					continue             // coverage:ignore
-				}
-				result.realPath, err = filepath.EvalSymlinks(absPath)
-				if err != nil {
-					result.realPath = absPath // coverage:ignore
-				} // coverage:ignore
-
-				result.content, err = os.ReadFile(result.realPath)
-				if err != nil {
-					result.readErr = err // coverage:ignore
-					parsed <- result     // coverage:ignore
-					continue             // coverage:ignore
-				}
-				// context/imports/file-level-refs are resolved from SQL in
-				// Phase 2 (processSourceFileResult) via the ASTWalker.
-				parsed <- result
-			}
-		})
-	}
-
-	// Walk directory and send jobs. Non-tree-sitter files (raw files) are
-	// processed inline since they're cheap (just file copy, no parsing).
-	var walkErr error
+// ingestSourceTree projects a source directory. The AST was pre-parsed by
+// ley-line into the engine's `_ast` db; mache runs NO tree-sitter (ADR-0012
+// step 4) and never reads a source file's bytes — every construct and every
+// file-level extract comes from the ASTWalker querying that db. The walk
+// therefore only resolves paths; projection is sequential (processNode + store
+// mutations) in a deterministic order.
+//
+// This used to be a worker pool that read every file's content in parallel —
+// a vestige of the in-process tree-sitter era, when the bytes were the parser's
+// input. After ADR-0012 nothing consumed them, yet the whole corpus sat in the
+// results slice for the length of the projection (mache-95a33d).
+func (e *Engine) ingestSourceTree(rootPath string) error {
+	var results []parsedSourceFile
 	var rawFiles []struct {
 		path    string
 		modTime time.Time
 	}
-	var fileCount atomic.Int64
-	go func() {
-		defer close(jobs)
-		walkErr = filepath.WalkDir(rootPath, func(p string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err // coverage:ignore
-			} // coverage:ignore
-			if d.IsDir() {
-				if p != rootPath && ShouldSkipDir(d.Name()) {
-					return filepath.SkipDir
-				}
-				if e.gitignore != nil && p != rootPath {
-					rel, relErr := filepath.Rel(rootPath, p)
-					if relErr == nil {
-						rel = filepath.ToSlash(rel)
-						if e.gitignore.Match(rel, true) {
-							return filepath.SkipDir
-						}
-					}
-				}
-				return nil
+	walkErr := filepath.WalkDir(rootPath, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err // coverage:ignore
+		} // coverage:ignore
+		if d.IsDir() {
+			if p != rootPath && ShouldSkipDir(d.Name()) {
+				return filepath.SkipDir
 			}
-			if e.gitignore != nil {
+			if e.gitignore != nil && p != rootPath {
 				rel, relErr := filepath.Rel(rootPath, p)
 				if relErr == nil {
 					rel = filepath.ToSlash(rel)
-					if e.gitignore.Match(rel, false) {
-						return nil
+					if e.gitignore.Match(rel, true) {
+						return filepath.SkipDir
 					}
-				}
-			}
-			if d.Type()&os.ModeSymlink != 0 {
-				target, err := os.Stat(p)         // coverage:ignore
-				if err == nil && target.IsDir() { // coverage:ignore
-					return nil // coverage:ignore
-				} // coverage:ignore
-			}
-			info, err := d.Info()
-			if err != nil {
-				return err // coverage:ignore
-			} // coverage:ignore
-			if ShouldSkipFile(p, info.Size()) {
-				return nil
-			}
-
-			ext := filepath.Ext(p)
-			langName, ok := langForExt(ext)
-			if ok {
-				// Skip unchanged files when an index is available.
-				// Use resolved (symlink-evaluated) path for consistent cache key,
-				// matching RecordFile which stores result.realPath.
-				if e.fileIndex != nil {
-					lookupPath := p                                            // coverage:ignore
-					if resolved, err := filepath.EvalSymlinks(p); err == nil { // coverage:ignore
-						lookupPath = resolved // coverage:ignore
-					} // coverage:ignore
-					if entry, ok := e.fileIndex[lookupPath]; ok { // coverage:ignore
-						if entry.ModTime.Equal(info.ModTime()) && entry.Size == info.Size() { // coverage:ignore
-							return nil // unchanged, skip re-parsing // coverage:ignore
-						} // coverage:ignore
-					}
-				}
-				fileCount.Add(1)
-				jobs <- sourceFileJob{
-					path:     p,
-					langName: langName,
-					modTime:  info.ModTime(),
-				}
-			} else {
-				if !isBinaryFile(p) {
-					rawFiles = append(rawFiles, struct {
-						path    string
-						modTime time.Time
-					}{p, info.ModTime()})
 				}
 			}
 			return nil
+		}
+		if e.gitignore != nil {
+			rel, relErr := filepath.Rel(rootPath, p)
+			if relErr == nil {
+				rel = filepath.ToSlash(rel)
+				if e.gitignore.Match(rel, false) {
+					return nil
+				}
+			}
+		}
+		if d.Type()&os.ModeSymlink != 0 {
+			target, err := os.Stat(p)         // coverage:ignore
+			if err == nil && target.IsDir() { // coverage:ignore
+				return nil // coverage:ignore
+			} // coverage:ignore
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err // coverage:ignore
+		} // coverage:ignore
+		if ShouldSkipFile(p, info.Size()) {
+			return nil
+		}
+
+		ext := filepath.Ext(p)
+		langName, ok := langForExt(ext)
+		if !ok {
+			if !isBinaryFile(p) {
+				rawFiles = append(rawFiles, struct {
+					path    string
+					modTime time.Time
+				}{p, info.ModTime()})
+			}
+			return nil
+		}
+
+		// Resolved (symlink-evaluated) path is the key RecordFile stores and
+		// the _ast source_id derives from, so resolve it once here.
+		absPath, err := filepath.Abs(p)
+		if err != nil {
+			return err // coverage:ignore
+		} // coverage:ignore
+		realPath, err := filepath.EvalSymlinks(absPath)
+		if err != nil {
+			realPath = absPath // coverage:ignore
+		} // coverage:ignore
+
+		// Skip unchanged files when an index is available.
+		if e.fileIndex != nil {
+			if entry, ok := e.fileIndex[realPath]; ok { // coverage:ignore
+				if entry.ModTime.Equal(info.ModTime()) && entry.Size == info.Size() { // coverage:ignore
+					return nil // unchanged, skip re-projecting // coverage:ignore
+				} // coverage:ignore
+			}
+		}
+		results = append(results, parsedSourceFile{
+			job: sourceFileJob{
+				path:     p,
+				langName: langName,
+				modTime:  info.ModTime(),
+			},
+			realPath: realPath,
 		})
-	}()
+		return nil
+	})
+	if walkErr != nil {
+		return walkErr // coverage:ignore
+	} // coverage:ignore
 
-	// Phase 2: Collect all parsed results, then sort by path for deterministic
-	// processing order. Dedup suffixes (e.g., init.from_b_go) depend on the
-	// order files are processed — alphabetical matches filepath.WalkDir behavior.
-	var firstErr error
-	var results []parsedSourceFile
-	// Wait for workers to finish in a separate goroutine so we can collect results.
-	doneCh := make(chan struct{})
-	go func() {
-		workerWg.Wait()
-		close(parsed)
-		close(doneCh)
-	}()
-
-	for result := range parsed {
-		results = append(results, result)
-	}
-
-	// Sort by walk path to match filepath.WalkDir's lexical order.
+	// Sort by walk path. Dedup suffixes (e.g., init.from_b_go) depend on the
+	// order files are projected, and this lexical order over the full path is
+	// the order every existing build has used — it is NOT WalkDir's order
+	// (which sorts per directory: "a/x.go" walks before "a-b.go"), so it stays
+	// an explicit sort rather than relying on walk order.
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].job.path < results[j].job.path
 	})
 
-	processed := 0
+	var firstErr error
 	for i := range results {
-		processed++
-		if processed%1000 == 0 {
-			log.Printf("Ingested %d/%d files...", processed, fileCount.Load()) // coverage:ignore
+		if (i+1)%1000 == 0 {
+			log.Printf("Ingested %d/%d files...", i+1, len(results)) // coverage:ignore
 		} // coverage:ignore
-
-		if results[i].readErr != nil {
-			if firstErr == nil { // coverage:ignore
-				firstErr = results[i].readErr // coverage:ignore
-			} // coverage:ignore
-			continue // coverage:ignore
-		}
-
 		if err := e.processSourceFileResult(&results[i]); err != nil {
 			if firstErr == nil { // coverage:ignore
 				firstErr = err // coverage:ignore
 			} // coverage:ignore
 		}
 	}
-
-	// Wait for walk to complete.
-	<-doneCh
-	if walkErr != nil {
-		return walkErr // coverage:ignore
-	} // coverage:ignore
 
 	// Process raw (non-tree-sitter) files sequentially (cheap, no parsing).
 	for _, rf := range rawFiles {
@@ -203,8 +146,8 @@ func (e *Engine) ingestSourceParallel(rootPath string) error {
 		}
 	}
 
-	if fileCount.Load() > 0 {
-		log.Printf("Ingested %d source files total (%d workers).", processed, numWorkers)
+	if len(results) > 0 {
+		log.Printf("Ingested %d source files total.", len(results))
 	}
 
 	return firstErr
@@ -230,10 +173,10 @@ func (e *Engine) sourceIDFor(realPath string) string {
 }
 
 // processSourceFileResult handles projection for a single source file. Both
-// ingestSourceFile (sequential) and ingestSourceParallel (phase 2) delegate here
-// to avoid divergent logic. The caller populates the parsedSourceFile struct
-// (path/content); construct resolution and every file-level extract come from
-// the ASTWalker querying the ley-line-parsed `_ast` db.
+// ingestSourceFile and ingestSourceTree delegate here to avoid divergent
+// logic. The caller populates the parsedSourceFile struct (path); construct
+// resolution and every file-level extract come from the ASTWalker querying
+// the ley-line-parsed `_ast` db — the file's bytes are never read.
 //
 // Steps:
 //  1. Filter schema nodes by language
@@ -384,11 +327,6 @@ func (e *Engine) ingestSourceFile(path, langName string, modTime time.Time) erro
 		return err // coverage:ignore
 	} // coverage:ignore
 
-	content, err := os.ReadFile(realPath)
-	if err != nil {
-		return err // coverage:ignore
-	} // coverage:ignore
-
 	result := &parsedSourceFile{
 		job: sourceFileJob{
 			path:     path,
@@ -396,7 +334,6 @@ func (e *Engine) ingestSourceFile(path, langName string, modTime time.Time) erro
 			modTime:  modTime,
 		},
 		realPath: realPath,
-		content:  content,
 	}
 
 	return e.processSourceFileResult(result)

--- a/internal/ingest/engine_treesitter.go
+++ b/internal/ingest/engine_treesitter.go
@@ -25,89 +25,29 @@ import (
 // results slice for the length of the projection (mache-95a33d).
 func (e *Engine) ingestSourceTree(rootPath string) error {
 	var results []parsedSourceFile
-	var rawFiles []struct {
-		path    string
-		modTime time.Time
-	}
-	walkErr := filepath.WalkDir(rootPath, func(p string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err // coverage:ignore
-		} // coverage:ignore
-		if d.IsDir() {
-			if p != rootPath && ShouldSkipDir(d.Name()) {
-				return filepath.SkipDir
-			}
-			if e.gitignore != nil && p != rootPath {
-				rel, relErr := filepath.Rel(rootPath, p)
-				if relErr == nil {
-					rel = filepath.ToSlash(rel)
-					if e.gitignore.Match(rel, true) {
-						return filepath.SkipDir
-					}
-				}
-			}
-			return nil
-		}
-		if e.gitignore != nil {
-			rel, relErr := filepath.Rel(rootPath, p)
-			if relErr == nil {
-				rel = filepath.ToSlash(rel)
-				if e.gitignore.Match(rel, false) {
-					return nil
-				}
-			}
-		}
-		if d.Type()&os.ModeSymlink != 0 {
-			target, err := os.Stat(p)         // coverage:ignore
-			if err == nil && target.IsDir() { // coverage:ignore
-				return nil // coverage:ignore
-			} // coverage:ignore
-		}
-		info, err := d.Info()
-		if err != nil {
-			return err // coverage:ignore
-		} // coverage:ignore
-		if ShouldSkipFile(p, info.Size()) {
-			return nil
-		}
-
-		ext := filepath.Ext(p)
-		langName, ok := langForExt(ext)
+	var rawFiles []rawFile
+	walkErr := e.walkProjectFiles(rootPath, func(p string, info os.FileInfo) error {
+		langName, ok := langForExt(filepath.Ext(p))
 		if !ok {
 			if !isBinaryFile(p) {
-				rawFiles = append(rawFiles, struct {
-					path    string
-					modTime time.Time
-				}{p, info.ModTime()})
+				rawFiles = append(rawFiles, rawFile{p, info.ModTime()})
 			}
 			return nil
 		}
-
-		// Resolved (symlink-evaluated) path is the key RecordFile stores and
-		// the _ast source_id derives from, so resolve it once here.
-		absPath, err := filepath.Abs(p)
+		// The resolved path is the key RecordFile stores and the _ast
+		// source_id derives from, so resolve it once here.
+		realPath, err := realPathOf(p)
 		if err != nil {
 			return err // coverage:ignore
 		} // coverage:ignore
-		realPath, err := filepath.EvalSymlinks(absPath)
-		if err != nil {
-			realPath = absPath // coverage:ignore
-		} // coverage:ignore
-
 		// Skip unchanged files when an index is available.
-		if e.fileIndex != nil {
-			if entry, ok := e.fileIndex[realPath]; ok { // coverage:ignore
-				if entry.ModTime.Equal(info.ModTime()) && entry.Size == info.Size() { // coverage:ignore
-					return nil // unchanged, skip re-projecting // coverage:ignore
-				} // coverage:ignore
-			}
+		if entry, ok := e.fileIndex[realPath]; ok { // coverage:ignore
+			if entry.ModTime.Equal(info.ModTime()) && entry.Size == info.Size() { // coverage:ignore
+				return nil // unchanged, skip re-projecting // coverage:ignore
+			} // coverage:ignore
 		}
 		results = append(results, parsedSourceFile{
-			job: sourceFileJob{
-				path:     p,
-				langName: langName,
-				modTime:  info.ModTime(),
-			},
+			job:      sourceFileJob{path: p, langName: langName, modTime: info.ModTime()},
 			realPath: realPath,
 		})
 		return nil
@@ -207,8 +147,53 @@ func (e *Engine) processSourceFileResult(result *parsedSourceFile) error {
 		SourceID:     sourceID,
 		ParentPrefix: "",
 	}
-	// File-level extracts (context/imports/file-level-refs) are served from
-	// SQL — no CGO parse runs. Each mirrors the sitter extract it replaced.
+	extractFileLevel(w, sourceID, result)
+
+	// 1. Filter schema nodes by language.
+	applicableNodes := filterNodesByLanguage(e.Schema.Nodes, result.job.langName)
+
+	// 2. No applicable schema nodes → route to _project_files/.
+	if len(applicableNodes) == 0 {
+		return e.routeToProjectFiles(result) // coverage:ignore
+	} // coverage:ignore
+
+	// 3. Extract file-level address refs (e.g., HCL variable declarations)
+	// by querying the _ast table for the same patterns.
+	var fileAddrRefs []string
+	if addrRefs, err := w.ExtractAddressRefs(sourceID, result.job.langName); err == nil {
+		fileAddrRefs = addrRefs
+	}
+	bt := &bufferingTarget{IngestionTarget: e.Store}
+	addFileLevelRefs(bt, result.realPath, result.fileLevelRefs)
+
+	// 5. processNode for each applicable schema node.
+	sourceFile := filepath.Base(result.job.path)
+	for _, nodeSchema := range applicableNodes {
+		if err := e.processNode(nodeSchema, w, root, "", sourceFile, result.realPath, result.job.modTime, bt, result.context, fileAddrRefs, nil, result.imports); err != nil {
+			// 6. Invalid query → route to _project_files/.
+			if strings.Contains(err.Error(), "invalid query") {
+				e.mu.Lock()
+				e.routedFiles[result.job.langName]++
+				e.mu.Unlock()
+				return e.routeToProjectFiles(result)
+			}
+			return fmt.Errorf("failed to process schema node %s: %w", nodeSchema.Name, err) // coverage:ignore
+		}
+	}
+
+	// 7. No nodes produced → route to _project_files/.
+	if len(bt.bufferedNodes) == 0 {
+		return e.routeToProjectFiles(result) // coverage:ignore
+	} // coverage:ignore
+
+	e.commitFileNodes(result.realPath, bt.bufferedNodes)
+	return nil
+}
+
+// extractFileLevel fills result's file-level extracts (context, imports,
+// file-level refs) from SQL — no CGO parse runs. Each mirrors the sitter
+// extract it replaced; a failed extract leaves its field empty, as before.
+func extractFileLevel(w *ASTWalker, sourceID string, result *parsedSourceFile) {
 	if ctxBytes, err := w.ExtractContext(sourceID, result.job.langName); err == nil {
 		result.context = ctxBytes
 	}
@@ -220,87 +205,55 @@ func (e *Engine) processSourceFileResult(result *parsedSourceFile) error {
 	if refs, err := w.ExtractFileLevelRefs(sourceID, result.job.langName); err == nil {
 		result.fileLevelRefs = refs
 	}
+}
 
-	bt := &bufferingTarget{IngestionTarget: e.Store}
-	sourceFile := filepath.Base(result.job.path)
+// fileLevelSentinelPrefix marks the synthetic caller_id file-level refs are
+// filed under; fan_out_skew skips rows with this prefix.
+const fileLevelSentinelPrefix = "_file_level:"
 
-	// 1. Filter schema nodes by language.
-	applicableNodes := filterNodesByLanguage(e.Schema.Nodes, result.job.langName)
-
-	// 2. No applicable schema nodes → route to _project_files/.
-	if len(applicableNodes) == 0 {
-		return e.ingestRawFileUnder(result.job.path, "_project_files", result.job.modTime) // coverage:ignore
-	} // coverage:ignore
-
-	// 3. Extract file-level address refs (e.g., HCL variable declarations)
-	// by querying the _ast table for the same patterns.
-	var fileAddrRefs []string
-	if addrRefs, err := w.ExtractAddressRefs(sourceID, result.job.langName); err == nil {
-		fileAddrRefs = addrRefs
+// addFileLevelRefs records refs (mache-02r9: top-level cobra RunE etc.) under
+// a SENTINEL caller_id rather than merging them into every construct's calls.
+// Earlier iterations folded them into fileAddrRefs (per-construct merge),
+// which inflated fan_out_skew — every function in a cobra-using file picked
+// up the cobra callback as a 'callee' even though it doesn't actually call
+// it. The sentinel form keeps the alive set correct for dead_code (token-only
+// check) without polluting any rule that aggregates by caller.
+func addFileLevelRefs(bt *bufferingTarget, realPath string, refs []string) {
+	sentinel := fileLevelSentinelPrefix + realPath
+	for _, token := range refs {
+		if err := bt.AddRef(token, sentinel); err != nil {
+			log.Printf("file-level ref %q: %v", token, err) // coverage:ignore
+		} // coverage:ignore
 	}
-	// File-level refs (mache-02r9: top-level cobra RunE etc.) are
-	// emitted with a SENTINEL caller_id rather than merged into
-	// every construct's calls. Earlier iterations folded them into
-	// fileAddrRefs (per-construct merge), which inflated fan_out_skew
-	// — every function in a cobra-using file picked up the cobra
-	// callback as a 'callee' even though it doesn't actually call it.
-	//
-	// The sentinel form keeps the alive set correct for dead_code
-	// (token-only check) without polluting any rule that aggregates
-	// by caller. fan_out_skew explicitly skips sentinel rows.
-	const fileLevelSentinelPrefix = "_file_level:"
-	if len(result.fileLevelRefs) > 0 {
-		sentinel := fileLevelSentinelPrefix + result.realPath
-		for _, token := range result.fileLevelRefs {
-			if err := bt.AddRef(token, sentinel); err != nil {
-				log.Printf("file-level ref %q: %v", token, err) // coverage:ignore
-			} // coverage:ignore
-		}
-	}
+}
 
-	// 5. processNode for each applicable schema node.
-	for _, nodeSchema := range applicableNodes {
-		if err := e.processNode(nodeSchema, w, root, "", sourceFile, result.realPath, result.job.modTime, bt, result.context, fileAddrRefs, nil, result.imports); err != nil {
-			// 6. Invalid query → route to _project_files/.
-			if strings.Contains(err.Error(), "invalid query") {
-				e.mu.Lock()
-				e.routedFiles[result.job.langName]++
-				e.mu.Unlock()
-				return e.ingestRawFileUnder(result.job.path, "_project_files", result.job.modTime)
-			}
-			return fmt.Errorf("failed to process schema node %s: %w", nodeSchema.Name, err) // coverage:ignore
-		}
-	}
+// routeToProjectFiles lands a source file the schema could not project as a
+// raw file under _project_files/.
+func (e *Engine) routeToProjectFiles(result *parsedSourceFile) error {
+	return e.ingestRawFileUnder(result.job.path, "_project_files", result.job.modTime)
+}
 
-	// 7. No nodes produced → route to _project_files/.
-	if len(bt.bufferedNodes) == 0 {
-		return e.ingestRawFileUnder(result.job.path, "_project_files", result.job.modTime) // coverage:ignore
-	} // coverage:ignore
-
-	// 8. Atomic swap of file nodes.
+// commitFileNodes atomically replaces realPath's nodes in the store, then
+// records the file for incremental re-ingestion plus its coverage row for
+// ADR-0013's _index_coverage table (mention-fidelity, since tree-sitter is
+// the L_0 producer in the fidelity poset; LSP and SSA producers write their
+// own binding/reachability rows for the same source_id).
+func (e *Engine) commitFileNodes(realPath string, nodes []*graph.Node) {
 	if ms, ok := e.Store.(*graph.MemoryStore); ok {
-		ms.ReplaceFileNodes(result.realPath, bt.bufferedNodes)
+		ms.ReplaceFileNodes(realPath, nodes)
 	} else {
-		e.Store.DeleteFileNodes(result.realPath) // coverage:ignore
-		for _, n := range bt.bufferedNodes {     // coverage:ignore
+		e.Store.DeleteFileNodes(realPath) // coverage:ignore
+		for _, n := range nodes {         // coverage:ignore
 			e.Store.AddNode(n) // coverage:ignore
 		} // coverage:ignore
 	}
-
-	// 9. Record file metadata for incremental re-ingestion + coverage row
-	//    for ADR-0013's _index_coverage table (mention-fidelity, since
-	//    tree-sitter is the L_0 producer in the fidelity poset). LSP and
-	//    SSA producers will write their own (binding/reachability) rows
-	//    for the same source_id.
 	if sw, ok := e.Store.(*SQLiteWriter); ok {
-		info, err := os.Stat(result.realPath) // coverage:ignore
-		if err == nil {                       // coverage:ignore
-			sw.RecordFile(result.realPath, info.ModTime(), info.Size())                         // coverage:ignore
-			sw.RecordIndexCoverage(result.realPath, "tree-sitter", "mention", time.Now(), true) // coverage:ignore
+		info, err := os.Stat(realPath) // coverage:ignore
+		if err == nil {                // coverage:ignore
+			sw.RecordFile(realPath, info.ModTime(), info.Size())                         // coverage:ignore
+			sw.RecordIndexCoverage(realPath, "tree-sitter", "mention", time.Now(), true) // coverage:ignore
 		} // coverage:ignore
 	}
-
-	return nil
 }
 
 // ingestSourceFile projects a single source file via the ASTWalker. Used by
@@ -314,15 +267,10 @@ func (e *Engine) ingestSourceFile(path, langName string, modTime time.Time) erro
 			"was removed in ADR-0012 step 4", path)
 	}
 
-	absPath, err := filepath.Abs(path)
+	realPath, err := realPathOf(path)
 	if err != nil {
 		return err // coverage:ignore
 	} // coverage:ignore
-	realPath, err := filepath.EvalSymlinks(absPath)
-	if err != nil {
-		realPath = absPath // coverage:ignore
-	} // coverage:ignore
-
 	if _, err := ensureFile(realPath, "a source file"); err != nil {
 		return err // coverage:ignore
 	} // coverage:ignore

--- a/internal/ingest/engine_walk_test.go
+++ b/internal/ingest/engine_walk_test.go
@@ -1,0 +1,60 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEngine_IngestDataTree_SharesProjectSkipRules pins that a data-schema
+// directory ingest walks through the same walkProjectFiles as the source-tree
+// ingest: hidden directories, .gitignore matches and binary files are skipped
+// by ONE set of rules, parsed extensions are projected and everything else
+// lands as a raw file. Until mache-95a33d the data walk was a second copy of
+// those rules, and it was untested.
+func TestEngine_IngestDataTree_SharesProjectSkipRules(t *testing.T) {
+	schema := &api.Topology{
+		Nodes: []api.Node{{
+			Name:     "users",
+			Selector: "$",
+			Children: []api.Node{{
+				Name:     "{{.name}}",
+				Selector: "users[*]",
+				Files:    []api.Leaf{{Name: "role", ContentTemplate: "{{.role}}"}},
+			}},
+		}},
+	}
+	root := t.TempDir()
+	write := func(rel string, data []byte) {
+		p := filepath.Join(root, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(p), 0o755))
+		require.NoError(t, os.WriteFile(p, data, 0o644))
+	}
+	write("data.json", []byte(`{"users":[{"name":"Alice","role":"admin"}]}`))
+	write("notes/readme.txt", []byte("plain text lands as a raw file\n"))
+	write(".hidden/trap.json", []byte(`{"users":[{"name":"Trap","role":"x"}]}`))
+	write("ignored.json", []byte(`{"users":[{"name":"Ignored","role":"x"}]}`))
+	write(".gitignore", []byte("ignored.json\n"))
+	write("blob.dat", []byte("\x00\x01\x02binary"))
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	require.NoError(t, engine.Ingest(root))
+
+	node, err := store.GetNode("users/Alice/role")
+	require.NoError(t, err, "data.json is parsed by the schema")
+	assert.Equal(t, "admin", string(node.Data))
+
+	_, err = store.GetNode("notes/readme.txt")
+	require.NoError(t, err, "a non-parsed, non-binary file lands as a raw file")
+
+	for _, absent := range []string{"users/Trap", "users/Ignored", "blob.dat"} {
+		_, err = store.GetNode(absent)
+		assert.ErrorIs(t, err, graph.ErrNotFound, "%s must be skipped", absent)
+	}
+}


### PR DESCRIPTION
## Summary

`mache build` (and `mache init`'s projection step) held every file's `ASTWalker` cache — index, source, language, package, address-ref, call-token — for the walker's whole lifetime, although nothing reads them once a file's nodes are written (serve-time callee extraction builds its own walkers). On mache's own 929 files that was **650 MB of a 1.7 GB peak RSS**. Separately, the Phase-1 worker pool still read every source file's bytes into memory — a vestige of in-process tree-sitter that nothing consumed after ADR-0012.

Four commits:

1. **`fix(ingest)`: evict per file** — `processSourceFileResult` defers `w.InvalidateSource(sourceID)`, so a file's caches die when its projection is committed (deferred, so the `_project_files` early-returns evict too). `ReIngestFile` already invalidated before re-ingesting, so the daemon path gains no reload.
2. **`fix(ingest)`: stop reading source bytes** — the worker pool / channels / atomics are gone. `ingestSourceTree` walks, resolves paths, sorts by full `job.path` (the explicit lexical sort the dedup suffixes depend on — NOT WalkDir's per-directory order), and projects sequentially exactly as before. `parsedSourceFile` no longer has a `content` field to fill.
3. **`docs(changelog)`**.
4. **`refactor(ingest)`**: the smell ratchet priced the `Ingest`/`processSourceFileResult` edits as new `long_function`/`fan_out_skew` debt (content-addressed keys), so the walk (`walkProjectFiles` + `gitignored`), path resolution (`realPathOf`), file-level extraction, sentinel refs, routing, and commit were split out. The data-tree path (`ingestDataTree`) now shares the same skip rules as the source path instead of a second hand-rolled walk.

## Measurements (mache self-build, 929 files, M3 Max)

| | before | after |
|---|---|---|
| peak RSS (projection) | 1,731 MB | **1,050 MB** |
| wall | unchanged | unchanged |
| projection output | — | **byte-identical** (`nodes`, `node_refs`, `node_defs`, `_files`, `_index_coverage` compared table-for-table as sorted sets vs the pre-change binary's output) |

The remaining ~870 MB is file-backed mmap of the leyline db (`mmap_size` 2 GiB in `TuneReadConnForBuild`); `mmap=0` costs 3.3× wall, so it stays. The leyline half of the cold-path budget (1.8 GB db / 3.5 GB RSS for 15 MB of source) is `mache-93e84b` (projection-v5).

## Gates (each mutation-verified)

- `TestEngine_Ingest_EvictsWalkerCachesPerFile` — after `Ingest` over a leyline-parsed fixture, every walker `sync.Map` is empty. Removing the `defer` leaves 12 retained entries → fails.
- `TestEngine_Ingest_NeverReadsSourceBytes` — `chmod 000` the source between leyline parse and mache projection; the projection must still succeed and produce `FuncA`. Re-adding an `os.ReadFile` → fails.
- `TestEngine_IngestDataTree_SharesProjectSkipRules` — hidden dir, `.gitignore`d file, and a binary blob are skipped on the data-tree path too; disabling `gitignored` → fails.

Closes mache-95a33d.
