### PR TITLE
[mache-daacc3] fix(schema): C# records are projected, positional parameters included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,18 @@ bumps may include breaking changes.
 
 ### Fixed
 
+- **C# records are projected, positional parameters included** (`mache-daacc3`).
+  `record` has been a first-class C# type declaration since C# 9 and is
+  idiomatic for DTOs and value types, but the preset had no container for it. A
+  record's members projected while the record itself did not exist, so an agent
+  that found `methods/Point.Manhattan` and looked for the type declaring it
+  found nothing, and `get_overview` showed a codebase with no record types in
+  it. `records/` now holds both `record` and `record struct`. A record's
+  positional parameters are its properties — the compiler generates an
+  init-only property per parameter, and they carry no `property_declaration`
+  node — so `record Point(int X, int Y)` now yields `properties/Point.X` and
+  `properties/Point.Y` rather than nothing.
+
 - **A re-ingested file keeps its node IDs, and leaves no husks**
   (`mache-399c25`). Two defects compounded on the live-refresh path. `claimedIDs`
   was reset only in `Ingest`, so `ReIngestFile` found the file's OWN previous IDs

--- a/docs/smell-baseline.json
+++ b/docs/smell-baseline.json
@@ -3295,7 +3295,7 @@
     {
       "rule_id": "long_function",
       "source_id": "internal/schemainfer/preset_fixture_test.go",
-      "node_hash": "a0309528c6dda27f9a8b50f9cc62a29bfe016a250b8274f9d2454ca42a3382a1",
+      "node_hash": "6a7e707d0bae415ee8ae31a606137921125112106c1c9d510546f9a987e11242",
       "count": 1
     },
     {

--- a/internal/schemainfer/csharp_preset_test.go
+++ b/internal/schemainfer/csharp_preset_test.go
@@ -23,6 +23,18 @@ func declaredCount(t *testing.T, astDB *sql.DB, nodeKind string) int {
 	return n
 }
 
+// recordPositionalProperties counts the parameters in a record's positional
+// list — the properties C# generates that have no property_declaration node of
+// their own. Matched on the node_id path, which is how the _ast records
+// structure, the same way the smell rules discriminate on it.
+func recordPositionalProperties(t *testing.T, astDB *sql.DB) int {
+	t.Helper()
+	var n int
+	require.NoError(t, astDB.QueryRow(
+		`SELECT count(*) FROM _ast WHERE node_kind = 'parameter' AND node_id LIKE '%record_declaration%'`).Scan(&n))
+	return n
+}
+
 // TestCsharpPreset_MembersAreTypeQualified pins mache-34c926.
 //
 // C# projected methods and properties as flat `methods/<name>` and
@@ -45,7 +57,15 @@ func TestCsharpPreset_MembersAreTypeQualified(t *testing.T) {
 		projectedNames(t, store, "methods"),
 		"an interface method and its implementation are different methods, and a record declares methods too")
 	assert.Equal(t,
-		[]string{"Catalog.Capacity", "Catalog.Count", "Entry.Id", "Entry.Kind", "ILookup.Count", "Point.Total"},
+		[]string{
+			"Catalog.Capacity", "Catalog.Count", "Entry.Id", "Entry.Kind", "ILookup.Count",
+			// A record's positional parameters ARE its properties in C#; the
+			// compiler generates an init-only property per parameter. They
+			// carry no property_declaration node, so a selector that only
+			// looks for one leaves the whole public surface of a positional
+			// record invisible (mache-daacc3).
+			"Point.Total", "Point.X", "Point.Y", "Span.Hi", "Span.Lo",
+		},
 		projectedNames(t, store, "properties"))
 
 	for _, dir := range []string{"methods", "properties"} {
@@ -58,10 +78,38 @@ func TestCsharpPreset_MembersAreTypeQualified(t *testing.T) {
 	// Every declaration is projected exactly once. Renaming members without
 	// this would be free to drop one.
 	assert.Equal(t, declaredCount(t, astDB, "method_declaration"), len(projectedNames(t, store, "methods")))
-	assert.Equal(t, declaredCount(t, astDB, "property_declaration"), len(projectedNames(t, store, "properties")))
+	assert.Equal(t,
+		declaredCount(t, astDB, "property_declaration")+recordPositionalProperties(t, astDB),
+		len(projectedNames(t, store, "properties")),
+		"a declared property reached no selector")
 
 	// The member's source is the member, not the type that declares it.
 	src := projectedSource(t, store, "methods/ILookup.Lookup/source")
 	assert.Contains(t, src, "Lookup(string id)")
 	assert.NotContains(t, src, "interface ILookup")
+}
+
+// TestCsharpPreset_RecordsAreProjected pins mache-daacc3. `record` has been a
+// first-class C# type declaration since C# 9 and is idiomatic for DTOs and
+// value types, but the preset had no container for it: a record's members
+// projected while the record itself did not exist, so an agent that found
+// `methods/Point.Manhattan` and looked for the type declaring it found
+// nothing, and `get_overview` showed a codebase with no record types in it.
+//
+// `record struct` produces a record_declaration too, so both forms land here.
+func TestCsharpPreset_RecordsAreProjected(t *testing.T) {
+	astDB, parseDir := lltest.ParseSourceViaLeyline(t, filepath.Join(testutil.PresetFixturesDir(t), "csharp"))
+	store := projectPreset(t, "csharp", astDB, parseDir)
+
+	assert.Equal(t, []string{"Point", "Span"}, projectedNames(t, store, "records"),
+		"`record Point` and `record struct Span` are both record declarations")
+	assert.Equal(t, declaredCount(t, astDB, "record_declaration"), len(projectedNames(t, store, "records")))
+
+	// A record is not a class and must not be filed as one — the id would lie
+	// about what the type is.
+	for _, name := range projectedNames(t, store, "classes") {
+		assert.NotContains(t, []string{"Point", "Span"}, name, "%s is a record, not a class", name)
+	}
+
+	assert.Contains(t, projectedSource(t, store, "records/Point/source"), "record Point(int X, int Y)")
 }

--- a/internal/schemainfer/preset_fixture_test.go
+++ b/internal/schemainfer/preset_fixture_test.go
@@ -196,6 +196,8 @@ func presetFixtureCases(t *testing.T) []presetFixtureCase {
 				// (mache-34c926).
 				"methods/Catalog.Insert", "methods/Catalog.Lookup", "methods/ILookup.Lookup",
 				"methods/Point.Manhattan", "methods/Span.Width",
+				"records/Point", "records/Span",
+				"properties/Point.X", "properties/Span.Lo",
 				"properties/Catalog.Count", "properties/ILookup.Count",
 			},
 			minNodes: 10,

--- a/schema/presets/csharp.json
+++ b/schema/presets/csharp.json
@@ -44,6 +44,22 @@
       ]
     },
     {
+      "name": "records",
+      "selector": "$",
+      "children": [
+        {
+          "name": "{{.name}}",
+          "selector": "(record_declaration name: (identifier) @name) @scope",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "structs",
       "selector": "$",
       "children": [
@@ -174,6 +190,16 @@
         {
           "name": "{{.type}}.{{.name}}",
           "selector": "(record_declaration name: (identifier) @type body: (declaration_list (property_declaration name: (identifier) @name) @scope))",
+          "files": [
+            {
+              "name": "source",
+              "content_template": "{{.scope}}"
+            }
+          ]
+        },
+        {
+          "name": "{{.type}}.{{.name}}",
+          "selector": "(record_declaration name: (identifier) @type (parameter_list (parameter name: (identifier) @name) @scope))",
           "files": [
             {
               "name": "source",


### PR DESCRIPTION
Closes bead `mache-daacc3`, filed while shipping #689 and left open deliberately so the decision below could be made with a measurement rather than inside that PR.

## What was missing

`record` has been a first-class C# type declaration since C# 9 and is idiomatic for DTOs and value types, but `csharp.json` had no container for it. A record's members projected while the record itself did not exist:

```
methods/Point.Manhattan   existed
properties/Point.Total    existed
records/Point             did not exist
classes/Point             did not exist
```

An agent that found the method and looked for the type declaring it found nothing, and `get_overview` showed a codebase with no record types in it. For a modern C# service that can be most of the domain model.

This was never a regression. Before #689 a record's methods projected too, just misnamed; the type has never been projected.

## The fix

`records/` mirrors the existing `classes/` container. The grammar emits `record_declaration` for both `record` and `record struct`, with `identifier` under field `name` and `declaration_list` under `body` — the same shape as class, struct and interface — so one selector covers both forms.

**Positional parameters.** `record Point(int X, int Y)` declares `X` and `Y` as public init-only properties. The compiler generates them, so there is no `property_declaration` node, and a selector that only looks for one leaves the entire public surface of a positional record invisible. They now project as `properties/Point.X` and `properties/Point.Y`, sourced to their declaration (`int X`).

That is the open question the bead asked to have answered either way. It is answered, not deferred.

## Tests

- **`TestCsharpPreset_RecordsAreProjected`** — `records/` is exactly `[Point, Span]`, `count(_ast record_declaration)` equals the projected count, neither name also appears under `classes/` (a record is not a class and an id that said so would lie), and `records/Point/source` is the declaration.
- **`TestCsharpPreset_MembersAreTypeQualified`** extended — the properties list now includes `Point.X`, `Point.Y`, `Span.Lo` and `Span.Hi`, and its parity assertion counts `property_declaration` nodes **plus** a record's positional parameters, so a declared property that reaches no selector is still caught.
- The csharp `presetFixtureCases` entry gains `records/` and a positional property.

Both fail with the preset reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtGhz7QzUHZi52a3FeNtEs
