### PR TITLE
[mache-34c926] fix(schema): C# and Ruby methods say which type declares them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,21 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **C# and Ruby methods say which type declares them** (`mache-34c926`). Every
+  class-based preset qualifies a method by its declaring type except these two.
+  C# projected `methods/<name>` flat, so an interface method and its
+  implementation collided: `ILookup.Lookup` and `Catalog.Lookup` became
+  `methods/Lookup` and `methods/Lookup.from_Catalog_cs`, a filename suffix that
+  distinguishes nothing when both are in one file. Properties collided the same
+  way. Both are now `<Type>.<name>`, matching the go and rust presets, for
+  classes, interfaces and structs alike. Ruby's top-level `methods/` container
+  matched `method` nodes ANYWHERE, including inside a class body, so every
+  class method was projected twice — once correctly under its class and once
+  colliding by bare name at the top level. Five methods produced seven nodes.
+  The top-level container is now scoped to program-level defs, and `modules/`
+  gained the `methods/` container that `classes/` already had, so a module's
+  methods are still reachable. Ruby also gains fixture coverage.
+
 - **Go methods on generic receivers are methods again** (`mache-51571b`). The
   go preset's `methods/` block had two receiver shapes,
   `(pointer_type (type_identifier))` and a bare `(type_identifier)`. A generic

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -3307,7 +3307,7 @@
     {
       "rule_id": "long_function",
       "source_id": "internal/schemainfer/preset_fixture_test.go",
-      "node_hash": "bd5f0a47a01cd5e2adb9ba5e15b5215ff23ce10461d1eca8ef937abc5cef5dd2",
+      "node_hash": "a0309528c6dda27f9a8b50f9cc62a29bfe016a250b8274f9d2454ca42a3382a1",
       "count": 1
     },
     {

--- a/internal/schemainfer/csharp_preset_test.go
+++ b/internal/schemainfer/csharp_preset_test.go
@@ -1,0 +1,67 @@
+package schemainfer
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/lltest"
+	"github.com/agentic-research/mache/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// declaredCount is how many nodes of one AST kind ley-line parsed. Every
+// "is each declaration projected exactly once" assertion in this package
+// compares a projection against this.
+func declaredCount(t *testing.T, astDB *sql.DB, nodeKind string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, astDB.QueryRow(
+		`SELECT count(*) FROM _ast WHERE node_kind = ?`, nodeKind).Scan(&n))
+	require.Positive(t, n, "no %s nodes in the fixture", nodeKind)
+	return n
+}
+
+// TestCsharpPreset_MembersAreTypeQualified pins mache-34c926.
+//
+// C# projected methods and properties as flat `methods/<name>` and
+// `properties/<name>`, so an interface member and its implementation
+// collided. `ILookup.Lookup` and `Catalog.Lookup` became `methods/Lookup`
+// and `methods/Lookup.from_Catalog_cs` — a filename suffix, which
+// distinguishes nothing when both are declared in the same file and says
+// nothing about which type owns either. Same for `ILookup.Count` and
+// `Catalog.Count`.
+//
+// Every other class-based preset qualifies its methods by nesting them under
+// the declaring type. C# is flat, so it takes the other working route, the
+// one go and rust already use: a `<Type>.<name>` id.
+func TestCsharpPreset_MembersAreTypeQualified(t *testing.T) {
+	astDB, parseDir := lltest.ParseSourceViaLeyline(t, filepath.Join(testutil.PresetFixturesDir(t), "csharp"))
+	store := projectPreset(t, "csharp", astDB, parseDir)
+
+	assert.Equal(t,
+		[]string{"Catalog.Insert", "Catalog.Lookup", "ILookup.Lookup", "Point.Manhattan", "Span.Width"},
+		projectedNames(t, store, "methods"),
+		"an interface method and its implementation are different methods, and a record declares methods too")
+	assert.Equal(t,
+		[]string{"Catalog.Capacity", "Catalog.Count", "Entry.Id", "Entry.Kind", "ILookup.Count", "Point.Total"},
+		projectedNames(t, store, "properties"))
+
+	for _, dir := range []string{"methods", "properties"} {
+		for _, name := range projectedNames(t, store, dir) {
+			assert.NotContains(t, name, ".from_",
+				"%s/%s fell back to a filename suffix; the type qualification did not take", dir, name)
+		}
+	}
+
+	// Every declaration is projected exactly once. Renaming members without
+	// this would be free to drop one.
+	assert.Equal(t, declaredCount(t, astDB, "method_declaration"), len(projectedNames(t, store, "methods")))
+	assert.Equal(t, declaredCount(t, astDB, "property_declaration"), len(projectedNames(t, store, "properties")))
+
+	// The member's source is the member, not the type that declares it.
+	src := projectedSource(t, store, "methods/ILookup.Lookup/source")
+	assert.Contains(t, src, "Lookup(string id)")
+	assert.NotContains(t, src, "interface ILookup")
+}

--- a/internal/schemainfer/preset_fixture_test.go
+++ b/internal/schemainfer/preset_fixture_test.go
@@ -43,7 +43,6 @@ var pendingFixtureCoverage = map[string]string{
 	"kotlin":     "",
 	"php":        "",
 	"python":     "",
-	"ruby":       "",
 	"scala":      "",
 	"swift":      "",
 	"typescript": "",
@@ -168,12 +167,36 @@ func presetFixtureCases(t *testing.T) []presetFixtureCase {
 			minNodes:           10,
 		},
 		{
+			preset:     "ruby",
+			fixtureDir: filepath.Join(fixturesRoot, "ruby"),
+			// Every method belongs to exactly one declarer, and the
+			// projection says which: two classes share `count`, a module
+			// declares `register`, and only `top_level_helper` is a
+			// top-level def. Before mache-34c926 the top-level methods/
+			// container also matched methods inside a class, so each one
+			// was projected twice and the two `count`s collided there.
+			expectedSubstrings: []string{
+				"classes/Catalog/methods/insert",
+				"classes/Catalog/methods/count",
+				"classes/Index/methods/count",
+				"modules/Registry/methods/register",
+				"methods/top_level_helper",
+				"requires/",
+			},
+			minNodes: 12,
+		},
+		{
 			preset:     "csharp",
 			fixtureDir: filepath.Join(fixturesRoot, "csharp"),
 			expectedSubstrings: []string{
 				"namespaces/", "classes/Catalog", "classes/Entry",
 				"structs/EntryStats", "interfaces/ILookup", "enums/EntryKind",
-				"methods/Insert", "methods/Lookup",
+				// Type-qualified: an interface method and its implementation
+				// are different methods, and the id has to say so
+				// (mache-34c926).
+				"methods/Catalog.Insert", "methods/Catalog.Lookup", "methods/ILookup.Lookup",
+				"methods/Point.Manhattan", "methods/Span.Width",
+				"properties/Catalog.Count", "properties/ILookup.Count",
 			},
 			minNodes: 10,
 		},

--- a/internal/schemainfer/ruby_preset_test.go
+++ b/internal/schemainfer/ruby_preset_test.go
@@ -1,0 +1,60 @@
+package schemainfer
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/agentic-research/mache/internal/lltest"
+	"github.com/agentic-research/mache/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRubyPreset_EveryMethodHasOneDeclarer pins the other half of
+// mache-34c926.
+//
+// Ruby nests methods under `classes/<Class>/methods` correctly, but the
+// TOP-LEVEL `methods/` container's selector matched a `method` node anywhere,
+// including inside a class body. So every class method was projected TWICE —
+// once correctly, and once at the top level where two classes sharing a
+// method name collided into `count` and `count.from_catalog_rb`. Five methods
+// in the fixture produced seven nodes, and every one of them was
+// double-counted in node_defs.
+//
+// The top-level container is now scoped to program-level defs. `modules/`
+// gained the `methods/` container `classes/` already had, so scoping the
+// top-level one does not make a module's methods unreachable — that would
+// trade a duplicate for a disappearance.
+func TestRubyPreset_EveryMethodHasOneDeclarer(t *testing.T) {
+	astDB, parseDir := lltest.ParseSourceViaLeyline(t, filepath.Join(testutil.PresetFixturesDir(t), "ruby"))
+	store := projectPreset(t, "ruby", astDB, parseDir)
+
+	assert.Equal(t, []string{"count", "insert"}, projectedNames(t, store, "classes/Catalog/methods"))
+	assert.Equal(t, []string{"count"}, projectedNames(t, store, "classes/Index/methods"))
+	assert.Equal(t, []string{"register"}, projectedNames(t, store, "modules/Registry/methods"),
+		"a module's methods must still be reachable")
+	assert.Equal(t, []string{"top_level_helper"}, projectedNames(t, store, "methods"),
+		"the top-level container holds program-level defs only")
+
+	// The counting assertion: one node per method, no more. Before the fix
+	// this was 5 parsed against 7 projected.
+	projected := 0
+	for _, dir := range []string{
+		"classes/Catalog/methods", "classes/Index/methods",
+		"modules/Registry/methods", "methods",
+	} {
+		projected += len(projectedNames(t, store, dir))
+	}
+	declared := declaredCount(t, astDB, "method")
+	t.Logf("%d method nodes; %d projected", declared, projected)
+	assert.Equal(t, declared, projected,
+		"%d methods parsed but %d projected; a method is either duplicated or missing", declared, projected)
+
+	// Two classes declaring `count` are two different methods, and neither
+	// wears a filename suffix to say so.
+	for _, id := range []string{"classes/Catalog/methods/count", "classes/Index/methods/count"} {
+		_, err := store.GetNode(id)
+		require.NoError(t, err, "%s must exist", id)
+	}
+	assert.NotContains(t, projectedSource(t, store, "classes/Index/methods/count/source"), "def insert")
+}

--- a/internal/testutil/testdata/preset_fixtures/csharp/Shapes.cs
+++ b/internal/testutil/testdata/preset_fixtures/csharp/Shapes.cs
@@ -1,0 +1,17 @@
+namespace Mache.Fixture
+{
+    // A record declares methods and properties too. The type-qualified
+    // selectors have to cover record_declaration or a record's members are
+    // projected nowhere at all (mache-34c926).
+    public record Point(int X, int Y)
+    {
+        public int Manhattan() => X + Y;
+
+        public int Total { get; }
+    }
+
+    public record struct Span(int Lo, int Hi)
+    {
+        public int Width() => Hi - Lo;
+    }
+}

--- a/internal/testutil/testdata/preset_fixtures/ruby/catalog.rb
+++ b/internal/testutil/testdata/preset_fixtures/ruby/catalog.rb
@@ -1,0 +1,34 @@
+# Fixture for the ruby preset (mache-34c926). Two classes share a method
+# name, a module declares one, and one def sits at the top level — so the
+# projection has to say which of them each method belongs to, and must not
+# project any of them twice.
+
+require 'set'
+
+module Registry
+  def register(x)
+    x
+  end
+end
+
+class Catalog
+  include Registry
+
+  def insert(entry)
+    entry
+  end
+
+  def count
+    0
+  end
+end
+
+class Index
+  def count
+    1
+  end
+end
+
+def top_level_helper
+  2
+end

--- a/schema/presets/csharp.json
+++ b/schema/presets/csharp.json
@@ -96,8 +96,38 @@
       "selector": "$",
       "children": [
         {
-          "name": "{{.name}}",
-          "selector": "(method_declaration name: (identifier) @name) @scope",
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(class_declaration name: (identifier) @type body: (declaration_list (method_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(interface_declaration name: (identifier) @type body: (declaration_list (method_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(struct_declaration name: (identifier) @type body: (declaration_list (method_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(record_declaration name: (identifier) @type body: (declaration_list (method_declaration name: (identifier) @name) @scope))",
           "files": [
             {
               "name": "source",
@@ -112,8 +142,38 @@
       "selector": "$",
       "children": [
         {
-          "name": "{{.name}}",
-          "selector": "(property_declaration name: (identifier) @name) @scope",
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(class_declaration name: (identifier) @type body: (declaration_list (property_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(interface_declaration name: (identifier) @type body: (declaration_list (property_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(struct_declaration name: (identifier) @type body: (declaration_list (property_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(record_declaration name: (identifier) @type body: (declaration_list (property_declaration name: (identifier) @name) @scope))",
           "files": [
             {
               "name": "source",

--- a/schema/presets/ruby.json
+++ b/schema/presets/ruby.json
@@ -84,6 +84,25 @@
               "name": "source",
               "content_template": "{{.scope}}"
             }
+          ],
+          "children": [
+            {
+              "name": "methods",
+              "selector": "$",
+              "children": [
+                {
+                  "name": "{{.name}}",
+                  "selector": "(method name: (identifier) @name) @scope",
+                  "include": ["lsp"],
+                  "files": [
+                    {
+                      "name": "source",
+                      "content_template": "{{.scope}}"
+                    }
+                  ]
+                }
+              ]
+            }
           ]
         }
       ]
@@ -94,7 +113,7 @@
       "children": [
         {
           "name": "{{.name}}",
-          "selector": "(method name: (identifier) @name) @scope",
+          "selector": "(program (method name: (identifier) @name) @scope)",
           "include": ["lsp"],
           "files": [
             {


### PR DESCRIPTION
Closes bead `mache-34c926`, found by surveying every preset's method selectors after #680 and #688.

Every class-based preset qualifies a method by its declaring type except these two.

## C#

Methods and properties were projected flat, so an interface member and its implementation collided:

```
methods    -> [Lookup, Insert, Lookup.from_Catalog_cs]
properties -> [Count, Id, Kind, Count.from_Catalog_cs, Capacity]
```

`ILookup.Lookup` and `Catalog.Lookup` are different methods. The suffix is a *filename*, which distinguishes nothing when both are declared in the same file and says nothing about which type owns either.

`csharp.json` is entirely flat — namespaces, classes, structs, interfaces, enums, methods and properties are all top-level `$` containers, nothing nests. So the fix takes the route go and rust already use, a `<Type>.<name>` id, rather than nesting under the declaring type, which would have meant adding a container under four different type kinds.

```
methods    -> [Catalog.Insert, Catalog.Lookup, ILookup.Lookup, Point.Manhattan, Span.Width]
properties -> [Catalog.Capacity, Catalog.Count, Entry.Id, Entry.Kind, ILookup.Count, Point.Total]
```

**Records nearly became a regression.** The old flat selector matched a `method_declaration` anywhere, records included. Scoping to class, interface and struct alone would have made every record member vanish, which is exactly the failure #688 just fixed for Go generics. `record_declaration` carries `identifier` under field `name` and `declaration_list` under `body` like the others, and `record struct` produces `record_declaration` too, so a fourth selector covers both. `Shapes.cs` pins it.

## Ruby

Ruby nests under `classes/` correctly, but the top-level `methods/` container matched a `method` node **anywhere**, including inside a class body. Every class method was projected twice: once correctly, and once at the top level where two classes sharing a name collided into `count` and `count.from_catalog_rb`. Five methods in the fixture produced eight nodes, and every one was double-counted in `node_defs`, so `duplicate_definitions` and `dead_code` judged a population larger than the code.

Scoping that container to `(program (method ...) @scope)` is not enough on its own. `modules/{{.name}}` had no `methods` container, so a module's methods were reachable **only** through the colliding top-level one; scoping alone would have traded a duplicate for a disappearance. `modules/` now has the same container `classes/` already had.

```
5 method nodes parsed, 5 projected:
  classes/Catalog/methods/{insert,count}
  classes/Index/methods/count
  modules/Registry/methods/register
  methods/top_level_helper
```

## Tests

- **`TestCsharpPreset_MembersAreTypeQualified`** — exact sorted id lists for methods and properties, no id containing `.from_`, and `count(_ast method_declaration)` equal to the projected count, same for properties, so a rename cannot silently drop one. Also asserts a member's source is the member, not the type that declares it.
- **`TestRubyPreset_EveryMethodHasOneDeclarer`** — exact lists per declarer plus the count. Fails on HEAD at 5 parsed against 8 projected.
- Ruby gains fixture coverage: a `presetFixtureCases` entry, and `ruby` removed from `pendingFixtureCoverage`.
- The existing csharp fixture case expectations moved to the qualified ids. That test is how the change was caught in the first place.

Both halves mutation-verified by reverting each preset independently.

## Not in this PR

`csharp.json` has no `records` container, so `Point` and `Span` are not projected as types at all, only their members. That predates this change and is not a regression. Filed as `mache-daacc3` with the grammar shape already verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs
