### PR TITLE
[mache-94f571] fix(ingest): a rendered name is one node-ID segment — slashed imports are reachable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **A rendered name is one node-ID segment; slashed imports are reachable
+  again** (`mache-94f571`). A schema name template is free to render a `/` —
+  every non-stdlib Go import path, every relative JS import — and the ID was
+  joined without escaping it. `SQLiteWriter.AddNode` derives `parent_id` and
+  `name` from the LAST `/`, so `main/imports/"golden/store"` was written with
+  the parent `main/imports/"golden`, which is not a node: `ListChildren` is
+  `WHERE parent_id = ?`, so `list_directory` and a mount both skipped it while
+  `node_defs` still listed its token. 1 such node on the `small-go-golden`
+  corpus, 1967 on mache itself — every import of a slashed path. Names are now
+  percent-encoded into a single segment (`"golden%2Fstore"`), `%` first so the
+  mapping stays injective. The definition TOKEN is unchanged, so `search` and
+  the smell rules still match the import as it is written in the source.
+  `TestProjectionInvariant_EveryParentIsANode` pins reachability on both
+  corpora.
+
 - **Rust methods are receiver-qualified; `functions/` holds free functions
   only** (`mache-c777ef`). The rust preset selected every `function_item` in a
   file as `functions/<name>`, so `fn new` in twenty impls collapsed into one

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -2621,13 +2621,13 @@
     {
       "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "9246131536ba1eb09d5fcf898e29deb2af2026bbe5c8e5b7829eb8f9918ace74",
+      "node_hash": "15e6d23eb0ccf610b9d1df7707258ca495987fb56d748711a34a73f1fcee338d",
       "count": 1
     },
     {
       "rule_id": "fan_out_skew",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "97d53d77010827d427cceaf37ec279bb08b6ef6a948d9673557cc33eacf59db6",
+      "node_hash": "5776764667f5ceb9d3bf5599acdfb793a02bcb3e6bb0398f7d28d04e8a924adb",
       "count": 1
     },
     {
@@ -3109,13 +3109,13 @@
     {
       "rule_id": "long_function",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "9246131536ba1eb09d5fcf898e29deb2af2026bbe5c8e5b7829eb8f9918ace74",
+      "node_hash": "15e6d23eb0ccf610b9d1df7707258ca495987fb56d748711a34a73f1fcee338d",
       "count": 1
     },
     {
       "rule_id": "long_function",
       "source_id": "internal/ingest/engine_walk.go",
-      "node_hash": "97d53d77010827d427cceaf37ec279bb08b6ef6a948d9673557cc33eacf59db6",
+      "node_hash": "5776764667f5ceb9d3bf5599acdfb793a02bcb3e6bb0398f7d28d04e8a924adb",
       "count": 1
     },
     {

--- a/internal/ingest/engine_segment_test.go
+++ b/internal/ingest/engine_segment_test.go
@@ -1,0 +1,91 @@
+package ingest
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/api"
+	"github.com/agentic-research/mache/graph"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSegmentEscape pins the two properties a node-ID segment needs: it holds
+// no '/', and the encoding is injective — `a/b` and `a%2Fb` are different
+// names and must stay different IDs (mache-94f571).
+func TestSegmentEscape(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{`"fmt"`, `"fmt"`},
+		{"Store.Add", "Store.Add"},
+		{`"golden/store"`, `"golden%2Fstore"`},
+		{"encoding/json", "encoding%2Fjson"},
+		{"a/b/c", "a%2Fb%2Fc"},
+		{"100%", "100%25"},
+		{"a%2Fb", "a%252Fb"},
+	} {
+		assert.Equal(t, tc.want, segmentEscape(tc.in), "segmentEscape(%q)", tc.in)
+		assert.NotContains(t, segmentEscape(tc.in), "/", "segmentEscape(%q) left a separator", tc.in)
+	}
+
+	// Injective: the two names that collide under a '/'-only escape.
+	assert.NotEqual(t, segmentEscape("a/b"), segmentEscape("a%2Fb"),
+		"escaping '/' without escaping '%' collapses two distinct names onto one ID")
+}
+
+// TestJoinSegment_KeepsNameInOneSegment is the property the ID depends on:
+// whatever the name renders, the joined path gains exactly one segment.
+func TestJoinSegment_KeepsNameInOneSegment(t *testing.T) {
+	assert.Equal(t, `main/imports/"golden%2Fstore"`, joinSegment("main/imports", `"golden/store"`))
+	assert.Equal(t, "main/imports", filepath.Dir(joinSegment("main/imports", `"golden/store"`)),
+		"the parent of the joined ID must be the path it was joined onto")
+}
+
+// TestEngine_SlashedNameIsOneNode projects a Go file importing a slashed path
+// through an imports schema shaped like the go preset's. Before mache-94f571
+// the import's ID was `main/imports/"golden/store"`, whose parent
+// `main/imports/"golden` is not a node — SQLiteWriter.AddNode split the ID at
+// its last '/', so ListChildren never returned it.
+func TestEngine_SlashedNameIsOneNode(t *testing.T) {
+	dir := t.TempDir()
+	goFile := filepath.Join(dir, "main.go")
+	src := "package main\n\nimport (\n\t\"fmt\"\n\t\"golden/store\"\n)\n\nfunc main() { fmt.Println(store.N) }\n"
+	require.NoError(t, os.WriteFile(goFile, []byte(src), 0o644))
+
+	schema := &api.Topology{Version: "1", Nodes: []api.Node{{
+		Name:     "{{.pkg}}",
+		Selector: "(source_file (package_clause (package_identifier) @pkg)) @scope",
+		Children: []api.Node{{
+			Name:     "imports",
+			Selector: "$",
+			Children: []api.Node{{
+				Name:     "{{.path}}",
+				Selector: "(import_spec path: (interpreted_string_literal) @path) @scope",
+				Files:    []api.Leaf{{Name: "source", ContentTemplate: "{{.scope}}"}},
+			}},
+		}},
+	}}}
+
+	store := graph.NewMemoryStore()
+	engine := NewEngine(schema, store)
+	attachLeylineAST(t, engine, goFile)
+	require.NoError(t, engine.Ingest(goFile))
+
+	kids, err := store.ListChildren("main/imports")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{`main/imports/"fmt"`, `main/imports/"golden%2Fstore"`}, kids,
+		"a slashed import path is one child of imports/, not a node nobody can reach")
+
+	const id = `main/imports/"golden%2Fstore"`
+	_, err = store.GetNode(id)
+	require.NoError(t, err, "%s must exist", id)
+	leaves, err := store.ListChildren(id)
+	require.NoError(t, err)
+	assert.Equal(t, []string{id + "/source"}, leaves)
+
+	// The ID is escaped; the DEFINITION TOKEN is not. `search` and the smell
+	// rules match the import as it is written in the source.
+	assert.Equal(t, []string{id}, store.LookupDef(`"golden/store"`),
+		"the def token keeps the source spelling")
+	assert.Empty(t, store.LookupDef(`"golden%2Fstore"`), "the escaped form is an ID, not a token")
+}

--- a/internal/ingest/engine_walk.go
+++ b/internal/ingest/engine_walk.go
@@ -30,6 +30,36 @@ func dedupSuffix(sourceFile string) string {
 	return ".from_" + sanitized
 }
 
+// segmentEscape makes a rendered name usable as exactly ONE segment of a node
+// ID. A node ID is a '/'-joined path and every consumer splits it back on '/':
+// SQLiteWriter.AddNode derives parent_id and name from the LAST '/', GraphFS
+// walks it component by component, ListChildren is `WHERE parent_id = ?`. A
+// name template is free to render a '/' — every non-stdlib Go import path,
+// every relative JS import — and the ID then split in the wrong place:
+// `main/imports/"golden/store"` was written with parent_id `main/imports/"golden`,
+// which is not a node, so ListChildren never returned it and 1939 nodes were
+// unreachable on mache itself (mache-94f571).
+//
+// Percent-encoding, '%' FIRST so the mapping stays injective: escaping only
+// '/' would give the distinct names `a/b` and `a%2Fb` the same ID.
+//
+// Only the ID is escaped. The rendered name is still what AddDef registers as
+// the definition token, so `search` and the smell rules keep matching the
+// symbol as it is written in the source.
+func segmentEscape(name string) string {
+	if !strings.ContainsAny(name, "%/") {
+		return name
+	}
+	name = strings.ReplaceAll(name, "%", "%25")
+	return strings.ReplaceAll(name, "/", "%2F")
+}
+
+// joinSegment appends a rendered name to a node path as ONE segment. Every
+// construct and leaf-file name reaches a node ID through here.
+func joinSegment(base, name string) string {
+	return filepath.Join(base, segmentEscape(name))
+}
+
 // idToPath is the inverse of toNodeID for rebuilding a filesystem path from a
 // claimed node ID.
 func idToPath(id string) string {
@@ -77,7 +107,7 @@ func (e *Engine) claimConstructID(id, parentPath, name, sourceFile string) strin
 
 	candidate := id
 	if sourceFile != "" {
-		suffixed := toNodeID(filepath.Join(parentPath, name+dedupSuffix(sourceFile)))
+		suffixed := toNodeID(joinSegment(parentPath, name+dedupSuffix(sourceFile)))
 		if _, taken := e.claimedIDs[suffixed]; !taken {
 			e.claimedIDs[suffixed] = 1
 			log.Printf("[WARN] duplicate construct name %q under %q — emitting %q; "+
@@ -163,7 +193,7 @@ func collectNodes(result *recordResult, schema api.Node, walker Walker, ctx any,
 			continue                                                                             // coverage:ignore
 		}
 
-		currentPath := filepath.Join(parentPath, name)
+		currentPath := joinSegment(parentPath, name)
 		id := toNodeID(currentPath)
 
 		node := &graph.Node{
@@ -190,7 +220,7 @@ func collectNodes(result *recordResult, schema api.Node, walker Walker, ctx any,
 				log.Printf("collectNodes: skip file name render %q: %v", fileSchema.Name, err) // coverage:ignore
 				continue                                                                       // coverage:ignore
 			}
-			filePath := filepath.Join(currentPath, fileName)
+			filePath := joinSegment(currentPath, fileName)
 			fileId := toNodeID(filePath)
 
 			var content string
@@ -332,7 +362,7 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 		}
 
 		// Normalize path
-		currentPath := filepath.Join(parentPath, name)
+		currentPath := joinSegment(parentPath, name)
 		id := toNodeID(currentPath)
 
 		// Dedup: two constructs whose schema name template renders the same
@@ -604,7 +634,7 @@ func (e *Engine) processNode(schema api.Node, walker Walker, ctx any, parentPath
 				log.Printf("processNode: skip file name render %q: %v", fileSchema.Name, err) // coverage:ignore
 				continue                                                                      // coverage:ignore
 			}
-			filePath := filepath.Join(currentPath, fileName)
+			filePath := joinSegment(currentPath, fileName)
 			fileId := toNodeID(filePath)
 
 			// Augment template values with doc comment text

--- a/internal/testfixtures/golden_test.go
+++ b/internal/testfixtures/golden_test.go
@@ -136,6 +136,49 @@ func TestDiffLines(t *testing.T) {
 	assert.Empty(t, added)
 }
 
+// TestProjectionInvariant_EveryParentIsANode is the reachability gate: a node
+// whose parent_id names no node is written to the db but is invisible to the
+// tree — ListChildren is `WHERE parent_id = ?`, so list_directory and a mount
+// both skip it while node_defs still lists its token.
+//
+// It caught the slashed-import defect (mache-94f571): SQLiteWriter.AddNode
+// derives parent_id from the LAST '/' of the ID, so a name that renders a '/'
+// split in the wrong place — `main/imports/"golden/store"` claimed the parent
+// `main/imports/"golden`, which does not exist. 1 orphan on small-go-golden,
+// 1939 on mache itself, every one of them an import of a slashed path.
+//
+// mache-self runs under the same opt-in as the other full-repo fixtures; it
+// is the only corpus wide enough to cover every preset shape mache projects.
+func TestProjectionInvariant_EveryParentIsANode(t *testing.T) {
+	for _, id := range []string{"small-go-golden", "mache-self"} {
+		t.Run(id, func(t *testing.T) {
+			if id == "mache-self" && os.Getenv("MACHE_E2E_LARGE") == "" {
+				t.Skip("full-repo fixture (~20s); set MACHE_E2E_LARGE=1 to run")
+			}
+			db := Get(t, id).DB()
+			const orphans = `SELECT n.id, n.parent_id FROM nodes n
+				WHERE n.parent_id IS NOT NULL AND n.parent_id != ''
+				  AND NOT EXISTS (SELECT 1 FROM nodes p WHERE p.id = n.parent_id)
+				ORDER BY n.id`
+			rows, err := db.Query(orphans)
+			require.NoError(t, err)
+			defer func() { _ = rows.Close() }()
+
+			var found []string
+			for rows.Next() {
+				var nodeID, parentID string
+				require.NoError(t, rows.Scan(&nodeID, &parentID))
+				found = append(found, nodeID+" -> "+parentID)
+			}
+			require.NoError(t, rows.Err())
+			assert.Empty(t, found,
+				"%d node(s) have a parent_id that is not a node id, so ListChildren can never "+
+					"return them; a rendered name reached the id with a '/' still in it "+
+					"(ingest.segmentEscape)", len(found))
+		})
+	}
+}
+
 // TestProjectionInvariants are the load-bearing intents behind rows in the
 // golden (mache-c0537f gate 3): a regeneration that silently dropped one of
 // these would still produce a self-consistent golden, so each is pinned by

--- a/testdata/golden/projection/small-go-golden.tsv
+++ b/testdata/golden/projection/small-go-golden.tsv
@@ -26,8 +26,8 @@ main/imports/"fmt"	main/imports	"fmt"	1	0		NULL		"import (\n\t\"fmt\"\n\t\"os\"\
 main/imports/"fmt".from_tool_go	main/imports	"fmt".from_tool_go	1	0		NULL		"import \"fmt\"\n\nconst Version = \"0.0.1\"\n\nvar defaultName = \"golden\"\n\n"	{"ast_scope_id":"tool.go/import_declaration/import_spec","ast_source_id":"tool.go","imports":{"fmt":"fmt"},"lang":"go","location":"tool.go:3:3","pkg":"main"}
 main/imports/"fmt".from_tool_go/source	main/imports/"fmt".from_tool_go	source	0	5		"\"fmt\""	$FIXTURE/tool.go	NULL	
 main/imports/"fmt"/source	main/imports/"fmt"	source	0	5		"\"fmt\""	$FIXTURE/main.go	NULL	
-main/imports/"golden/store"	main/imports/"golden	store"	1	0		NULL		"import (\n\t\"fmt\"\n\t\"os\"\n\n\t\"golden/store\"\n)\n\nvar cfg = store.Config{Limit: 2}\n\n"	{"ast_scope_id":"main.go/import_declaration/import_spec_list/import_spec_2","ast_source_id":"main.go","imports":{"fmt":"fmt","os":"os","store":"golden/store"},"lang":"go","location":"main.go:7:7","pkg":"main"}
-main/imports/"golden/store"/source	main/imports/"golden/store"	source	0	14		"\"golden/store\""	$FIXTURE/main.go	NULL	
+main/imports/"golden%2Fstore"	main/imports	"golden%2Fstore"	1	0		NULL		"import (\n\t\"fmt\"\n\t\"os\"\n\n\t\"golden/store\"\n)\n\nvar cfg = store.Config{Limit: 2}\n\n"	{"ast_scope_id":"main.go/import_declaration/import_spec_list/import_spec_2","ast_source_id":"main.go","imports":{"fmt":"fmt","os":"os","store":"golden/store"},"lang":"go","location":"main.go:7:7","pkg":"main"}
+main/imports/"golden%2Fstore"/source	main/imports/"golden%2Fstore"	source	0	14		"\"golden/store\""	$FIXTURE/main.go	NULL	
 main/imports/"os"	main/imports	"os"	1	0		NULL		"import (\n\t\"fmt\"\n\t\"os\"\n\n\t\"golden/store\"\n)\n\nvar cfg = store.Config{Limit: 2}\n\n"	{"ast_scope_id":"main.go/import_declaration/import_spec_list/import_spec_1","ast_source_id":"main.go","imports":{"fmt":"fmt","os":"os","store":"golden/store"},"lang":"go","location":"main.go:5:5","pkg":"main"}
 main/imports/"os"/source	main/imports/"os"	source	0	4		"\"os\""	$FIXTURE/main.go	NULL	
 main/methods	main	methods	1	0		NULL		NULL	{"imports":{},"lang":"go","pkg":"main"}
@@ -135,18 +135,18 @@ gomod:fmt	main/functions/init/source
 gomod:fmt	main/functions/main/source
 gomod:fmt	main/imports/"fmt".from_tool_go/source
 gomod:fmt	main/imports/"fmt"/source
-gomod:fmt	main/imports/"golden/store"/source
+gomod:fmt	main/imports/"golden%2Fstore"/source
 gomod:fmt	main/imports/"os"/source
 gomod:fmt	main/variables/cfg/source
 gomod:fmt	main/variables/defaultName/source
 gomod:golden/store	main/functions/main/source
 gomod:golden/store	main/imports/"fmt"/source
-gomod:golden/store	main/imports/"golden/store"/source
+gomod:golden/store	main/imports/"golden%2Fstore"/source
 gomod:golden/store	main/imports/"os"/source
 gomod:golden/store	main/variables/cfg/source
 gomod:os	main/functions/main/source
 gomod:os	main/imports/"fmt"/source
-gomod:os	main/imports/"golden/store"/source
+gomod:os	main/imports/"golden%2Fstore"/source
 gomod:os	main/imports/"os"/source
 gomod:os	main/variables/cfg/source
 gomod:sort	store/functions/init/source
@@ -188,7 +188,7 @@ string	store/types/Item/source
 "errors"	store/imports/"errors"
 "fmt"	main/imports/"fmt"
 "fmt"	main/imports/"fmt".from_tool_go
-"golden/store"	main/imports/"golden/store"
+"golden/store"	main/imports/"golden%2Fstore"
 "os"	main/imports/"os"
 "sort"	store/imports/"sort"
 "strings"	store/imports/"strings"
@@ -217,7 +217,7 @@ main	main/functions/main
 main	main/functions/main.from_main_go
 main."fmt"	main/imports/"fmt"
 main."fmt"	main/imports/"fmt".from_tool_go
-main."golden/store"	main/imports/"golden/store"
+main."golden/store"	main/imports/"golden%2Fstore"
 main."os"	main/imports/"os"
 main.Version	main/constants/Version
 main.cfg	main/variables/cfg


### PR DESCRIPTION
Closes bead `mache-94f571`.

## What was wrong

A schema name template is free to render a `/` — every non-stdlib Go import path, every relative JS import. The ID was joined without escaping it, and `SQLiteWriter.AddNode` derives `parent_id` and `name` from the **last** `/`:

```
id        = main/imports/"golden/store"
parent_id = main/imports/"golden        <- no such node
name      = store"
```

`ListChildren` is `WHERE parent_id = ?`, so `list_directory` and a mount both skipped the node while `node_defs` still listed its token. Reproduced before touching anything: **1** such node on `small-go-golden`, **1967** on mache itself — every import of a slashed path. (The bead said 1939; the repo has grown.)

13 presets project `imports/` and most of those languages allow a `/` in the path, so this was never Go-only. Python, Rust and Java use `.` and `::` and were unaffected.

## The fix

`segmentEscape`: `%` → `%25`, then `/` → `%2F`. `%` is escaped **first** so the mapping stays injective — escaping only `/` would give the distinct names `a/b` and `a%2Fb` the same ID. `joinSegment` is the single place it is applied, and all five ID-building sites in `engine_walk.go` go through it: two construct names and two leaf-file names across `collectNodes`/`processNode`, plus the dedup-suffixed form in `claimConstructID`.

**The escape is applied at the join, not at the render**, and that distinction is the load-bearing part. The rendered name is also what `AddDef` registers as the definition token. Escaping at the render site would have rewritten `node_defs.token` to `"golden%2Fstore"` and broken every consumer that keys on the symbol as it is written: `search`, `find_definition`, `dead_code`, `duplicate_definitions`. The golden proves the split landed correctly — the def rows `"golden/store"` and `main."golden/store"` are unchanged, only the `node_id` they point at moved.

## Golden

7 rows removed, 7 added, all of them the `golden/store` import: 2 `nodes`, 3 `node_refs`, 2 `node_defs`. `parent_id` goes from `main/imports/"golden` to `main/imports`, `name` from `store"` to `"golden%2Fstore"`.

## Tests

| test | pins |
|---|---|
| `TestSegmentEscape` | no `/` survives; `a/b` and `a%2Fb` stay distinct IDs |
| `TestJoinSegment_KeepsNameInOneSegment` | the parent of the joined ID is the path it was joined onto |
| `TestEngine_SlashedNameIsOneNode` | end-to-end: `imports/` lists the slashed import, its `source` leaf hangs off it, the def token keeps the source spelling |
| `TestProjectionInvariant_EveryParentIsANode` | no node has a `parent_id` that is not a node id, on `small-go-golden` and on `mache-self` |

All four fail with `segmentEscape` reverted to the identity (1 orphan on `small-go-golden`, 1967 on `mache-self`). The invariant test sits next to `TestGoldenProjection` and is the gate that would have caught this class on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs
