### PR TITLE
[mache-c777ef] fix(schema): rust methods are receiver-qualified — functions/ holds free functions only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,33 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **Rust methods are receiver-qualified; `functions/` holds free functions
+  only** (`mache-c777ef`). The rust preset selected every `function_item` in a
+  file as `functions/<name>`, so `fn new` in twenty impls collapsed into one
+  node plus `.from_<file>` suffixes, and an `impl` block's methods were only
+  reachable through the block. Impl and trait methods now project as
+  `methods/<Receiver>.<name>` with the method's own body — `Cell.new` for
+  `impl<T> Cell<T>`, `Point.new` for `impl geometry::Point`, `Grid.into_iter`
+  for `impl IntoIterator for &'a Grid`, `[u8].hash32` for an un-nameable
+  receiver — and `functions/` holds free, module-level and nested functions
+  only. `implementations/` stays an index by receiver, now with no generic
+  arguments in its names. On ley-line-open's rs/ (320 files) that is 77
+  distinct `methods/*.new` against 77 `fn new` in the parse (1 before); on the
+  `medium-rust-rosary` corpus every one of 2538 `function_item` nodes is
+  projected exactly once (1881 functions + 657 methods), which
+  `TestRustPreset_EveryFunctionItemProjectedOnce` now pins.
+
+  Two engine changes carry it. Selectors accept tree-sitter's `(_)` wildcard
+  step (`(impl_item type: (_ type: (type_identifier) @receiver))` reaches a
+  receiver through whatever wraps it), and an inner-`@scope` selector whose
+  scope path reaches nothing is no longer a match — it used to fall back to
+  the outer node, projecting a function-less module as `functions/<mod>`.
+  Sibling schema nodes are now an ordered choice per construct: the first to
+  match a scope node under a parent owns it, so a preset can list receiver
+  shapes most-specific-first with a `(_)` catch-all that never re-projects
+  what the specific shapes named. No shipped preset had overlapping siblings
+  before, so no other projection changes (the golden gate agrees).
+
 - **`duplicate_definitions` judges one population** (`mache-117c0a`). The rule
   counted a token's copies over every definition in the db but only reported
   the non-vendored, non-generated ones, so a vendored corpus that happened to

--- a/docs/schemas/rust.md
+++ b/docs/schemas/rust.md
@@ -1,0 +1,90 @@
+---
+status: current
+covers-version: v0.21.1
+last-verified: 2026-09-10
+sources-of-truth:
+  - schema/presets/rust.json
+  - internal/ingest/ast_walker_selector.go
+  - internal/ingest/engine_walk.go
+audience: [agents, contributors]
+---
+
+# Rust Schema Reference
+
+Reference for the Rust preset (`schema/presets/rust.json`, mirrored by
+`examples/rust-schema.json`) — what it projects and the naming rules an agent
+can rely on. Companion to [`go.md`](go.md).
+
+## What lands where
+
+| Directory          | Construct                                                       | Node name                   | `source`                       |
+| ------------------ | --------------------------------------------------------------- | --------------------------- | ------------------------------ |
+| `functions/`       | `fn` at file level, inside a `mod`, or nested in a block        | `{name}`                    | the `fn` item                  |
+| `methods/`         | `fn` inside an `impl` block or a `trait` (including defaults)   | `{Receiver}.{name}`         | that one `fn` — never the block |
+| `implementations/` | each `impl` block, as an index by receiver                      | `{Receiver}`                | none (LSP files only)          |
+| `structs/` `enums/` `traits/` `type_aliases/` `constants/` `statics/` `modules/` `macros/` `imports/` | the item | `{name}` | the item |
+
+Names that collide across files get `.from_<file>` suffixes, as everywhere in
+mache. `fn new` in twenty impls is twenty `methods/<Type>.new` nodes, not one
+node plus nineteen suffixes (`mache-c777ef`).
+
+## The receiver
+
+`{Receiver}` is the **type identifier** of the impl's self type, with generic
+arguments, references, and module paths stripped:
+
+| Source                                        | `methods/`            | `implementations/` |
+| --------------------------------------------- | --------------------- | ------------------ |
+| `impl Grid`                                   | `Grid.new`            | `Grid`             |
+| `impl<T: Clone> Cell<T>`                      | `Cell.new`            | `Cell`             |
+| `impl geometry::Point`                        | `Point.new`           | `Point`            |
+| `impl<'a> IntoIterator for &'a Grid`          | `Grid.into_iter`      | `Grid`             |
+| `impl<'a, T> fmt::Debug for &'a Cell<T>`      | `Cell.fmt`            | `Cell`             |
+| `impl<T> Default for geometry::Vec2<T>`       | `Vec2.default`        | `Vec2`             |
+| `trait Hash32 { fn describe(&self) … }`       | `Hash32.describe`     | —                  |
+
+When the self type has no type identifier — `impl Hash32 for [u8]`, `for u32`,
+`for (u8, u8)` — the receiver is the type's own source text: `[u8].hash32`,
+`u32.hash32`, `(u8, u8).hash32`.
+
+The trait being implemented is not part of the name: `Cell.fmt` says nothing
+about `fmt::Debug`. Two impls of different traits that share a method name on
+the same receiver in one file collide and get a suffix.
+
+## How the preset spells it
+
+Each receiver shape is one selector under `methods/`, listed most-specific
+first and ending in a catch-all:
+
+```
+(impl_item type: (type_identifier) @receiver                                  body: …)
+(impl_item type: (_ type: (type_identifier) @receiver)                        body: …)
+(impl_item type: (_ name: (type_identifier) @receiver)                        body: …)
+(impl_item type: (_ type: (_ type: (type_identifier) @receiver))              body: …)
+(impl_item type: (_ type: (_ name: (type_identifier) @receiver))              body: …)
+(impl_item type: (_ type: (_ type: (_ name: (type_identifier) @receiver)))    body: …)
+(impl_item type: (_) @receiver                                                body: …)
+```
+
+with `body: (declaration_list (function_item name: (identifier) @name) @scope)`.
+Two selector-engine rules make this work, and apply to every source preset:
+
+- **`(_)` is a wildcard step** — tree-sitter's "any named node". It still
+  honours its field label, so `(_ type: …)` and `(_ name: …)` are different
+  steps. The outer node of a selector cannot be a wildcard.
+- **Sibling schema nodes are an ordered choice.** The first sibling (in schema
+  order) to match a construct under a parent owns it; later siblings skip it.
+  That is why the catch-all never re-projects a method a specific shape already
+  named. `$` containers are not part of the choice.
+
+A selector whose inner `@scope` path reaches nothing is **not a match** — a
+`mod` with no functions does not project as `functions/<mod>`.
+
+## Pinned by
+
+- `internal/schemainfer/rust_preset_test.go` — the table above, on
+  `internal/testutil/testdata/preset_fixtures/rust/`; and on the
+  `medium-rust-rosary` corpus, every `function_item` ley-line parses is projected
+  exactly once, as a function or a method.
+- `internal/ingest/ast_walker_wildcard_test.go` — the two selector-engine rules
+  and the no-fallback rule, each mutation-verified.

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -130,18 +130,6 @@
     },
     {
       "rule_id": "duplicate_code",
-      "source_id": "graph/memstore_refs.go",
-      "node_hash": "46f2403c69c9de2af6f74cae551334eec62aa15df1365e56fab9e321e74952e0",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
-      "source_id": "graph/memstore_refs.go",
-      "node_hash": "ee4f85a37cc04468423b528bb0098eb9982d383f4e3e6037cdfbd96c87d57a5c",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
       "source_id": "graph/shared_test.go",
       "node_hash": "19c5c579ef162e2df82abdca4473e11d520cdccc58e12e883319abfdf6ce466c",
       "count": 1
@@ -354,18 +342,6 @@
       "rule_id": "duplicate_code",
       "source_id": "internal/ingest/ast_walker.go",
       "node_hash": "8391d804d6088462f5c5935a571c100169503b8cf1d7bfc022cb4e13e61a68ea",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
-      "source_id": "internal/ingest/ast_walker_bench_test.go",
-      "node_hash": "59c91c2349f4ddf252cc8ab049beffc0ef127fbbf9b297a48b8d83847a1705d9",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
-      "source_id": "internal/ingest/ast_walker_bench_test.go",
-      "node_hash": "efb00c026800feeeea4a8525867c4487bf4ab8d6b1b55b667974b3a271b36a71",
       "count": 1
     },
     {
@@ -870,18 +846,6 @@
       "rule_id": "duplicate_code",
       "source_id": "internal/leyline/trigger_test.go",
       "node_hash": "c4fceec08b7f30920688f630d9bd6e127712392fe470036c3394c92b992e433b",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
-      "source_id": "internal/leylinegraph/call_extractor_ast_test.go",
-      "node_hash": "1de11520930e944bab6c0ed5a898bafb37c8159367588d3f0a4a30f1c2a2d7ae",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_code",
-      "source_id": "internal/leylinegraph/call_extractor_ast_test.go",
-      "node_hash": "bb6184ecceb31a65b0a1af18f7595a06bedb5d474ef9951642e6783ef20a16bd",
       "count": 1
     },
     {
@@ -2086,30 +2050,6 @@
     },
     {
       "rule_id": "duplicate_definitions",
-      "source_id": "internal/daemonguard/daemonguard.go",
-      "node_hash": "bed96556794cc0350743e9409dad420c335ff433c6bb158e4a4ea3865c5ab882",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "internal/ingest/ast_walker_callees_e2e_test.go",
-      "node_hash": "a193148b63e5b7e52c0f5ad9136f87204729740b2b74fcd2efb9b11e0d30db4a",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "internal/ingest/ast_walker_calls_test.go",
-      "node_hash": "b928587340c55a85e39b4aa555059503e88d9616064ea0d37c5c0c9e12b34603",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "internal/ingest/ast_walker_calls_test.go",
-      "node_hash": "fc5332f96ee5aa439fa9eab3c2066fd96a4c10cc35d6dafb1ed27da72215a169",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
       "source_id": "internal/ingest/interfaces.go",
       "node_hash": "c3b025cbf8ab6151fa19b13919b291be8d51bdbb76658657a86a4411c4e0f443",
       "count": 1
@@ -2357,12 +2297,6 @@
     {
       "rule_id": "duplicate_definitions",
       "source_id": "internal/smells/serve_find_smells_test.go",
-      "node_hash": "ca881141cc6af7a1c8218073ff298e1afaa5193e7b09ec9a824ca33351887eb8",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "internal/smells/serve_find_smells_test.go",
       "node_hash": "e842c5f569f14327205ee17291c15d1a4da809827b51b0fd1555db72ffb588e3",
       "count": 1
     },
@@ -2394,12 +2328,6 @@
       "rule_id": "duplicate_definitions",
       "source_id": "internal/testfixtures/registry.go",
       "node_hash": "bcf49daa83e24b1ad144198908e166d220acfd9750e538ea8d4ca85f0020efc5",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "internal/testutil/testdata/preset_fixtures/bash/build.sh",
-      "node_hash": "8eb85cec23a7ca368fb26176279dd600eb61ac130f84bb064a763c8071ca8496",
       "count": 1
     },
     {
@@ -2460,12 +2388,6 @@
       "rule_id": "duplicate_definitions",
       "source_id": "resolve/resolver.go",
       "node_hash": "3a189f799e19baad69ed672c7be7b2a88b8ada1c72b8b7fc65888882f48f77c6",
-      "count": 1
-    },
-    {
-      "rule_id": "duplicate_definitions",
-      "source_id": "scripts/arena.sh",
-      "node_hash": "98c8e9bd6961bfd434147bd520f96e029bf4501d5e8f7f8a0837722c117b8e12",
       "count": 1
     },
     {
@@ -2686,12 +2608,6 @@
     },
     {
       "rule_id": "fan_out_skew",
-      "source_id": "internal/ingest/engine.go",
-      "node_hash": "812e36775509d1b7e5bf9a1665e5d4740f14757a06904d486b56c11f983b5bdd",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_ingest.go",
       "node_hash": "7a9416ba9eaba79249404fce39303899d49b8ea04ae0a4fd30dfdbb3b6412e52",
       "count": 1
@@ -2704,18 +2620,6 @@
     },
     {
       "rule_id": "fan_out_skew",
-      "source_id": "internal/ingest/engine_treesitter.go",
-      "node_hash": "ad8f1d2f1c167ad9348509cfc4a6e02baa8895559bc6a04f6ba703fe6217074c",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "internal/ingest/engine_treesitter.go",
-      "node_hash": "f19f313b668730523fe6464579d93e6a89cc966837a5630994d507f2a71e5bc0",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_walk.go",
       "node_hash": "9246131536ba1eb09d5fcf898e29deb2af2026bbe5c8e5b7829eb8f9918ace74",
       "count": 1
@@ -2723,7 +2627,7 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "c5fd7a9428c9a4f0508d88c9c739e37bb8c301061f02dd0ae5578ca139e02035",
+      "node_hash": "97d53d77010827d427cceaf37ec279bb08b6ef6a948d9673557cc33eacf59db6",
       "count": 1
     },
     {
@@ -2760,12 +2664,6 @@
       "rule_id": "fan_out_skew",
       "source_id": "internal/leylinegraph/leyline.go",
       "node_hash": "5d4322bf06fa5eb297df63e6a5c010a40da52ca8e95e0d37cdea89b1fbb5ea29",
-      "count": 1
-    },
-    {
-      "rule_id": "fan_out_skew",
-      "source_id": "internal/lltest/project.go",
-      "node_hash": "efa78a4cad1ac0a973d12b921d394520dd007c52e5a77fd45b49ef3ccaabbb23",
       "count": 1
     },
     {
@@ -3174,44 +3072,8 @@
     },
     {
       "rule_id": "long_function",
-      "source_id": "internal/ingest/ast_walker.go",
-      "node_hash": "93e47d063405a62ffbff353fe012abe535d8a22bf24cb332c6927affa8fb38cc",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/ast_walker_calls.go",
-      "node_hash": "928d8fde26adfc657571cde04575a7d0ca8e043aa057df5270f98e5ac83aac14",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/ast_walker_selector.go",
-      "node_hash": "0aed7a3fa396ecc0daee7de143d0b24475f2745a583d0d3e13535cfd52882f72",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/ast_walker_test.go",
-      "node_hash": "4cde04af136a6f28cd9517446ed023c9dc10cd8f287fd51e9d1c879f02f637b9",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/ast_walker_test.go",
-      "node_hash": "a109b1c321585cf399ffb7f1babfdbfd843e4233e4d177ab42f50a5ac127f491",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
       "source_id": "internal/ingest/callees_noast_e2e_test.go",
       "node_hash": "0d4ed96b8c2d80b7c01d5f7d0570f839a873e68514e674fa1596f4f88626949d",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/engine.go",
-      "node_hash": "812e36775509d1b7e5bf9a1665e5d4740f14757a06904d486b56c11f983b5bdd",
       "count": 1
     },
     {
@@ -3246,18 +3108,6 @@
     },
     {
       "rule_id": "long_function",
-      "source_id": "internal/ingest/engine_treesitter.go",
-      "node_hash": "ad8f1d2f1c167ad9348509cfc4a6e02baa8895559bc6a04f6ba703fe6217074c",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/engine_treesitter.go",
-      "node_hash": "f19f313b668730523fe6464579d93e6a89cc966837a5630994d507f2a71e5bc0",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
       "source_id": "internal/ingest/engine_walk.go",
       "node_hash": "9246131536ba1eb09d5fcf898e29deb2af2026bbe5c8e5b7829eb8f9918ace74",
       "count": 1
@@ -3265,19 +3115,13 @@
     {
       "rule_id": "long_function",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "c5fd7a9428c9a4f0508d88c9c739e37bb8c301061f02dd0ae5578ca139e02035",
+      "node_hash": "97d53d77010827d427cceaf37ec279bb08b6ef6a948d9673557cc33eacf59db6",
       "count": 1
     },
     {
       "rule_id": "long_function",
       "source_id": "internal/ingest/git.go",
       "node_hash": "4670e6f63a95a4e178b3bcdce558f4dccae073ebe47a2273ac5e7989350ca42e",
-      "count": 1
-    },
-    {
-      "rule_id": "long_function",
-      "source_id": "internal/ingest/sqlite_writer.go",
-      "node_hash": "645e500bb4b1c24bb5ba66ded902987f0e34d1677da6c34d66b00198c6f3b9f9",
       "count": 1
     },
     {

--- a/examples/rust-schema.json
+++ b/examples/rust-schema.json
@@ -15,7 +15,123 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(function_item name: (identifier) @name) @scope",
+          "selector": "(source_file (function_item name: (identifier) @name) @scope)",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(mod_item body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(block (function_item name: (identifier) @name) @scope)",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "methods",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (type_identifier) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (type_identifier) @receiver) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ name: (type_identifier) @receiver) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (type_identifier) @receiver)) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ name: (type_identifier) @receiver)) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (_ name: (type_identifier) @receiver))) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(trait_item name: (type_identifier) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
           "include": ["lsp"],
           "files": [
             {
@@ -84,6 +200,36 @@
         {
           "name": "{{.name}}",
           "selector": "(impl_item type: (type_identifier) @name) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (type_identifier) @name)) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ name: (type_identifier) @name)) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (type_identifier) @name))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ name: (type_identifier) @name))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (_ name: (type_identifier) @name)))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_) @name) @scope",
           "include": ["lsp"]
         }
       ]

--- a/internal/ingest/ast_walker_lookup.go
+++ b/internal/ingest/ast_walker_lookup.go
@@ -41,26 +41,39 @@ func (idx *fileIndex) childrenByKind(parentID string, leaf pathStep, ancestry []
 }
 
 // descendantsByKind returns up to limit (0 = all) descendants of parentID
-// matching leaf whose path up to parentID reads ancestry — kinds and fields
-// both, so `receiver: (parameter_list ...)` reaches the receiver's list and
-// never the parameters' (mache-91d903). Candidates are the file's nodes of
-// the leaf kind under parentID's id prefix, in start_byte order; each is
-// verified by climbing.
+// matching leaf whose path down from parentID reads ancestry — kinds and
+// fields both, so `receiver: (parameter_list ...)` reaches the receiver's
+// list and never the parameters' (mache-91d903). It walks DOWN the children
+// adjacency one step at a time: the frontier after each step is the nodes it
+// matched, in start_byte order, so the result is in document order and a
+// wildcard step (`(_)`) costs the same as a named one — there is no
+// per-kind candidate list to consult (mache-c777ef).
 func (idx *fileIndex) descendantsByKind(parentID string, leaf pathStep, ancestry []pathStep, limit int) []astNode {
-	prefix := parentID + "/"
+	frontier := []string{parentID}
+	for _, step := range ancestry {
+		var next []string
+		for _, p := range frontier {
+			for _, ci := range idx.children[p] {
+				if step.matches(idx.all[ci]) {
+					next = append(next, idx.all[ci].id)
+				}
+			}
+		}
+		if len(next) == 0 {
+			return nil
+		}
+		frontier = next
+	}
 	var out []astNode
-	for _, i := range idx.byKind[leaf.kind] {
-		n := idx.all[i]
-		if !strings.HasPrefix(n.id, prefix) || !leaf.matches(n) {
-			continue
-		}
-		top, ok := idx.climb(i, ancestry)
-		if !ok || idx.all[top].parentID != parentID {
-			continue
-		}
-		out = append(out, n.toAST())
-		if limit > 0 && len(out) == limit {
-			break
+	for _, p := range frontier {
+		for _, ci := range idx.children[p] {
+			if !leaf.matches(idx.all[ci]) {
+				continue
+			}
+			out = append(out, idx.all[ci].toAST())
+			if limit > 0 && len(out) == limit {
+				return out
+			}
 		}
 	}
 	return out
@@ -95,20 +108,19 @@ type scopeUnit struct {
 // single outer node expands to one unit PER inner scope node reached by
 // scopePath — so grouped declarations like `type ( Alpha; Beta )` project
 // each member, matching tree-sitter's one-match-per-inner-node semantics —
-// falling back to the outer node when none resolves, which preserves the
-// single-node behavior for odd shapes.
+// and to NONE when no inner node resolves: the pattern did not match. (It
+// used to fall back to the outer node, which turned `(mod_item body:
+// (declaration_list (function_item ...) @scope))` on a function-less module
+// into a match whose captures resolved against the module itself —
+// mache-c777ef.)
 func (idx *fileIndex) scopeUnits(outer []astNode, scopePath []pathStep) []scopeUnit {
 	units := make([]scopeUnit, 0, len(outer))
 	for _, o := range outer {
-		var inners []astNode
-		if len(scopePath) > 0 {
-			inners = idx.childrenByKind(o.id, scopePath[len(scopePath)-1], scopePath[:len(scopePath)-1])
-		}
-		if len(inners) == 0 {
+		if len(scopePath) == 0 {
 			units = append(units, scopeUnit{outerID: o.id, scope: o})
 			continue
 		}
-		for _, in := range inners {
+		for _, in := range idx.childrenByKind(o.id, scopePath[len(scopePath)-1], scopePath[:len(scopePath)-1]) {
 			units = append(units, scopeUnit{outerID: o.id, scope: in})
 		}
 	}

--- a/internal/ingest/ast_walker_selector.go
+++ b/internal/ingest/ast_walker_selector.go
@@ -32,16 +32,23 @@ type selectorPattern struct {
 // the field it must sit under in its parent. An empty field is a wildcard —
 // `(parameter_list (parameter_declaration ...))` accepts a parameter_declaration
 // under any field, which is tree-sitter's own semantics for an unlabelled
-// child pattern.
+// child pattern. So is the kind wildcardKind: `(impl_item type: (_ type:
+// (type_identifier) @receiver))` reaches the receiver's type_identifier
+// through whatever wraps it — generic_type, reference_type, pointer_type —
+// which is tree-sitter's `(_)`, any named node.
 type pathStep struct {
 	kind  string
 	field string
 }
 
-// matches reports whether n is this step: its kind, and its field when the
-// step names one.
+// wildcardKind is tree-sitter's `_`: a step that matches a node of any kind.
+// Only named nodes are indexed, so `(_)` and bare `_` are the same here.
+const wildcardKind = "_"
+
+// matches reports whether n is this step: its kind (any, for the wildcard),
+// and its field when the step names one.
 func (p pathStep) matches(n idxNode) bool {
-	return n.astKind == p.kind && (p.field == "" || n.field == p.field)
+	return (p.kind == wildcardKind || n.astKind == p.kind) && (p.field == "" || n.field == p.field)
 }
 
 type selectorCapture struct {
@@ -144,6 +151,11 @@ func parseSelector(selector string) (*selectorPattern, error) {
 
 	if pattern.outerKind == "" {
 		return nil, fmt.Errorf("no node kind in selector: %s", selector)
+	}
+	// The outer node is looked up by kind across the file; a wildcard there
+	// would be every node.
+	if pattern.outerKind == wildcardKind {
+		return nil, fmt.Errorf("outer node of selector cannot be the wildcard (_): %s", selector)
 	}
 
 	return pattern, nil

--- a/internal/ingest/ast_walker_wildcard_test.go
+++ b/internal/ingest/ast_walker_wildcard_test.go
@@ -1,0 +1,144 @@
+package ingest
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// rustWalker parses one Rust source with the pinned leyline and returns an
+// ASTWalker over it plus the root that keys the file (leyline keys a file
+// parsed from a directory by its path relative to that directory).
+func rustWalker(t *testing.T, src string) (*ASTWalker, ASTRoot) {
+	t.Helper()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "lib.rs"), []byte(src), 0o644))
+	db, err := sql.Open("sqlite", parseWithLeyline(t, dir))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return NewASTWalker(db), ASTRoot{DB: db, SourceID: "lib.rs"}
+}
+
+// captured is the string value of capture name across matches, in match order.
+func captured(t *testing.T, matches []Match, name string) []string {
+	t.Helper()
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		v, ok := m.Values()[name].(string)
+		require.True(t, ok, "capture %q missing from match %v", name, m.Values())
+		out = append(out, v)
+	}
+	return out
+}
+
+func TestParseSelector_RejectsWildcardOuter(t *testing.T) {
+	_, err := parseSelector("(_ name: (identifier) @name) @scope")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outer node of selector cannot be the wildcard")
+}
+
+// The receiver of a generic impl (`impl<T> Cell<T>`) is a type_identifier one
+// level below the impl_item's `type:` child — which is a generic_type, not a
+// type_identifier, so `(impl_item type: (type_identifier) @receiver ...)`
+// cannot reach it. A wildcard step `(_ type: ...)` matches any kind at that
+// level while still honouring the field (mache-c777ef).
+func TestASTWalker_Query_WildcardStep_ReachesGenericReceiver(t *testing.T) {
+	w, root := rustWalker(t, `pub struct Cell<T> { v: T }
+
+impl<T: Clone> Cell<T> {
+    pub fn new(v: T) -> Self { Cell { v } }
+    pub fn get(&self) -> &T { &self.v }
+}
+`)
+	const body = " body: (declaration_list (function_item name: (identifier) @name) @scope))"
+
+	plain, err := w.Query(root, "(impl_item type: (type_identifier) @receiver"+body)
+	require.NoError(t, err)
+	assert.Empty(t, plain, "a generic impl's type: child is a generic_type, not a type_identifier")
+
+	viaWildcard, err := w.Query(root, "(impl_item type: (_ type: (type_identifier) @receiver)"+body)
+	require.NoError(t, err)
+	require.Len(t, viaWildcard, 2, "one match per method under the impl")
+	assert.Equal(t, []string{"Cell", "Cell"}, captured(t, viaWildcard, "receiver"))
+	assert.Equal(t, []string{"new", "get"}, captured(t, viaWildcard, "name"))
+	for _, scope := range captured(t, viaWildcard, "scope") {
+		assert.True(t, strings.HasPrefix(scope, "pub fn "), "@scope is the method itself, got %q", scope)
+		assert.NotContains(t, scope, "impl", "@scope must not widen to the impl block")
+	}
+
+	// A wildcard step still honours its field: `name:` is not `type:`.
+	wrongField, err := w.Query(root, "(impl_item type: (_ name: (type_identifier) @receiver)"+body)
+	require.NoError(t, err)
+	assert.Empty(t, wrongField, "generic_type has a type: child, not a name: child")
+
+	// A bare wildcard capture yields the node's own source text.
+	raw, err := w.Query(root, "(impl_item type: (_) @receiver"+body)
+	require.NoError(t, err)
+	require.Len(t, raw, 2)
+	assert.Equal(t, []string{"Cell<T>", "Cell<T>"}, captured(t, raw, "receiver"))
+}
+
+// An inner-@scope selector whose scope path reaches nothing is NOT a match.
+// It used to fall back to the outer node, so a function-less module matched
+// `(mod_item body: (declaration_list (function_item ...) @scope))` with @name
+// resolving to the module's own name — projecting `functions/empty` for a
+// module that defines no function (mache-c777ef).
+func TestASTWalker_Query_InnerScope_NoOuterFallback(t *testing.T) {
+	w, root := rustWalker(t, `pub mod empty { pub struct Nothing; }
+
+pub mod full { pub fn origin() -> u32 { 0 } }
+
+fn plain() -> u32 { let v = 1; v }
+`)
+	inMod, err := w.Query(root, "(mod_item body: (declaration_list (function_item name: (identifier) @name) @scope))")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"origin"}, captured(t, inMod, "name"),
+		"only the module that defines a function matches; `empty` must not fall back to the mod_item")
+
+	inBlock, err := w.Query(root, "(block (function_item name: (identifier) @name) @scope)")
+	require.NoError(t, err)
+	assert.Empty(t, inBlock, "a block with no nested fn is no match, whatever identifiers it contains")
+}
+
+// Sibling schema nodes are an ordered choice per scope node: when two
+// selectors under the same parent resolve the same @scope, the first in
+// schema order claims it and the later one is skipped — the rust preset's
+// receiver-shape alternatives rely on this so a method is projected once.
+// Siblings under a different parent are unaffected (mache-c777ef).
+func TestEngine_SiblingSelectors_FirstClaimsScope(t *testing.T) {
+	src := []api.Leaf{{Name: "source", ContentTemplate: "{{.scope}}"}}
+	byFn := "(function_item name: (identifier) @name) @scope"
+	schema := &api.Topology{Version: "1", Nodes: []api.Node{
+		{Name: "fns", Selector: "$", Children: []api.Node{
+			{Name: "first_{{.name}}", Selector: "(source_file " + byFn + ")", Files: src},
+			{Name: "second_{{.name}}", Selector: byFn, Files: src},
+		}},
+		{Name: "other", Selector: "$", Children: []api.Node{
+			{Name: "third_{{.name}}", Selector: byFn, Files: src},
+		}},
+	}}
+
+	dir := t.TempDir()
+	rsFile := filepath.Join(dir, "lib.rs")
+	require.NoError(t, os.WriteFile(rsFile, []byte("pub fn alpha() {}\n"), 0o644))
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	attachLeylineAST(t, engine, rsFile)
+	require.NoError(t, engine.Ingest(rsFile))
+
+	fns, err := store.ListChildren("fns")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"fns/first_alpha"}, fns, "the first sibling claims the function; the second must not project it again")
+
+	other, err := store.ListChildren("other")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"other/third_alpha"}, other, "a sibling under another parent is a separate choice")
+}

--- a/internal/ingest/engine_refs.go
+++ b/internal/ingest/engine_refs.go
@@ -42,6 +42,23 @@ type bufferingTarget struct {
 	// a construct dir reports zero children until ReplaceFileNodes runs, which
 	// is the whole window ingest operates in.
 	bufferedChildren map[string][]string
+	// claimedScopes holds the (parentPath, scope node id) pairs a schema node
+	// has already projected in this file, for processNode's ordered choice
+	// between sibling schema nodes (scopeClaimer).
+	claimedScopes map[[2]string]struct{}
+}
+
+// claimScope implements scopeClaimer.
+func (b *bufferingTarget) claimScope(parentPath, scopeID string) bool {
+	key := [2]string{parentPath, scopeID}
+	if _, taken := b.claimedScopes[key]; taken {
+		return false
+	}
+	if b.claimedScopes == nil {
+		b.claimedScopes = make(map[[2]string]struct{})
+	}
+	b.claimedScopes[key] = struct{}{}
+	return true
 }
 
 // ListChildren unions the underlying store's answer with the file nodes this

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -267,6 +267,14 @@ func listChildrenTolerant(store IngestionTarget, id string) ([]string, error) {
 	return kids, nil
 }
 
+// scopeClaimer arbitrates sibling schema nodes that match the same construct:
+// claimScope reports whether the scope node scopeID under parentPath is still
+// unclaimed, claiming it. The per-file bufferingTarget implements it; the
+// JSON path's stores do not, and JSON matches carry no scope id anyway.
+type scopeClaimer interface {
+	claimScope(parentPath, scopeID string) bool
+}
+
 // processNode is the schema-driven recursion that walks a single Match through
 // the topology, mutating the store as it goes. Counterpart to collectNodes,
 // which is the pure (store-free) variant for parallel SQLite ingest.
@@ -295,6 +303,24 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 						parentRoot.ParentPrefix == childCtx.ParentPrefix { // coverage:ignore
 						continue // coverage:ignore
 					}
+				}
+			}
+		}
+
+		// Sibling schema nodes are an ORDERED CHOICE over the constructs
+		// they match: the first sibling (in schema order) to match a scope
+		// node under a parent owns it, and later siblings skip it. That is
+		// what lets a preset spell one construct as a list of shapes, most
+		// specific first — `impl Foo`, `impl Foo<T>`, `impl &Foo`, then a
+		// `(_)` catch-all — without the catch-all re-projecting every
+		// method the specific shapes already named (mache-c777ef). `$`
+		// containers are excluded: every one of them is the same scope by
+		// construction. The claim is per file (it lives on the file's
+		// bufferingTarget), so re-ingesting a file starts clean.
+		if schema.Selector != "$" {
+			if as, ok := match.(ASTScope); ok && as.ASTScopeID() != "" {
+				if sc, ok := store.(scopeClaimer); ok && !sc.claimScope(parentPath, as.ASTScopeID()) {
+					continue
 				}
 			}
 		}

--- a/internal/lltest/project.go
+++ b/internal/lltest/project.go
@@ -26,6 +26,21 @@ import (
 // pinned leyline isn't cached — mirroring every other leyline e2e test.
 func IngestSourceViaLeyline(t *testing.T, engine *ingest.Engine, srcPath string) {
 	t.Helper()
+	db, parseDir := ParseSourceViaLeyline(t, srcPath)
+	engine.SetASTWalker(ingest.NewASTWalker(db))
+	if err := engine.Ingest(parseDir); err != nil {
+		t.Fatalf("ingest %s: %v", parseDir, err)
+	}
+}
+
+// ParseSourceViaLeyline is the parse half of IngestSourceViaLeyline: it
+// parses srcPath with the pinned leyline binary and returns the opened `_ast`
+// db (closed at test cleanup) and the directory that was parsed — the path to
+// ingest, and the root leyline keyed every source_id against. Tests that need
+// the parse output itself, not just its projection (a count of `_ast` nodes
+// to check the projection against), call this and ingest separately.
+func ParseSourceViaLeyline(t *testing.T, srcPath string) (*sql.DB, string) {
+	t.Helper()
 
 	bin, err := leyline.ResolveBinary(false) // never download in tests
 	if err != nil {
@@ -42,24 +57,7 @@ func IngestSourceViaLeyline(t *testing.T, engine *ingest.Engine, srcPath string)
 			"after in-process tree-sitter removal (mache-37ae8b)", err)
 	}
 
-	parseDir := srcPath
-	info, err := os.Stat(srcPath)
-	if err != nil {
-		t.Fatalf("stat %s: %v", srcPath, err)
-	}
-	if !info.IsDir() {
-		// leyline parse takes a directory; stage the single file.
-		staged := t.TempDir()
-		content, rerr := os.ReadFile(srcPath)
-		if rerr != nil {
-			t.Fatalf("read %s: %v", srcPath, rerr)
-		}
-		if werr := os.WriteFile(filepath.Join(staged, filepath.Base(srcPath)), content, 0o644); werr != nil {
-			t.Fatalf("stage %s: %v", srcPath, werr)
-		}
-		parseDir = staged
-	}
-
+	parseDir := parseRoot(t, srcPath)
 	dbFile := filepath.Join(t.TempDir(), "ast.db")
 	cmd := exec.Command(bin, "parse", parseDir, "-o", dbFile)
 	cmd.Stdout = os.Stderr
@@ -73,9 +71,28 @@ func IngestSourceViaLeyline(t *testing.T, engine *ingest.Engine, srcPath string)
 		t.Fatalf("open _ast db: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
+	return db, parseDir
+}
 
-	engine.SetASTWalker(ingest.NewASTWalker(db))
-	if err := engine.Ingest(parseDir); err != nil {
-		t.Fatalf("ingest %s: %v", parseDir, err)
+// parseRoot is the directory `leyline parse` is pointed at for srcPath: the
+// path itself when it is a directory, else a temp dir the single file is
+// staged into (leyline parse takes a directory).
+func parseRoot(t *testing.T, srcPath string) string {
+	t.Helper()
+	info, err := os.Stat(srcPath)
+	if err != nil {
+		t.Fatalf("stat %s: %v", srcPath, err)
 	}
+	if info.IsDir() {
+		return srcPath
+	}
+	staged := t.TempDir()
+	content, err := os.ReadFile(srcPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", srcPath, err)
+	}
+	if err := os.WriteFile(filepath.Join(staged, filepath.Base(srcPath)), content, 0o644); err != nil {
+		t.Fatalf("stage %s: %v", srcPath, err)
+	}
+	return staged
 }

--- a/internal/schemainfer/preset_schemas_test.go
+++ b/internal/schemainfer/preset_schemas_test.go
@@ -123,10 +123,12 @@ func TestPresetNames(t *testing.T) {
 // costs more than reading most whole files.
 //
 // It bought nothing, either: every method body inside those blocks is already
-// captured individually under `functions/`, so the blob was a second, coarser
+// captured individually under `methods/`, so the blob was a second, coarser
 // copy of content the projection already had.
 //
 // The node stays as an index of which types have impls; only the body goes.
+// There is one child per receiver shape (mache-c777ef) and the rule holds for
+// each: an index entry, never a body.
 func TestRustPreset_ImplementationsIsAnIndexNotABlob(t *testing.T) {
 	topo, err := LoadPresetSchema("rust")
 	require.NoError(t, err)
@@ -139,13 +141,14 @@ func TestRustPreset_ImplementationsIsAnIndexNotABlob(t *testing.T) {
 		}
 	}
 	require.NotNil(t, impl, "the rust preset must still expose an implementations index")
-	require.Len(t, impl.Children, 1)
+	require.NotEmpty(t, impl.Children)
 
-	child := impl.Children[0]
-	assert.Empty(t, child.Files,
-		"implementations/<Type> must not carry a source file: its selector matches the whole "+
-			"impl_item, so {{.scope}} is the entire block (95KB across 43 nodes on ley-line's rs/), "+
-			"duplicating method bodies already captured per-construct under functions/")
-	assert.Contains(t, child.Selector, "impl_item",
-		"the index itself must survive — this test is about the body, not the node")
+	for _, child := range impl.Children {
+		assert.Empty(t, child.Files,
+			"implementations/<Type> (%s) must not carry a source file: its selector matches the whole "+
+				"impl_item, so {{.scope}} is the entire block (95KB across 43 nodes on ley-line's rs/), "+
+				"duplicating method bodies already captured per-construct under methods/", child.Selector)
+		assert.Contains(t, child.Selector, "impl_item",
+			"the index itself must survive — this test is about the body, not the node")
+	}
 }

--- a/internal/schemainfer/rust_preset_test.go
+++ b/internal/schemainfer/rust_preset_test.go
@@ -1,0 +1,136 @@
+package schemainfer
+
+import (
+	"database/sql"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/agentic-research/mache/graph"
+	"github.com/agentic-research/mache/internal/ingest"
+	"github.com/agentic-research/mache/internal/lltest"
+	"github.com/agentic-research/mache/internal/testfixtures"
+	"github.com/agentic-research/mache/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// projectRust ingests parseDir, ley-line-parsed into astDB, with the rust
+// preset into a MemoryStore.
+func projectRust(t *testing.T, astDB *sql.DB, parseDir string) *graph.MemoryStore {
+	t.Helper()
+	schema, err := LoadPresetSchema("rust")
+	require.NoError(t, err)
+	store := graph.NewMemoryStore()
+	engine := ingest.NewEngine(schema, store)
+	engine.SetASTWalker(ingest.NewASTWalker(astDB))
+	require.NoError(t, engine.Ingest(parseDir))
+	return store
+}
+
+// projectedNames lists the base names of dir's children, sorted. A missing
+// dir is an empty list, so an assertion on its contents still fails visibly.
+func projectedNames(t *testing.T, store *graph.MemoryStore, dir string) []string {
+	t.Helper()
+	ids, err := store.ListChildren(dir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(ids))
+	for _, id := range ids {
+		names = append(names, strings.TrimPrefix(id, dir+"/"))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// projectedSource is the rendered content of node id.
+func projectedSource(t *testing.T, store *graph.MemoryStore, id string) string {
+	t.Helper()
+	n, err := store.GetNode(id)
+	require.NoError(t, err, "get %s", id)
+	buf := make([]byte, n.ContentSize())
+	read, err := store.ReadContent(id, buf, 0)
+	require.NoError(t, err, "read %s", id)
+	return string(buf[:read])
+}
+
+// TestRustPreset_MethodsAreReceiverQualified pins the bead's acceptance on
+// the rust fixture (mache-c777ef defect 1):
+//
+//	(a) every impl method is methods/<Receiver>.<name>, whose source is that
+//	    one fn — never the impl block;
+//	(b) functions/ holds free functions only — no impl method, and nothing
+//	    for a module or block that defines no function;
+//	(c) implementations/ is an index of impl blocks by receiver, with no
+//	    source and no generic arguments leaking into the name.
+//
+// The receiver shapes come from impls.rs (inherent impls, free functions) and
+// traits.rs (trait impls), one impl per shape of the impl_item's `type:`
+// child; lib.rs adds the plain-receiver impls.
+func TestRustPreset_MethodsAreReceiverQualified(t *testing.T) {
+	astDB, parseDir := lltest.ParseSourceViaLeyline(t, filepath.Join(testutil.PresetFixturesDir(t), "rust"))
+	store := projectRust(t, astDB, parseDir)
+
+	wantMethods := []string{
+		"Catalog.count", "Catalog.insert", "Catalog.lookup", "Catalog.new", // lib.rs
+		"Cell.fmt", "Cell.get", "Cell.new",
+		"Grid.into_iter", "Grid.new",
+		"Hash32.describe", // a trait's default method
+		"Point.new",
+		"Vec2.default",
+		"[u8].hash32", "u32.hash32", "(u8, u8).hash32",
+	}
+	sort.Strings(wantMethods)
+	assert.Equal(t, wantMethods, projectedNames(t, store, "methods"))
+
+	for _, m := range wantMethods {
+		src := projectedSource(t, store, "methods/"+m+"/source")
+		name := m[strings.LastIndex(m, ".")+1:]
+		assert.Contains(t, src, "fn "+name+"(", "methods/%s/source is the method itself", m)
+		assert.NotContains(t, src, "impl ", "methods/%s/source must not widen to the impl block", m)
+		assert.NotContains(t, src, "trait ", "methods/%s/source must not widen to the trait", m)
+		assert.Equal(t, 1, strings.Count(src, "fn "), "methods/%s/source holds exactly one fn", m)
+	}
+	assert.Equal(t, "pub fn get(&self) -> &T {\n        &self.value\n    }",
+		projectedSource(t, store, "methods/Cell.get/source"))
+
+	assert.Equal(t, []string{"free", "nested", "open", "origin", "plain"}, projectedNames(t, store, "functions"),
+		"functions/ is free functions only: no impl method, no `empty` module, no block tail `v`")
+
+	impls := projectedNames(t, store, "implementations")
+	assert.Equal(t, []string{"(u8, u8)", "Catalog", "Cell", "Grid", "Point", "Vec2", "[u8]", "u32"}, impls)
+	for _, name := range impls {
+		id := "implementations/" + name
+		assert.NotContains(t, name, "<", "%s: generic arguments leaked into the receiver name", id)
+		children, err := store.ListChildren(id)
+		require.NoError(t, err)
+		assert.NotContains(t, children, id+"/source", "%s is an index entry, not a copy of the impl block", id)
+	}
+}
+
+// TestRustPreset_EveryFunctionItemProjectedOnce is the corpus-scale form of
+// the same invariant on a real crate: every `function_item` ley-line parsed
+// is projected exactly once, as a free function or as a method — no method
+// swallowed by its impl block, no function projected twice by two receiver
+// shapes matching the same impl (mache-c777ef).
+func TestRustPreset_EveryFunctionItemProjectedOnce(t *testing.T) {
+	testfixtures.RequireTier(t, "medium")
+	srcPath, err := testfixtures.ResolvePath("medium-rust-rosary")
+	require.NoError(t, err)
+	astDB, parseDir := lltest.ParseSourceViaLeyline(t, srcPath)
+	store := projectRust(t, astDB, parseDir)
+
+	var functionItems int
+	require.NoError(t, astDB.QueryRow(`SELECT count(*) FROM _ast WHERE node_kind = 'function_item'`).Scan(&functionItems))
+	require.Positive(t, functionItems)
+
+	functions := projectedNames(t, store, "functions")
+	methods := projectedNames(t, store, "methods")
+	t.Logf("%d function_item nodes; functions/=%d methods/=%d", functionItems, len(functions), len(methods))
+	assert.Equal(t, functionItems, len(functions)+len(methods),
+		"%d function_item nodes parsed; %d projected under functions/ and %d under methods/",
+		functionItems, len(functions), len(methods))
+	assert.NotEmpty(t, methods)
+}

--- a/internal/testutil/testdata/preset_fixtures/rust/impls.rs
+++ b/internal/testutil/testdata/preset_fixtures/rust/impls.rs
@@ -1,0 +1,69 @@
+//! Receiver shapes the rust preset must project as `methods/<Receiver>.<name>`
+//! — one node per method, never the impl block (mache-c777ef). Each impl is a
+//! distinct shape of the impl_item's `type:` child; the inherent impls and
+//! the free functions live here, the trait impls in traits.rs.
+
+pub mod geometry {
+    pub struct Point {
+        pub x: i32,
+        pub y: i32,
+    }
+
+    pub struct Vec2<T> {
+        pub x: T,
+        pub y: T,
+    }
+
+    pub fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+pub mod empty {
+    pub struct Nothing;
+}
+
+pub struct Grid {
+    cells: Vec<u8>,
+}
+
+pub struct Cell<T> {
+    value: T,
+}
+
+// type_identifier
+impl Grid {
+    pub fn new() -> Self {
+        Grid { cells: Vec::new() }
+    }
+}
+
+// generic_type -> type: type_identifier
+impl<T: Clone> Cell<T> {
+    pub fn new(value: T) -> Self {
+        Cell { value }
+    }
+
+    pub fn get(&self) -> &T {
+        &self.value
+    }
+}
+
+// scoped_type_identifier -> name: type_identifier
+impl geometry::Point {
+    pub fn new(x: i32, y: i32) -> Self {
+        geometry::Point { x, y }
+    }
+}
+
+pub fn free() -> u32 {
+    fn nested() -> u32 {
+        7
+    }
+    nested()
+}
+
+fn plain() -> u32 {
+    let v = 1;
+    v
+}

--- a/internal/testutil/testdata/preset_fixtures/rust/traits.rs
+++ b/internal/testutil/testdata/preset_fixtures/rust/traits.rs
@@ -1,0 +1,60 @@
+//! Trait impls for the receiver shapes in impls.rs (mache-c777ef): the
+//! reference, scoped-generic and nameless (`[u8]`, `u32`, `(u8, u8)`) forms,
+//! plus a trait with a default method. The trait being implemented never
+//! reaches the method name.
+
+use std::fmt;
+
+use crate::impls::{geometry, Cell, Grid};
+
+// reference_type -> type: type_identifier
+impl<'a> IntoIterator for &'a Grid {
+    type Item = &'a u8;
+    type IntoIter = std::slice::Iter<'a, u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.cells.iter()
+    }
+}
+
+// reference_type -> type: generic_type -> type: type_identifier
+impl<'a, T: fmt::Debug> fmt::Debug for &'a Cell<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Cell({:?})", self.value)
+    }
+}
+
+// generic_type -> type: scoped_type_identifier -> name: type_identifier
+impl<T: Default> Default for geometry::Vec2<T> {
+    fn default() -> Self {
+        geometry::Vec2 { x: T::default(), y: T::default() }
+    }
+}
+
+pub trait Hash32 {
+    fn hash32(&self) -> u32;
+
+    fn describe(&self) -> String {
+        format!("hash {}", self.hash32())
+    }
+}
+
+// array_type, primitive_type, tuple_type: no type_identifier to name the
+// receiver by, so the receiver is the type's own text.
+impl Hash32 for [u8] {
+    fn hash32(&self) -> u32 {
+        self.iter().fold(0u32, |h, b| h.wrapping_mul(31).wrapping_add(*b as u32))
+    }
+}
+
+impl Hash32 for u32 {
+    fn hash32(&self) -> u32 {
+        *self
+    }
+}
+
+impl Hash32 for (u8, u8) {
+    fn hash32(&self) -> u32 {
+        (self.0 as u32) << 8 | self.1 as u32
+    }
+}

--- a/schema/presets/rust.json
+++ b/schema/presets/rust.json
@@ -51,7 +51,123 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(function_item name: (identifier) @name) @scope",
+          "selector": "(source_file (function_item name: (identifier) @name) @scope)",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(mod_item body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(block (function_item name: (identifier) @name) @scope)",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "methods",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (type_identifier) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (type_identifier) @receiver) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ name: (type_identifier) @receiver) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (type_identifier) @receiver)) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ name: (type_identifier) @receiver)) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (_ name: (type_identifier) @receiver))) body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(impl_item type: (_) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
+          "include": ["lsp"],
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.receiver}}.{{.name}}",
+          "selector": "(trait_item name: (type_identifier) @receiver body: (declaration_list (function_item name: (identifier) @name) @scope))",
           "include": ["lsp"],
           "files": [
             {
@@ -120,6 +236,36 @@
         {
           "name": "{{.name}}",
           "selector": "(impl_item type: (type_identifier) @name) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (type_identifier) @name)) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ name: (type_identifier) @name)) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (type_identifier) @name))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ name: (type_identifier) @name))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_ type: (_ type: (_ name: (type_identifier) @name)))) @scope",
+          "include": ["lsp"]
+        },
+        {
+          "name": "{{.name}}",
+          "selector": "(impl_item type: (_) @name) @scope",
           "include": ["lsp"]
         }
       ]


### PR DESCRIPTION
Closes bead `mache-c777ef` (defect 1).

## What was wrong

The rust preset projected every impl method as `functions/<name>`, so `fn new` in twenty impls collapsed into one node plus nineteen `.from_<file>` suffixes, and `implementations/<Type>/source` was the whole impl block — an agent asking for `Cell.get` got either a wrong-file `new` or a blob.

## What changed

**Preset** (`schema/presets/rust.json`, mirrored in `examples/rust-schema.json`)
- `methods/<Receiver>.<name>/source` — exactly one `fn`. Receiver = the impl's type identifier with generics, references and module paths stripped: `Cell.new`, `Point.new`, `Grid.into_iter`, `Vec2.default`; nameless self types use their own text: `[u8].hash32`, `u32.hash32`, `(u8, u8).hash32`. Trait default methods: `Hash32.describe`.
- `functions/` — free functions only (file, `mod`, nested).
- `implementations/<Receiver>` — an index, no source.

**Selector engine** (`internal/ingest/ast_walker_selector.go`, `ast_walker_lookup.go`)
- `(_)` is a wildcard step (tree-sitter's any-named-node) that still honours its field label; the outer node may not be a wildcard.
- A selector whose inner `@scope` path resolves nothing is not a match (no fallback to the outer node) — an empty `mod` no longer projects as a function.

**Engine** (`engine_walk.go`, `engine_refs.go`)
- Sibling schema nodes are an ordered choice per scope node: the first sibling in schema order claims a construct, later siblings skip it. That is what lets the preset list receiver shapes most-specific-first with a `(_)` catch-all. No shipped preset had overlapping siblings, so the golden gate is unchanged.

**Docs**: `docs/schemas/rust.md` (receiver table, the two engine rules), CHANGELOG entry.

## Numbers

| corpus | measurement |
|---|---|
| ley-line-open `rs/` (320 files) | 77 `methods/*.new` vs 77 `fn new` in `_ast`; 5266 function_items = functions + methods |
| `medium-rust-rosary` | 2538 function_items = 1881 `functions/` + 657 `methods/` — pinned by `TestRustPreset_EveryFunctionItemProjectedOnce` |

## Tests (all mutation-verified)

- `internal/ingest/ast_walker_wildcard_test.go` — wildcard step (with/without field), outer-wildcard rejection, no-outer-fallback, sibling ordered choice. Each killed by reverting its one engine change.
- `internal/schemainfer/rust_preset_test.go` — the receiver table on `preset_fixtures/rust/{impls,traits}.rs`; corpus parity on medium-rust-rosary. Killed by: preset reverted; catch-all moved first (`&'a Cell<T>.fmt`); the scoped-generic shape dropped (`geometry::Vec2<T>.default`).
- `TestRustPreset_ImplementationsIsAnIndexNotABlob` tightened: every `implementations/` child has no files.

## Smell baseline

Regenerated with `task smells:baseline`. The only grandfathered entry that moved is `processNode` (its hash changed with the ordered-choice check). The other removed lines are orphaned entries for functions that no longer exist at those hashes. The new code itself is clean: `ParseSourceViaLeyline` fan-out 35→26 by extracting `parseRoot`, the fixture split so neither file is a god_file (18/16 vs 34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs